### PR TITLE
fix(ios): 修复 iPad 消息长按菜单定位

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationCommentaryRow.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationCommentaryRow.swift
@@ -15,12 +15,7 @@ struct ConversationCommentaryRow: View {
             .messageContextMenu(
                 for: message,
                 retry: {},
-                stop: { sessionStore.sendCtrlC() },
-                preview: {
-                    commentaryBody
-                        .frame(maxWidth: layout.assistantBubbleMaxWidth, alignment: .leading)
-                        .padding(16)
-                }
+                stop: { sessionStore.sendCtrlC() }
             )
             .accessibilityElement(children: .contain)
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageAccessories.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageAccessories.swift
@@ -65,10 +65,7 @@ struct SystemNotice: View {
     var body: some View {
         noticeSurface
             .contentShape(Capsule())
-            .messageContextMenu(for: message) {
-                noticeSurface
-                    .frame(maxWidth: layout.systemMaxWidth)
-            }
+            .messageContextMenu(for: message)
             .frame(maxWidth: layout.systemMaxWidth)
     }
 
@@ -99,10 +96,7 @@ struct RuntimeSummaryCard: View {
     var body: some View {
         cardSurface
             .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .messageContextMenu(for: message) {
-                cardSurface
-                    .frame(maxWidth: cardMaxWidth, alignment: .leading)
-            }
+            .messageContextMenu(for: message)
             .frame(maxWidth: cardMaxWidth, alignment: .leading)
     }
 
@@ -387,35 +381,97 @@ struct RuntimeSummaryCard: View {
     }
 }
 
+struct MessageContextMenuPreview: View {
+    @EnvironmentObject private var themeStore: ThemeStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    let message: ConversationMessage
+
+    static let maximumCharacterCount = 600
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: 18, style: .continuous)
+
+        Text(Self.displayText(for: message.content))
+            .font(themeStore.uiFont(.body))
+            .foregroundStyle(foreground)
+            .lineLimit(8)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            // 预览只重建轻量纯文本，避免复杂 Markdown 和图片在 iPadOS 的
+            // context menu 转场中被重复渲染，同时让系统按内容宽度摆放菜单。
+            .frame(maxWidth: 520, alignment: .leading)
+            .background(background, in: shape)
+            .overlay {
+                shape.strokeBorder(tokens.border.opacity(0.42), lineWidth: 1)
+            }
+            .contentShape(.contextMenuPreview, shape)
+    }
+
+    static func displayText(for content: String) -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return L10n.text("ui.content")
+        }
+
+        let candidate = trimmed.prefix(maximumCharacterCount + 1)
+        guard candidate.count > maximumCharacterCount else {
+            return trimmed
+        }
+        return String(candidate.prefix(maximumCharacterCount)) + "…"
+    }
+
+    private var foreground: Color {
+        message.role == .user ? tokens.userBubbleForeground : tokens.primaryText
+    }
+
+    private var background: Color {
+        switch message.role {
+        case .user:
+            return tokens.userBubble
+        case .assistant:
+            return tokens.assistantBubble
+        case .system:
+            return tokens.systemBubble
+        }
+    }
+
+    private var tokens: ThemeTokens {
+        themeStore.tokens(for: colorScheme)
+    }
+}
+
 extension View {
-    func messageContextMenu<Preview: View>(
+    func messageContextMenu(
         for message: ConversationMessage,
         retry: (() -> Void)? = nil,
-        stop: (() -> Void)? = nil,
-        @ViewBuilder preview: @escaping () -> Preview
+        stop: (() -> Void)? = nil
     ) -> some View {
-        _ = preview
-        // iPadOS 对 contextMenu 自定义预览会重新构建复杂 Markdown/图片气泡，长按时容易触发 SwiftUI 内部崩溃；
-        // 这里保留复制/重试/停止动作，禁用预览来换取稳定性。
-        return contextMenu {
-            Button {
-                UIPasteboard.general.string = message.content
-            } label: {
-                Label(L10n.text("ui.copy"), systemImage: "doc.on.doc")
-            }
-
-            if message.role == .user && message.sendStatus == .failed, let retry {
-                Button(action: retry) {
-                    Label(L10n.text("ui.try_again"), systemImage: "arrow.clockwise")
+        // interaction 形状由各消息表面自行定义；这里单独约束系统抬起动画的预览形状，
+        // 避免 List 的全宽宿主行参与 context menu 转场。
+        contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .contextMenu {
+                Button {
+                    UIPasteboard.general.string = message.content
+                } label: {
+                    Label(L10n.text("ui.copy"), systemImage: "doc.on.doc")
                 }
-            }
 
-            if message.role == .assistant && message.sendStatus == .sending, let stop {
-                Button(role: .destructive, action: stop) {
-                    Label(L10n.text("ui.stop"), systemImage: "stop.circle")
+                if message.role == .user && message.sendStatus == .failed, let retry {
+                    Button(action: retry) {
+                        Label(L10n.text("ui.try_again"), systemImage: "arrow.clockwise")
+                    }
                 }
+
+                if message.role == .assistant && message.sendStatus == .sending, let stop {
+                    Button(role: .destructive, action: stop) {
+                        Label(L10n.text("ui.stop"), systemImage: "stop.circle")
+                    }
+                }
+            } preview: {
+                MessageContextMenuPreview(message: message)
             }
-        }
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageBubble.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageBubble.swift
@@ -41,10 +41,6 @@ struct MessageBubble: View {
                 },
                 stop: {
                     sessionStore.sendCtrlC()
-                },
-                preview: {
-                    userImageContent(style: style)
-                        .frame(maxWidth: maxBubbleWidth, alignment: .trailing)
                 }
             )
     }
@@ -60,10 +56,6 @@ struct MessageBubble: View {
                 },
                 stop: {
                     sessionStore.sendCtrlC()
-                },
-                preview: {
-                    bubbleChrome
-                        .frame(maxWidth: maxBubbleWidth, alignment: bubbleAlignment)
                 }
             )
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationActivityRows.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationActivityRows.swift
@@ -162,9 +162,7 @@ struct ConversationActivityRow: View, Equatable {
     var body: some View {
         HStack(spacing: 0) {
             rowSurface
-                .messageContextMenu(for: message) {
-                    rowSurface.frame(maxWidth: layout.assistantBubbleMaxWidth, alignment: .leading)
-                }
+                .messageContextMenu(for: message)
                 .frame(maxWidth: layout.assistantBubbleMaxWidth, alignment: .leading)
 
             Spacer(minLength: layout.messageSideSpacer)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/MarkdownRenderingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/MarkdownRenderingTests.swift
@@ -3,6 +3,19 @@ import XCTest
 
 @MainActor
 final class MarkdownRenderingTests: XCTestCase {
+    func testMessageContextMenuPreviewTextIsTrimmedAndBounded() {
+        XCTAssertEqual(
+            MessageContextMenuPreview.displayText(for: "  可复制内容\n"),
+            "可复制内容"
+        )
+
+        let longContent = String(repeating: "测", count: MessageContextMenuPreview.maximumCharacterCount + 1)
+        let preview = MessageContextMenuPreview.displayText(for: longContent)
+
+        XCTAssertEqual(preview.count, MessageContextMenuPreview.maximumCharacterCount + 1)
+        XCTAssertTrue(preview.hasSuffix("…"))
+    }
+
     func testMarkdownParserBuildsGFMBlocks() {
         let result = MarkdownParser.shared.parse("""
         # 标题


### PR DESCRIPTION
## 问题

iPad 上长按右侧消息气泡时，系统会把整条 `List` 行作为 Context Menu 预览和定位参考，导致“复制”菜单出现在屏幕左侧。

根因是统一的 `messageContextMenu` 虽然接收了预览闭包，但实际丢弃闭包并调用无自定义预览的 `contextMenu`。在全宽消息行中，iPadOS 因此使用了行级宿主视图。

## 修改

- 为所有消息菜单提供统一的轻量纯文本预览，限制为 520pt、8 行和 600 个字符。
- 显式设置 `.contentShape(.contextMenuPreview, ...)`，约束系统抬起动画的预览形状。
- 删除各消息类型中未被使用的复杂 Markdown/图片预览闭包。
- 保留复制、失败重试和停止生成等既有菜单行为。
- 增加预览文本去空白和长度上限测试。

## 影响

- Context Menu 会按内容尺寸显示在消息附近，不再以全宽列表行为锚点。
- 预览不会重复渲染 Markdown 和图片，继续规避此前 iPadOS 长按转场的稳定性问题。
- 不修改现有 `List`、滚动复用和消息布局架构。

## 验证

- `git diff --check`
- `xcodebuild build-for-testing -project ios/MimiRemote/MimiRemote.xcodeproj -scheme MimiRemote -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`
  - `TEST BUILD SUCCEEDED`

尚未启动模拟器；合并前建议在 iPad 横屏中对用户、助手和图片消息各执行一次长按回归。
