### PR TITLE
将侧栏操作移至顶部

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -119,43 +119,6 @@ struct UnifiedWorkbenchShell: View {
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
             .environment(\.defaultMinListRowHeight, 38)
-
-            Divider().overlay(tokens.border.opacity(0.7))
-
-            VStack(spacing: 8) {
-                Button {
-                    // 设置是临时配置面板，不改变用户当前所在的会话或工作区。
-                    presentedSheet = .settings
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "gearshape")
-                            .frame(width: 22)
-                        Text("设置")
-                        Spacer()
-                    }
-                    .font(themeStore.uiFont(.callout, weight: .medium))
-                    .foregroundStyle(presentedSheet == .settings ? tokens.primaryText : tokens.secondaryText)
-                    .padding(.horizontal, 12)
-                    .frame(height: 40)
-                    .background(presentedSheet == .settings ? tokens.selectionFill : Color.clear, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                }
-                .buttonStyle(.plain)
-
-                Button {
-                    presentedSheet = .newSession
-                } label: {
-                    Label("新会话", systemImage: "plus")
-                        .font(themeStore.uiFont(.callout, weight: .semibold))
-                        .foregroundStyle(tokens.primaryActionForeground)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 46)
-                }
-                .buttonStyle(.glassProminent)
-                .buttonBorderShape(.roundedRectangle(radius: 12))
-                .tint(tokens.primaryAction)
-                .accessibilityLabel("新建会话")
-            }
-            .padding(14)
         }
         .background(tokens.sidebarBackground.ignoresSafeArea())
         .toolbar {
@@ -174,9 +137,13 @@ struct UnifiedWorkbenchShell: View {
                             Text("Mimi Remote")
                                 .font(themeStore.uiFont(.headline, weight: .semibold))
                                 .foregroundStyle(tokens.primaryText)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.82)
                             Text(connectionSubtitle)
                                 .font(themeStore.uiFont(.caption2))
                                 .foregroundStyle(tokens.tertiaryText)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.82)
                         }
 
                         Circle()
@@ -187,6 +154,35 @@ struct UnifiedWorkbenchShell: View {
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Mimi Remote，\(connectionSubtitle)")
                 }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    presentedSheet = .newSession
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 15, weight: .semibold))
+                }
+                .buttonStyle(.glassProminent)
+                .buttonBorderShape(.circle)
+                .tint(tokens.primaryAction)
+                .accessibilityLabel("新建会话")
+                .accessibilityIdentifier("sidebar.newSession")
+            }
+            // 固定间距会阻止系统把两个操作合并进同一个玻璃容器，保持为独立圆钮。
+            ToolbarSpacer(.fixed, placement: .topBarTrailing)
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    // 设置是临时配置面板，不改变用户当前所在的会话或工作区。
+                    presentedSheet = .settings
+                } label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 15, weight: .semibold))
+                }
+                .buttonStyle(.glass)
+                .buttonBorderShape(.circle)
+                .foregroundStyle(tokens.secondaryText)
+                .accessibilityLabel("打开设置")
+                .accessibilityIdentifier("sidebar.settings")
             }
         }
         .task {


### PR DESCRIPTION
## 目标

优化 iPhone 与 iPad 侧栏的操作层级，去掉底部突兀且占空间的新会话大按钮。

## 方案

- 将“新会话”和“设置”移动到侧栏顶部工具栏
- 使用两个独立圆形按钮：新会话为主色，设置为中性样式
- 使用固定 `ToolbarSpacer` 阻止 Liquid Glass 自动合并两个按钮
- 移除底部固定操作区，让最近会话列表获得更多可用高度
- 为紧凑宽度下的标题和连接状态增加单行缩放保护
- 保留无障碍标签，并为两个按钮增加稳定的无障碍标识

## 影响

- iPhone 上首屏能展示更多最近会话，主要操作更接近顶部导航区
- iPad 侧栏不再被底部大按钮切断，布局更轻量
- 新会话和设置的功能入口及弹层行为保持不变

## 验证

- `xcodebuild -quiet -project ios/MimiRemote/MimiRemote.xcodeproj -scheme MimiRemote -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
- iPhone 17e Simulator 定向运行 `ConversationDataFlowTests` 中的配额摘要与圆环指标测试
- `git diff --check`

## 依赖关系

此 PR 基于配额圆环分支 `agent/add-codex-usage-rings`，用于保持改动边界清晰；对应基础 PR 为 #6。
