### PR TITLE
优化工作区浏览与会话快捷操作

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -833,12 +833,22 @@ struct ComposerView: View {
 
     @ViewBuilder
     private var toolbarMenuRow: some View {
-        HStack(spacing: 8) {
-            addContentButton
-            composerMoreMenu
+        // 高频配置直接平铺在输入框旁边；空间不足时只让这一组横向滚动，
+        // 避免把发送、语音等主操作挤出屏幕，也不再要求先打开“配置”总菜单。
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                addContentButton
+                voiceLanguageMenu
+                runSettingsMenu
+                permissionMenu
+                planButton
+                goalButton
+            }
+            .padding(.vertical, 1)
         }
         .font(themeStore.uiFont(.caption, weight: .medium))
         .controlSize(.regular)
+        .accessibilityElement(children: .contain)
     }
 
     private var voiceMicControl: some View {
@@ -905,24 +915,16 @@ struct ComposerView: View {
 
     @ViewBuilder
     private var addContentButton: some View {
-        let tokens = themeStore.tokens(for: colorScheme)
-
         Button {
             showsAddContentPanel.toggle()
         } label: {
-            Image(systemName: "plus")
-                .font(themeStore.uiFont(size: 15, weight: .bold))
-                .foregroundStyle(tokens.accent)
-                .frame(width: 28, height: 28)
-                .frame(width: 44, height: 44)
-                .background(tokens.selectionFill, in: Capsule())
-                .overlay {
-                    Capsule()
-                        .strokeBorder(tokens.border.opacity(0.86), lineWidth: 1)
-                }
+            composerToolbarControlLabel(
+                title: nil,
+                systemImage: "plus",
+                accessibilityLabel: "添加内容"
+            )
         }
         .buttonStyle(.plain)
-        .contentShape(Capsule())
         .accessibilityLabel("添加内容")
         .help("添加图片、Skill、Mention 或快捷短语")
         .popover(isPresented: $showsAddContentPanel, arrowEdge: .bottom) {
@@ -953,54 +955,6 @@ struct ComposerView: View {
             .environmentObject(themeStore)
             .presentationCompactAdaptation(.sheet)
         }
-    }
-
-    @ViewBuilder
-    private var composerMoreMenu: some View {
-        Menu {
-            Section("输入") {
-                Button {
-                    showsAddContentPanel = true
-                } label: {
-                    Label("添加附件或引用", systemImage: "paperclip")
-                }
-            }
-            Section("发送模式") {
-                Button {
-                    setSendMode(composerState.isGoalModeSelected ? .standard : .goal)
-                } label: {
-                    Label("目标任务", systemImage: composerState.isGoalModeSelected ? "checkmark" : "target")
-                }
-                Button {
-                    setSendMode(composerState.isPlanModeSelected ? .standard : .plan)
-                } label: {
-                    Label("计划", systemImage: composerState.isPlanModeSelected ? "checkmark" : "list.clipboard")
-                }
-            }
-            Section("运行") {
-                permissionMenu
-                runSettingsMenu
-                voiceLanguageMenu
-            }
-        } label: {
-            ViewThatFits(in: .horizontal) {
-                // 模型和权限已在输入框上方常驻展示，这里只保留明确的配置入口，避免信息重复。
-                Label("配置", systemImage: "slider.horizontal.3")
-                    .lineLimit(1)
-                Image(systemName: "slider.horizontal.3")
-                    .accessibilityLabel("配置")
-            }
-            .frame(minHeight: 44)
-        }
-        .buttonStyle(.glass)
-        .tint(themeStore.tokens(for: colorScheme).accent)
-        .accessibilityLabel("运行设置")
-        .accessibilityValue(moreMenuAccessibilitySummary)
-        .accessibilityHint("添加附件、选择发送模式、权限和运行选项")
-    }
-
-    private var moreMenuAccessibilitySummary: String {
-        "\(composerState.permissionMode.title)，运行，语音 \(selectedVoiceLanguage.title)"
     }
 
     private var skillShortcutMenu: some View {
@@ -1084,11 +1038,10 @@ struct ComposerView: View {
     private var goalButton: some View {
         let selected = composerState.isGoalModeSelected
         return composerModeButton(
-            title: "目标",
+            title: "目标任务",
             systemImage: "target",
             selected: selected,
             accessibilityLabel: "目标任务模式",
-            showsTitle: composerModeButtonShowsTitle,
             action: {
                 setSendMode(selected ? .standard : .goal)
             }
@@ -1104,7 +1057,6 @@ struct ComposerView: View {
             systemImage: "list.clipboard",
             selected: selected,
             accessibilityLabel: "计划模式",
-            showsTitle: composerModeButtonShowsTitle,
             action: {
                 setSendMode(selected ? .standard : .plan)
             }
@@ -1113,51 +1065,63 @@ struct ComposerView: View {
         .help(selected ? "关闭计划模式" : "将下一次发送设为 Codex 计划模式")
     }
 
-    private var composerModeButtonShowsTitle: Bool {
-        !isCompactComposer
-    }
-
-    @ViewBuilder
     private func composerModeButton(
         title: String,
         systemImage: String,
         selected: Bool,
         accessibilityLabel: String,
-        showsTitle: Bool,
         action: @escaping () -> Void
     ) -> some View {
-        let tokens = themeStore.tokens(for: colorScheme)
-        if selected {
-            Button(action: action) {
-                composerModeButtonLabel(title: title, systemImage: systemImage, showsTitle: showsTitle)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(tokens.accent)
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityValue("已选择")
-            .accessibilityHint("只切换发送模式，不会立即发送")
-        } else {
-            Button(action: action) {
-                composerModeButtonLabel(title: title, systemImage: systemImage, showsTitle: showsTitle)
-                    .foregroundStyle(tokens.accent)
-            }
-            .buttonStyle(.bordered)
-            .tint(tokens.accent)
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityValue("未选择")
-            .accessibilityHint("只切换发送模式，不会立即发送")
+        Button(action: action) {
+            composerToolbarControlLabel(
+                title: title,
+                systemImage: systemImage,
+                isSelected: selected,
+                accessibilityLabel: accessibilityLabel
+            )
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(selected ? "已选择" : "未选择")
+        .accessibilityHint("只切换发送模式，不会立即发送")
     }
 
-    @ViewBuilder
-    private func composerModeButtonLabel(title: String, systemImage: String, showsTitle: Bool) -> some View {
-        if showsTitle {
-            Label(title, systemImage: systemImage)
-        } else {
+    private func composerToolbarControlLabel(
+        title: String?,
+        systemImage: String,
+        isSelected: Bool = false,
+        tint: Color? = nil,
+        accessibilityLabel: String
+    ) -> some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+        let foreground = isSelected ? tokens.primaryActionForeground : (tint ?? tokens.accent)
+
+        return HStack(spacing: 6) {
             Image(systemName: systemImage)
                 .font(themeStore.uiFont(size: 14, weight: .semibold))
-                .frame(width: 22, height: 22)
+            if let title {
+                Text(title)
+                    .lineLimit(1)
+            }
         }
+        .font(themeStore.uiFont(.caption, weight: .semibold))
+        .foregroundStyle(foreground)
+        .frame(height: 44)
+        .padding(.horizontal, title == nil ? 0 : 12)
+        .frame(minWidth: 44)
+        .background(
+            isSelected ? tokens.accent : tokens.elevatedSurface,
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
+        .overlay {
+            if !isSelected {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(tokens.border.opacity(0.9), lineWidth: 1)
+            }
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityLabel(accessibilityLabel)
     }
 
     @ViewBuilder
@@ -1249,11 +1213,15 @@ struct ComposerView: View {
                 }
             }
         } label: {
-            Label(selectedVoiceLanguage.title, systemImage: "globe")
-                .foregroundStyle(themeStore.tokens(for: colorScheme).accent)
+            composerToolbarControlLabel(
+                title: selectedVoiceLanguage.title,
+                systemImage: "globe",
+                accessibilityLabel: "语音语言"
+            )
         }
-        .buttonStyle(.bordered)
-        .tint(themeStore.tokens(for: colorScheme).accent)
+        .buttonStyle(.plain)
+        .accessibilityLabel("语音语言")
+        .accessibilityValue(selectedVoiceLanguage.title)
     }
 
     private var runSettingsMenu: some View {
@@ -1271,11 +1239,15 @@ struct ComposerView: View {
                 }
             }
         } label: {
-            Label("运行", systemImage: "gearshape")
-                .foregroundStyle(themeStore.tokens(for: colorScheme).accent)
+            composerToolbarControlLabel(
+                title: "运行",
+                systemImage: "gearshape",
+                accessibilityLabel: "运行设置"
+            )
         }
-        .buttonStyle(.bordered)
-        .tint(themeStore.tokens(for: colorScheme).accent)
+        .buttonStyle(.plain)
+        .accessibilityLabel("运行设置")
+        .accessibilityValue(selectedModelSummaryTitle)
     }
 
     private var modelOptionsMenu: some View {
@@ -1365,9 +1337,14 @@ struct ComposerView: View {
                 Text(permissionWireSummary)
             }
         } label: {
-            Label(composerState.permissionMode.title, systemImage: composerState.permissionMode.systemImage)
+            composerToolbarControlLabel(
+                title: composerState.permissionMode.title,
+                systemImage: composerState.permissionMode.systemImage,
+                tint: permissionTint,
+                accessibilityLabel: "权限模式"
+            )
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(.plain)
         .accessibilityLabel("权限模式")
         .accessibilityValue(permissionTitle)
     }

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -50,7 +50,6 @@ struct WorkspaceRootView: View {
     @State private var selectedWorkspaceID: String?
     @State private var catalogState: CatalogState = .idle
     @State private var isPresentingOpenWorkspace = false
-    @State private var presentedProject: AgentProject?
 
     init(
         onOpenInSessions: @escaping (AgentProject) -> Void,
@@ -64,7 +63,7 @@ struct WorkspaceRootView: View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         NavigationStack {
-            workspaceGrid(tokens: tokens)
+            workspaceBrowser(tokens: tokens)
                 .navigationTitle("工作区")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -96,64 +95,28 @@ struct WorkspaceRootView: View {
         .sheet(isPresented: $isPresentingOpenWorkspace) {
             OpenWorkspaceSheet()
         }
-        .sheet(item: $presentedProject) { project in
-            NavigationStack {
-                workspaceDetailForm(project: project)
-                    .toolbar {
-                        ToolbarItem(placement: .topBarTrailing) {
-                            Button("完成") { presentedProject = nil }
-                        }
-                    }
-            }
-            .presentationDetents([.medium, .large])
-            .presentationDragIndicator(.visible)
-        }
         .background(tokens.background.ignoresSafeArea())
     }
 
-    private func workspaceGrid(tokens: ThemeTokens) -> some View {
-        ScrollView {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 260, maximum: 360), spacing: 14)],
-                alignment: .center,
-                spacing: 14
-            ) {
-                if catalogState == .loading && sessionStore.sidebarProjects.isEmpty {
-                    ForEach(0..<4, id: \.self) { _ in
-                        WorkspaceLibraryCard(
-                            project: AgentProject(id: UUID().uuidString, name: "正在加载工作区", path: "/Users/you/code/project"),
-                            sessionCount: 0,
-                            worktreeCount: 0,
-                            isUnavailable: false,
-                            tokens: tokens
-                        ) {}
-                        .redacted(reason: .placeholder)
+    private func workspaceBrowser(tokens: ThemeTokens) -> some View {
+        VStack(spacing: 0) {
+            workspaceStrip(tokens: tokens)
+
+            Divider()
+                .overlay(tokens.border.opacity(0.7))
+
+            if let selectedProject {
+                workspaceDetailForm(project: selectedProject)
+                    .id(selectedProject.id)
+                    .refreshable {
+                        await refreshCatalog()
                     }
-                } else {
-                    ForEach(sessionStore.sidebarProjects) { project in
-                        WorkspaceLibraryCard(
-                            project: project,
-                            sessionCount: sessionStore.sessions(forProjectID: project.id).count,
-                            worktreeCount: sessionStore.managedWorktrees(rootProjectID: sessionStore.rootProjectID(forProjectID: project.id)).count,
-                            isUnavailable: sessionStore.isWorkspaceUnavailable(project.id),
-                            tokens: tokens
-                        ) {
-                            selectedWorkspaceID = project.id
-                            presentedProject = project
-                        }
-                    }
-                }
+            } else if !sessionStore.sidebarProjects.isEmpty {
+                ContentUnavailableView("请选择工作区", systemImage: "folder")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 22)
-            .padding(.bottom, 30)
-            .frame(maxWidth: 960)
-            .frame(maxWidth: .infinity)
         }
         .background(tokens.background.ignoresSafeArea())
-        .refreshable {
-            await refreshCatalog()
-        }
         .overlay {
             if sessionStore.sidebarProjects.isEmpty, catalogState != .loading {
                 ContentUnavailableView {
@@ -171,6 +134,62 @@ struct WorkspaceRootView: View {
         }
     }
 
+    private func workspaceStrip(tokens: ThemeTokens) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 14) {
+                    if catalogState == .loading && sessionStore.sidebarProjects.isEmpty {
+                        ForEach(0..<4, id: \.self) { index in
+                            WorkspaceLibraryCard(
+                                project: AgentProject(id: "loading-\(index)", name: "正在加载工作区", path: "/Users/you/code/project"),
+                                sessionCount: 0,
+                                worktreeCount: 0,
+                                isUnavailable: false,
+                                isSelected: false,
+                                tokens: tokens
+                            ) {}
+                            .frame(width: 320)
+                            .redacted(reason: .placeholder)
+                        }
+                    } else {
+                        ForEach(sessionStore.sidebarProjects) { project in
+                            WorkspaceLibraryCard(
+                                project: project,
+                                sessionCount: sessionStore.sessions(forProjectID: project.id).count,
+                                worktreeCount: sessionStore.managedWorktrees(rootProjectID: sessionStore.rootProjectID(forProjectID: project.id)).count,
+                                isUnavailable: sessionStore.isWorkspaceUnavailable(project.id),
+                                isSelected: selectedWorkspaceID == project.id,
+                                tokens: tokens
+                            ) {
+                                // 工作区页面只更新本地浏览选择，避免切换卡片时意外改变当前会话上下文。
+                                selectedWorkspaceID = project.id
+                            }
+                            .frame(width: 320)
+                            .id(project.id)
+                        }
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 18)
+            }
+            .frame(height: 178)
+            .onChange(of: selectedWorkspaceID) { _, selectedID in
+                guard let selectedID else { return }
+                withAnimation(.easeInOut(duration: 0.22)) {
+                    proxy.scrollTo(selectedID, anchor: .center)
+                }
+            }
+            .onAppear {
+                guard let selectedWorkspaceID else { return }
+                // 恢复已有选择时主动定位卡片，保证选中项不会留在横向列表的屏幕外。
+                DispatchQueue.main.async {
+                    proxy.scrollTo(selectedWorkspaceID, anchor: .center)
+                }
+            }
+        }
+        .accessibilityLabel("工作区列表")
+    }
+
     private func workspaceDetailForm(project: AgentProject) -> some View {
         WorkspaceDetailForm(
             project: project,
@@ -184,11 +203,9 @@ struct WorkspaceRootView: View {
                 sessionStore.toggleWorkspaceInSessions(project)
             },
             onOpenInSessions: {
-                presentedProject = nil
                 onOpenInSessions(project)
             },
             onStartSession: { runtimeChoice in
-                presentedProject = nil
                 onStartSession(project, runtimeChoice)
             }
         )
@@ -276,6 +293,7 @@ private struct WorkspaceLibraryCard: View {
     let sessionCount: Int
     let worktreeCount: Int
     let isUnavailable: Bool
+    let isSelected: Bool
     let tokens: ThemeTokens
     let action: () -> Void
 
@@ -303,9 +321,9 @@ private struct WorkspaceLibraryCard: View {
                     }
 
                     Spacer(minLength: 8)
-                    Image(systemName: "chevron.right")
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "chevron.down")
                         .font(themeStore.uiFont(.caption, weight: .semibold))
-                        .foregroundStyle(tokens.tertiaryText)
+                        .foregroundStyle(isSelected ? tokens.primaryAction : tokens.tertiaryText)
                 }
 
                 HStack(spacing: 8) {
@@ -322,11 +340,14 @@ private struct WorkspaceLibraryCard: View {
             .background(tokens.surface.opacity(0.72), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .stroke(tokens.border.opacity(0.72), lineWidth: 1)
+                    .stroke(
+                        isSelected ? tokens.primaryAction : tokens.border.opacity(0.72),
+                        lineWidth: isSelected ? 2 : 1
+                    )
             }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("工作区 \(project.name)，\(sessionCount) 个会话")
+        .accessibilityLabel("工作区 \(project.name)，\(sessionCount) 个会话\(isSelected ? "，已选择" : "")")
     }
 
     private func metric(_ value: String, title: String, systemImage: String) -> some View {
@@ -383,7 +404,5 @@ private struct WorkspaceDetailForm: View {
             }
         }
         .formStyle(.grouped)
-        .navigationTitle(project.name)
-        .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -74,25 +74,6 @@ struct UnifiedWorkbenchShell: View {
 
     private func sidebar(tokens: ThemeTokens) -> some View {
         VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Mimi Remote")
-                        .font(themeStore.uiFont(.title3, weight: .semibold))
-                        .foregroundStyle(tokens.primaryText)
-                    Text(connectionSubtitle)
-                        .font(themeStore.uiFont(.caption))
-                        .foregroundStyle(tokens.tertiaryText)
-                }
-                Spacer()
-                Circle()
-                    .fill(connectionTone(tokens: tokens))
-                    .frame(width: 8, height: 8)
-                    .accessibilityLabel(connectionSubtitle)
-            }
-            .padding(.horizontal, 18)
-            .padding(.top, 18)
-            .padding(.bottom, 12)
-
             List(selection: $selection) {
                 Section {
                     sidebarDestinationRow(
@@ -177,6 +158,28 @@ struct UnifiedWorkbenchShell: View {
             .padding(14)
         }
         .background(tokens.sidebarBackground.ignoresSafeArea())
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                // 标题放进系统顶栏，才能与 iPad 的侧栏收起按钮保持同一行。
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Mimi Remote")
+                            .font(themeStore.uiFont(.headline, weight: .semibold))
+                            .foregroundStyle(tokens.primaryText)
+                        Text(connectionSubtitle)
+                            .font(themeStore.uiFont(.caption2))
+                            .foregroundStyle(tokens.tertiaryText)
+                    }
+
+                    Circle()
+                        .fill(connectionTone(tokens: tokens))
+                        .frame(width: 7, height: 7)
+                        .accessibilityHidden(true)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Mimi Remote，\(connectionSubtitle)")
+            }
+        }
         .task {
             await sessionStore.refreshSessionLibraryIndex()
         }

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -2740,7 +2740,9 @@ final class SessionStore: ObservableObject {
 #if DEBUG
         guard !isDebugWorkbenchUISeedActive else { return }
 #endif
-        let workspaces = Array(recentWorkspaces.prefix(8)).filter { workspace in
+        // 全局“最近”最终只展示 8 条，但要得到正确的全局 Top 8，必须读取每个已打开工作区的
+        // 首屏候选；不能先截断工作区，否则较早打开的工作区即使刚有新会话也永远不会入选。
+        let workspaces = recentWorkspaces.filter { workspace in
             // 当前工作区已经由 refreshAll/轮询维护完整首屏时，会话库直接复用本地投影。
             // 再用 limit=8 请求一次会和 limit=20 共用 gateway 预算，却无法命中 exact single-flight。
             !(workspace.id == selectedProjectID && !sessions(forProjectID: workspace.id).isEmpty)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -10194,6 +10194,56 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertEqual(store.filteredSessions.map(\.id), [session.id])
     }
 
+    func testRecentSessionsUsesLatestActivityAcrossEveryWorkspace() async {
+        let projects = (0..<9).map { makeProject(id: "proj_recent_\($0)") }
+        let workspaces = projects.enumerated().map { index, project in
+            AgentWorkspace(
+                project: project,
+                lastOpenedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
+        let projectSessions = Dictionary(uniqueKeysWithValues: projects.enumerated().map { index, project in
+            let updatedAt = index == 8 ? 1_000 : 100 + index
+            return (
+                project.id,
+                [makeSession(
+                    id: "thread_recent_\(index)",
+                    projectID: project.id,
+                    title: "最近会话 \(index)",
+                    status: "history",
+                    source: "codex",
+                    updatedAt: Date(timeIntervalSince1970: TimeInterval(updatedAt))
+                )]
+            )
+        })
+        let client = MockSessionStoreClient(
+            projects: projects,
+            sessions: [],
+            projectSessions: projectSessions
+        )
+        let appStore = AppStore()
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: makeRecentWorkspaceStore(
+                workspaces: workspaces,
+                endpoint: appStore.endpoint
+            ),
+            clientFactory: { client }
+        )
+
+        await store.refreshAll(autoAttach: true)
+        await store.refreshSessionLibraryIndex()
+
+        // 第 9 个工作区虽然更早打开，但它的会话活动时间最新，必须排在全局“最近”第一位。
+        XCTAssertEqual(
+            store.recentSessions.map(\.id),
+            (1...8).reversed().map { "thread_recent_\($0)" }
+        )
+        XCTAssertEqual(Set(client.requestedWorkspaceIDs), Set(projects.map(\.id)))
+    }
+
     func testMultiRuntimeHistoryPreservesEconomyAndFullLoadModes() async throws {
         let project = AgentProject(id: "proj_multi_history_mode", name: "History Mode", path: "/tmp/multi-history-mode")
         let config = makeDirectAppServerConfig(


### PR DESCRIPTION
## 目标

简化 iPad 工作台的工作区浏览和会话输入操作，并修正侧栏“最近”会话的全局排序范围。

## 变更

- “最近”会话从所有已打开工作区收集候选，再按最后活动时间取全局最新 8 条。
- 工作区页面改为上方横向项目卡片、下方原位详情，移除项目详情弹窗。
- 输入区平铺语言、运行、权限、计划和目标任务入口，并与加号统一尺寸和视觉样式。
- 将 Mimi Remote 标题和连接状态移动到系统顶栏，与侧栏收起按钮保持同一行。
- 新增覆盖第 9 个工作区仍可进入全局最近列表的回归测试。

## 原因与影响

此前会话索引只扫描最近打开的前 8 个工作区，因此更早打开但刚产生新会话的工作区不会进入“最近”列表。工作区详情和输入配置还依赖弹窗或多级菜单，增加了常用操作的点击次数。

本次改动只加载各工作区的轻量会话首屏，不读取消息历史；请求仍按两组并发执行。工作区选择使用本地稳定状态，不会在浏览卡片时改变当前活动会话。

## 验证

- iPad Simulator Debug 完整编译通过。
- 定向测试通过：`testRecentSessionsUsesLatestActivityAcrossEveryWorkspace`（1 passed）。
- 模拟器实际验证侧栏排序、工作区原位切换、输入区平铺控件和标题栏布局。
- `git diff --check` 通过。
