### PR TITLE
精简工作区并稳定会话尾部定位

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift
@@ -776,8 +776,11 @@ struct ConversationTimelineView: View {
                     }
                 }
                 .listStyle(.plain)
-                // 尾部跟随使用内容边缘，不再把动态 List 行解析成 UICollectionView IndexPath。
-                // 会话切换或过程行折叠时，即使数据快照正在提交，也不会滚向已失效的行下标。
+                // 每个会话使用独立的 List 身份，避免 UITableView 复用上一个会话的 contentOffset。
+                // 新会话挂载时从底部创建，比事后纠正旧滚动位置更稳定。
+                .id(sessionStore.selectedSessionID)
+                // ScrollPosition 负责持续跟随；首帧和会话切换还会用已校验存在的末行 ID 兜底，
+                // 避免 List 只更新绑定、却没有真正提交底层 contentOffset。
                 .scrollPosition($timelineScrollPosition)
                 .scrollContentBackground(.hidden)
                 .scrollDismissesKeyboard(.interactively)
@@ -802,15 +805,23 @@ struct ConversationTimelineView: View {
 
                 if shouldShowReturnToTailButton(timelineItems: timelineItems) {
                     Button {
-                        returnToTimelineTail(timelineItems: timelineItems)
+                        returnToTimelineTail(timelineItems: timelineItems, proxy: proxy)
                     } label: {
                         returnToTailLabel
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(tokens.accent)
-                    .controlSize(.small)
-                    .padding(.trailing, layout.horizontalInset)
-                    .padding(.bottom, 18)
+                    // 固定尺寸的纯图标浮层不会因“新消息/回到底部”文案切换而跳宽，
+                    // 44pt 点击区也能让它稳定贴在时间线右下角。
+                    .buttonStyle(.plain)
+                    .frame(width: 44, height: 44)
+                    .background(tokens.accent, in: Circle())
+                    .overlay {
+                        Circle()
+                            .stroke(Color.white.opacity(0.20), lineWidth: 1)
+                    }
+                    .contentShape(Circle())
+                    .shadow(color: Color.black.opacity(0.16), radius: 6, y: 3)
+                    .padding(.trailing, max(layout.horizontalInset, 16))
+                    .padding(.bottom, 16)
                     .accessibilityLabel(returnToTailAccessibilityLabel)
                 }
             }
@@ -827,6 +838,19 @@ struct ConversationTimelineView: View {
                 expandedProcessedGroupIDs.removeAll()
                 timelineItemCache.removeAll()
                 cancelPendingTailScrollAttempts()
+                // ScrollPosition 是 View 级状态，不会随 selectedSessionID 自动重建；
+                // 切换会话时必须显式丢弃旧位置，并立即为已有缓存消息安排强制贴底。
+                timelineScrollPosition = ScrollPosition(edge: .bottom)
+                if newID != nil {
+                    queueTailScrollAttempts(
+                        timelineItems: timelineItems,
+                        proxy: proxy,
+                        sessionID: newID,
+                        expectedTailItemID: timelineItems.last?.id,
+                        animatedFirstAttempt: false,
+                        force: true
+                    )
+                }
             }
             .onChange(of: messages.last?.id) { _, newID in
                 guard newID != nil else {
@@ -838,6 +862,7 @@ struct ConversationTimelineView: View {
                     isTailFollowLockedByLocalSubmit = true
                     queueTailScrollAttempts(
                         timelineItems: timelineItems,
+                        proxy: proxy,
                         sessionID: sessionStore.selectedSessionID,
                         expectedTailItemID: timelineItems.last?.id,
                         animatedFirstAttempt: true,
@@ -850,6 +875,7 @@ struct ConversationTimelineView: View {
                     // 覆盖首次布局时机，确保落在真正的底部而不是空白区。
                     queueTailScrollAttempts(
                         timelineItems: timelineItems,
+                        proxy: proxy,
                         sessionID: sessionStore.selectedSessionID,
                         expectedTailItemID: timelineItems.last?.id,
                         animatedFirstAttempt: false,
@@ -859,6 +885,7 @@ struct ConversationTimelineView: View {
                 }
                 queueTailScrollAttempts(
                     timelineItems: timelineItems,
+                    proxy: proxy,
                     sessionID: sessionStore.selectedSessionID,
                     expectedTailItemID: timelineItems.last?.id,
                     animatedFirstAttempt: true,
@@ -869,6 +896,7 @@ struct ConversationTimelineView: View {
                 // 流式增量会高频改写最后一条内容；请求会自动合并，同一更新周期只滚一次。
                 queueTailScrollAttempts(
                     timelineItems: timelineItems,
+                    proxy: proxy,
                     sessionID: sessionStore.selectedSessionID,
                     expectedTailItemID: timelineItems.last?.id,
                     animatedFirstAttempt: false,
@@ -881,6 +909,7 @@ struct ConversationTimelineView: View {
                 // 监听派生 row id，确保折叠发生时底部跟随逻辑仍然有机会重锚。
                 queueTailScrollAttempts(
                     timelineItems: timelineItems,
+                    proxy: proxy,
                     sessionID: sessionStore.selectedSessionID,
                     expectedTailItemID: timelineItems.last?.id,
                     animatedFirstAttempt: false,
@@ -896,10 +925,13 @@ struct ConversationTimelineView: View {
                 // 用 task(id:) 补一条首帧重锚路径，避免 List 默认停在最早消息。
                 queueTailScrollAttempts(
                     timelineItems: timelineItems,
+                    proxy: proxy,
                     sessionID: sessionStore.selectedSessionID,
                     expectedTailItemID: timelineItems.last?.id,
                     animatedFirstAttempt: false,
-                    force: false
+                    // 首次打开/切换会话不能被尚未稳定的滚动几何拦截；
+                    // 后续新消息仍尊重用户主动上翻，不会强行抢回底部。
+                    force: forceNextMessageTailScroll
                 )
             }
             .onDisappear {
@@ -1034,12 +1066,10 @@ struct ConversationTimelineView: View {
     }
 
     private var returnToTailLabel: some View {
-        Label(returnToTailTitle, systemImage: "arrow.down.circle.fill")
-            .font(themeStore.uiFont(.caption, weight: .semibold))
-    }
-
-    private var returnToTailTitle: String {
-        hasUnseenTailMessage ? "新消息" : "回到底部"
+        Image(systemName: "arrow.down.to.line")
+            .font(themeStore.uiFont(.body, weight: .bold))
+            .foregroundStyle(Color.white)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var returnToTailAccessibilityLabel: String {
@@ -1094,8 +1124,12 @@ struct ConversationTimelineView: View {
         themeStore.tokens(for: colorScheme).secondaryText
     }
 
-    private func forceScrollToTimelineTail(timelineItems: [ConversationTimelineItem], animated: Bool) {
-        guard !timelineItems.isEmpty else {
+    private func forceScrollToTimelineTail(
+        timelineItems: [ConversationTimelineItem],
+        proxy: ScrollViewProxy,
+        animated: Bool
+    ) {
+        guard let tailItemID = timelineItems.last?.id else {
             return
         }
         guard !isPreservingHistoryScroll else {
@@ -1105,11 +1139,12 @@ struct ConversationTimelineView: View {
         hasUnseenTailMessage = false
         isTimelineNearBottom = true
         forceNextMessageTailScroll = false
-        scrollToTimelineTail(animated: animated)
+        scrollToTimelineTail(tailItemID: tailItemID, proxy: proxy, animated: animated)
     }
 
     private func queueTailScrollAttempts(
         timelineItems: [ConversationTimelineItem],
+        proxy: ScrollViewProxy,
         sessionID: SessionID?,
         expectedTailItemID: String?,
         animatedFirstAttempt: Bool,
@@ -1150,23 +1185,30 @@ struct ConversationTimelineView: View {
             else {
                 return
             }
-            forceScrollToTimelineTail(timelineItems: timelineItems, animated: animatedFirstAttempt)
+            forceScrollToTimelineTail(
+                timelineItems: timelineItems,
+                proxy: proxy,
+                animated: animatedFirstAttempt
+            )
 
             guard retriesAfterLayout else {
                 return
             }
-            // 首次挂载或 Markdown 行高变化时补一次无动画贴底；只有这个任务仍是最新请求才执行。
-            try? await Task.sleep(nanoseconds: 160_000_000)
-            guard !Task.isCancelled,
-                  tailScrollAttemptGeneration == attemptGeneration,
-                  userScrollAwayGeneration == scrollAwayGeneration,
-                  sessionStore.selectedSessionID == sessionID,
-                  currentTimelineTailItemID() == expectedTailItemID,
-                  !isPreservingHistoryScroll
-            else {
-                return
+            // 首次挂载、Markdown 排版和 List 快照可能分多个布局周期完成。
+            // 分两次重锚；用户一旦主动上翻，generation 检查会立刻停止后续滚动。
+            for delay in [120_000_000, 320_000_000] as [UInt64] {
+                try? await Task.sleep(nanoseconds: delay)
+                guard !Task.isCancelled,
+                      tailScrollAttemptGeneration == attemptGeneration,
+                      userScrollAwayGeneration == scrollAwayGeneration,
+                      sessionStore.selectedSessionID == sessionID,
+                      currentTimelineTailItemID() == expectedTailItemID,
+                      !isPreservingHistoryScroll
+                else {
+                    return
+                }
+                forceScrollToTimelineTail(timelineItems: timelineItems, proxy: proxy, animated: false)
             }
-            forceScrollToTimelineTail(timelineItems: timelineItems, animated: false)
         }
     }
 
@@ -1176,13 +1218,17 @@ struct ConversationTimelineView: View {
         tailScrollAttemptGeneration += 1
     }
 
-    private func returnToTimelineTail(timelineItems: [ConversationTimelineItem]) {
+    private func returnToTimelineTail(
+        timelineItems: [ConversationTimelineItem],
+        proxy: ScrollViewProxy
+    ) {
         hasUnseenTailMessage = false
         shouldFollowMessageTail = true
         isTailFollowLockedByLocalSubmit = true
         isTimelineNearBottom = true
         queueTailScrollAttempts(
             timelineItems: timelineItems,
+            proxy: proxy,
             sessionID: sessionStore.selectedSessionID,
             expectedTailItemID: timelineItems.last?.id,
             animatedFirstAttempt: true,
@@ -1191,13 +1237,25 @@ struct ConversationTimelineView: View {
         )
     }
 
-    private func scrollToTimelineTail(animated: Bool) {
+    private func scrollToTimelineTail(
+        tailItemID: String,
+        proxy: ScrollViewProxy,
+        animated: Bool
+    ) {
         if animated {
             withAnimation(.easeOut(duration: 0.18)) {
                 timelineScrollPosition.scrollTo(edge: .bottom)
+                proxy.scrollTo(tailItemID, anchor: .bottom)
             }
         } else {
-            timelineScrollPosition.scrollTo(edge: .bottom)
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                timelineScrollPosition.scrollTo(edge: .bottom)
+                // ScrollPosition 在 List 首帧可能只更新绑定而没有落到底层 contentOffset；
+                // 对已验证仍存在的最后一行做显式定位，保证打开会话默认看到最新消息。
+                proxy.scrollTo(tailItemID, anchor: .bottom)
+            }
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -199,12 +199,7 @@ struct WorkspaceRootView: View {
 
     private func workspaceDetail(project: AgentProject) -> some View {
         WorkspaceDetailView(
-            project: project,
-            sessionCount: sessionStore.sessions(forProjectID: project.id).count,
-            worktreeCount: sessionStore.managedWorktrees(rootProjectID: sessionStore.rootProjectID(forProjectID: project.id)).count,
             recentSessions: Array(sessionStore.sessions(forProjectID: project.id).prefix(5)),
-            isUnavailable: sessionStore.isWorkspaceUnavailable(project.id),
-            lastActivity: lastActivityText(for: project),
             isShownInSessions: sessionStore.isWorkspaceShownInSessions(project.id),
             claudeChannelAvailable: sessionStore.hasClaudeRuntimeChannel,
             onToggleSessionVisibility: {
@@ -273,22 +268,6 @@ struct WorkspaceRootView: View {
             catalogState = .failed(error.localizedDescription)
         }
     }
-
-    private func lastActivityText(for project: AgentProject) -> String {
-        guard let date = sessionStore.sessions(forProjectID: project.id)
-            .compactMap({ $0.updatedAt ?? $0.createdAt })
-            .max()
-        else {
-            return "暂无"
-        }
-        return Self.timeFormatter.string(from: date)
-    }
-
-    private static let timeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter
-    }()
 
     private enum CatalogState: Equatable {
         case idle
@@ -375,12 +354,7 @@ private struct WorkspaceDetailView: View {
     @EnvironmentObject private var themeStore: ThemeStore
     @Environment(\.colorScheme) private var colorScheme
 
-    let project: AgentProject
-    let sessionCount: Int
-    let worktreeCount: Int
     let recentSessions: [AgentSession]
-    let isUnavailable: Bool
-    let lastActivity: String
     let isShownInSessions: Bool
     let claudeChannelAvailable: Bool
     let onToggleSessionVisibility: () -> Void
@@ -393,7 +367,8 @@ private struct WorkspaceDetailView: View {
 
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                workspaceSummary(tokens: tokens)
+                // 项目名称、路径和状态已在上方选中卡片中展示，这里直接进入操作区，
+                // 避免同一屏重复一整套工作区摘要。
                 workspaceActions(tokens: tokens)
                 recentSessionsSection(tokens: tokens)
             }
@@ -404,76 +379,6 @@ private struct WorkspaceDetailView: View {
             .frame(maxWidth: .infinity, alignment: .center)
         }
         .background(tokens.background.ignoresSafeArea())
-    }
-
-    private func workspaceSummary(tokens: ThemeTokens) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: isUnavailable ? "folder.badge.questionmark" : "folder.fill")
-                    .font(themeStore.uiFont(size: 20, weight: .semibold))
-                    .foregroundStyle(isUnavailable ? tokens.warning : tokens.primaryAction)
-                    .frame(width: 42, height: 42)
-                    .background((isUnavailable ? tokens.warning : tokens.primaryAction).opacity(0.12), in: RoundedRectangle(cornerRadius: 11, style: .continuous))
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(project.name)
-                        .font(themeStore.uiFont(.headline, weight: .semibold))
-                        .foregroundStyle(tokens.primaryText)
-                        .lineLimit(1)
-                    Text(project.path)
-                        .font(themeStore.uiFont(.caption))
-                        .foregroundStyle(tokens.secondaryText)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .textSelection(.enabled)
-                }
-
-                Spacer(minLength: 8)
-
-                Label(isUnavailable ? "需要重试" : "可访问", systemImage: isUnavailable ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
-                    .font(themeStore.uiFont(.caption, weight: .semibold))
-                    .foregroundStyle(isUnavailable ? tokens.warning : tokens.success)
-                    .padding(.horizontal, 9)
-                    .padding(.vertical, 6)
-                    .background((isUnavailable ? tokens.warning : tokens.success).opacity(0.11), in: Capsule())
-            }
-
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 8) {
-                    summaryMetric(value: "\(sessionCount)", title: "会话", systemImage: "bubble.left.and.bubble.right", tokens: tokens)
-                    summaryMetric(value: "\(worktreeCount)", title: "Worktree", systemImage: "arrow.triangle.branch", tokens: tokens)
-                    summaryMetric(value: lastActivity, title: "最近活动", systemImage: "clock", tokens: tokens)
-                }
-
-                VStack(spacing: 8) {
-                    summaryMetric(value: "\(sessionCount)", title: "会话", systemImage: "bubble.left.and.bubble.right", tokens: tokens)
-                    summaryMetric(value: "\(worktreeCount)", title: "Worktree", systemImage: "arrow.triangle.branch", tokens: tokens)
-                    summaryMetric(value: lastActivity, title: "最近活动", systemImage: "clock", tokens: tokens)
-                }
-            }
-        }
-        .padding(16)
-        .background(tokens.surface, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(tokens.border.opacity(0.72), lineWidth: 1)
-        }
-    }
-
-    private func summaryMetric(value: String, title: String, systemImage: String, tokens: ThemeTokens) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: systemImage)
-                .foregroundStyle(tokens.primaryAction)
-            Text(value)
-                .fontWeight(.semibold)
-                .foregroundStyle(tokens.primaryText)
-            Text(title)
-                .foregroundStyle(tokens.secondaryText)
-        }
-        .font(themeStore.uiFont(.caption))
-        .padding(.horizontal, 10)
-        .frame(maxWidth: .infinity, minHeight: 34, alignment: .leading)
-        .background(tokens.elevatedSurface.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     private func workspaceActions(tokens: ThemeTokens) -> some View {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 import Combine
+import SwiftUI
+import UIKit
 @testable import MimiRemote
 
 @MainActor
@@ -141,6 +143,63 @@ final class ConversationDataFlowTests: XCTestCase {
             isTailFollowLockedByLocalSubmit: false,
             isTimelineNearBottom: false
         ))
+    }
+
+    func testConversationTimelineStartsAtTailAfterSwitchingFromScrolledSession() async throws {
+        let firstSessionID = "tail-position-first"
+        let secondSessionID = "tail-position-second"
+        let conversationStore = ConversationStore()
+        for index in 0..<36 {
+            conversationStore.appendSystem("会话 A 消息 \(index)", sessionID: firstSessionID)
+            conversationStore.appendSystem("会话 B 消息 \(index)", sessionID: secondSessionID)
+        }
+
+        let sessionStore = SessionStore(
+            appStore: AppStore(),
+            conversationStore: conversationStore,
+            logStore: LogStore()
+        )
+        sessionStore.selectedSessionID = firstSessionID
+        let themeSuiteName = "TailPositionTests.\(UUID().uuidString)"
+        let themeDefaults = try XCTUnwrap(UserDefaults(suiteName: themeSuiteName))
+        let themeStore = ThemeStore(defaults: themeDefaults)
+
+        let view = ConversationView()
+            .environmentObject(sessionStore)
+            .environmentObject(conversationStore)
+            .environmentObject(themeStore)
+            .environment(\.colorScheme, .light)
+        let host = UIHostingController(rootView: view)
+        let windowScene = try XCTUnwrap(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+        )
+        let window = UIWindow(windowScene: windowScene)
+        window.frame = CGRect(x: 0, y: 0, width: 420, height: 820)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer {
+            window.isHidden = true
+            themeDefaults.removePersistentDomain(forName: themeSuiteName)
+        }
+
+        host.view.frame = window.bounds
+        host.view.layoutIfNeeded()
+        try await Task.sleep(nanoseconds: 700_000_000)
+
+        let firstScrollView = try XCTUnwrap(conversationTimelineScrollView(in: host.view))
+        XCTAssertLessThanOrEqual(distanceFromBottom(firstScrollView), 4)
+
+        // 先把会话 A 人工停在顶部，再切换会话；会话 B 必须丢弃旧 contentOffset 并默认展示最新消息。
+        firstScrollView.setContentOffset(
+            CGPoint(x: 0, y: -firstScrollView.adjustedContentInset.top),
+            animated: false
+        )
+        sessionStore.selectedSessionID = secondSessionID
+        try await Task.sleep(nanoseconds: 900_000_000)
+        host.view.layoutIfNeeded()
+
+        let secondScrollView = try XCTUnwrap(conversationTimelineScrollView(in: host.view))
+        XCTAssertLessThanOrEqual(distanceFromBottom(secondScrollView), 4)
     }
 
     func testTimestampCaptionMarksFallbackTimes() {
@@ -15800,4 +15859,33 @@ private func makeSession(
         preview: preview,
         activeTurnID: activeTurnID
     )
+}
+
+@MainActor
+private func conversationTimelineScrollView(in rootView: UIView) -> UIScrollView? {
+    var candidates: [UIScrollView] = []
+
+    func collect(from view: UIView) {
+        if let scrollView = view as? UIScrollView,
+           scrollView.bounds.width >= rootView.bounds.width * 0.75,
+           scrollView.contentSize.height > scrollView.bounds.height + 80 {
+            candidates.append(scrollView)
+        }
+        view.subviews.forEach(collect)
+    }
+
+    collect(from: rootView)
+    // Composer 里也可能包含 UIScrollView；时间线的内容高度最大，按此稳定选中 List。
+    return candidates.max { lhs, rhs in
+        lhs.contentSize.height < rhs.contentSize.height
+    }
+}
+
+@MainActor
+private func distanceFromBottom(_ scrollView: UIScrollView) -> CGFloat {
+    let maximumOffsetY = max(
+        -scrollView.adjustedContentInset.top,
+        scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom
+    )
+    return abs(maximumOffsetY - scrollView.contentOffset.y)
 }


### PR DESCRIPTION
## 变更内容

- 移除工作区详情中与顶部选中卡片重复的项目摘要，直接展示快捷操作和最近会话。
- 将底部“新会话”按钮改为胶囊轮廓，与侧栏“会话 / 工作区”的系统选中态保持一致。
- 工作区卡片只展示用户明确打开过的目录；后端候选目录继续供“打开目录”选择器使用，但不再自动加入列表。
- 将“回到底部”文字浮层改为固定 44pt 圆形图标按钮，避免文案切换造成尺寸和位置跳动。
- 为每个会话隔离 List 滚动身份；打开或切换会话时重置 `ScrollPosition`，并通过末条消息 ID 显式定位到底部。
- 增加真实 SwiftUI 宿主回归测试，覆盖“会话 A 上翻后切换到长会话 B”的场景。

## 原因

工作区顶部卡片与详情摘要重复展示项目名称、路径、会话数、Worktree 和可访问状态，占用了首屏空间。

旧版 `refreshWorkspaceCatalog()` 把 `projects()` 返回的所有候选目录自动写进最近工作区，导致父目录和未主动打开的文件夹一起出现。现在通过明确打开时间区分用户工作区，并在进入页面时清理旧版自动灌入项。

会话时间线此前只依赖 `ScrollPosition(edge: .bottom)`。在 List 首次挂载或切换会话时，绑定值可能已经是底部，但底层 `contentOffset` 没有真正提交，导致页面偶发停留在历史位置。回到底部按钮又会因“新消息/回到底部”文案切换改变宽度，视觉位置不稳定。

## 用户影响

- 工作区页面更紧凑，核心操作更靠前。
- 侧栏主导航和底部新会话按钮使用一致的胶囊选中轮廓。
- 工作区恢复为按需打开模式，只保留用户选择的几个目录。
- 回到底部按钮尺寸和位置稳定，同时保留完整无障碍文案。
- 新建、打开或切换会话时默认可靠展示最新消息；用户主动上翻历史后仍不会被流式更新强行拉回底部。

## 验证

- `git diff --check`
- iOS Debug 构建通过
- `build-for-testing` 通过
- iPad Air 11-inch (M4)、iOS 27 Simulator 专项测试通过（3/3）：
  - `ConversationDataFlowTests.testConversationTimelineStartsAtTailAfterSwitchingFromScrolledSession`
  - `ConversationDataFlowTests.testWorkspaceCatalogKeepsOnlyExplicitlyOpenedDirectories`
  - `ConversationDataFlowTests.testWorkspaceCatalogRefreshDoesNotChangeActiveSessionContext`
