### PR TITLE
fix: ignore generated skill release assets

### DIFF
--- a/packaging/public/.gitignore
+++ b/packaging/public/.gitignore
@@ -13,6 +13,7 @@ config.json
 bin/
 /dist/
 /dist-macos/
+/dist-skill/
 
 # 日志与临时文件
 /logs/

--- a/scripts/check-packaging.sh
+++ b/scripts/check-packaging.sh
@@ -154,6 +154,8 @@ if [[ -f scripts/export-public-backend.sh ]]; then
     || fail "公开镜像导出脚本没有包含 Codex Skill。"
   grep -Fq 'scripts/package-skill.sh' scripts/export-public-backend.sh \
     || fail "公开镜像导出脚本没有包含 Skill 打包入口。"
+  grep -Fxq '/dist-skill/' packaging/public/.gitignore \
+    || fail "公开镜像没有忽略 Skill 构建目录，GoReleaser 正式发布会因工作区不干净而失败。"
 fi
 
 release_docs=(README.md docs/install-upgrade-rollback.md)


### PR DESCRIPTION
## 修改

- 公开镜像忽略 `/dist-skill/` 构建目录
- Packaging 门禁检查该忽略规则，防止正式发布回归

## 根因

Release 工作流在 GoReleaser 前生成 Codex Skill，未忽略的 `dist-skill/` 让 GoReleaser 判定工作区为 dirty 并终止。

## 验证

- `bash ./scripts/check-packaging.sh`
- `git diff --check`