### PR TITLE
新增 Codex 剩余用量双环

### DIFF
--- a/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
@@ -2018,6 +2018,30 @@ struct CodexUsageWindowDisplay: Equatable, Identifiable {
         }
         return "已用 \(usedPercentText)"
     }
+
+    /// 账号接口返回的是“已用比例”，左上角圆环表达的是“剩余比例”，统一在展示模型中换算，
+    /// 避免不同页面各自计算后出现语义相反或越界的问题。
+    var remainingProgress: Double? {
+        progress.map { min(max(1 - $0, 0), 1) }
+    }
+
+    var remainingPercentText: String? {
+        guard let remainingProgress else {
+            return nil
+        }
+        let percent = remainingProgress * 100
+        if abs(percent.rounded() - percent) < 0.0001 {
+            return "\(Int(percent.rounded()))%"
+        }
+        return String(format: "%.1f%%", percent)
+    }
+
+    var remainingText: String {
+        guard let remainingPercentText else {
+            return "等待刷新"
+        }
+        return "剩余 \(remainingPercentText)"
+    }
 }
 
 // app-server 的账号限额以 primary/secondary 返回；移动端按 Codex 当前语义分别展示为 5h/7d，

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -162,22 +162,31 @@ struct UnifiedWorkbenchShell: View {
             ToolbarItem(placement: .principal) {
                 // 标题放进系统顶栏，才能与 iPad 的侧栏收起按钮保持同一行。
                 HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Mimi Remote")
-                            .font(themeStore.uiFont(.headline, weight: .semibold))
-                            .foregroundStyle(tokens.primaryText)
-                        Text(connectionSubtitle)
-                            .font(themeStore.uiFont(.caption2))
-                            .foregroundStyle(tokens.tertiaryText)
-                    }
+                    CodexUsageRingsControl(
+                        display: sessionStore.accountCodexUsageWindowsDisplay,
+                        onRefresh: {
+                            await sessionStore.refreshCodexUsage()
+                        }
+                    )
 
-                    Circle()
-                        .fill(connectionTone(tokens: tokens))
-                        .frame(width: 7, height: 7)
-                        .accessibilityHidden(true)
+                    HStack(spacing: 8) {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Mimi Remote")
+                                .font(themeStore.uiFont(.headline, weight: .semibold))
+                                .foregroundStyle(tokens.primaryText)
+                            Text(connectionSubtitle)
+                                .font(themeStore.uiFont(.caption2))
+                                .foregroundStyle(tokens.tertiaryText)
+                        }
+
+                        Circle()
+                            .fill(connectionTone(tokens: tokens))
+                            .frame(width: 7, height: 7)
+                            .accessibilityHidden(true)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Mimi Remote，\(connectionSubtitle)")
                 }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Mimi Remote，\(connectionSubtitle)")
             }
         }
         .task {
@@ -293,6 +302,264 @@ struct UnifiedWorkbenchShell: View {
         }
     }
 }
+
+/// 侧栏标题旁的账号剩余用量入口。图形尺寸跟随横向尺寸环境变化，
+/// 因而 iPad mini 分屏和 iPhone 会自动使用更紧凑的版本。
+private struct CodexUsageRingsControl: View {
+    @EnvironmentObject private var themeStore: ThemeStore
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    let display: CodexUsageWindowsDisplay
+    let onRefresh: () async -> Void
+
+    @State private var showsDetails = false
+    @State private var isRefreshing = false
+
+    var body: some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+        let metrics = CodexUsageRingMetrics(isCompact: horizontalSizeClass == .compact)
+
+        Button {
+            showsDetails.toggle()
+        } label: {
+            usageRings(metrics: metrics, tokens: tokens)
+                .frame(width: metrics.hitSize, height: metrics.hitSize)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Codex 剩余用量")
+        .accessibilityValue(accessibilityValue)
+        .accessibilityIdentifier("sidebar.codexUsageRings")
+        .popover(isPresented: $showsDetails, arrowEdge: .top) {
+            usageDetails(tokens: tokens)
+                .presentationCompactAdaptation(.sheet)
+                .presentationDetents([.height(300), .medium])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    private func usageRings(metrics: CodexUsageRingMetrics, tokens: ThemeTokens) -> some View {
+        let fiveHour = window(.fiveHour)
+        let sevenDay = window(.sevenDay)
+
+        return ZStack {
+            usageRing(
+                progress: sevenDay?.remainingProgress,
+                diameter: metrics.diameter,
+                lineWidth: metrics.outerLineWidth,
+                tint: tint(for: .sevenDay),
+                tokens: tokens
+            )
+            usageRing(
+                progress: fiveHour?.remainingProgress,
+                diameter: metrics.innerDiameter,
+                lineWidth: metrics.innerLineWidth,
+                tint: tint(for: .fiveHour),
+                tokens: tokens
+            )
+
+            if !hasUsageProgress {
+                Text("?")
+                    .font(.system(size: metrics.questionMarkSize, weight: .bold, design: .rounded))
+                    .foregroundStyle(tokens.tertiaryText)
+            }
+        }
+        .frame(width: metrics.diameter, height: metrics.diameter)
+        .accessibilityHidden(true)
+    }
+
+    private func usageRing(
+        progress: Double?,
+        diameter: CGFloat,
+        lineWidth: CGFloat,
+        tint: Color,
+        tokens: ThemeTokens
+    ) -> some View {
+        ZStack {
+            Circle()
+                .stroke(tokens.tertiaryText.opacity(0.18), lineWidth: lineWidth)
+
+            if let progress {
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+            }
+        }
+        .frame(width: diameter, height: diameter)
+        .animation(.snappy(duration: 0.25), value: progress)
+    }
+
+    private func usageDetails(tokens: ThemeTokens) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Codex 剩余用量")
+                        .font(themeStore.uiFont(.headline, weight: .semibold))
+                        .foregroundStyle(tokens.primaryText)
+                    Text(display.hasLiveData ? "5h 和 7d 账号窗口" : "尚未取得账号用量")
+                        .font(themeStore.uiFont(.caption))
+                        .foregroundStyle(tokens.secondaryText)
+                }
+
+                Spacer(minLength: 8)
+
+                Button {
+                    Task { await refreshUsage() }
+                } label: {
+                    Group {
+                        if isRefreshing {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 14, weight: .semibold))
+                        }
+                    }
+                    .frame(width: 34, height: 34)
+                    .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(tokens.secondaryText)
+                .background(tokens.surface.opacity(0.72), in: Circle())
+                .overlay {
+                    Circle()
+                        .stroke(tokens.border.opacity(0.72), lineWidth: 1)
+                }
+                .disabled(isRefreshing)
+                .accessibilityLabel("刷新 Codex 用量")
+            }
+
+            VStack(spacing: 14) {
+                usageWindowRow(kind: .fiveHour, tokens: tokens)
+                Divider().overlay(tokens.border.opacity(0.72))
+                usageWindowRow(kind: .sevenDay, tokens: tokens)
+            }
+
+            HStack(spacing: 7) {
+                Image(systemName: display.hasLiveData ? "checkmark.seal" : "info.circle")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(display.creditText)
+                    .font(themeStore.uiFont(.caption, weight: .medium))
+                    .lineLimit(2)
+            }
+            .foregroundStyle(tokens.secondaryText)
+        }
+        .padding(16)
+        .frame(width: horizontalSizeClass == .compact ? nil : 300)
+        .frame(maxWidth: horizontalSizeClass == .compact ? .infinity : nil, alignment: .leading)
+    }
+
+    private func usageWindowRow(kind: CodexUsageWindowKind, tokens: ThemeTokens) -> some View {
+        let item = window(kind)
+        let progress = item?.remainingProgress ?? 0
+        let tint = tint(for: kind)
+
+        return VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Circle()
+                    .stroke(tint, lineWidth: 2.5)
+                    .frame(width: 12, height: 12)
+                Text(kind.label)
+                    .font(themeStore.uiFont(.callout, weight: .semibold))
+                    .foregroundStyle(tokens.primaryText)
+                    .monospacedDigit()
+                Text(kind.title)
+                    .font(themeStore.uiFont(.caption, weight: .medium))
+                    .foregroundStyle(tokens.secondaryText)
+
+                Spacer(minLength: 8)
+
+                Text(item?.remainingText ?? "等待刷新")
+                    .font(themeStore.uiFont(.callout, weight: .semibold))
+                    .foregroundStyle(item?.remainingProgress == nil ? tokens.secondaryText : tint)
+                    .monospacedDigit()
+            }
+
+            ProgressView(value: progress)
+                .tint(tint)
+                .opacity(item?.remainingProgress == nil ? 0.3 : 1)
+
+            Text(item?.resetText ?? "暂无重置时间")
+                .font(themeStore.uiFont(.caption))
+                .foregroundStyle(tokens.secondaryText)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(kind.label) Codex 剩余用量")
+        .accessibilityValue("\(item?.remainingText ?? "等待刷新")，\(item?.resetText ?? "暂无重置时间")")
+    }
+
+    private func refreshUsage() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        await onRefresh()
+    }
+
+    private func window(_ kind: CodexUsageWindowKind) -> CodexUsageWindowDisplay? {
+        display.windows.first { $0.kind == kind }
+    }
+
+    private var hasUsageProgress: Bool {
+        display.windows.contains { $0.remainingProgress != nil }
+    }
+
+    private func tint(for kind: CodexUsageWindowKind) -> Color {
+        switch kind {
+        case .fiveHour:
+            return .cyan
+        case .sevenDay:
+            return .pink
+        }
+    }
+
+    private var accessibilityValue: String {
+        let fiveHour = window(.fiveHour)?.remainingText ?? "等待刷新"
+        let sevenDay = window(.sevenDay)?.remainingText ?? "等待刷新"
+        return "5 小时\(fiveHour)，7 天\(sevenDay)"
+    }
+}
+
+struct CodexUsageRingMetrics {
+    let diameter: CGFloat
+    let innerDiameter: CGFloat
+    let outerLineWidth: CGFloat
+    let innerLineWidth: CGFloat
+    let hitSize: CGFloat
+    let questionMarkSize: CGFloat
+
+    init(isCompact: Bool) {
+        diameter = isCompact ? 30 : 34
+        innerDiameter = isCompact ? 20 : 23
+        outerLineWidth = isCompact ? 3.4 : 3.8
+        innerLineWidth = isCompact ? 3 : 3.2
+        // 图形在 iPhone 上收紧，但点击区始终保持 44pt，兼顾窄屏排版和触控可用性。
+        hitSize = 44
+        questionMarkSize = isCompact ? 7 : 8
+    }
+}
+
+#if DEBUG
+#Preview("Codex 用量双环自适应") {
+    let loaded = CodexUsageWindowsDisplay.make(
+        rateLimit: RateLimitSummary(primaryUsedPercent: 62, secondaryUsedPercent: 38)
+    )
+    let pending = CodexUsageWindowsDisplay.make(rateLimit: nil)
+
+    HStack(spacing: 24) {
+        CodexUsageRingsControl(display: loaded, onRefresh: {})
+            .environment(\.horizontalSizeClass, .regular)
+        CodexUsageRingsControl(display: loaded, onRefresh: {})
+            .environment(\.horizontalSizeClass, .compact)
+        CodexUsageRingsControl(display: pending, onRefresh: {})
+            .environment(\.horizontalSizeClass, .compact)
+    }
+    .environmentObject(ThemeStore())
+    .padding(20)
+}
+#endif
 
 private struct NewSessionSheet: View {
     @Environment(\.dismiss) private var dismiss

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -14999,16 +14999,43 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(windowsDisplay.hasLiveData)
         XCTAssertEqual(fiveHourWindow.primaryText, "已用 60%")
         XCTAssertEqual(fiveHourWindow.progress ?? -1, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(fiveHourWindow.remainingProgress ?? -1, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(fiveHourWindow.remainingPercentText, "40%")
+        XCTAssertEqual(fiveHourWindow.remainingText, "剩余 40%")
         XCTAssertEqual(fiveHourWindow.resetDate, Date(timeIntervalSince1970: TimeInterval(resetEpoch)))
         XCTAssertEqual(fiveHourWindow.resetText.hasSuffix(" 重置"), true)
         XCTAssertEqual(sevenDayWindow.primaryText, "已用 42%")
+        XCTAssertEqual(sevenDayWindow.remainingProgress ?? -1, 0.58, accuracy: 0.0001)
+        XCTAssertEqual(sevenDayWindow.remainingText, "剩余 58%")
         XCTAssertNil(sevenDayWindow.resetDate)
         XCTAssertEqual(sevenDayWindow.resetText, "暂无重置时间")
 
         let pendingWindowsDisplay = CodexUsageWindowsDisplay.make(rateLimit: nil, now: now)
         XCTAssertFalse(pendingWindowsDisplay.hasLiveData)
-        XCTAssertEqual(try XCTUnwrap(pendingWindowsDisplay.windows.first { $0.kind == .fiveHour }).primaryText, "等待刷新")
+        let pendingFiveHour = try XCTUnwrap(pendingWindowsDisplay.windows.first { $0.kind == .fiveHour })
+        XCTAssertEqual(pendingFiveHour.primaryText, "等待刷新")
+        XCTAssertNil(pendingFiveHour.remainingProgress)
+        XCTAssertNil(pendingFiveHour.remainingPercentText)
+        XCTAssertEqual(pendingFiveHour.remainingText, "等待刷新")
         XCTAssertEqual(try XCTUnwrap(pendingWindowsDisplay.windows.first { $0.kind == .sevenDay }).primaryText, "等待刷新")
+
+        let boundedWindows = CodexUsageWindowsDisplay.make(
+            rateLimit: RateLimitSummary(primaryUsedPercent: -10, secondaryUsedPercent: 125),
+            now: now
+        )
+        let boundedFiveHour = try XCTUnwrap(boundedWindows.windows.first { $0.kind == .fiveHour })
+        let boundedSevenDay = try XCTUnwrap(boundedWindows.windows.first { $0.kind == .sevenDay })
+        XCTAssertEqual(boundedFiveHour.remainingProgress ?? -1, 1, accuracy: 0.0001)
+        XCTAssertEqual(boundedFiveHour.remainingText, "剩余 100%")
+        XCTAssertEqual(boundedSevenDay.remainingProgress ?? -1, 0, accuracy: 0.0001)
+        XCTAssertEqual(boundedSevenDay.remainingText, "剩余 0%")
+
+        let fractionalWindows = CodexUsageWindowsDisplay.make(
+            rateLimit: RateLimitSummary(primaryUsedPercent: 10.5),
+            now: now
+        )
+        let fractionalFiveHour = try XCTUnwrap(fractionalWindows.windows.first { $0.kind == .fiveHour })
+        XCTAssertEqual(fractionalFiveHour.remainingText, "剩余 89.5%")
 
         let eightyPercent = try XCTUnwrap(CodexUsageDisplaySummary.make(rateLimit: RateLimitSummary(primaryUsedPercent: 80), now: now))
         XCTAssertFalse(eightyPercent.isNearLimit)
@@ -15048,6 +15075,18 @@ extension ConversationDataFlowTests {
         )
         XCTAssertFalse(try XCTUnwrap(secondaryWindows.windows.first { $0.kind == .fiveHour }).isExhausted)
         XCTAssertTrue(try XCTUnwrap(secondaryWindows.windows.first { $0.kind == .sevenDay }).isExhausted)
+    }
+
+    func testUsageRingMetricsAdaptToIPadMiniAndIPhone() {
+        let iPadMini = CodexUsageRingMetrics(isCompact: false)
+        XCTAssertEqual(iPadMini.diameter, 34)
+        XCTAssertEqual(iPadMini.innerDiameter, 23)
+        XCTAssertEqual(iPadMini.hitSize, 44)
+
+        let iPhone = CodexUsageRingMetrics(isCompact: true)
+        XCTAssertEqual(iPhone.diameter, 30)
+        XCTAssertEqual(iPhone.innerDiameter, 20)
+        XCTAssertEqual(iPhone.hitSize, 44)
     }
 
     func testDirectRuntimeAttachesUsageDisplayForAvailableRateLimit() async throws {


### PR DESCRIPTION
## 变更内容

- 在侧栏标题左侧增加 Apple 运动圆环风格的 Codex 双层剩余用量入口
- 外环展示 7d 剩余量，内环展示 5h 剩余量，并补充无数据状态
- 点击后在 iPad 展示 popover、在 iPhone 紧凑环境展示 sheet，可查看精确百分比、重置时间并手动刷新
- 按横向尺寸环境适配 iPad、iPad mini、分屏和 iPhone，图形尺寸为 34pt/30pt，点击区保持 44pt
- 增加剩余比例换算、边界值和设备尺寸测试

## 设计原因

现有账号用量数据已经包含 5h 和 7d 窗口，但用户需要进入设置页才能查看。双环入口利用侧栏标题左侧空白区域，让剩余额度可以被快速感知，同时不增加新的后端接口或依赖。

## 用户影响

用户可以直接从左上角判断 Codex 额度余量，并通过点击查看精确数据。iPad mini 分屏和 iPhone 会自动收紧图形尺寸，不会挤压标题。

## 验证

- `testCodexUsageDisplaySummaryFormatsRateLimit`
- `testUsageRingMetricsAdaptToIPadMiniAndIPhone`
- iPhone 17e / iOS 27.0 Simulator：2 个测试通过，0 失败
- iPad mini 目标编译完成；iOS 27 beta Simulator 的 test worker 启动异常，未产生设备端测试结果
