### PR TITLE
补充侧栏顶部操作布局到 main

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -119,44 +119,6 @@ struct UnifiedWorkbenchShell: View {
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
             .environment(\.defaultMinListRowHeight, 38)
-
-            Divider().overlay(tokens.border.opacity(0.7))
-
-            VStack(spacing: 8) {
-                Button {
-                    // 设置是临时配置面板，不改变用户当前所在的会话或工作区。
-                    presentedSheet = .settings
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "gearshape")
-                            .frame(width: 22)
-                        Text("设置")
-                        Spacer()
-                    }
-                    .font(themeStore.uiFont(.callout, weight: .medium))
-                    .foregroundStyle(presentedSheet == .settings ? tokens.primaryText : tokens.secondaryText)
-                    .padding(.horizontal, 12)
-                    .frame(height: 40)
-                    .background(presentedSheet == .settings ? tokens.selectionFill : Color.clear, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                }
-                .buttonStyle(.plain)
-
-                Button {
-                    presentedSheet = .newSession
-                } label: {
-                    Label("新会话", systemImage: "plus")
-                        .font(themeStore.uiFont(.callout, weight: .semibold))
-                        .foregroundStyle(tokens.primaryActionForeground)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 46)
-                }
-                .buttonStyle(.glassProminent)
-                // 与上方 List 的选中态统一使用胶囊轮廓，避免一个偏圆、一个偏方。
-                .buttonBorderShape(.capsule)
-                .tint(tokens.primaryAction)
-                .accessibilityLabel("新建会话")
-            }
-            .padding(14)
         }
         .background(tokens.sidebarBackground.ignoresSafeArea())
         .toolbar {
@@ -175,9 +137,13 @@ struct UnifiedWorkbenchShell: View {
                             Text("Mimi Remote")
                                 .font(themeStore.uiFont(.headline, weight: .semibold))
                                 .foregroundStyle(tokens.primaryText)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.82)
                             Text(connectionSubtitle)
                                 .font(themeStore.uiFont(.caption2))
                                 .foregroundStyle(tokens.tertiaryText)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.82)
                         }
 
                         Circle()
@@ -188,6 +154,35 @@ struct UnifiedWorkbenchShell: View {
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Mimi Remote，\(connectionSubtitle)")
                 }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    presentedSheet = .newSession
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 15, weight: .semibold))
+                }
+                .buttonStyle(.glassProminent)
+                .buttonBorderShape(.circle)
+                .tint(tokens.primaryAction)
+                .accessibilityLabel("新建会话")
+                .accessibilityIdentifier("sidebar.newSession")
+            }
+            // 固定间距会阻止系统把两个操作合并进同一个玻璃容器，保持为独立圆钮。
+            ToolbarSpacer(.fixed, placement: .topBarTrailing)
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    // 设置是临时配置面板，不改变用户当前所在的会话或工作区。
+                    presentedSheet = .settings
+                } label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 15, weight: .semibold))
+                }
+                .buttonStyle(.glass)
+                .buttonBorderShape(.circle)
+                .foregroundStyle(tokens.secondaryText)
+                .accessibilityLabel("打开设置")
+                .accessibilityIdentifier("sidebar.settings")
             }
         }
         .task {


### PR DESCRIPTION
## 目标

将此前误合入功能分支、未进入 `main` 的侧栏顶部操作布局补充合并到主分支。

## 根因

PR #7 的目标分支是 `agent/add-codex-usage-rings`，而该分支对应的 PR #6 已经提前合入 `main`。因此 PR #7 虽显示已合并，其提交并未进入 `main`，后续 TestFlight 构建仍保留底部大按钮。

## 改动

- 移除侧栏底部固定的“设置”和“新会话”区域
- 在顶部工具栏增加两个独立圆形按钮
  - 主色加号：新建会话
  - 中性齿轮：打开设置
- 使用固定 `ToolbarSpacer` 避免系统自动把两个按钮合并到同一玻璃容器
- 为紧凑宽度下的标题和连接状态增加单行缩放保护
- 保留无障碍标签和稳定标识

## 影响

- iPhone 与 iPad 侧栏可展示更多最近会话
- 操作入口更轻量，功能和弹层行为保持不变
- 本 PR 从最新 `main` 创建，不包含原堆叠分支的额外改动

## 验证

- `xcodebuild -quiet -project ios/MimiRemote/MimiRemote.xcodeproj -scheme MimiRemote -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
- `git diff --check origin/main...HEAD`
