### PR TITLE
统一侧栏圆角并恢复按需工作区

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -83,11 +83,9 @@ struct WorkspaceRootView: View {
         }
         .task {
             synchronizeSelection()
-            if sessionStore.sidebarProjects.isEmpty && !sessionStore.isLoading {
-                await refreshCatalog()
-            } else if !sessionStore.sidebarProjects.isEmpty {
-                catalogState = .loaded
-            }
+            // 每次进入工作区都做轻量目录同步，同时执行旧版自动候选数据清理；
+            // 该请求不改变当前会话和 WebSocket，上层选择保持稳定。
+            await refreshCatalog()
         }
         .onChange(of: sessionStore.sidebarProjects.map(\.id)) { _, _ in
             synchronizeSelection()

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -151,7 +151,8 @@ struct UnifiedWorkbenchShell: View {
                         .frame(height: 46)
                 }
                 .buttonStyle(.glassProminent)
-                .buttonBorderShape(.roundedRectangle(radius: 12))
+                // 与上方 List 的选中态统一使用胶囊轮廓，避免一个偏圆、一个偏方。
+                .buttonBorderShape(.capsule)
                 .tint(tokens.primaryAction)
                 .accessibilityLabel("新建会话")
             }

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -1869,19 +1869,19 @@ final class SessionStore: ObservableObject {
         let fetchedProjects = try await clientFactory().projects()
         setProjectsIfChanged(fetchedProjects)
 
-        var nextWorkspaces = recentWorkspaces
-        let knownIDs = Set(nextWorkspaces.map(\.id))
-        for project in fetchedProjects where !knownIDs.contains(project.id) {
-            nextWorkspaces.append(AgentWorkspace(project: project))
-        }
-        nextWorkspaces.sort { lhs, rhs in
-            let lhsDate = lhs.lastOpenedAt ?? .distantPast
-            let rhsDate = rhs.lastOpenedAt ?? .distantPast
-            if lhsDate != rhsDate {
-                return lhsDate > rhsDate
+        // projects() 是后端可选目录，不等于用户已打开的工作区。旧实现把所有候选目录
+        // 自动写进最近列表；手动 openWorkspace/rememberWorkspace 会写入 lastOpenedAt，
+        // 因此这里只保留明确打开过的目录，并顺带迁移清理旧版自动灌入项。
+        let nextWorkspaces = recentWorkspaces
+            .filter { $0.lastOpenedAt != nil }
+            .sorted { lhs, rhs in
+                let lhsDate = lhs.lastOpenedAt ?? .distantPast
+                let rhsDate = rhs.lastOpenedAt ?? .distantPast
+                if lhsDate != rhsDate {
+                    return lhsDate > rhsDate
+                }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
-            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-        }
         recentWorkspaceStore.save(nextWorkspaces, endpoint: appStore.endpoint)
         setRecentWorkspacesIfChanged(nextWorkspaces)
     }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -4346,6 +4346,43 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertEqual(store.sidebarProjects.map(\.id), [project.id])
     }
 
+    func testWorkspaceCatalogKeepsOnlyExplicitlyOpenedDirectories() async throws {
+        let openedProject = makeProject(id: "opened-project")
+        let legacyAutoProject = makeProject(id: "legacy-auto-project")
+        let unopenedCandidate = makeProject(id: "unopened-candidate")
+        let openedWorkspace = AgentWorkspace(
+            project: openedProject,
+            lastOpenedAt: Date(timeIntervalSince1970: 100)
+        )
+        // 旧版目录刷新会把 projects() 候选项直接写入 recent，特征是没有明确打开时间。
+        let legacyAutoWorkspace = AgentWorkspace(project: legacyAutoProject)
+        let appStore = AppStore()
+        let recentStore = makeRecentWorkspaceStore(
+            workspaces: [openedWorkspace, legacyAutoWorkspace],
+            endpoint: appStore.endpoint
+        )
+        let client = MockSessionStoreClient(
+            projects: [openedProject, legacyAutoProject, unopenedCandidate],
+            sessions: []
+        )
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: recentStore,
+            clientFactory: { client }
+        )
+
+        await store.refreshAll(autoAttach: false)
+        XCTAssertEqual(Set(store.sidebarProjects.map(\.id)), [openedProject.id, legacyAutoProject.id])
+
+        try await store.refreshWorkspaceCatalog()
+
+        XCTAssertEqual(store.projects.map(\.id), [openedProject.id, legacyAutoProject.id, unopenedCandidate.id])
+        XCTAssertEqual(store.sidebarProjects.map(\.id), [openedProject.id])
+        XCTAssertEqual(recentStore.load(endpoint: appStore.endpoint).map(\.id), [openedProject.id])
+    }
+
     func testApprovalSummaryDecodesLegacyPayloadAndRequiresDetailsForApproval() throws {
         let legacyJSON = #"{"id":"approval-legacy","title":"运行命令","kind":"command","count":1}"#
         let legacy = try JSONDecoder().decode(ApprovalSummary.self, from: Data(legacyJSON.utf8))


### PR DESCRIPTION
## 变更内容

- 将侧栏底部“新会话”按钮改为胶囊轮廓，与“会话 / 工作区”的系统选中态保持一致。
- 工作区卡片只展示用户明确打开过的目录，不再把后端 `projects()` 候选目录自动加入列表。
- 进入工作区时迁移清理旧版自动灌入、且没有明确打开时间的目录。
- 增加目录筛选回归测试。

## 原因

底部“新会话”原来使用固定 12pt 圆角矩形，而侧栏选中态是胶囊形，视觉上一个偏方、一个偏圆。

`refreshWorkspaceCatalog()` 之前把后端候选目录当成用户最近工作区保存，导致父目录和未主动打开的文件夹全部展示。候选目录应该只服务于“打开目录”选择，工作区列表仍按用户明确打开记录维护。

## 用户影响

- 侧栏主操作的选中轮廓一致。
- 工作区恢复为按需打开模式，只显示用户选择的几个目录。
- 已经由旧版本自动加入的候选目录会在进入工作区时自动清理。

## 验证

- `git diff --check`
- iPad Air 11-inch (M4)、iOS 27 Simulator 专项测试通过（3/3）：
  - `ConversationDataFlowTests.testWorkspaceCatalogKeepsOnlyExplicitlyOpenedDirectories`
  - `ConversationDataFlowTests.testWorkspaceCatalogRefreshDoesNotChangeActiveSessionContext`
  - `ConversationDataFlowTests.testConversationTimelineStartsAtTailAfterSwitchingFromScrolledSession`

