### PR TITLE
feat(claude): query OAuth usage on demand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alleycat-claude-bridge"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "alleycat-bridge-core",
  "alleycat-codex-proto",

--- a/bridges/claude/crates/claude-bridge/Cargo.toml
+++ b/bridges/claude/crates/claude-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alleycat-claude-bridge"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 license = "GPL-3.0-only"
 authors.workspace = true

--- a/bridges/claude/crates/claude-bridge/src/bridge.rs
+++ b/bridges/claude/crates/claude-bridge/src/bridge.rs
@@ -352,7 +352,7 @@ async fn dispatch_request(
             to_value(handlers::lifecycle::handle_account_read(state, typed))
         }
         "account/rateLimits/read" => {
-            to_value(handlers::lifecycle::handle_account_rate_limits_read(state))
+            to_value(handlers::lifecycle::handle_account_rate_limits_read(state).await)
         }
         "account/login/start" => {
             let typed: p::LoginAccountParams = decode(params)?;

--- a/bridges/claude/crates/claude-bridge/src/handlers/lifecycle.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/lifecycle.rs
@@ -70,12 +70,47 @@ pub fn handle_account_read(
     }
 }
 
-/// Surface whatever `rate_limit_event` the claude event pump last saw. Until
-/// any process emits one, the response is the empty default — codex clients
-/// treat that as "no rate-limit metadata yet".
-pub fn handle_account_rate_limits_read(
+/// 优先从 Claude OAuth usage endpoint 主动读取账号窗口；不可用时退回当前连接
+/// 已观测到的 `rate_limit_event`。两条链路都失败才明确返回 unavailable。
+pub async fn handle_account_rate_limits_read(
     state: &Arc<ConnectionState>,
 ) -> p::GetAccountRateLimitsResponse {
+    const OAUTH_CACHE_SECS: i64 = 60;
+    const OAUTH_RETRY_SECS: i64 = 15;
+    let now = chrono::Utc::now().timestamp();
+    if let Some(snapshot) = state.cached_oauth_rate_limit(now, OAUTH_CACHE_SECS) {
+        return p::GetAccountRateLimitsResponse {
+            rate_limits: snapshot,
+            rate_limits_by_limit_id: None,
+        };
+    }
+    // 设置页可能同时触发多次刷新。串行化首次 Keychain/API 查询，让后续请求
+    // 等待并复用缓存，避免后到的 unavailable 覆盖先到的成功结果。
+    let _refresh_guard = state.lock_oauth_rate_limit_refresh().await;
+    let now = chrono::Utc::now().timestamp();
+    if let Some(snapshot) = state.cached_oauth_rate_limit(now, OAUTH_CACHE_SECS) {
+        return p::GetAccountRateLimitsResponse {
+            rate_limits: snapshot,
+            rate_limits_by_limit_id: None,
+        };
+    }
+    if state.begin_oauth_rate_limit_refresh(now, OAUTH_RETRY_SECS) {
+        match crate::oauth_usage::fetch_rate_limit_snapshot().await {
+            Ok(snapshot) => {
+                state.store_oauth_rate_limit(snapshot.clone(), now);
+                return p::GetAccountRateLimitsResponse {
+                    rate_limits: snapshot,
+                    rate_limits_by_limit_id: None,
+                };
+            }
+            Err(err) => {
+                // OAuth 是展示增强能力；凭据缺失、过期或临时网络失败都必须安全
+                // 降级到官方事件缓存，不能影响 Claude 会话与发送链路。
+                tracing::debug!(error = %err, "Claude OAuth usage unavailable; falling back to observed events");
+            }
+        }
+    }
+
     let infos: Vec<_> = state.caches().rate_limit_infos.into_values().collect();
     if infos.is_empty() {
         return p::GetAccountRateLimitsResponse {

--- a/bridges/claude/crates/claude-bridge/src/lib.rs
+++ b/bridges/claude/crates/claude-bridge/src/lib.rs
@@ -4,6 +4,7 @@ pub mod approval;
 pub mod bridge;
 pub mod handlers;
 pub mod index;
+mod oauth_usage;
 pub mod pool;
 pub mod server;
 pub mod state;

--- a/bridges/claude/crates/claude-bridge/src/main.rs
+++ b/bridges/claude/crates/claude-bridge/src/main.rs
@@ -79,6 +79,6 @@ fn socket_arg() -> Option<PathBuf> {
 mod tests {
     #[test]
     fn package_is_the_compatibility_release() {
-        assert_eq!(env!("CARGO_PKG_VERSION"), "0.2.4");
+        assert_eq!(env!("CARGO_PKG_VERSION"), "0.2.5");
     }
 }

--- a/bridges/claude/crates/claude-bridge/src/oauth_usage.rs
+++ b/bridges/claude/crates/claude-bridge/src/oauth_usage.rs
@@ -1,0 +1,397 @@
+//! Claude OAuth usage 查询。
+//!
+//! Claude Code 的 headless `stream-json` 不会主动执行 `/usage`，但已登录账号的
+//! OAuth 凭据可以访问 Claude Code 自己使用的 usage endpoint。这里仅在客户端
+//! 明确请求 `account/rateLimits/read` 时查询，并保留原有 `rate_limit_event` 降级，
+//! 不把凭据写入参数、日志或磁盘缓存。
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use alleycat_codex_proto as p;
+use chrono::DateTime;
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const USAGE_ENDPOINT: &str = "https://api.anthropic.com/api/oauth/usage";
+const OAUTH_BETA_HEADER: &str = "oauth-2025-04-20";
+const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(12);
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OAuthUsageError {
+    #[error("Claude OAuth 凭据不可用")]
+    CredentialsUnavailable,
+    #[error("Claude OAuth 凭据缺少 user:profile scope")]
+    MissingProfileScope,
+    #[error("Claude OAuth 凭据已过期")]
+    CredentialsExpired,
+    #[error("读取 Claude OAuth 凭据失败")]
+    CredentialReadFailed,
+    #[error("Claude OAuth usage 查询工具不可用")]
+    QueryToolUnavailable,
+    #[error("Claude OAuth usage 查询超时")]
+    QueryTimedOut,
+    #[error("Claude OAuth usage 查询失败")]
+    QueryFailed,
+    #[error("Claude OAuth usage 返回 HTTP {0}")]
+    HTTPStatus(u16),
+    #[error("Claude OAuth usage 返回格式无效")]
+    InvalidResponse,
+}
+
+#[derive(Debug, Clone)]
+struct OAuthCredentials {
+    access_token: String,
+    scopes: Vec<String>,
+    expires_at_ms: Option<f64>,
+    subscription_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CredentialRoot {
+    #[serde(rename = "claudeAiOauth")]
+    claude_ai_oauth: Option<CredentialPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CredentialPayload {
+    #[serde(default, rename = "accessToken")]
+    access_token: Option<String>,
+    #[serde(default)]
+    scopes: Vec<String>,
+    #[serde(default, rename = "expiresAt")]
+    expires_at_ms: Option<f64>,
+    #[serde(default, rename = "subscriptionType")]
+    subscription_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthUsageResponse {
+    #[serde(default)]
+    five_hour: Option<OAuthUsageWindow>,
+    #[serde(default)]
+    seven_day: Option<OAuthUsageWindow>,
+    #[serde(default)]
+    seven_day_sonnet: Option<OAuthUsageWindow>,
+    #[serde(default)]
+    seven_day_opus: Option<OAuthUsageWindow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthUsageWindow {
+    #[serde(default)]
+    utilization: Option<f64>,
+    #[serde(default)]
+    resets_at: Option<String>,
+}
+
+pub(crate) async fn fetch_rate_limit_snapshot() -> Result<p::RateLimitSnapshot, OAuthUsageError> {
+    let credentials = load_credentials().await?;
+    validate_credentials(&credentials)?;
+    let response = query_usage(&credentials.access_token).await?;
+    snapshot_from_response(response, credentials.subscription_type)
+}
+
+async fn load_credentials() -> Result<OAuthCredentials, OAuthUsageError> {
+    if let Some(credentials) = read_credentials_file().await? {
+        return Ok(credentials);
+    }
+    if let Some(credentials) = read_keychain_credentials().await? {
+        return Ok(credentials);
+    }
+    Err(OAuthUsageError::CredentialsUnavailable)
+}
+
+async fn read_credentials_file() -> Result<Option<OAuthCredentials>, OAuthUsageError> {
+    let Some(home) = std::env::var_os("HOME").filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(home).join(".claude/.credentials.json");
+    let data = match tokio::fs::read(&path).await {
+        Ok(data) => data,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(OAuthUsageError::CredentialReadFailed),
+    };
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = tokio::fs::metadata(&path)
+            .await
+            .map_err(|_| OAuthUsageError::CredentialReadFailed)?;
+        // 凭据文件若对组或其他用户可读，宁可不用，也不扩大既有安全问题。
+        if metadata.permissions().mode() & 0o077 != 0 {
+            return Err(OAuthUsageError::CredentialReadFailed);
+        }
+    }
+
+    parse_credentials(&data)
+}
+
+#[cfg(target_os = "macos")]
+async fn read_keychain_credentials() -> Result<Option<OAuthCredentials>, OAuthUsageError> {
+    let mut command = Command::new("/usr/bin/security");
+    command
+        .args(["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let child = command
+        .spawn()
+        .map_err(|_| OAuthUsageError::CredentialReadFailed)?;
+    let output = timeout(Duration::from_secs(4), child.wait_with_output())
+        .await
+        .map_err(|_| OAuthUsageError::QueryTimedOut)?
+        .map_err(|_| OAuthUsageError::CredentialReadFailed)?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    parse_credentials(&output.stdout)
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn read_keychain_credentials() -> Result<Option<OAuthCredentials>, OAuthUsageError> {
+    Ok(None)
+}
+
+fn parse_credentials(data: &[u8]) -> Result<Option<OAuthCredentials>, OAuthUsageError> {
+    let root: CredentialRoot =
+        serde_json::from_slice(data).map_err(|_| OAuthUsageError::CredentialReadFailed)?;
+    let Some(payload) = root.claude_ai_oauth else {
+        return Ok(None);
+    };
+    let access_token = payload.access_token.unwrap_or_default().trim().to_string();
+    if access_token.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(OAuthCredentials {
+        access_token,
+        scopes: payload.scopes,
+        expires_at_ms: payload.expires_at_ms,
+        subscription_type: payload.subscription_type,
+    }))
+}
+
+fn validate_credentials(credentials: &OAuthCredentials) -> Result<(), OAuthUsageError> {
+    if !credentials
+        .scopes
+        .iter()
+        .any(|scope| scope == "user:profile")
+    {
+        return Err(OAuthUsageError::MissingProfileScope);
+    }
+    if let Some(expires_at_ms) = credentials.expires_at_ms.filter(|value| *value > 0.0) {
+        let now_ms = chrono::Utc::now().timestamp_millis() as f64;
+        if expires_at_ms <= now_ms + 30_000.0 {
+            return Err(OAuthUsageError::CredentialsExpired);
+        }
+    }
+    if !safe_header_token(&credentials.access_token) {
+        return Err(OAuthUsageError::CredentialReadFailed);
+    }
+    Ok(())
+}
+
+fn safe_header_token(token: &str) -> bool {
+    !token.is_empty()
+        && token
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() && byte != b'"' && byte != b'\\')
+}
+
+async fn query_usage(access_token: &str) -> Result<OAuthUsageResponse, OAuthUsageError> {
+    let curl = if tokio::fs::try_exists("/usr/bin/curl")
+        .await
+        .unwrap_or(false)
+    {
+        "/usr/bin/curl"
+    } else {
+        "curl"
+    };
+    let beta_header = format!("anthropic-beta: {OAUTH_BETA_HEADER}");
+    let mut command = Command::new(curl);
+    command
+        .args([
+            // 禁用用户级 .curlrc，避免代理、输出或调试配置意外改变凭据请求。
+            "-q",
+            "--silent",
+            "--show-error",
+            "--connect-timeout",
+            "3",
+            "--max-time",
+            "10",
+            "--request",
+            "GET",
+            "--header",
+            "Accept: application/json",
+            "--header",
+            "Content-Type: application/json",
+            "--header",
+            beta_header.as_str(),
+            "--header",
+            "User-Agent: claude-code/2.1.0",
+            "--write-out",
+            "\n%{http_code}",
+            "--config",
+            "-",
+            USAGE_ENDPOINT,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let mut child = command
+        .spawn()
+        .map_err(|_| OAuthUsageError::QueryToolUnavailable)?;
+    let config = format!("header = \"Authorization: Bearer {access_token}\"\n");
+    let mut stdin = child.stdin.take().ok_or(OAuthUsageError::QueryFailed)?;
+    stdin
+        .write_all(config.as_bytes())
+        .await
+        .map_err(|_| OAuthUsageError::QueryFailed)?;
+    drop(stdin);
+
+    let output = timeout(COMMAND_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| OAuthUsageError::QueryTimedOut)?
+        .map_err(|_| OAuthUsageError::QueryFailed)?;
+    if !output.status.success() {
+        return Err(OAuthUsageError::QueryFailed);
+    }
+    let (body, status) = split_curl_output(&output.stdout)?;
+    if status != 200 {
+        return Err(OAuthUsageError::HTTPStatus(status));
+    }
+    serde_json::from_slice(body).map_err(|_| OAuthUsageError::InvalidResponse)
+}
+
+fn split_curl_output(output: &[u8]) -> Result<(&[u8], u16), OAuthUsageError> {
+    let Some(index) = output.iter().rposition(|byte| *byte == b'\n') else {
+        return Err(OAuthUsageError::InvalidResponse);
+    };
+    let status = std::str::from_utf8(&output[index + 1..])
+        .ok()
+        .and_then(|value| value.trim().parse::<u16>().ok())
+        .ok_or(OAuthUsageError::InvalidResponse)?;
+    Ok((&output[..index], status))
+}
+
+fn snapshot_from_response(
+    response: OAuthUsageResponse,
+    subscription_type: Option<String>,
+) -> Result<p::RateLimitSnapshot, OAuthUsageError> {
+    let primary = response
+        .five_hour
+        .as_ref()
+        .and_then(|window| rate_limit_window(window, 300));
+    let secondary = response
+        .seven_day
+        .as_ref()
+        .and_then(|window| rate_limit_window(window, 10_080))
+        .or_else(|| {
+            response
+                .seven_day_sonnet
+                .as_ref()
+                .and_then(|window| rate_limit_window(window, 10_080))
+        })
+        .or_else(|| {
+            response
+                .seven_day_opus
+                .as_ref()
+                .and_then(|window| rate_limit_window(window, 10_080))
+        });
+    if primary.is_none() && secondary.is_none() {
+        return Err(OAuthUsageError::InvalidResponse);
+    }
+
+    Ok(p::RateLimitSnapshot {
+        limit_id: Some("claude".into()),
+        limit_name: Some("Claude".into()),
+        primary,
+        secondary,
+        credits: None,
+        plan_type: subscription_type.map(Value::String),
+        rate_limit_reached_type: None,
+        availability: Some("available".into()),
+        unavailable_reason: None,
+    })
+}
+
+fn rate_limit_window(window: &OAuthUsageWindow, duration: i64) -> Option<p::RateLimitWindow> {
+    let used_percent = window
+        .utilization
+        .filter(|value| value.is_finite())
+        // OAuth usage endpoint 已经返回 0...100 的百分比，不再乘 100。
+        .map(|value| (value.clamp(0.0, 100.0) + 1e-9).floor() as i32);
+    let resets_at = window
+        .resets_at
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.timestamp());
+    (used_percent.is_some() || resets_at.is_some()).then_some(p::RateLimitWindow {
+        used_percent,
+        window_duration_mins: Some(duration),
+        resets_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_keychain_credentials_without_exposing_token() {
+        let data = br#"{"claudeAiOauth":{"accessToken":"test-oauth-token","expiresAt":4102444800000,"scopes":["user:profile"],"subscriptionType":"pro"}}"#;
+        let credentials = parse_credentials(data).unwrap().unwrap();
+        assert_eq!(credentials.scopes, vec!["user:profile"]);
+        assert_eq!(credentials.subscription_type.as_deref(), Some("pro"));
+        assert!(validate_credentials(&credentials).is_ok());
+    }
+
+    #[test]
+    fn maps_oauth_percentages_and_reset_times() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour":{"utilization":0.0,"resets_at":"2026-07-20T16:00:00.433227+00:00"},
+                "seven_day":{"utilization":33.9,"resets_at":"2026-07-20T20:00:00.433254+00:00"}
+            }"#,
+        )
+        .unwrap();
+        let snapshot = snapshot_from_response(response, Some("pro".into())).unwrap();
+        assert_eq!(snapshot.primary.unwrap().used_percent, Some(0));
+        assert_eq!(snapshot.secondary.unwrap().used_percent, Some(33));
+        assert_eq!(snapshot.plan_type, Some(Value::String("pro".into())));
+        assert_eq!(snapshot.availability.as_deref(), Some("available"));
+    }
+
+    #[test]
+    fn falls_back_to_model_weekly_window() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{"seven_day_sonnet":{"utilization":42,"resets_at":"2026-07-21T00:00:00Z"}}"#,
+        )
+        .unwrap();
+        let snapshot = snapshot_from_response(response, None).unwrap();
+        assert!(snapshot.primary.is_none());
+        assert_eq!(snapshot.secondary.unwrap().used_percent, Some(42));
+    }
+
+    #[test]
+    fn rejects_header_injection_tokens() {
+        assert!(!safe_header_token("token\nheader: injected"));
+        assert!(!safe_header_token("token\\value"));
+        assert!(safe_header_token("test-oauth-token_123"));
+    }
+
+    #[test]
+    fn splits_curl_body_and_status() {
+        let (body, status) = split_curl_output(b"{\"five_hour\":null}\n200").unwrap();
+        assert_eq!(body, b"{\"five_hour\":null}");
+        assert_eq!(status, 200);
+    }
+}

--- a/bridges/claude/crates/claude-bridge/src/state.rs
+++ b/bridges/claude/crates/claude-bridge/src/state.rs
@@ -16,8 +16,8 @@ use serde_json::Value;
 use tokio::sync::oneshot;
 
 use alleycat_codex_proto::{
-    ApprovalsReviewer, AskForApproval, InitializeCapabilities, JsonRpcMessage, ReasoningEffort,
-    RequestId, SandboxMode, ThreadItem, Turn, TurnError, TurnStatus,
+    ApprovalsReviewer, AskForApproval, InitializeCapabilities, JsonRpcMessage, RateLimitSnapshot,
+    ReasoningEffort, RequestId, SandboxMode, ThreadItem, Turn, TurnError, TurnStatus,
 };
 
 use crate::index::ClaudeSessionRef;
@@ -54,6 +54,7 @@ pub struct ConnectionState {
     /// SSH launcher, need the cwd to be validated by that remote process.
     trust_persisted_cwd: bool,
     caches: Mutex<ClaudeCaches>,
+    oauth_rate_limit_refresh: tokio::sync::Mutex<()>,
     thread_logs: Mutex<HashMap<String, Vec<RecordedTurn>>>,
 }
 
@@ -95,6 +96,16 @@ pub struct ClaudeCaches {
     /// Claude 每次事件只携带一个窗口；按类型缓存，避免 5h/7d 连续到达时
     /// 后一个把前一个覆盖掉。
     pub rate_limit_infos: HashMap<String, RateLimitInfo>,
+    /// OAuth usage 主动查询的短缓存。只保存百分比与重置时间，不保存凭据。
+    pub oauth_rate_limit: Option<CachedOAuthRateLimit>,
+    /// 失败也短暂退避，避免设置页并发刷新连续访问 Keychain/OAuth endpoint。
+    pub oauth_last_attempt_at: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedOAuthRateLimit {
+    pub snapshot: RateLimitSnapshot,
+    pub fetched_at: i64,
 }
 
 impl ClaudeCaches {
@@ -105,6 +116,34 @@ impl ClaudeCaches {
             .unwrap_or_else(|| "unknown".into());
         self.rate_limit_infos.insert(key, info);
         self.rate_limit_infos.values().cloned().collect()
+    }
+
+    pub fn cached_oauth_rate_limit(
+        &self,
+        now: i64,
+        max_age_secs: i64,
+    ) -> Option<RateLimitSnapshot> {
+        self.oauth_rate_limit.as_ref().and_then(|cached| {
+            (now.saturating_sub(cached.fetched_at) <= max_age_secs).then(|| cached.snapshot.clone())
+        })
+    }
+
+    pub fn begin_oauth_rate_limit_refresh(&mut self, now: i64, min_interval_secs: i64) -> bool {
+        if self
+            .oauth_last_attempt_at
+            .is_some_and(|last| now.saturating_sub(last) < min_interval_secs)
+        {
+            return false;
+        }
+        self.oauth_last_attempt_at = Some(now);
+        true
+    }
+
+    pub fn store_oauth_rate_limit(&mut self, snapshot: RateLimitSnapshot, fetched_at: i64) {
+        self.oauth_rate_limit = Some(CachedOAuthRateLimit {
+            snapshot,
+            fetched_at,
+        });
     }
 }
 
@@ -156,6 +195,7 @@ impl ConnectionState {
             launcher,
             trust_persisted_cwd,
             caches: Mutex::new(ClaudeCaches::default()),
+            oauth_rate_limit_refresh: tokio::sync::Mutex::new(()),
             thread_logs: Mutex::new(HashMap::new()),
         }
     }
@@ -296,6 +336,35 @@ impl ConnectionState {
     pub fn refresh_rate_limit_cache(&self, info: RateLimitInfo) -> Vec<RateLimitInfo> {
         let mut slot = self.caches.lock().unwrap();
         slot.refresh_rate_limit(info)
+    }
+
+    pub fn cached_oauth_rate_limit(
+        &self,
+        now: i64,
+        max_age_secs: i64,
+    ) -> Option<RateLimitSnapshot> {
+        self.caches
+            .lock()
+            .unwrap()
+            .cached_oauth_rate_limit(now, max_age_secs)
+    }
+
+    pub async fn lock_oauth_rate_limit_refresh(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.oauth_rate_limit_refresh.lock().await
+    }
+
+    pub fn begin_oauth_rate_limit_refresh(&self, now: i64, min_interval_secs: i64) -> bool {
+        self.caches
+            .lock()
+            .unwrap()
+            .begin_oauth_rate_limit_refresh(now, min_interval_secs)
+    }
+
+    pub fn store_oauth_rate_limit(&self, snapshot: RateLimitSnapshot, fetched_at: i64) {
+        self.caches
+            .lock()
+            .unwrap()
+            .store_oauth_rate_limit(snapshot, fetched_at);
     }
 
     pub fn record_turn_started(&self, thread_id: &str, turn_id: String, started_at: i64) {

--- a/docs/codex-protocol-support.md
+++ b/docs/codex-protocol-support.md
@@ -28,7 +28,9 @@ Go Gateway 当前开放 25 个 client frame method，其中 `initialized` 是 no
 
 所有带 `threadId` 的管理操作都要求该 thread 已由当前 Gateway 连接通过 allowlist cwd 授权。
 
-Claude 实验通道使用更小的独立 allowlist。`alleycat-claude-bridge >= 0.2.1` 时额外开放 `account/rateLimits/read`，请求参数固定改写为 `{}`；`0.2.3` 起补齐百分比映射。Claude Code 2.1.92 headless `stream-json` 不执行 statusline sink，bridge 没有事件缓存时返回 `rateLimits.availability=unavailable`、`unavailableReason=headless_statusline_unavailable`；收到官方 `rate_limit_event` 后，按 `rateLimitType` 合并缓存 5h/7d 窗口，把真实 `utilization` 映射为 `usedPercent`，并同时返回重置时间。未观测到 utilization 的窗口保留 `unavailableReason=usage_percentage_unavailable`，不会伪造为 `0%`；只有 `rejected` 会映射为额度耗尽，`allowed_warning` 不阻断发送。Gateway 不访问 Anthropic 私有接口或凭证文件。
+Claude 实验通道使用更小的独立 allowlist。`alleycat-claude-bridge >= 0.2.1` 时额外开放 `account/rateLimits/read`，请求参数固定改写为 `{}`；`0.2.3` 起补齐事件百分比映射。`0.2.5` 起优先复用 Claude Code 已登录凭据主动读取 OAuth usage：macOS 从登录 Keychain 的 `Claude Code-credentials` 获取短期 access token，其他平台可使用权限收紧的 `~/.claude/.credentials.json`，随后请求固定的 Anthropic OAuth usage beta endpoint，将 5h/7d 窗口映射为现有协议。token 只通过子进程 stdin 传给禁用 `.curlrc` 的系统 `curl`，不进入命令参数、日志或磁盘缓存；成功快照缓存 60 秒，Keychain、scope、过期、网络、HTTP 或解析失败均不影响会话链路。
+
+OAuth usage endpoint 不是稳定公开 API，可能被 Anthropic 调整。主动查询失败时 bridge 继续降级到官方 `rate_limit_event`：按 `rateLimitType` 合并缓存 5h/7d 窗口，把事件中的 0...1 `utilization` 映射为 `usedPercent`。未观测到 utilization 的窗口保留 `unavailableReason=usage_percentage_unavailable`，不会伪造为 `0%`；只有 `rejected` 会映射为额度耗尽，`allowed_warning` 不阻断发送。主动查询和事件缓存都不可用时返回 `rateLimits.availability=unavailable`、`unavailableReason=headless_statusline_unavailable`。
 
 Claude bridge 必须通过标准 `--version` 门禁才会被标记为可用；审批反向请求的响应和随后到达的 `serverRequest/resolved` notification 均透明透传。bridge 版本缺失、低于 `0.2.1` 或运行中退出时，Gateway 返回结构化错误并终止等待。bridge 已并入当前仓库，可执行 `cargo install --git https://github.com/gaixianggeng/codex-ipad-agent.git --locked --force --bin alleycat-claude-bridge alleycat-claude-bridge` 安装；导入来源固定记录在 `bridges/claude/UPSTREAM.md`。
 

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -46,7 +46,7 @@ iPhone / iPad SwiftUI App
 | 输入输出 | 富 Markdown、图片输入、历史图片按需加载、语音转写、文件安全读取和 QuickLook；当前会话可导出 ANSI 清洗后的有界 UTF-8 日志，导出头部不读取连接凭据 | PDF/大型 artifact 的富预览和后台下载尚未实现；日志正文可能包含用户命令、代码和工具输出，分享前需自行检查 |
 | 能力发现 | Skills 和 MCP 配置只读浏览、allowlist actions | 不在 iPad 上启停 MCP、修改 Codex 配置或处理 OAuth |
 | 移动体验 | iPhone/iPad 自适应、深浅色、主题和字号、Codex 5h/7d 用量、提醒、运行态通知、通知点击回到当前 Mac 会话；通知未授权时提醒仍可保留为 App 内状态并明确告知，冷启动/回前台清理过期提醒；通知 payload 不含 Token 或明文 endpoint，错 Mac 只提示手动切换档案；凭据失效终止重试；NWPath 事件按递增序号交付并丢弃迟到旧状态，离线暂停、恢复单次重连和 jitter 退避，首次 unknown→在线只在已有网络错误或挂起会话时恢复一次；首次配对提交后最多等待 45 秒恢复项目/会话，已有档案修复或切换等待 10 秒，超时保留 Keychain 凭据且打开设置可直接重试；保存、重命名和删除多台 Mac 档案，每台独立 Keychain Token，验证后单活切换；重命名只更新非敏感显示名，不重建连接；忘记/删除凭据必须二次确认并在执行前重验目标档案 | 后台 push、离线通知、连接档案云同步和离线队列持久化尚未实现 |
-| Claude | 仓库内 `alleycat-claude-bridge >= 0.2.1` 实验通道，当前 `0.2.4` 支持审批闭环、历史记录过滤、额度百分比和 Fable 5 模型目录 | 默认关闭；每个 WebSocket 一个 bridge；不支持 goal、archive、fork；Claude Code 2.1.92 headless 不执行 statusline sink，仅展示官方 `rate_limit_event` 已观测窗口的真实百分比与重置时间，并按 5h/7d 类型合并缓存；尚无任意时刻主动读取双窗口快照的官方 headless API，未观测到时明确显示暂无数据；CLI 凭证失效时需在 Mac 重新登录 |
+| Claude | 仓库内 `alleycat-claude-bridge >= 0.2.1` 实验通道，当前 `0.2.5` 支持审批闭环、历史记录过滤、OAuth 额度查询、事件降级和 Fable 5 模型目录 | 默认关闭；每个 WebSocket 一个 bridge；不支持 goal、archive、fork；优先复用 Claude Code Keychain/凭据文件只读查询 Anthropic OAuth usage beta endpoint，返回 5h/7d 百分比与重置时间并短缓存；内部 beta endpoint 变化、凭据缺少 `user:profile`、过期或查询失败时降级到官方 `rate_limit_event`，两者均不可用才显示暂无数据；CLI 凭证失效时需在 Mac 重新登录 |
 
 完整能力矩阵见 [Codex Mac App 功能对照](codex-mac-feature-parity.md)。
 


### PR DESCRIPTION
## 变更

- 在 Claude bridge 的 `account/rateLimits/read` 中主动查询 Claude Code OAuth usage，映射 5 小时与 7 天窗口。
- macOS 复用登录 Keychain 中的 Claude Code 凭据；其他平台兼容权限收紧的 `~/.claude/.credentials.json`。
- token 仅通过子进程 stdin 注入固定 curl 请求，不进入 argv、日志或磁盘缓存；增加超时、60 秒成功缓存和 15 秒失败退避。
- OAuth 查询失败时继续降级到已有官方 `rate_limit_event` 缓存，不影响 Claude 会话与发送链路。
- Claude bridge 版本升级到 0.2.5，并补充中文协议/项目状态说明；App 无需改动。

## 原因

Claude Code headless `stream-json` 不会执行交互式 `/usage` 或 statusline，因此设置页在尚未收到 `rate_limit_event` 时只能显示暂无数据。CodexBar 的实现证明可以复用 Claude Code OAuth 登录态读取同一 usage endpoint；本次只实现这条最小查询链路，保留原有事件兜底。

## 风险与兼容

Anthropic OAuth usage endpoint 属于 beta/internal 能力，未来可能调整。接口、凭据、scope、网络或解析异常都会安全降级，不扩大为会话故障，也不要求 iOS App 更新。

## 验证

- `cargo fmt --all -- --check`
- `cargo test --locked -p alleycat-codex-proto -p alleycat-bridge-core -p alleycat-claude-bridge`
- `go test ./...`
- 本机安装 `alleycat-claude-bridge 0.2.5` 并原子重启 agentd
- 通过真实 agentd Claude WebSocket 完成 `initialize` + `account/rateLimits/read` 端到端验证，5 小时/7 天窗口均正常返回
