### PR TITLE
feat(claude): harden reconnect session lifecycle

### DIFF
--- a/bridges/claude/crates/bridge-core/src/lib.rs
+++ b/bridges/claude/crates/bridge-core/src/lib.rs
@@ -30,7 +30,10 @@ pub use server::{
 };
 #[cfg(unix)]
 pub use server::{ServerOptions, serve_unix};
-pub use session::{AttachKind, AttachOutcome, Session, SessionRegistry, SessionRegistryConfig};
+pub use session::{
+    AttachKind, AttachOutcome, AttachReservation, Session, SessionRegistry, SessionRegistryConfig,
+    TurnGuard,
+};
 pub use thread_index::{
     DEFAULT_LIST_LIMIT, Hydrator, IndexEntry, ListFilter, ListPage, ListSort, MAX_LIST_LIMIT,
     ThreadIndex, ThreadIndexHandle, encode_backwards_cursor, resolve_list_limit,

--- a/bridges/claude/crates/bridge-core/src/server.rs
+++ b/bridges/claude/crates/bridge-core/src/server.rs
@@ -209,6 +209,10 @@ where
     if let Some(params) = attach_params(&first) {
         let resolved = registry.resolve_attach(params.session_key.clone(), agent, params.last_seen);
         write_json_line(&mut writer, &attached_ack(&params.session_key, &resolved)).await?;
+        // Held for the whole connection: it covers the gap between claiming
+        // the session and installing the attachment, and costs nothing after
+        // that, since an attached session is never idle anyway.
+        let _reservation = resolved.reservation;
         return serve_split_with_session(
             bridge,
             reader,
@@ -413,13 +417,19 @@ where
     let conn = Conn::from_session(Arc::clone(&session));
 
     let attach = session.install_attachment(last_seen);
+    // Only this connection's own attachment may be torn down below. A client
+    // that reconnects before we notice this socket is dead has already
+    // preempted the slot, and detaching it here would kill the live stream it
+    // just set up — and mark a session detached that someone is attached to,
+    // which hands a live session to the reaper.
+    let generation = attach.generation;
     let writer_task = tokio::spawn(drain_attachment(writer, attach, Arc::clone(&session)));
 
     if let Some(value) = pending {
         dispatch_inbound(&bridge, &conn, value).await;
     }
     let result = run_reader(bridge, &conn, &mut reader).await;
-    session.drop_attachment();
+    session.drop_attachment(generation);
     let _ = writer_task.await;
     result
 }

--- a/bridges/claude/crates/bridge-core/src/session/mod.rs
+++ b/bridges/claude/crates/bridge-core/src/session/mod.rs
@@ -10,12 +10,12 @@ pub mod registry;
 pub mod ring;
 
 use std::collections::HashMap;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 
 use crate::state::{Capabilities, PendingServerRequest, ServerRequestError};
 
@@ -63,19 +63,21 @@ pub struct AttachHandle {
     /// Frames the client missed while detached, in seq order.
     pub backlog: Vec<Sequenced>,
     /// Synthetic `serverRequest/replay` frame to emit after the backlog, if
-    /// there are any outstanding requests at attach time. None for fresh
-    /// attaches or reattaches with no outstanding requests.
+    /// there are any outstanding requests at attach time. None only when
+    /// nothing is waiting on the user.
     pub replay_redelivery: Option<Value>,
     /// New live channel; producers `enqueue` after this point will push here.
     pub live_rx: mpsc::UnboundedReceiver<Sequenced>,
+    /// Which attachment this handle owns. Hand it back to
+    /// [`Session::drop_attachment`] so a connection only ever tears down its
+    /// own stream.
+    pub generation: u64,
 }
 
 #[derive(Debug)]
 struct Attachment {
     live_tx: mpsc::UnboundedSender<Sequenced>,
     /// Monotonic counter incremented on every fresh `install_attachment`.
-    /// Surfaced via `Session::attachment_generation()` for log correlation.
-    #[allow(dead_code)]
     generation: u64,
 }
 
@@ -114,6 +116,59 @@ pub struct Session {
     /// so the most recent uncertain frame is re-sent — duplicates over
     /// missing data.
     last_attempted_seq: AtomicU64,
+    /// Turns currently executing against this session, held up by
+    /// [`Session::begin_turn`] guards.
+    ///
+    /// The reaper measures idleness as "how long since a client detached",
+    /// which says nothing about whether work is still running: a long tool
+    /// call can go minutes without emitting a frame. Without this counter a
+    /// phone that closes the app mid-task would have its session dropped out
+    /// from under a turn that is still going, and the turn would keep filling
+    /// a replay ring nobody can reach again.
+    active_turns: AtomicUsize,
+    /// Connections that have claimed this session but have not installed
+    /// their attachment yet.
+    ///
+    /// Resolving an attach and installing it are necessarily separate — the
+    /// ack goes out in between — and in that gap the session still looks
+    /// detached and idle. Without a claim the reaper drops it right out from
+    /// under the connection that just picked it up: that connection keeps
+    /// serving from an Arc no longer in the registry, and the next reconnect
+    /// mints a blank session instead of resuming.
+    attach_reservations: AtomicUsize,
+    /// Set once the session has been abandoned and reclaimed. Producers watch
+    /// it so a turn still running against a session nobody can reach any more
+    /// stops instead of burning tokens into a ring with no reader.
+    cancelled: AtomicBool,
+    cancel_signal: Notify,
+}
+
+/// Keeps a session marked busy for as long as a turn is running. Drop order
+/// does the bookkeeping, so a panicking or cancelled turn still releases it.
+#[derive(Debug)]
+pub struct TurnGuard {
+    session: Arc<Session>,
+}
+
+impl Drop for TurnGuard {
+    fn drop(&mut self) {
+        self.session.active_turns.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Holds a session against the reaper from the moment a connection claims it
+/// until that connection is done with it.
+#[derive(Debug)]
+pub struct AttachReservation {
+    session: Arc<Session>,
+}
+
+impl Drop for AttachReservation {
+    fn drop(&mut self) {
+        self.session
+            .attach_reservations
+            .fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl std::fmt::Debug for Session {
@@ -147,6 +202,10 @@ impl Session {
             attachment_generation: AtomicU64::new(0),
             detach: Mutex::new(DetachState { detached_at: None }),
             last_attempted_seq: AtomicU64::new(0),
+            active_turns: AtomicUsize::new(0),
+            attach_reservations: AtomicUsize::new(0),
+            cancelled: AtomicBool::new(false),
+            cancel_signal: Notify::new(),
         }
     }
 
@@ -185,6 +244,61 @@ impl Session {
         if let Some(attachment) = attachment.as_ref() {
             // Best-effort: if the drainer is gone, the message is still in
             // the ring and a future reattach will replay it.
+            let _ = attachment.live_tx.send(Sequenced {
+                seq,
+                payload,
+                bytes: 0,
+            });
+        }
+        seq
+    }
+
+    /// Publish a server→client request: make it outstanding and put it on the
+    /// wire as one indivisible step.
+    ///
+    /// Doing these separately leaves a window that a reattach can land in.
+    /// Registered-but-not-yet-enqueued, the request is in the replay snapshot
+    /// while its frame is not yet in the ring — so the client gets the
+    /// synthetic replay, and then `enqueue` hands the *original* request to
+    /// the attachment that was just installed. Two copies of one prompt, and
+    /// the second arrives by the ordinary request path, which a client that
+    /// has not rehydrated may answer on its own.
+    ///
+    /// The attachment lock is the barrier: `install_attachment` holds it
+    /// across its entire snapshot, so the two cannot interleave. Lock order
+    /// here is attachment → pending → outstanding → ring; `enqueue` releases
+    /// the ring before touching the attachment, so nothing ever holds ring
+    /// while waiting for attachment and the orders cannot invert.
+    pub fn publish_server_request(
+        &self,
+        id: String,
+        method: String,
+        params: Value,
+        responder: oneshot::Sender<Result<Value, ServerRequestError>>,
+        mut payload: Value,
+    ) -> u64 {
+        let attachment = self.attachment.lock().unwrap();
+        self.pending.lock().unwrap().insert(
+            id.clone(),
+            PendingServerRequest {
+                method: method.clone(),
+                responder,
+            },
+        );
+        self.outstanding
+            .lock()
+            .unwrap()
+            .insert(id, OutstandingRequest { method, params });
+
+        let seq = {
+            let mut ring = self.ring.lock().unwrap();
+            let next = ring.next_seq_peek();
+            stamp_alleycat_seq(&mut payload, next);
+            ring.push(payload.clone())
+        };
+        if let Some(attachment) = attachment.as_ref() {
+            // Best-effort, exactly as in `enqueue`: with no live drainer the
+            // frame still sits in the ring for the next reattach.
             let _ = attachment.live_tx.send(Sequenced {
                 seq,
                 payload,
@@ -294,11 +408,27 @@ impl Session {
         };
         drop(ring_guard);
 
-        let replay_redelivery = if matches!(outcome, AttachOutcome::Resumed) {
-            outstanding_replay_message(&self.outstanding.lock().unwrap())
-        } else {
-            None
-        };
+        let outstanding = self.outstanding.lock().unwrap();
+        // A prompt raised while the client was away sits in two places: the
+        // ring, because it was enqueued like any frame, and the outstanding
+        // table. Delivering both hands the client the same approval twice —
+        // and the first copy arrives as an ordinary server request, which a
+        // client that has not yet rehydrated may auto-dismiss, answering it
+        // upstream for real. The synthetic replay would then draw a card for
+        // a request that is already resolved. So the replay notification is
+        // the single restoration path, and the ring copies step aside.
+        let backlog: Vec<Sequenced> = backlog
+            .into_iter()
+            .filter(|frame| !is_unanswered_server_request(&frame.payload, &outstanding))
+            .collect();
+        // Whatever we could or couldn't replay, a prompt still waiting on the
+        // user is state the client has to be told about — it is the whole
+        // reason the session is still here. DriftReload is where this matters
+        // most: the backlog is empty precisely because a lot happened while
+        // they were gone, so the replay notification is the only thing that
+        // tells them the turn is parked on a question rather than stuck.
+        let replay_redelivery = outstanding_replay_message(&outstanding);
+        drop(outstanding);
 
         let (live_tx, live_rx) = mpsc::unbounded_channel();
         let generation = self.attachment_generation.fetch_add(1, Ordering::Relaxed) + 1;
@@ -308,10 +438,14 @@ impl Session {
             live_tx,
             generation,
         });
-        drop(attachment_slot);
 
-        // Clear detach bookkeeping while attached.
+        // Clear detach bookkeeping while still holding the attachment lock, so
+        // "is attached" and "when did it detach" can never disagree. Dropping
+        // the slot lock first leaves a window where a concurrent detach writes
+        // its timestamp after we cleared it, marking a session detached that
+        // someone is attached to — and handing a live session to the reaper.
         self.detach.lock().unwrap().detached_at = None;
+        drop(attachment_slot);
 
         AttachHandle {
             outcome,
@@ -320,22 +454,44 @@ impl Session {
             backlog,
             replay_redelivery,
             live_rx,
+            generation,
         }
     }
 
-    /// Clear the attachment slot. Producer enqueues continue to go into the
-    /// ring; only the live forwarding stops. If `pending_grace` is configured
-    /// and elapses without a reattach, the session reaper will drain pending
-    /// requests with `ConnectionClosed` (see [`SessionRegistry`]).
-    pub fn drop_attachment(&self) {
+    /// Clear the attachment slot owned by `generation`. Producer enqueues
+    /// continue to go into the ring; only the live forwarding stops.
+    ///
+    /// The generation check is what makes a handover safe. A client that
+    /// reconnects before the old connection has noticed it is dead preempts
+    /// the slot, and the old reader then finishes and calls this — without
+    /// the check it would tear down the *new* client's stream and mark a
+    /// session detached that in fact has someone attached, handing it to the
+    /// reaper. Returns whether this call actually detached anything.
+    pub fn drop_attachment(&self, generation: u64) -> bool {
         let mut slot = self.attachment.lock().unwrap();
+        match slot.as_ref() {
+            Some(current) if current.generation != generation => return false,
+            None => return false,
+            _ => {}
+        }
         *slot = None;
-        drop(slot);
+        // Timestamp under the same lock that cleared the slot — see
+        // `install_attachment` for why the two must move together.
         self.detach.lock().unwrap().detached_at = Some(Instant::now());
+        drop(slot);
+        true
     }
 
     pub fn is_attached(&self) -> bool {
         self.attachment.lock().unwrap().is_some()
+    }
+
+    /// Generation of the most recently installed attachment. Useful for log
+    /// correlation; a connection tearing down its own stream should pass the
+    /// generation from its own [`AttachHandle`] instead, so it cannot detach
+    /// a successor that preempted it.
+    pub fn attachment_generation(&self) -> u64 {
+        self.attachment_generation.load(Ordering::Relaxed)
     }
 
     /// True when the session has been detached for at least `grace`. While
@@ -349,6 +505,84 @@ impl Session {
 
     pub fn has_outstanding_requests(&self) -> bool {
         !self.outstanding.lock().unwrap().is_empty()
+    }
+
+    /// Mark a turn as running until the returned guard is dropped. Callers
+    /// hold it for the whole turn — from accepting the prompt to emitting the
+    /// terminal event — so the session survives a client that goes away in
+    /// the middle.
+    pub fn begin_turn(self: &Arc<Self>) -> TurnGuard {
+        self.active_turns.fetch_add(1, Ordering::SeqCst);
+        TurnGuard {
+            session: Arc::clone(self),
+        }
+    }
+
+    pub fn has_active_turns(&self) -> bool {
+        self.active_turns.load(Ordering::SeqCst) > 0
+    }
+
+    /// Claim the session on behalf of a connection that is about to attach.
+    /// Held until that connection is finished, so the reaper cannot drop a
+    /// session mid-handover.
+    pub fn reserve_attach(self: &Arc<Self>) -> AttachReservation {
+        self.attach_reservations.fetch_add(1, Ordering::SeqCst);
+        AttachReservation {
+            session: Arc::clone(self),
+        }
+    }
+
+    /// Reclaim an abandoned session: fail everything waiting on the client
+    /// and tell any running turn to stop.
+    ///
+    /// Removing the registry's `Arc` is not enough to free anything — an
+    /// approval future holds the session through its own chain of `Arc`s, so
+    /// the pending responder, the ring and the agent process all stay alive,
+    /// now permanently unreachable. Cancelling is what actually unwinds them:
+    /// the awaiting handlers resolve with `ConnectionClosed` and drop their
+    /// references, and the turn observing [`Session::cancelled`] winds down
+    /// and releases its process.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+        self.cancel_signal.notify_waiters();
+        self.cancel_all_pending();
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// Resolves once the session has been reclaimed. Producers select on it
+    /// alongside their own work so an abandoned turn does not run on forever.
+    pub async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+        let notified = self.cancel_signal.notified();
+        // Re-check after arming: `cancel` may have fired in between, and the
+        // notification it sent has no waiter to wake.
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
+    }
+
+    /// Whether a connection is partway through taking this session over.
+    /// Even the hard backstop respects it: dropping a session while a client
+    /// is attaching would strand that connection on an unregistered Arc.
+    pub fn has_pending_attach(&self) -> bool {
+        self.attach_reservations.load(Ordering::SeqCst) > 0
+    }
+
+    /// Whether the session has work or a claim that must not be thrown away:
+    /// a turn in flight, an approval prompt waiting on a human, or a
+    /// connection partway through attaching. The first two are states the
+    /// user expects to still be there when they reopen the app; the third is
+    /// a client that is picking the session up right now.
+    pub fn is_busy(&self) -> bool {
+        self.has_active_turns()
+            || self.has_outstanding_requests()
+            || self.attach_reservations.load(Ordering::SeqCst) > 0
     }
 
     /// Read-only snapshot of `(current_seq, floor_seq)`. Useful for probing
@@ -374,6 +608,26 @@ fn stamp_alleycat_seq(payload: &mut Value, seq: u64) {
     if let Some(obj) = payload.as_object_mut() {
         obj.insert("_alleycat_seq".to_string(), Value::from(seq));
     }
+}
+
+/// True when `payload` is a server→client request whose id is still unanswered
+/// — one the replay notification is about to restore, so the ring's copy of it
+/// must not go out as well.
+fn is_unanswered_server_request(
+    payload: &Value,
+    outstanding: &HashMap<String, OutstandingRequest>,
+) -> bool {
+    if outstanding.is_empty() || payload.get("method").and_then(Value::as_str).is_none() {
+        return false;
+    }
+    // Request ids are keyed by their `Display` form, which is the bare string
+    // for string ids and the digits for numeric ones.
+    let key = match payload.get("id") {
+        Some(Value::String(id)) => id.clone(),
+        Some(Value::Number(id)) => id.to_string(),
+        _ => return false,
+    };
+    outstanding.contains_key(&key)
 }
 
 fn outstanding_replay_message(outstanding: &HashMap<String, OutstandingRequest>) -> Option<Value> {
@@ -500,7 +754,7 @@ mod tests {
     }
 
     #[test]
-    fn outstanding_replay_emitted_on_resume_only() {
+    fn outstanding_replay_emitted_whenever_something_awaits_the_user() {
         let session = Session::new("pi", "node-abc".into(), 16, 1 << 20);
         session.enqueue(notif("first"));
         let (tx, _rx) = oneshot::channel();
@@ -510,13 +764,44 @@ mod tests {
             serde_json::json!({"command": "rm -rf /"}),
             tx,
         );
-        // Fresh attach: no replay redelivery even with outstanding present.
+        // However the client arrives, it has to learn that a prompt is
+        // parked on it — otherwise the turn just looks stuck.
         let h_fresh = session.install_attachment(None);
-        assert!(h_fresh.replay_redelivery.is_none());
-        // Re-attach within window: redelivery emitted.
+        assert!(h_fresh.replay_redelivery.is_some());
         session.enqueue(notif("second"));
         let h_resume = session.install_attachment(Some(1));
         assert!(h_resume.replay_redelivery.is_some());
+    }
+
+    #[test]
+    fn outstanding_replay_survives_a_drifted_reattach() {
+        // Came back after a long absence: the ring rolled over, so there is
+        // no backlog to replay. The waiting approval is exactly what the
+        // client still needs, and it is all it will get.
+        let session = Session::new("pi", "node-abc".into(), 2, 1 << 20);
+        let (tx, _rx) = oneshot::channel();
+        session.register_pending(
+            "req-1".into(),
+            "command/approve".into(),
+            serde_json::json!({"command": "cargo install"}),
+            tx,
+        );
+        for _ in 0..5 {
+            session.enqueue(notif("chatter"));
+        }
+        let handle = session.install_attachment(Some(0));
+        assert!(matches!(handle.outcome, AttachOutcome::DriftReload));
+        assert!(handle.backlog.is_empty());
+        assert!(handle.replay_redelivery.is_some());
+    }
+
+    #[test]
+    fn no_replay_redelivery_when_nothing_awaits_the_user() {
+        let session = Session::new("pi", "node-abc".into(), 16, 1 << 20);
+        session.enqueue(notif("first"));
+        session.enqueue(notif("second"));
+        let handle = session.install_attachment(Some(1));
+        assert!(handle.replay_redelivery.is_none());
     }
 
     #[test]
@@ -544,7 +829,7 @@ mod tests {
         assert!(!session.detached_for(Duration::from_millis(0)));
         let _h = session.install_attachment(None);
         assert!(!session.detached_for(Duration::from_millis(0)));
-        session.drop_attachment();
+        session.drop_attachment(session.attachment_generation());
         assert!(session.detached_for(Duration::from_millis(0)));
     }
 }

--- a/bridges/claude/crates/bridge-core/src/session/registry.rs
+++ b/bridges/claude/crates/bridge-core/src/session/registry.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
-use crate::session::{AgentId, AttachOutcome, NodeId, Session};
+use crate::session::{AgentId, AttachOutcome, AttachReservation, NodeId, Session};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttachKind {
@@ -35,6 +35,11 @@ pub struct ResolvedAttach {
     pub kind: AttachKind,
     pub current_seq: u64,
     pub floor_seq: u64,
+    /// Holds the session against the reaper until the caller drops it. Keep
+    /// it alive for at least as long as it takes to install the attachment —
+    /// the ack goes out in between, and until then the session still looks
+    /// detached and idle.
+    pub reservation: AttachReservation,
     /// Cursor that should be threaded into `Session::install_attachment`.
     ///
     /// Differs from the client's supplied `last_seen` in one case: when the
@@ -50,8 +55,20 @@ pub struct ResolvedAttach {
 pub struct SessionRegistryConfig {
     pub ring_max_msgs: usize,
     pub ring_max_bytes: usize,
+    /// How long a session with **no work in flight** may sit unattached
+    /// before it is dropped. It is not a cap on how long a task may run: a
+    /// session running a turn, or holding an approval prompt, is never idle
+    /// no matter how long its client has been gone.
     pub idle_ttl: Duration,
-    pub pending_grace: Duration,
+    /// Backstop for a busy session whose client never comes back at all.
+    ///
+    /// Waiting indefinitely is the intended behaviour for someone who closed
+    /// the app and will return — but a session can also become permanently
+    /// unreachable, because the client reinstalled, lost the stored key, or
+    /// changed it. Such a session would otherwise hold its ring and its agent
+    /// process forever. Set far beyond any real "I'll deal with it later", so
+    /// it only ever catches the abandoned case.
+    pub busy_hard_ttl: Duration,
 }
 
 impl Default for SessionRegistryConfig {
@@ -60,7 +77,7 @@ impl Default for SessionRegistryConfig {
             ring_max_msgs: 2048,
             ring_max_bytes: 16 << 20,
             idle_ttl: Duration::from_secs(600),
-            pending_grace: Duration::from_secs(60),
+            busy_hard_ttl: Duration::from_secs(24 * 60 * 60),
         }
     }
 }
@@ -120,10 +137,10 @@ impl SessionRegistry {
         agent: AgentId,
         last_seen: Option<u64>,
     ) -> ResolvedAttach {
-        let (session, was_existing) = {
+        let (session, was_existing, reservation) = {
             let mut inner = self.inner.lock().unwrap();
             let key = (node_id.clone(), agent);
-            if let Some(existing) = inner.get(&key) {
+            let (session, was_existing) = if let Some(existing) = inner.get(&key) {
                 (existing.clone(), true)
             } else {
                 let fresh = Arc::new(Session::new(
@@ -134,7 +151,12 @@ impl SessionRegistry {
                 ));
                 inner.insert(key, fresh.clone());
                 (fresh, false)
-            }
+            };
+            // Claim it before releasing the registry lock, so a reaper tick
+            // cannot slip in and drop a session this caller has already been
+            // handed.
+            let reservation = session.reserve_attach();
+            (session, was_existing, reservation)
         };
         let (current_seq, floor_seq) = session.peek_seq();
 
@@ -163,6 +185,7 @@ impl SessionRegistry {
             current_seq,
             floor_seq,
             effective_last_seen,
+            reservation,
         }
     }
 
@@ -178,62 +201,72 @@ impl SessionRegistry {
         self.inner.lock().unwrap().values().cloned().collect()
     }
 
-    /// Spawn a background task that periodically:
-    /// 1. Cancels pending server-requests in sessions detached longer than
-    ///    `pending_grace` (caller's outstanding approval prompts time out).
-    /// 2. Drops sessions detached longer than `idle_ttl` AND with no
-    ///    outstanding requests.
+    /// Spawn a background task that periodically drops sessions detached
+    /// longer than `idle_ttl` that have no work in flight.
     ///
     /// Returns the task handle so the daemon can join on shutdown. Holds a
     /// `Weak` to the registry so dropping the registry stops the reaper.
     pub fn spawn_reaper(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
         let weak = Arc::downgrade(self);
-        let pending_grace = self.config.pending_grace;
         let idle_ttl = self.config.idle_ttl;
+        let busy_hard_ttl = self.config.busy_hard_ttl;
         // Sweep on a coarse interval — the work is cheap and timing precision
         // matters less than not waking up needlessly.
-        let interval = std::cmp::min(
-            std::cmp::min(pending_grace / 4, idle_ttl / 4),
-            Duration::from_secs(30),
-        )
-        .max(Duration::from_secs(1));
+        let interval =
+            std::cmp::min(idle_ttl / 4, Duration::from_secs(30)).max(Duration::from_secs(1));
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(interval).await;
                 let Some(registry) = weak.upgrade() else {
                     break;
                 };
-                registry.tick(pending_grace, idle_ttl);
+                registry.tick_with(idle_ttl, busy_hard_ttl);
             }
         })
     }
 
-    /// One reaper tick. Public for tests so we can drive deterministic
-    /// expiry without sleeping.
-    pub fn tick(&self, pending_grace: Duration, idle_ttl: Duration) {
-        // Phase 1: cancel pending in sessions past pending_grace. Don't drop
-        // them yet — they may still be useful (the agent process is still
-        // running and can be reattached for a new turn).
-        for session in self.snapshot() {
-            if session.detached_for(pending_grace) && session.has_outstanding_requests() {
-                session.cancel_all_pending();
-            }
-        }
-        // Phase 2: drop fully-idle sessions.
-        let mut to_drop: Vec<(NodeId, AgentId)> = Vec::new();
+    /// One reaper tick at the configured hard TTL. Public for tests so we can
+    /// drive deterministic expiry without sleeping.
+    ///
+    /// Losing the client is not a reason to tear anything down. A session is
+    /// dropped only once it is both unattached past `idle_ttl` and idle in
+    /// the real sense — no turn running, no approval waiting on a human.
+    /// Closing the app mid-task, or leaving an approval unanswered overnight,
+    /// leaves the work exactly where it was; the session is reachable again
+    /// by attaching with the same key.
+    pub fn tick(&self, idle_ttl: Duration) {
+        self.tick_with(idle_ttl, self.config.busy_hard_ttl);
+    }
+
+    /// As [`Self::tick`], with an explicit backstop for sessions that stay
+    /// busy. A session nobody can reach any more — the client reinstalled,
+    /// or lost the key naming it — would otherwise pin its ring and its agent
+    /// process for the life of the daemon.
+    pub fn tick_with(&self, idle_ttl: Duration, busy_hard_ttl: Duration) {
+        // Decide and remove inside one critical section. Collecting keys,
+        // releasing the lock and then deleting unconditionally would drop
+        // sessions that became live in between — the phone reconnecting is
+        // exactly the moment a long-idle session stops being idle.
+        let mut abandoned: Vec<Arc<Session>> = Vec::new();
         {
-            let inner = self.inner.lock().unwrap();
-            for ((node_id, agent), session) in inner.iter() {
-                if session.detached_for(idle_ttl) && !session.has_outstanding_requests() {
-                    to_drop.push((node_id.clone(), *agent));
-                }
-            }
-        }
-        if !to_drop.is_empty() {
             let mut inner = self.inner.lock().unwrap();
-            for key in to_drop {
-                inner.remove(&key);
-            }
+            inner.retain(|_, session| {
+                if session.detached_for(busy_hard_ttl) && !session.has_pending_attach() {
+                    // Only the hard backstop reclaims a session that still has
+                    // work attached to it, so only it has anything to unwind.
+                    if session.is_busy() {
+                        abandoned.push(Arc::clone(session));
+                    }
+                    return false;
+                }
+                !session.detached_for(idle_ttl) || session.is_busy()
+            });
+        }
+        // Outside the registry lock: cancelling wakes handlers that may reach
+        // back into the session, and there is no reason to hold up other
+        // attaches while they unwind.
+        for session in abandoned {
+            session.cancel();
         }
     }
 }
@@ -246,7 +279,6 @@ pub type SessionRegistryWeak = Weak<SessionRegistry>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::ServerRequestError;
     use serde_json::Value;
     use tokio::sync::oneshot;
 
@@ -282,9 +314,9 @@ mod tests {
         let session = reg.get_or_create("node-abc".into(), "pi");
         // Attach + immediately detach so detached_at is set.
         let _h = session.install_attachment(None);
-        session.drop_attachment();
-        // Use zero grace/ttl so the session expires immediately.
-        reg.tick(Duration::from_millis(0), Duration::from_millis(0));
+        session.drop_attachment(session.attachment_generation());
+        // Zero ttl so the session expires immediately.
+        reg.tick(Duration::from_millis(0));
         assert!(reg.get("node-abc", "pi").is_none());
     }
 
@@ -294,15 +326,36 @@ mod tests {
         let session = reg.get_or_create("node-abc".into(), "pi");
         let _handle = session.install_attachment(None);
         session.enqueue(notif("a"));
-        reg.tick(Duration::from_millis(0), Duration::from_millis(0));
+        reg.tick(Duration::from_millis(0));
         assert!(reg.get("node-abc", "pi").is_some());
     }
 
     #[test]
-    fn tick_cancels_pending_past_grace_but_keeps_session() {
+    fn tick_keeps_detached_session_with_a_turn_running() {
+        // The app was closed mid-task. Nothing about that means the task
+        // should stop, so the session stays until the turn releases it.
         let reg = SessionRegistry::new(SessionRegistryConfig::default());
         let session = reg.get_or_create("node-abc".into(), "pi");
-        let (tx, rx) = oneshot::channel();
+        let _h = session.install_attachment(None);
+        session.drop_attachment(session.attachment_generation());
+        let turn = session.begin_turn();
+
+        reg.tick(Duration::from_millis(0));
+        assert!(reg.get("node-abc", "pi").is_some());
+
+        drop(turn);
+        reg.tick(Duration::from_millis(0));
+        assert!(reg.get("node-abc", "pi").is_none());
+    }
+
+    #[test]
+    fn tick_keeps_pending_approval_alive_indefinitely() {
+        // "Needs the user" is a resting state, not a failure: the prompt has
+        // to still be there whenever they get back to their phone, and it is
+        // replayed to them on reattach.
+        let reg = SessionRegistry::new(SessionRegistryConfig::default());
+        let session = reg.get_or_create("node-abc".into(), "pi");
+        let (tx, mut rx) = oneshot::channel();
         session.register_pending(
             "r-1".into(),
             "command/approve".into(),
@@ -310,14 +363,15 @@ mod tests {
             tx,
         );
         let _h = session.install_attachment(None);
-        session.drop_attachment();
-        // Past pending_grace but well under idle_ttl: cancel pending, keep
-        // the session itself for potential reuse on reattach.
-        reg.tick(Duration::from_millis(0), Duration::from_secs(3600));
+        session.drop_attachment(session.attachment_generation());
+
+        reg.tick(Duration::from_millis(0));
         assert!(reg.get("node-abc", "pi").is_some());
-        match rx.blocking_recv() {
-            Ok(Err(ServerRequestError::ConnectionClosed)) => {}
-            other => panic!("expected ConnectionClosed, got {other:?}"),
-        }
+        assert!(session.has_outstanding_requests());
+        // The waiting handler is still waiting — nothing cancelled it.
+        assert!(matches!(
+            rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
     }
 }

--- a/bridges/claude/crates/bridge-core/tests/session_resilience.rs
+++ b/bridges/claude/crates/bridge-core/tests/session_resilience.rs
@@ -9,7 +9,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use alleycat_bridge_core::session::{AttachKind, Session, SessionRegistry, SessionRegistryConfig};
+use alleycat_bridge_core::session::{
+    AttachKind, AttachOutcome, Session, SessionRegistry, SessionRegistryConfig,
+};
 use alleycat_bridge_core::state::ServerRequestError;
 use serde_json::{Value, json};
 use tokio::sync::oneshot;
@@ -37,7 +39,7 @@ async fn detach_then_reattach_replays_missed_frames() {
     assert_eq!(f1.payload["method"], "turn/started");
 
     // Client disconnects.
-    session.drop_attachment();
+    session.drop_attachment(session.attachment_generation());
     drop(a);
 
     // Producer keeps running while detached.
@@ -66,7 +68,7 @@ async fn fresh_attach_after_drop_when_resume_cursor_omitted() {
     let session = Arc::new(Session::new("pi", "node-A".into(), 64, 1 << 20));
     session.enqueue(notif("event-1"));
     let _a = session.install_attachment(None);
-    session.drop_attachment();
+    session.drop_attachment(session.attachment_generation());
 
     // Reattach without resume cursor — caller treats it as a fresh client,
     // backlog is empty even though the ring still has the frame.
@@ -82,7 +84,7 @@ async fn drift_when_cursor_predates_ring_floor() {
     session.enqueue(notif("a"));
     session.enqueue(notif("b"));
     session.enqueue(notif("c"));
-    session.drop_attachment();
+    session.drop_attachment(session.attachment_generation());
 
     let b = session.install_attachment(Some(0));
     assert!(matches!(
@@ -117,7 +119,7 @@ async fn outstanding_server_request_redelivered_on_reattach() {
     session.enqueue(notif("turn/progress"));
 
     // Client disconnects mid-prompt, before answering.
-    session.drop_attachment();
+    session.drop_attachment(session.attachment_generation());
 
     // Reattach within the grace window. After backlog replay, the drainer
     // emits a `serverRequest/replay` notification listing the still-
@@ -144,34 +146,67 @@ async fn outstanding_server_request_redelivered_on_reattach() {
 }
 
 #[tokio::test]
-async fn pending_grace_expiry_cancels_outstanding_requests() {
+async fn detached_session_awaiting_approval_is_never_reaped() {
+    // The turn asked the user something and the phone went away. That is a
+    // resting state, not a failure: the prompt waits, and the session that
+    // owns it must still be there whenever they come back — however long
+    // that takes.
     let cfg = SessionRegistryConfig {
         ring_max_msgs: 64,
         ring_max_bytes: 1 << 20,
-        idle_ttl: Duration::from_secs(3600),
-        pending_grace: Duration::from_millis(0),
+        idle_ttl: Duration::from_millis(0),
+        ..Default::default()
     };
     let registry = SessionRegistry::new(cfg.clone());
     let session = registry.get_or_create("node-A".into(), "pi");
 
     let _a = session.install_attachment(None);
-    let (tx, rx) = oneshot::channel::<Result<Value, ServerRequestError>>();
+    let (tx, mut rx) = oneshot::channel::<Result<Value, ServerRequestError>>();
     let req_id = session.next_request_id();
     session.register_pending(req_id, "command/approve".into(), json!({}), tx);
-    session.drop_attachment();
+    session.drop_attachment(session.attachment_generation());
 
-    // Manual reaper tick: pending_grace=0 so we cancel immediately;
-    // idle_ttl is large so the session itself sticks around.
-    registry.tick(cfg.pending_grace, cfg.idle_ttl);
+    // Well past idle_ttl, but the session is busy, so nothing happens to it.
+    registry.tick(cfg.idle_ttl);
 
-    // Reaper cancelled the pending oneshot — the original handler that was
-    // awaiting the response receives ConnectionClosed.
-    match rx.await {
-        Ok(Err(ServerRequestError::ConnectionClosed)) => {}
-        other => panic!("expected ConnectionClosed, got {other:?}"),
-    }
-    // Session itself survives — a fresh attach lands as Resumed.
     assert!(registry.get("node-A", "pi").is_some());
+    assert!(session.has_outstanding_requests());
+    // The handler awaiting the decision was left alone.
+    assert!(matches!(
+        rx.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+}
+
+#[tokio::test]
+async fn detached_session_running_a_turn_is_never_reaped() {
+    // Closing the app mid-task must not stop the task. The session lives as
+    // long as the turn does, and only becomes reapable once the turn ends.
+    let cfg = SessionRegistryConfig {
+        idle_ttl: Duration::from_millis(0),
+        ..Default::default()
+    };
+    let registry = SessionRegistry::new(cfg.clone());
+    let session = registry.get_or_create("node-A".into(), "pi");
+    let _a = session.install_attachment(None);
+    session.drop_attachment(session.attachment_generation());
+
+    let turn = session.begin_turn();
+    registry.tick(cfg.idle_ttl);
+    assert!(registry.get("node-A", "pi").is_some());
+
+    // Events produced while nobody was attached are still in the ring, so a
+    // client that comes back mid-turn resumes rather than starting blank.
+    session.note_drainer_attempt(session.enqueue(notif("item/started")));
+    session.enqueue(notif("item/completed"));
+    let resolved = registry.resolve_attach("node-A".into(), "pi", Some(1));
+    assert_eq!(resolved.kind, AttachKind::Resumed);
+    // That client is gone again; its claim goes with it.
+    drop(resolved);
+
+    drop(turn);
+    registry.tick(cfg.idle_ttl);
+    assert!(registry.get("node-A", "pi").is_none());
 }
 
 #[tokio::test]
@@ -218,7 +253,7 @@ async fn auto_resume_uses_server_tracked_cursor_when_no_resume_field() {
     session.note_drainer_attempt(f2.seq);
 
     // Stream dies before the drainer gets to seq 3 / 4.
-    session.drop_attachment();
+    session.drop_attachment(session.attachment_generation());
     drop(a);
     session.enqueue(notif("item/completed"));
     session.enqueue(notif("turn/completed"));
@@ -263,7 +298,7 @@ async fn auto_resume_picks_drift_when_buffer_overflowed() {
     let _a = session.install_attachment(None);
     session.note_drainer_attempt(session.enqueue(notif("a")));
     session.note_drainer_attempt(session.enqueue(notif("b")));
-    session.drop_attachment();
+    session.drop_attachment(session.attachment_generation());
     // After detach, the gap continues to fill — pushes seqs that evict
     // the previously-attempted ones from the ring.
     session.enqueue(notif("c"));
@@ -308,4 +343,220 @@ async fn second_attach_preempts_first() {
     // Second sees the new frame.
     let frame = second.live_rx.recv().await.unwrap();
     assert_eq!(frame.payload["method"], "post-preempt");
+}
+
+#[tokio::test]
+async fn busy_session_nobody_can_reach_is_eventually_reclaimed() {
+    // Waiting forever is right for a user who will come back. It is not right
+    // for a session that has become unreachable — the client reinstalled, or
+    // lost the key that names it — because that one pins its ring and its
+    // agent process for the life of the daemon.
+    let registry = SessionRegistry::new(SessionRegistryConfig::default());
+    let weak = {
+        let session = registry.get_or_create("node-gone".into(), "pi");
+        let handle = session.install_attachment(None);
+        let (tx, mut rx) = oneshot::channel::<Result<Value, ServerRequestError>>();
+        let req_id = session.next_request_id();
+        session.register_pending(req_id, "command/approve".into(), json!({}), tx);
+        let turn = session.begin_turn();
+        session.drop_attachment(handle.generation);
+
+        // Under the backstop, a waiting approval keeps it indefinitely.
+        registry.tick_with(Duration::from_millis(0), Duration::from_secs(24 * 60 * 60));
+        assert!(registry.get("node-gone", "pi").is_some());
+        assert!(matches!(
+            rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        // Past it, the abandoned session is reclaimed even though it reads
+        // busy. Dropping the registry's Arc frees nothing on its own — the
+        // waiting handler still holds the session — so the reclaim has to
+        // actually unwind what is attached to it.
+        registry.tick_with(Duration::from_millis(0), Duration::from_millis(0));
+        assert!(registry.get("node-gone", "pi").is_none());
+
+        // The handler awaiting the approval is released, not left hanging.
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Err(ServerRequestError::ConnectionClosed))
+        ));
+        assert!(!session.has_outstanding_requests());
+        // And a turn still running is told to wind down.
+        assert!(session.is_cancelled());
+        session.cancelled().await;
+
+        drop(turn);
+        Arc::downgrade(&session)
+    };
+
+    // Nothing is holding the session any more: it is genuinely reclaimed, not
+    // merely unreachable.
+    assert!(
+        weak.upgrade().is_none(),
+        "被回收的会话仍被持有，ring 和进程槽位不会释放"
+    );
+}
+
+#[tokio::test]
+async fn reaper_cannot_drop_a_session_being_picked_up() {
+    // The reaper fires in the gap between a client claiming the session and
+    // installing its attachment — the ack is still going out, so the session
+    // reads as detached and idle. Dropping it there leaves the connection
+    // serving from an Arc that is no longer registered, and the next
+    // reconnect mints a blank session instead of resuming.
+    let cfg = SessionRegistryConfig {
+        idle_ttl: Duration::from_millis(0),
+        ..Default::default()
+    };
+    let registry = SessionRegistry::new(cfg.clone());
+    let seeded = registry.get_or_create("node-A".into(), "pi");
+    let first = seeded.install_attachment(None);
+    seeded.note_drainer_attempt(seeded.enqueue(notif("turn/started")));
+    seeded.drop_attachment(first.generation);
+
+    // Claimed but not yet attached — exactly the ack window.
+    let resolved = registry.resolve_attach("node-A".into(), "pi", Some(0));
+    assert_eq!(resolved.kind, AttachKind::Resumed);
+    registry.tick(cfg.idle_ttl);
+
+    let still_there = registry
+        .get("node-A", "pi")
+        .expect("正在被接管的会话不能被回收");
+    assert!(
+        Arc::ptr_eq(&still_there, &resolved.session),
+        "注册表里必须还是同一个会话，否则重连拿到的是空白会话"
+    );
+
+    // Once the connection is done, it becomes reapable again.
+    drop(resolved);
+    registry.tick(cfg.idle_ttl);
+    assert!(registry.get("node-A", "pi").is_none());
+}
+
+#[tokio::test]
+async fn approval_publishing_cannot_interleave_with_a_reattach() {
+    // Registering the request and putting it on the wire must look atomic to
+    // a reattach. Landing between them, the client would get the replay
+    // snapshot (already outstanding) and then the live original (enqueued
+    // after) — the same prompt twice, the second by the ordinary request
+    // path a client may answer on its own.
+    let session = Arc::new(Session::new("pi", "node-A".into(), 64, 1 << 20));
+    let first = session.install_attachment(None);
+    session.note_drainer_attempt(session.enqueue(notif("turn/started")));
+    session.drop_attachment(first.generation);
+
+    let req_id = session.next_request_id();
+    let (tx, _rx) = oneshot::channel::<Result<Value, ServerRequestError>>();
+    session.publish_server_request(
+        req_id.clone(),
+        "item/commandExecution/requestApproval".into(),
+        json!({"command": "cargo install"}),
+        tx,
+        json!({
+            "jsonrpc": "2.0",
+            "id": req_id.clone(),
+            "method": "item/commandExecution/requestApproval",
+            "params": {"command": "cargo install"},
+        }),
+    );
+
+    let handle = session.install_attachment(Some(1));
+    let from_backlog = handle
+        .backlog
+        .iter()
+        .filter(|frame| frame.payload.get("id").and_then(Value::as_str) == Some(req_id.as_str()))
+        .count();
+    assert_eq!(from_backlog, 0, "审批不应同时从 backlog 再来一份");
+    let replay = handle.replay_redelivery.expect("审批应通过 replay 恢复");
+    assert_eq!(replay["params"]["outstanding"][0]["id"], json!(req_id));
+}
+
+#[tokio::test]
+async fn approval_raised_while_detached_is_restored_exactly_once() {
+    // The turn asked for approval after the phone dropped off. The prompt is
+    // now in two places — the ring, because it was enqueued like any frame,
+    // and the outstanding table. The reattaching client must see it once: a
+    // second copy arrives as an ordinary server request, and a client that
+    // has not rehydrated yet may answer it upstream on its own, leaving the
+    // replay card pointing at a request that is already resolved.
+    let session = Arc::new(Session::new("pi", "node-A".into(), 64, 1 << 20));
+    let first = session.install_attachment(None);
+    session.note_drainer_attempt(session.enqueue(notif("turn/started")));
+    session.drop_attachment(first.generation);
+
+    // Disconnected: the turn runs on and raises an approval.
+    session.enqueue(notif("item/started"));
+    let (tx, _rx) = oneshot::channel::<Result<Value, ServerRequestError>>();
+    let req_id = session.next_request_id();
+    let approval = json!({
+        "jsonrpc": "2.0",
+        "id": req_id.clone(),
+        "method": "item/commandExecution/requestApproval",
+        "params": {"threadId": "thr_1", "command": "cargo install"},
+    });
+    session.register_pending(
+        req_id.clone(),
+        "item/commandExecution/requestApproval".into(),
+        json!({"threadId": "thr_1", "command": "cargo install"}),
+        tx,
+    );
+    session.enqueue(approval);
+
+    let handle = session.install_attachment(Some(1));
+    assert_eq!(handle.outcome, AttachOutcome::Resumed);
+
+    let replayed_requests = handle
+        .backlog
+        .iter()
+        .filter(|frame| frame.payload.get("id").and_then(Value::as_str) == Some(req_id.as_str()))
+        .count();
+    assert_eq!(
+        replayed_requests, 0,
+        "未应答的审批不应再从 backlog 走一遍：{:?}",
+        handle.backlog
+    );
+    // 其余事件照常补播。
+    assert!(
+        handle
+            .backlog
+            .iter()
+            .any(|frame| frame.payload["method"] == "item/started"),
+        "普通事件仍须补播：{:?}",
+        handle.backlog
+    );
+
+    let replay = handle
+        .replay_redelivery
+        .expect("待应答审批应通过 replay 恢复");
+    let entries = replay["params"]["outstanding"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["id"], json!(req_id));
+    assert_eq!(
+        entries[0]["method"],
+        "item/commandExecution/requestApproval"
+    );
+}
+
+#[tokio::test]
+async fn preempted_connection_cannot_detach_its_successor() {
+    // The phone reconnects over a dead-but-not-yet-noticed socket. When the
+    // old reader finally unblocks and tears itself down, it must not take the
+    // new client's stream with it — nor mark the session detached, which
+    // would offer a session someone is actively using to the reaper.
+    let session = Arc::new(Session::new("pi", "node-A".into(), 64, 1 << 20));
+    let stale = session.install_attachment(None);
+    let mut live = session.install_attachment(None);
+
+    assert!(!session.drop_attachment(stale.generation));
+    assert!(session.is_attached());
+    assert!(!session.detached_for(Duration::from_millis(0)));
+
+    session.enqueue(notif("still-flowing"));
+    let frame = live.live_rx.recv().await.unwrap();
+    assert_eq!(frame.payload["method"], "still-flowing");
+
+    // The current owner still detaches normally.
+    assert!(session.drop_attachment(live.generation));
+    assert!(!session.is_attached());
 }

--- a/bridges/claude/crates/claude-bridge/src/approval.rs
+++ b/bridges/claude/crates/claude-bridge/src/approval.rs
@@ -457,24 +457,24 @@ async fn send_server_request(
     // set deterministically across iroh disconnects.
     let req_id_str = state.session().next_request_id();
     let req_id = RequestId::String(req_id_str);
+    let frame = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: JsonRpcVersion,
+        id: req_id.clone(),
+        method: method.to_string(),
+        params: Some(params.clone()),
+    });
+    // Becoming outstanding and reaching the wire must be one step: a reattach
+    // landing between them would show the client both the replay snapshot and
+    // the live request.
     let rx = state
-        .register_pending_request(req_id.clone(), method.to_string(), params.clone())
-        .await;
+        .publish_server_request(req_id.clone(), method.to_string(), params, frame)
+        .await
+        .map_err(|_| ApprovalError::ConnectionClosed)?;
     let mut guard = PendingRequestGuard {
         state: Arc::clone(state),
         request_id: req_id.clone(),
         armed: true,
     };
-
-    let frame = JsonRpcMessage::Request(JsonRpcRequest {
-        jsonrpc: JsonRpcVersion,
-        id: req_id.clone(),
-        method: method.to_string(),
-        params: Some(params),
-    });
-    state
-        .send(frame)
-        .map_err(|_| ApprovalError::ConnectionClosed)?;
 
     let result = if let Some(deadline) = timeout {
         match tokio::time::timeout(deadline, rx).await {

--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -32,6 +32,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+use alleycat_bridge_core::session::TurnGuard;
 use alleycat_codex_proto as p;
 
 use crate::approval;
@@ -274,6 +275,12 @@ pub async fn handle_turn_start(
     // Subscribe BEFORE writing the prompt so the first event isn't lost.
     let events_rx = handle.subscribe_events();
 
+    // Claim the session before the prompt reaches claude: from here on there
+    // is work in flight, and it has to outlive whatever the client's network
+    // — or the user's decision to close the app — does next. Dropped on the
+    // error path below; otherwise handed to the pump.
+    let turn_guard = state.session().begin_turn();
+
     if let Err(e) = handle.send_serialized(&envelope) {
         clear_active_turn(&params.thread_id);
         state.claude_pool().mark_idle(&params.thread_id).await;
@@ -287,14 +294,17 @@ pub async fn handle_turn_start(
     // uses the first user message's first line as the preview.
     maybe_backfill_preview(state, &params.thread_id, &params.input).await;
 
-    spawn_event_pump(EventPumpArgs {
-        state: Arc::clone(state),
-        thread_id: params.thread_id.clone(),
-        turn_id: turn_id.clone(),
-        handle: Arc::clone(&handle),
-        events_rx,
-        started_at,
-    });
+    spawn_event_pump(
+        EventPumpArgs {
+            state: Arc::clone(state),
+            thread_id: params.thread_id.clone(),
+            turn_id: turn_id.clone(),
+            handle: Arc::clone(&handle),
+            events_rx,
+            started_at,
+        },
+        turn_guard,
+    );
 
     Ok(p::TurnStartResponse { turn })
 }
@@ -496,9 +506,14 @@ struct EventPumpArgs {
     started_at: i64,
 }
 
-fn spawn_event_pump(args: EventPumpArgs) {
+fn spawn_event_pump(args: EventPumpArgs, turn_guard: TurnGuard) {
     tokio::spawn(async move {
         run_event_pump(args).await;
+        // Released only here. For as long as the pump runs, the session is
+        // busy and the reaper leaves it alone — the client closing the app
+        // mid-turn is not a reason to stop the work or throw away the events
+        // it is still producing.
+        drop(turn_guard);
     });
 }
 
@@ -510,8 +525,24 @@ async fn run_event_pump(mut args: EventPumpArgs) {
     let interaction_gate = Arc::new(AsyncMutex::new(()));
     let mut interaction_tasks = Vec::new();
 
+    // Set when the session was reclaimed out from under this turn: nobody can
+    // reach it any more, so there is no point producing events for it.
+    let mut abandoned = false;
+
     loop {
-        let event = match args.events_rx.recv().await {
+        let received = tokio::select! {
+            biased;
+            // A reclaimed session means the client is gone for good — not
+            // merely disconnected, which the whole design exists to survive.
+            // Stop rather than keep driving claude for a stream no one can
+            // ever read.
+            _ = args.state.session().cancelled() => {
+                abandoned = true;
+                break;
+            }
+            received = args.events_rx.recv() => received,
+        };
+        let event = match received {
             Ok(ev) => ev,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(
@@ -659,7 +690,20 @@ async fn run_event_pump(mut args: EventPumpArgs) {
         .record_turn_completed(&args.thread_id, &args.turn_id, completed_at, status, error);
 
     clear_active_turn(&args.thread_id);
-    args.state.claude_pool().mark_idle(&args.thread_id).await;
+    if abandoned {
+        // Nobody will ever resume this thread through this session, so don't
+        // leave its claude process parked in the pool waiting for the idle
+        // sweep — release it now and free the slot. The transcript is on disk
+        // either way, so a later `--resume` still works.
+        tracing::info!(
+            thread_id = %args.thread_id,
+            turn_id = %args.turn_id,
+            "session reclaimed while a turn was running; releasing claude process"
+        );
+        args.state.claude_pool().release(&args.thread_id).await;
+    } else {
+        args.state.claude_pool().mark_idle(&args.thread_id).await;
+    }
 }
 
 /// Map a `ServerNotification` to its `method` string and consult the

--- a/bridges/claude/crates/claude-bridge/src/state.rs
+++ b/bridges/claude/crates/claude-bridge/src/state.rs
@@ -259,6 +259,35 @@ impl ConnectionState {
         }
     }
 
+    /// Register a server→client request and put its frame on the wire in one
+    /// step. See [`Session::publish_server_request`]: registering first and
+    /// sending after leaves a window where a reattach delivers the prompt
+    /// twice.
+    pub async fn publish_server_request(
+        &self,
+        request_id: RequestId,
+        method: String,
+        params: Value,
+        frame: JsonRpcMessage,
+    ) -> Result<oneshot::Receiver<Result<Value, ServerRequestError>>, SendError> {
+        let payload = serde_json::to_value(&frame).map_err(|_| SendError::ConnectionClosed)?;
+        let (tx, rx) = oneshot::channel();
+        let key = request_id.to_string();
+        let (core_tx, core_rx) =
+            oneshot::channel::<Result<Value, alleycat_bridge_core::state::ServerRequestError>>();
+        self.session
+            .publish_server_request(key, method, params, core_tx, payload);
+        tokio::spawn(async move {
+            let mapped = match core_rx.await {
+                Ok(Ok(v)) => Ok(v),
+                Ok(Err(e)) => Err(e.into()),
+                Err(_) => Err(ServerRequestError::ConnectionClosed),
+            };
+            let _ = tx.send(mapped);
+        });
+        Ok(rx)
+    }
+
     pub async fn register_pending_request(
         &self,
         request_id: RequestId,

--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -921,9 +921,10 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 		OutputBuffer: cfg.Session.OutputBufferBytes,
 	})
 
+	apiHandler, apiRouter := httpapi.NewRouterWithRuntime(cfg, registry, manager, checker, version, nil)
 	server := &http.Server{
 		Addr:              cfg.Listen,
-		Handler:           httpapi.NewRouterWithRuntime(cfg, registry, manager, checker, version, nil),
+		Handler:           apiHandler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -935,7 +936,7 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 			for _, opened := range listeners {
 				_ = opened.Close()
 			}
-			_ = shutdownServeResources(manager, appServerWSProcess)
+			_ = shutdownServeResources(manager, appServerWSProcess, apiRouter)
 			return fmt.Errorf("监听 %s 失败：%w", address, err)
 		}
 		listeners = append(listeners, listener)
@@ -964,7 +965,7 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 	defer signal.Stop(stopCh)
 	return waitForServeExit(stopCh, errCh, func() error {
 		return shutdownServe(server, serveHTTPDrainTimeout, func() error {
-			return shutdownServeResources(manager, appServerWSProcess)
+			return shutdownServeResources(manager, appServerWSProcess, apiRouter)
 		})
 	})
 }
@@ -1056,11 +1057,14 @@ func managedAppServerExitedError(process *appserver.ManagedWebSocketProcess) err
 	return fmt.Errorf("%s", message)
 }
 
-func shutdownServeResources(manager *session.Manager, appServerWSProcess *appserver.ManagedWebSocketProcess) error {
+func shutdownServeResources(manager *session.Manager, appServerWSProcess *appserver.ManagedWebSocketProcess, apiRouter *httpapi.Router) error {
 	// listener 绑定失败，或 HTTP 已完成 drain 后，都必须回收运行时资源，避免会话/托管子进程成为孤儿。
 	if manager != nil {
 		manager.Shutdown()
 	}
+	// 常驻 Claude bridge 独立进程组，不会随 agentd 退出而结束；它还会再拉起 Claude Code
+	// 子进程，漏掉这一步就会在每次重启后留下一整棵仍在跑的孤儿进程树。
+	apiRouter.Shutdown()
 	if appServerWSProcess != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), serveRuntimeShutdownTimeout)
 		err := appServerWSProcess.Shutdown(ctx)

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -1286,6 +1286,46 @@ func TestAppServerGatewayRejectsInvalidThreadNameAndReviewParams(t *testing.T) {
 	assertNoUpstreamFrame(t, received)
 }
 
+// The pending table is per-connection but the prompts it guards are not: a
+// resident bridge keeps an approval open across a disconnect and lists it in
+// serverRequest/replay on attach. Those ids have to be registered from the
+// notification, or the user's answer comes back and gets rejected as never
+// having been issued — a prompt that reappears and then cannot be answered.
+func TestAppServerGatewayRegistersReplayedServerRequests(t *testing.T) {
+	policy := &appServerGatewayPolicy{
+		runtimeID:             "claude",
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	replay := []byte(`{"jsonrpc":"2.0","method":"serverRequest/replay","params":{"outstanding":[` +
+		`{"id":"req-abc","method":"item/commandExecution/requestApproval","params":{"threadId":"thr_1"}},` +
+		`{"id":7,"method":"item/tool/requestUserInput","params":{"threadId":"thr_1"}},` +
+		`{"id":"req-nope","method":"account/chatgptAuthTokens/refresh","params":{}}]}}`)
+	got, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, replay)
+	if policyErr != nil || !forward || !bytes.Equal(got, replay) {
+		t.Fatalf("replay 通知应原样转发 forward=%v err=%+v got=%s", forward, policyErr, got)
+	}
+
+	for _, expected := range []struct {
+		rawID  string
+		method string
+	}{
+		{`"req-abc"`, "item/commandExecution/requestApproval"},
+		{`7`, "item/tool/requestUserInput"},
+	} {
+		rawID := json.RawMessage(expected.rawID)
+		frame := &appServerGatewayFrame{ID: &rawID, Result: json.RawMessage(`{"decision":"approve"}`)}
+		if _, err := policy.validateClientResponse([]byte(`{"id":`+expected.rawID+`,"result":{"decision":"approve"}}`), frame); err != nil {
+			t.Fatalf("重放的 server request 应可被回答 id=%s err=%v", expected.rawID, err)
+		}
+	}
+
+	// 移动端渲染不了的方法不登记：它永远不会被回答，登记只会占着 pending 表。
+	unsupported := json.RawMessage(`"req-nope"`)
+	if _, ok := policy.consumePendingServerRequest(&unsupported); ok {
+		t.Fatal("未被移动端支持的重放请求不应登记 pending")
+	}
+}
+
 func TestAppServerGatewayServerRequestAllowlistMatchesMobileCapabilities(t *testing.T) {
 	policy := &appServerGatewayPolicy{
 		runtimeID:             "codex",

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -11,9 +11,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -386,7 +388,89 @@ while IFS= read -r line; do sleep 10; done
 	}
 }
 
-func TestClaudeGatewayDisconnectTerminatesBridgeProcessGroup(t *testing.T) {
+// The bridge is resident: a client dropping its WebSocket must not take the
+// process down, because the turn it started is still running inside it.
+func TestClaudeGatewayDisconnectLeavesBridgeRunning(t *testing.T) {
+	dir := t.TempDir()
+	startsPath := filepath.Join(dir, "starts")
+	bridge := writeTestBridge(t, fmt.Sprintf(`#!/bin/sh
+printf 'x' >> %q
+while IFS= read -r line; do :; done
+`, startsPath))
+	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridge
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	t.Cleanup(router.claudeBridge.shutdown)
+
+	conn := dialAuthedGatewayRuntime(t, server.URL, "claude")
+	readTestFileEventually(t, startsPath)
+	bridgePID := claudeBridgePID(t, router)
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give a would-be teardown time to land, then confirm the process is still
+	// there and a second client reuses it rather than spawning a replacement.
+	time.Sleep(300 * time.Millisecond)
+	if err := syscall.Kill(bridgePID, 0); err != nil {
+		t.Fatalf("断开 WS 后 Claude bridge 不应退出：pid=%d err=%v", bridgePID, err)
+	}
+	second := dialAuthedGatewayRuntime(t, server.URL, "claude")
+	defer second.Close()
+	if got := claudeBridgePID(t, router); got != bridgePID {
+		t.Fatalf("重连应复用常驻 bridge：first=%d second=%d", bridgePID, got)
+	}
+}
+
+// Shutting the supervisor down is what reaps the bridge, and it must take the
+// whole process group so Claude Code children do not outlive agentd.
+// A bridge that starts but never binds its socket must fail the start and
+// leave the supervisor usable. ensure() holds the supervisor lock across
+// start(), so anything in there that waits on the reaper — which takes the
+// same lock — wedges every later connection, not just this one.
+func TestClaudeBridgeStartTimeoutDoesNotWedgeSupervisor(t *testing.T) {
+	previous := claudeBridgeStartTimeout
+	claudeBridgeStartTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { claudeBridgeStartTimeout = previous })
+
+	// Ignores --socket entirely: alive, but nothing ever listens.
+	silent := writeTestBridge(t, "#!/bin/sh\nsleep 30\n")
+	supervisor := newClaudeBridgeSupervisor()
+	t.Cleanup(supervisor.shutdown)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := supervisor.ensure(silent, nil, nil)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("bridge 从未监听 socket，ensure 应当失败")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ensure 在启动超时后卡死，supervisor 锁没有释放")
+	}
+
+	// The supervisor must still be able to take another attempt.
+	second := make(chan error, 1)
+	go func() {
+		_, err := supervisor.ensure(silent, nil, nil)
+		second <- err
+	}()
+	select {
+	case <-second:
+	case <-time.After(10 * time.Second):
+		t.Fatal("首次启动失败后 supervisor 不再接受新的启动请求")
+	}
+}
+
+func TestClaudeBridgeShutdownTerminatesProcessGroup(t *testing.T) {
 	childPIDPath := filepath.Join(t.TempDir(), "child.pid")
 	bridge := writeTestBridge(t, fmt.Sprintf(`#!/bin/sh
 sleep 30 &
@@ -394,7 +478,7 @@ echo $! > %q
 while IFS= read -r line; do sleep 30; done
 `, childPIDPath))
 	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
-	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, func(cfg *config.Config) {
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, func(cfg *config.Config) {
 		cfg.Claude.Enabled = true
 		cfg.Claude.BridgeBin = bridge
 		cfg.Claude.MaxConcurrentBridges = 3
@@ -403,12 +487,223 @@ while IFS= read -r line; do sleep 30; done
 	defer server.Close()
 
 	conn := dialAuthedGatewayRuntime(t, server.URL, "claude")
+	defer conn.Close()
 	childPID := parseTestPID(t, string(readTestFileEventually(t, childPIDPath)))
 	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
-	if err := conn.Close(); err != nil {
+
+	router.claudeBridge.shutdown()
+	waitForProcessExit(t, childPID)
+}
+
+func claudeBridgePID(t *testing.T, router *Router) int {
+	t.Helper()
+	router.claudeBridge.mu.Lock()
+	defer router.claudeBridge.mu.Unlock()
+	if router.claudeBridge.cmd == nil || router.claudeBridge.cmd.Process == nil {
+		t.Fatal("Claude bridge 未运行")
+	}
+	return router.claudeBridge.cmd.Process.Pid
+}
+
+// A client that names its session gets bound to a bridge session that survives
+// the WebSocket, and a reconnect asks to resume from the last sequence number
+// agentd actually relayed.
+func TestClaudeGatewayAttachesNamedSessionAndResumesFromCursor(t *testing.T) {
+	attachPath := filepath.Join(t.TempDir(), "attach.jsonl")
+	bridge := writeTestBridge(t, fmt.Sprintf(`#!/bin/sh
+IFS= read -r line
+printf '%%s\n' "$line" >> %q
+printf '{"jsonrpc":"2.0","method":"_alleycat/attached","params":{"sessionKey":"dev-1","kind":"fresh","currentSeq":0,"floorSeq":0}}\n'
+printf '{"jsonrpc":"2.0","id":42,"result":{"ok":true},"_alleycat_seq":7}\n'
+while IFS= read -r line; do :; done
+`, attachPath))
+	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
+	handler, _ := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridge
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	conn := dialAuthedGatewaySession(t, server.URL, "claude", "dev-1")
+	first := readTestFileLineEventually(t, attachPath, `_alleycat/attach`)
+	if !bytes.Contains(first, []byte(`"sessionKey":"dev-1"`)) {
+		t.Fatalf("首次 attach 应带上客户端会话名：%s", first)
+	}
+	if bytes.Contains(first, []byte("lastSeen")) {
+		t.Fatalf("尚无已投递序号时不应发送 lastSeen：%s", first)
+	}
+	// Wait until the seq-stamped frame has been relayed, so the cursor is set.
+	if raw := readGatewayRaw(t, conn); bytes.Contains(raw, []byte("_alleycat/attached")) {
+		t.Fatalf("attach 应答属于传输层，不应转发给客户端：%s", raw)
+	}
+	_ = conn.Close()
+
+	second := dialAuthedGatewaySession(t, server.URL, "claude", "dev-1")
+	defer second.Close()
+	resumed := readTestFileLineEventually(t, attachPath, "lastSeen")
+	if !bytes.Contains(resumed, []byte(`"lastSeen":7`)) {
+		t.Fatalf("重连应从最后转发的序号续传：%s", resumed)
+	}
+}
+
+// Without a session name nothing is claimed, so the bridge keeps giving the
+// connection an isolated session.
+func TestClaudeGatewayOmitsAttachWithoutSessionName(t *testing.T) {
+	receivedPath := filepath.Join(t.TempDir(), "received.jsonl")
+	bridge := writeTestBridge(t, fmt.Sprintf(`#!/bin/sh
+while IFS= read -r line; do
+  printf '%%s\n' "$line" >> %q
+done
+`, receivedPath))
+	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
+	handler, _ := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridge
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	conn := dialAuthedGatewayRuntime(t, server.URL, "claude")
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"id":5,"method":"model/list","params":{}}`)); err != nil {
 		t.Fatal(err)
 	}
-	waitForProcessExit(t, childPID)
+	received := readTestFileLineEventually(t, receivedPath, "model/list")
+	if bytes.Contains(received, []byte("_alleycat/attach")) {
+		t.Fatalf("未命名会话不应发送 attach 前导帧：%s", received)
+	}
+}
+
+// A cursor only means something inside the sequence it came from. If the
+// bridge answers with anything but "resumed" it is counting from scratch, and
+// holding on to the old number is worse than having none: the replay ring
+// answers a cursor above its current sequence with an empty slice and no
+// error, so the next attach would look successful while skipping everything.
+func TestClaudeGatewayDropsCursorWhenBridgeRenumbers(t *testing.T) {
+	dir := t.TempDir()
+	attachPath := filepath.Join(dir, "attach.jsonl")
+	markPath := filepath.Join(dir, "emitted")
+	bridge := writeTestBridge(t, fmt.Sprintf(`#!/bin/sh
+IFS= read -r line
+printf '%%s\n' "$line" >> %q
+printf '{"jsonrpc":"2.0","method":"_alleycat/attached","params":{"sessionKey":"dev-2","kind":"fresh","currentSeq":0,"floorSeq":0}}\n'
+if [ ! -f %q ]; then
+  : > %q
+  printf '{"jsonrpc":"2.0","id":9,"result":{"ok":true},"_alleycat_seq":7}\n'
+fi
+while IFS= read -r line; do :; done
+`, attachPath, markPath, markPath))
+	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridge
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// First connection banks a cursor at seq 7.
+	conn := dialAuthedGatewaySession(t, server.URL, "claude", "dev-2")
+	readGatewayRaw(t, conn)
+	_ = conn.Close()
+
+	// Second connection proves the cursor was live, and is told the session
+	// was minted fresh — so the cursor must not survive it.
+	second := dialAuthedGatewaySession(t, server.URL, "claude", "dev-2")
+	defer second.Close()
+	resumed := readTestFileLineEventually(t, attachPath, "lastSeen")
+	if !bytes.Contains(resumed, []byte(`"lastSeen":7`)) {
+		t.Fatalf("第二次 attach 应带上已投递的序号：%s", resumed)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, ok := router.claudeBridge.resumeCursor("dev-2"); !ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("attach 应答为 fresh 后应丢弃过期游标")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// The iPad app already names its connection with `thread_id`. Resume has to
+// work off that, or the whole resident-bridge path stays dead for the only
+// client we ship.
+func TestClaudeGatewayAttachesUsingThreadIDWhenUnnamed(t *testing.T) {
+	attachPath := filepath.Join(t.TempDir(), "attach.jsonl")
+	bridge := writeTestBridge(t, fmt.Sprintf(`#!/bin/sh
+IFS= read -r line
+printf '%%s\n' "$line" >> %q
+printf '{"jsonrpc":"2.0","method":"_alleycat/attached","params":{"sessionKey":"thr_abc","kind":"fresh","currentSeq":0,"floorSeq":0}}\n'
+while IFS= read -r line; do :; done
+`, attachPath))
+	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
+	handler, _ := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridge
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	target := wsURL(server.URL, appServerGatewayPath) + "?runtime=claude&thread_id=thr_abc"
+	conn, _, err := websocket.DefaultDialer.Dial(target, http.Header{
+		"Authorization": []string{"Bearer " + testToken},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	first := readTestFileLineEventually(t, attachPath, `_alleycat/attach`)
+	if !bytes.Contains(first, []byte(`"sessionKey":"thr_abc"`)) {
+		t.Fatalf("未带 session 时应回退用 thread_id 作为会话名：%s", first)
+	}
+}
+
+func TestClaudeGatewaySessionKeySelection(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{"显式 session 优先于 thread_id", "session=dev-1&thread_id=thr_abc", "dev-1"},
+		{"缺 session 时回退 thread_id", "thread_id=thr_abc", "thr_abc"},
+		{"空 session 视作未指定", "session=&thread_id=thr_abc", "thr_abc"},
+		// 显式指定就以它为准：非法的 session 不静默改用另一个会话名，
+		// 否则客户端会以为自己续上了实际没续上的会话。
+		{"非法 session 不回退", "session=bad/name&thread_id=thr_abc", ""},
+		{"非法 thread_id 退化为匿名", "thread_id=bad:name", ""},
+		{"超长键退化为匿名", "thread_id=" + strings.Repeat("a", 129), ""},
+		{"两者都无", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/app-server/ws?"+tc.query, nil)
+			if got := claudeGatewaySessionKey(req); got != tc.want {
+				t.Fatalf("claudeGatewaySessionKey(%q) = %q，期望 %q", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func dialAuthedGatewaySession(t *testing.T, serverURL string, runtimeID string, sessionKey string) *websocket.Conn {
+	t.Helper()
+	target := wsURL(serverURL, appServerGatewayPath) +
+		"?runtime=" + url.QueryEscape(runtimeID) +
+		"&session=" + url.QueryEscape(sessionKey)
+	conn, _, err := websocket.DefaultDialer.Dial(target, http.Header{
+		"Authorization": []string{"Bearer " + testToken},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
 }
 
 func TestClaudeGatewayRejectsUnsupportedMethod(t *testing.T) {
@@ -2112,6 +2407,20 @@ func appServerGatewayRouterFixtureWithTokenFile(t *testing.T, upstreamURL string
 
 func appServerGatewayRouterFixtureWithConfig(t *testing.T, upstreamURL string, customize func(*config.Config)) (http.Handler, string) {
 	t.Helper()
+	handler, _, projectDir := buildAppServerGatewayFixture(t, upstreamURL, customize)
+	return handler, projectDir
+}
+
+// appServerGatewayRouterFixtureWithRouter is for tests that need to reach the
+// Router's long-lived state, such as the resident Claude bridge.
+func appServerGatewayRouterFixtureWithRouter(t *testing.T, upstreamURL string, customize func(*config.Config)) (http.Handler, *Router) {
+	t.Helper()
+	handler, router, _ := buildAppServerGatewayFixture(t, upstreamURL, customize)
+	return handler, router
+}
+
+func buildAppServerGatewayFixture(t *testing.T, upstreamURL string, customize func(*config.Config)) (http.Handler, *Router, string) {
+	t.Helper()
 	cfg, registry, manager, checker, projectDir := appServerGatewayBaseFixture(t)
 	cfg.AppServer = config.AppServerConfig{
 		Transport:   "ws",
@@ -2122,7 +2431,11 @@ func appServerGatewayRouterFixtureWithConfig(t *testing.T, upstreamURL string, c
 	if customize != nil {
 		customize(&cfg)
 	}
-	return NewRouterWithRuntime(cfg, registry, manager, checker, "test", nil), projectDir
+	handler, router := NewRouterWithRuntime(cfg, registry, manager, checker, "test", nil)
+	// Any fixture that reaches the Claude gateway starts a resident bridge;
+	// without this they leak a process per test.
+	t.Cleanup(router.claudeBridge.shutdown)
+	return handler, router, projectDir
 }
 
 func testAppServerTokenFile(t *testing.T, token string) string {
@@ -2243,22 +2556,62 @@ func dialAuthedGatewayRuntime(t *testing.T, serverURL string, runtimeID string) 
 	return conn
 }
 
+// writeTestBridge produces a stand-in for alleycat-claude-bridge. `body` is a
+// line-oriented shell script describing how the bridge answers one connection,
+// exactly as when the bridge spoke stdio; the wrapper hands it to the
+// fakebridge helper, which owns the Unix socket agentd now dials.
 func writeTestBridge(t *testing.T, body string) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "fake-claude-bridge")
+	dir := t.TempDir()
 	const shebang = "#!/bin/sh\n"
-	if strings.HasPrefix(body, shebang) {
-		body = strings.TrimPrefix(body, shebang)
+	body = shebang + strings.TrimPrefix(body, shebang)
+	bodyPath := filepath.Join(dir, "connection.sh")
+	if err := os.WriteFile(bodyPath, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	body = shebang + `if [ "${1:-}" = "--version" ]; then
+
+	path := filepath.Join(dir, "fake-claude-bridge")
+	wrapper := fmt.Sprintf(`#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
   printf 'alleycat-claude-bridge 0.2.1\n'
   exit 0
 fi
-` + body
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+exec %q -body %q "$@"
+`, fakeBridgeHelper(t), bodyPath)
+	if err := os.WriteFile(path, []byte(wrapper), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return path
+}
+
+var (
+	fakeBridgeOnce sync.Once
+	fakeBridgePath string
+	fakeBridgeErr  error
+)
+
+// fakeBridgeHelper builds the socket-serving helper once for the whole package
+// and returns its path.
+func fakeBridgeHelper(t *testing.T) string {
+	t.Helper()
+	fakeBridgeOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "fakebridge")
+		if err != nil {
+			fakeBridgeErr = err
+			return
+		}
+		out := filepath.Join(dir, "fakebridge")
+		cmd := exec.Command("go", "build", "-o", out, "./testdata/fakebridge")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			fakeBridgeErr = fmt.Errorf("building fakebridge: %v\n%s", err, output)
+			return
+		}
+		fakeBridgePath = out
+	})
+	if fakeBridgeErr != nil {
+		t.Fatal(fakeBridgeErr)
+	}
+	return fakeBridgePath
 }
 
 type gatewayErrorFrame struct {

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,6 +138,7 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 		return payload, true, nil
 	}
 	if strings.TrimSpace(frame.Method) != "" && frame.ID == nil {
+		p.rememberReplayedServerRequests(&frame)
 		if appServerRuntimeRedactsInlineImages(p.runtimeID) && appServerMediaRedactNotificationsEnabled() {
 			if redacted, changed := p.router.redactInlineHistoryImagesInGatewayResponse(payload); changed {
 				payload = redacted
@@ -383,6 +385,46 @@ func (p *appServerGatewayPolicy) prunePendingClientRequestsLocked(now time.Time)
 	for id, pending := range p.pendingClientRequests {
 		if pending.createdAt.IsZero() || now.Sub(pending.createdAt) > appServerGatewayPendingClientRequestTTL {
 			delete(p.pendingClientRequests, id)
+		}
+	}
+}
+
+// rememberReplayedServerRequests re-registers the server requests a resident
+// bridge reports as still unanswered when a connection attaches.
+//
+// The pending table is per-connection, but the requests it guards are not:
+// the bridge holds an approval prompt open across a disconnect, and announces
+// the survivors in a `serverRequest/replay` notification. That frame carries
+// no JSON-RPC id of its own, so without this the ids inside it were never
+// registered and `validateClientResponse` rejected the user's answer as "not
+// issued by app-server" — the prompt would come back after a reconnect and
+// then refuse to be answered.
+func (p *appServerGatewayPolicy) rememberReplayedServerRequests(frame *appServerGatewayFrame) {
+	if strings.TrimSpace(frame.Method) != claudeBridgeServerRequestReplayMethod || len(frame.Params) == 0 {
+		return
+	}
+	var params struct {
+		Outstanding []struct {
+			ID     *json.RawMessage `json:"id"`
+			Method string           `json:"method"`
+		} `json:"outstanding"`
+	}
+	if err := json.Unmarshal(frame.Params, &params); err != nil {
+		log.Printf("claude bridge serverRequest/replay 解析失败 err=%v", err)
+		return
+	}
+	for _, entry := range params.Outstanding {
+		if entry.ID == nil || strings.TrimSpace(entry.Method) == "" {
+			continue
+		}
+		if !appServerServerRequestAllowed(p.runtimeID, entry.Method) {
+			// The client cannot render it, so it will never answer it; leaving
+			// it unregistered keeps the pending table honest.
+			continue
+		}
+		if err := p.rememberPendingServerRequest(entry.ID, entry.Method); err != nil {
+			log.Printf("claude bridge 重放 server request 登记失败 method=%s err=%v",
+				sanitizeGatewayDiagnostic(entry.Method), err)
 		}
 	}
 }

--- a/internal/httpapi/claude_bridge_supervisor.go
+++ b/internal/httpapi/claude_bridge_supervisor.go
@@ -1,0 +1,295 @@
+package httpapi
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// claudeBridgeStartTimeout bounds how long we wait for a freshly spawned bridge
+// to bind its socket before declaring the start failed. Overridable so tests
+// can exercise the timeout path without a ten-second wait.
+var claudeBridgeStartTimeout = 10 * time.Second
+
+// macOS caps sockaddr_un.sun_path at 104 bytes. A socket we cannot bind is a
+// confusing failure deep inside the bridge, so reject the path up front.
+const claudeBridgeMaxSocketPath = 100
+
+// claudeBridgeSupervisor owns a single resident `alleycat-claude-bridge`
+// running in `--socket` mode.
+//
+// The bridge used to be spawned per WebSocket connection, which tied every
+// piece of in-flight state to the life of a phone's network link: dropping the
+// connection killed the process, and with it the running turn, the Claude
+// child processes and the replay ring that exists precisely to survive a
+// reconnect. Keeping one process behind a socket lets a connection come and go
+// while the turn keeps running.
+type claudeBridgeSupervisor struct {
+	mu         sync.Mutex
+	dir        string
+	socketPath string
+	cmd        *exec.Cmd
+	// done is closed by the reaper once the process has been waited on. It is
+	// the only exit signal anyone else waits for: cmd.Wait has exactly one
+	// consumer, so startup and shutdown cannot starve each other of it.
+	done chan struct{}
+	// exited is set by the reaper once the process is gone, so the next
+	// ensure() starts a replacement instead of dialing a dead socket.
+	exited  bool
+	stopped bool
+
+	// cursors records, per session key, the highest sequence number we
+	// finished relaying, so a reconnecting client resumes from there rather
+	// than from what the bridge merely wrote to the socket. Bounded because
+	// the keys come from clients.
+	cursorMu   sync.Mutex
+	cursors    map[string]uint64
+	cursorFIFO []string
+}
+
+// claudeBridgeMaxCursors caps the resume-cursor table. Far above the handful
+// of devices a single agentd serves; the bound only exists so client-chosen
+// keys cannot grow the map without limit.
+const claudeBridgeMaxCursors = 64
+
+func newClaudeBridgeSupervisor() *claudeBridgeSupervisor {
+	return &claudeBridgeSupervisor{cursors: map[string]uint64{}}
+}
+
+// noteDelivered advances the resume cursor for a session. Sequence numbers
+// only move forward; a replayed frame must not rewind it.
+func (s *claudeBridgeSupervisor) noteDelivered(sessionKey string, seq uint64) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	if current, ok := s.cursors[sessionKey]; ok {
+		if seq > current {
+			s.cursors[sessionKey] = seq
+		}
+		return
+	}
+	if len(s.cursorFIFO) >= claudeBridgeMaxCursors {
+		oldest := s.cursorFIFO[0]
+		s.cursorFIFO = s.cursorFIFO[1:]
+		delete(s.cursors, oldest)
+	}
+	s.cursorFIFO = append(s.cursorFIFO, sessionKey)
+	s.cursors[sessionKey] = seq
+}
+
+func (s *claudeBridgeSupervisor) resumeCursor(sessionKey string) (uint64, bool) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	seq, ok := s.cursors[sessionKey]
+	return seq, ok
+}
+
+// forgetCursor drops a cursor the bridge told us is no longer replayable, so
+// the next attach starts clean instead of asking for a sequence below the ring
+// floor again.
+func (s *claudeBridgeSupervisor) forgetCursor(sessionKey string) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	delete(s.cursors, sessionKey)
+	for i, key := range s.cursorFIFO {
+		if key == sessionKey {
+			s.cursorFIFO = append(s.cursorFIFO[:i], s.cursorFIFO[i+1:]...)
+			break
+		}
+	}
+}
+
+// ensure returns the socket path of a running bridge, starting one if needed.
+func (s *claudeBridgeSupervisor) ensure(bin string, args []string, env map[string]string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return "", errors.New("Claude bridge 管理器已停止")
+	}
+	if s.cmd != nil && !s.exited {
+		return s.socketPath, nil
+	}
+	if s.cmd != nil {
+		log.Printf("claude bridge exited; starting a replacement")
+		s.reset()
+	}
+	if err := s.start(bin, args, env); err != nil {
+		s.reset()
+		return "", err
+	}
+	return s.socketPath, nil
+}
+
+// start spawns the bridge and blocks until its socket accepts a connection.
+// Caller must hold s.mu.
+func (s *claudeBridgeSupervisor) start(bin string, args []string, env map[string]string) error {
+	if s.dir == "" {
+		dir, err := os.MkdirTemp("", "mimi-claude")
+		if err != nil {
+			return fmt.Errorf("创建 Claude bridge 运行目录失败：%w", err)
+		}
+		s.dir = dir
+	}
+	socketPath := filepath.Join(s.dir, "bridge.sock")
+	if len(socketPath) > claudeBridgeMaxSocketPath {
+		return fmt.Errorf("Claude bridge socket 路径过长（%d 字节）：%s", len(socketPath), socketPath)
+	}
+	// A leftover node from a crashed predecessor would make bind fail.
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("清理 Claude bridge socket 失败：%w", err)
+	}
+
+	cmd := exec.Command(bin, append(append([]string{}, args...), "--socket", socketPath)...)
+	cmd.Env = buildClaudeBridgeEnv(env)
+	configureGatewayCommandProcessGroup(cmd)
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("创建 Claude bridge stderr 失败：%w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("启动 Claude bridge 失败：%w", err)
+	}
+	go captureClaudeBridgeStderr(stderr)
+
+	done := make(chan struct{})
+	s.cmd = cmd
+	s.done = done
+	s.socketPath = socketPath
+	s.exited = false
+	go s.reap(cmd, done)
+
+	if err := waitForClaudeBridgeSocket(socketPath, done, claudeBridgeStartTimeout); err != nil {
+		// Kill and walk away without waiting on the reaper: we hold s.mu, and
+		// the reaper takes it before closing done, so waiting here would
+		// deadlock the supervisor — and with it every later ensure() — for a
+		// bridge that merely failed to bind in time. The reaper still runs and
+		// still reaps; ensure() clears the bookkeeping, and the `s.cmd == cmd`
+		// guard keeps this dead process from clobbering its replacement.
+		terminateGatewayProcessGroup(cmd, syscall.SIGKILL)
+		return err
+	}
+	return nil
+}
+
+// reap waits on the process and marks the supervisor dirty so a later ensure()
+// restarts it. It only touches shared state while cmd is still the current
+// process, so a shutdown-then-restart cycle cannot have an old reaper clobber
+// new state.
+func (s *claudeBridgeSupervisor) reap(cmd *exec.Cmd, done chan struct{}) {
+	err := cmd.Wait()
+	s.mu.Lock()
+	if s.cmd == cmd {
+		s.exited = true
+	}
+	s.mu.Unlock()
+	if err != nil {
+		log.Printf("claude bridge exited err=%v", err)
+	} else {
+		log.Printf("claude bridge exited")
+	}
+	close(done)
+}
+
+// dial opens a connection to the resident bridge. Each WebSocket connection
+// gets its own socket connection; the bridge multiplexes them onto sessions.
+func (s *claudeBridgeSupervisor) dial() (net.Conn, error) {
+	s.mu.Lock()
+	socketPath := s.socketPath
+	alive := s.cmd != nil && !s.exited
+	s.mu.Unlock()
+	if !alive || socketPath == "" {
+		return nil, errors.New("Claude bridge 未运行")
+	}
+	// The socket node exists from bind, but listen lands a moment later, so a
+	// dial racing a just-started bridge can see ECONNREFUSED. Retry briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.DialTimeout("unix", socketPath, time.Second)
+		if err == nil {
+			return conn, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// shutdown terminates the bridge process group and removes the socket
+// directory. The supervisor refuses to start again afterwards.
+func (s *claudeBridgeSupervisor) shutdown() {
+	s.mu.Lock()
+	s.stopped = true
+	cmd, done, exited, dir := s.cmd, s.done, s.exited, s.dir
+	s.dir = ""
+	s.reset()
+	s.mu.Unlock()
+
+	// Terminate outside the lock: the reaper takes it on its way out.
+	if cmd != nil && !exited {
+		// The bridge spawns Claude Code children; signal the whole group so a
+		// restart does not inherit orphans still holding the workspace.
+		terminateClaudeBridge(cmd, done)
+	}
+	if dir != "" {
+		_ = os.RemoveAll(dir)
+	}
+}
+
+// terminateClaudeBridge signals the whole process group, escalating to SIGKILL
+// if the bridge does not go quietly. It waits on the reaper's done channel,
+// which has no competing consumer.
+func terminateClaudeBridge(cmd *exec.Cmd, done <-chan struct{}) {
+	terminateGatewayProcessGroup(cmd, syscall.SIGTERM)
+	select {
+	case <-done:
+		return
+	case <-time.After(300 * time.Millisecond):
+	}
+	terminateGatewayProcessGroup(cmd, syscall.SIGKILL)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		log.Printf("claude bridge process did not exit after SIGKILL pid=%d", gatewayProcessID(cmd))
+	}
+}
+
+// reset clears process bookkeeping without touching s.dir, which is reused
+// across restarts. Caller must hold s.mu.
+func (s *claudeBridgeSupervisor) reset() {
+	s.cmd = nil
+	s.done = nil
+	s.socketPath = ""
+	s.exited = false
+}
+
+// waitForClaudeBridgeSocket polls until the bridge has bound its socket, the
+// process dies, or the deadline passes.
+//
+// It deliberately checks for the socket node rather than dialing it: a probe
+// connection is a real bridge connection, and one that opens and closes at
+// once would churn a session for nothing. dial retries instead, which also
+// covers the sliver between bind and listen.
+func waitForClaudeBridgeSocket(socketPath string, done <-chan struct{}, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		select {
+		case <-done:
+			return errors.New("Claude bridge 启动后立即退出")
+		default:
+		}
+		if _, err := os.Stat(socketPath); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("Claude bridge 在 %s 内未监听 socket", timeout)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}

--- a/internal/httpapi/claude_gateway.go
+++ b/internal/httpapi/claude_gateway.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -24,6 +25,33 @@ import (
 
 const claudeBridgePolicyErrorCode = -32081
 const claudeBridgeProbeCacheTTL = 5 * time.Second
+
+// Transport-level handshake with the resident bridge. Mirrors ATTACH_METHOD /
+// ATTACHED_METHOD in bridges/claude/crates/bridge-core/src/server.rs.
+const claudeBridgeAttachMethod = "_alleycat/attach"
+const claudeBridgeAttachedMethod = "_alleycat/attached"
+
+// claudeBridgeSeqField is the top-level stamp the bridge puts on every
+// outbound frame so a reconnect can resume from a known point.
+const claudeBridgeSeqField = "_alleycat_seq"
+
+// claudeBridgeServerRequestReplayMethod is the notification a bridge sends on
+// attach listing the server requests still waiting on the user.
+const claudeBridgeServerRequestReplayMethod = "serverRequest/replay"
+
+// claudeBridgeFrameSeq reads the replay sequence number off an upstream frame.
+func claudeBridgeFrameSeq(payload []byte) (uint64, bool) {
+	if !bytes.Contains(payload, []byte(`"`+claudeBridgeSeqField+`"`)) {
+		return 0, false
+	}
+	var frame struct {
+		Seq *uint64 `json:"_alleycat_seq"`
+	}
+	if err := json.Unmarshal(payload, &frame); err != nil || frame.Seq == nil {
+		return 0, false
+	}
+	return *frame.Seq, true
+}
 
 type appServerBridgeProbe struct {
 	Status    string
@@ -182,35 +210,36 @@ func (r *Router) appServerClaudeGatewayWS(w http.ResponseWriter, req *http.Reque
 	defer cancel()
 	bin := firstNonEmpty(probe.Path, strings.TrimSpace(r.cfg.Claude.BridgeBin))
 	start := time.Now()
-	cmd := exec.Command(bin, r.cfg.Claude.Args...)
-	cmd.Env = buildClaudeBridgeEnv(r.cfg.Claude.Env)
-	configureGatewayCommandProcessGroup(cmd)
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		writeGatewayRuntimeError(client, "CLAUDE_BRIDGE_STDIN_FAILED", "创建 Claude bridge stdin 失败")
-		return
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		writeGatewayRuntimeError(client, "CLAUDE_BRIDGE_STDOUT_FAILED", "创建 Claude bridge stdout 失败")
-		return
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		writeGatewayRuntimeError(client, "CLAUDE_BRIDGE_STDERR_FAILED", "创建 Claude bridge stderr 失败")
-		return
-	}
-	if err := cmd.Start(); err != nil {
+	if _, err := r.claudeBridge.ensure(bin, r.cfg.Claude.Args, r.cfg.Claude.Env); err != nil {
+		log.Printf("claude bridge ensure failed err=%v", err)
 		writeGatewayRuntimeError(client, "CLAUDE_BRIDGE_START_FAILED", "启动 Claude bridge 失败")
 		return
 	}
-	waitCh := make(chan error, 1)
-	go func() { waitCh <- cmd.Wait() }()
+	upstream, err := r.claudeBridge.dial()
+	if err != nil {
+		log.Printf("claude bridge dial failed err=%v", err)
+		writeGatewayRuntimeError(client, "CLAUDE_BRIDGE_UNAVAILABLE", "连接 Claude bridge 失败")
+		return
+	}
+	defer upstream.Close()
+
+	// The bridge outlives this connection, so a client that names a session
+	// resumes the one it had; an unnamed client gets an isolated session and
+	// today's semantics.
+	sessionKey := claudeGatewaySessionKey(req)
+	reader := bufio.NewReaderSize(upstream, 64*1024)
+	var upstreamWriteMu sync.Mutex
+	if sessionKey != "" {
+		if err := r.attachClaudeBridgeSession(reader, upstream, &upstreamWriteMu, sessionKey); err != nil {
+			log.Printf("claude bridge attach failed session=%s err=%v", sanitizeGatewayDiagnostic(sessionKey), err)
+			writeGatewayRuntimeError(client, "CLAUDE_BRIDGE_UNAVAILABLE", "连接 Claude bridge 会话失败")
+			return
+		}
+	}
 
 	monitor := r.monitor.startGatewayConnection(requestRemoteHost(req), req.Host, "claude:"+filepath.Base(bin), time.Since(start))
 	done := make(chan string, 3)
 	var clientWriteMu sync.Mutex
-	var stdinWriteMu sync.Mutex
 	configureGatewayReadConn(client)
 	policy := &appServerGatewayPolicy{
 		router:                r,
@@ -223,38 +252,121 @@ func (r *Router) appServerClaudeGatewayWS(w http.ResponseWriter, req *http.Reque
 	defer policy.close()
 
 	go func() {
-		captureClaudeBridgeStderr(stderr)
+		done <- copyClientFramesToClaudeBridge(client, upstream, &clientWriteMu, &upstreamWriteMu, policy, monitor)
 	}()
 	go func() {
-		done <- copyClientFramesToClaudeBridge(client, stdin, &clientWriteMu, &stdinWriteMu, policy, monitor)
-	}()
-	go func() {
-		done <- copyClaudeBridgeFrames(ctx, stdout, client, &clientWriteMu, policy, monitor)
+		done <- copyClaudeBridgeFrames(ctx, reader, client, &clientWriteMu, policy, monitor, r.claudeBridge, sessionKey)
 	}()
 	go func() {
 		pingClientGateway(ctx, client, &clientWriteMu)
 		done <- "ping_failed_or_context_done"
 	}()
 
-	reason := ""
-	commandExited := false
-	select {
-	case reason = <-done:
-	case err := <-waitCh:
-		commandExited = true
-		reason = "bridge_exit"
-		if err != nil {
-			reason += ": " + trimRelayString(err.Error(), 120)
-		}
-		writeGatewayRuntimeError(client, "CLAUDE_BRIDGE_EXITED", "Claude bridge 已退出，本轮连接已中断")
-	}
+	reason := <-done
 	cancel()
-	_ = stdin.Close()
+	_ = upstream.Close()
 	_ = client.Close()
-	shutdownGatewayCommand(cmd, waitCh, commandExited)
 	if monitor != nil {
 		monitor.finish(reason)
 	}
+}
+
+// claudeGatewaySessionKey reads the client's resumable-session name.
+//
+// `session` names it outright. Absent that, the thread the client opened is
+// the right resume unit: a thread is what the user thinks of as "the task
+// still running", and it is what they expect to find alive after the phone
+// drops off the network. Clients that send neither keep the pre-resident
+// behaviour: a fresh bridge session per connection, with nothing replayed.
+func claudeGatewaySessionKey(req *http.Request) string {
+	query := req.URL.Query()
+	if raw := strings.TrimSpace(query.Get("session")); raw != "" {
+		return sanitizedClaudeSessionKey(raw)
+	}
+	return sanitizedClaudeSessionKey(strings.TrimSpace(query.Get("thread_id")))
+}
+
+// sanitizedClaudeSessionKey drops anything that is not a short, plain
+// identifier. The key is client-chosen and travels into the bridge's session
+// registry and back out into logs, so it must carry no framing or control
+// characters. Rejecting degrades to an unnamed session rather than failing the
+// connection.
+func sanitizedClaudeSessionKey(key string) string {
+	if key == "" || len(key) > 128 {
+		return ""
+	}
+	for _, c := range key {
+		isSafe := c == '-' || c == '_' ||
+			(c >= '0' && c <= '9') ||
+			(c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z')
+		if !isSafe {
+			return ""
+		}
+	}
+	return key
+}
+
+// attachClaudeBridgeSession performs the socket handshake that binds this
+// connection to a named bridge session, resuming from the last sequence number
+// we managed to deliver to a client.
+func (r *Router) attachClaudeBridgeSession(reader *bufio.Reader, upstream io.Writer, mu *sync.Mutex, sessionKey string) error {
+	params := map[string]any{"sessionKey": sessionKey}
+	cursor, hadCursor := r.claudeBridge.resumeCursor(sessionKey)
+	if hadCursor {
+		params["lastSeen"] = cursor
+	}
+	preamble, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  claudeBridgeAttachMethod,
+		"params":  params,
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeStdioBridgeCompactedFrame(upstream, mu, preamble); err != nil {
+		return err
+	}
+	line, oversize, err := readBridgeStdoutLine(reader, int(appServerGatewayReadLimit))
+	if oversize {
+		return errors.New("Claude bridge attach 应答超出大小上限")
+	}
+	if err != nil && len(bytes.TrimSpace(line)) == 0 {
+		return fmt.Errorf("读取 Claude bridge attach 应答失败：%w", err)
+	}
+	var ack struct {
+		Method string `json:"method"`
+		Params struct {
+			Kind       string `json:"kind"`
+			CurrentSeq uint64 `json:"currentSeq"`
+			FloorSeq   uint64 `json:"floorSeq"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(line), &ack); err != nil {
+		return fmt.Errorf("解析 Claude bridge attach 应答失败：%w", err)
+	}
+	if ack.Method != claudeBridgeAttachedMethod {
+		return fmt.Errorf("Claude bridge attach 应答方法异常：%s", sanitizeGatewayDiagnostic(ack.Method))
+	}
+	if ack.Params.Kind == "driftReload" {
+		// The turn ran on past what the replay ring holds. Nothing is replayed,
+		// so the client only sees events from here on and has to rehydrate the
+		// thread itself — which it already does on every reconnect.
+		log.Printf("claude bridge session drifted past replay window session=%s floor=%d",
+			sanitizeGatewayDiagnostic(sessionKey), ack.Params.FloorSeq)
+	}
+	// Only "resumed" means the bridge is still counting in the sequence our
+	// cursor came from. Anything else is a renumbered session, and keeping the
+	// old cursor is worse than having none: the replay ring answers a cursor
+	// above its current sequence with an empty slice and no error, so the next
+	// attach would report "resumed" while silently skipping everything the new
+	// session had produced.
+	if hadCursor && (ack.Params.Kind != "resumed" || ack.Params.CurrentSeq < cursor) {
+		log.Printf("claude bridge session renumbered; dropping resume cursor session=%s kind=%s cursor=%d current=%d",
+			sanitizeGatewayDiagnostic(sessionKey), sanitizeGatewayDiagnostic(ack.Params.Kind), cursor, ack.Params.CurrentSeq)
+		r.claudeBridge.forgetCursor(sessionKey)
+	}
+	return nil
 }
 
 func (r *Router) acquireClaudeBridgeSlot() bool {
@@ -319,12 +431,11 @@ func copyClientFramesToClaudeBridge(client *websocket.Conn, stdin io.Writer, cli
 	}
 }
 
-func copyClaudeBridgeFrames(ctx context.Context, stdout io.Reader, client *websocket.Conn, clientWriteMu *sync.Mutex, policy *appServerGatewayPolicy, monitor *relayGatewayConnMonitor) string {
+func copyClaudeBridgeFrames(ctx context.Context, reader *bufio.Reader, client *websocket.Conn, clientWriteMu *sync.Mutex, policy *appServerGatewayPolicy, monitor *relayGatewayConnMonitor, supervisor *claudeBridgeSupervisor, sessionKey string) string {
 	// bufio.Scanner 在单行超过 buffer 上限时会以 ErrTooLong 终止扫描，等于让一条超大
 	// 帧（例如一次超大文件 Read 的 base64 输出）撕掉整条 WS 连接、触发客户端重连循环。
 	// 改用有界逐行读取：超过上限的单帧只丢弃并记诊断，连接继续存活。上限沿用客户端
 	// WS 读上限——比它更大的帧客户端本就无法接收，丢弃是唯一安全选择。
-	reader := bufio.NewReaderSize(stdout, 64*1024)
 	maxLine := int(appServerGatewayReadLimit)
 	for {
 		select {
@@ -341,6 +452,15 @@ func copyClaudeBridgeFrames(ctx context.Context, stdout io.Reader, client *webso
 		} else if payload := bytes.TrimSpace(line); len(payload) > 0 {
 			if reason, ok := forwardClaudeBridgeFrame(payload, client, clientWriteMu, policy, monitor); ok {
 				return reason
+			}
+			// Only frames we finished handling advance the cursor, so whatever
+			// died in flight when the socket broke gets replayed. Frames the
+			// policy dropped count as handled: replaying them would only get
+			// them dropped again.
+			if sessionKey != "" {
+				if seq, ok := claudeBridgeFrameSeq(payload); ok {
+					supervisor.noteDelivered(sessionKey, seq)
+				}
 			}
 		}
 		if err != nil {
@@ -670,30 +790,6 @@ func configureGatewayCommandProcessGroup(cmd *exec.Cmd) {
 		return
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-}
-
-func shutdownGatewayCommand(cmd *exec.Cmd, waitCh <-chan error, alreadyExited bool) {
-	if cmd == nil {
-		return
-	}
-	// Claude bridge 可能再拉起 Claude Code 子进程；断线时必须按进程组收口，
-	// 不能只 kill bridge leader，否则会留下继续执行的孤儿任务。
-	terminateGatewayProcessGroup(cmd, syscall.SIGTERM)
-	if alreadyExited {
-		terminateGatewayProcessGroup(cmd, syscall.SIGKILL)
-		return
-	}
-	select {
-	case <-waitCh:
-		terminateGatewayProcessGroup(cmd, syscall.SIGKILL)
-	case <-time.After(300 * time.Millisecond):
-		terminateGatewayProcessGroup(cmd, syscall.SIGKILL)
-		select {
-		case <-waitCh:
-		case <-time.After(2 * time.Second):
-			log.Printf("claude bridge process did not exit after SIGKILL pid=%d", gatewayProcessID(cmd))
-		}
-	}
 }
 
 func terminateGatewayProcessGroup(cmd *exec.Cmd, signal syscall.Signal) {

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -55,6 +55,7 @@ type Router struct {
 	claudeMu                      sync.Mutex
 	claudeProbe                   appServerBridgeProbe
 	activeClaudeBridge            int
+	claudeBridge                  *claudeBridgeSupervisor
 	managedWorktreesMu            sync.Mutex
 	managedWorktrees              map[string]managedWorktree
 	managedWorktreeCleanupMu      sync.Mutex
@@ -68,10 +69,15 @@ type Router struct {
 }
 
 func NewRouter(cfg config.Config, registry *projects.Registry, manager *session.Manager, checker *doctor.Checker, version string) http.Handler {
-	return NewRouterWithRuntime(cfg, registry, manager, checker, version, nil)
+	handler, _ := NewRouterWithRuntime(cfg, registry, manager, checker, version, nil)
+	return handler
 }
 
-func NewRouterWithRuntime(cfg config.Config, registry *projects.Registry, manager *session.Manager, checker *doctor.Checker, version string, runtime SessionRuntime) http.Handler {
+// NewRouterWithRuntime also hands back the *Router so a caller that owns the
+// process lifetime can shut down what the handler started. That matters now
+// that the Claude bridge is resident: it survives individual connections by
+// design, so nothing else would ever reap it.
+func NewRouterWithRuntime(cfg config.Config, registry *projects.Registry, manager *session.Manager, checker *doctor.Checker, version string, runtime SessionRuntime) (http.Handler, *Router) {
 	r := &Router{
 		cfg:      cfg,
 		projects: registry,
@@ -94,6 +100,7 @@ func NewRouterWithRuntime(cfg config.Config, registry *projects.Registry, manage
 		managedWorktreePendingUses:  map[string]int{},
 		gitTestFlightJobs:           map[string]*gitTestFlightReleaseJob{},
 		pairingClaims:               map[string]time.Time{},
+		claudeBridge:                newClaudeBridgeSupervisor(),
 	}
 	r.refreshClaudeBridgeProbe(false)
 	r.upstreamReadiness = newAppServerReadinessProbe(r.probeAppServerUpstream)
@@ -139,7 +146,18 @@ func NewRouterWithRuntime(cfg config.Config, registry *projects.Registry, manage
 	mux.Handle("/api/app-server/config", r.auth.Middleware(http.HandlerFunc(r.appServerConfigHandler)))
 	mux.Handle("/api/app-server/history-media/", r.auth.Middleware(http.HandlerFunc(r.appServerHistoryMediaHandler)))
 	mux.Handle("/api/app-server/ws", r.auth.Middleware(http.HandlerFunc(r.appServerGatewayWS)))
-	return logging(limitAPIRequestBodies(mux), r.monitor)
+	return logging(limitAPIRequestBodies(mux), r.monitor), r
+}
+
+// Shutdown releases the long-lived runtimes the router started. Call it after
+// the HTTP server has drained: the resident Claude bridge spawns Claude Code
+// children of its own, and killing it earlier would cut turns that in-flight
+// requests are still watching.
+func (r *Router) Shutdown() {
+	if r == nil {
+		return
+	}
+	r.claudeBridge.shutdown()
 }
 
 func sameOriginOrNoOrigin(r *http.Request) bool {

--- a/internal/httpapi/testdata/fakebridge/main.go
+++ b/internal/httpapi/testdata/fakebridge/main.go
@@ -1,0 +1,58 @@
+// Command fakebridge stands in for alleycat-claude-bridge in gateway tests.
+//
+// The real bridge serves a Unix socket and multiplexes connections onto
+// sessions. Reproducing that in a shell stub is not practical, so this helper
+// owns the socket and runs a caller-supplied shell script per connection with
+// stdin/stdout wired to it — letting tests keep expressing bridge behaviour as
+// the same small line-oriented scripts they used when the bridge spoke stdio.
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	body := flag.String("body", "", "path to the shell script serving one connection")
+	socket := flag.String("socket", "", "unix socket to listen on")
+	flag.Parse()
+
+	if *socket == "" {
+		log.Fatal("fakebridge: --socket is required")
+	}
+	listener, err := net.Listen("unix", *socket)
+	if err != nil {
+		log.Fatalf("fakebridge: listen: %v", err)
+	}
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		go serve(conn, *body)
+	}
+}
+
+func serve(conn net.Conn, body string) {
+	defer conn.Close()
+	cmd := exec.Command("/bin/sh", body)
+	cmd.Stdin = conn
+	cmd.Stderr = os.Stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	// Copy rather than assigning conn to cmd.Stdout so the script's output
+	// reaches the socket as it is written, without waiting for exit.
+	_, _ = io.Copy(conn, stdout)
+	_ = cmd.Wait()
+}

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		CE32FFAC6FF1C8B88332FADF /* ConversationLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E9BE6E1D3AD3BE0B2C111B /* ConversationLayout.swift */; };
 		CE8D6606331D38D9A5FF738B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE04A73144E31515A65F5830 /* Assets.xcassets */; };
 		D4B700AC9DF628887258F469 /* SessionStoreTurns.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38A8CE5A8F1D7EE3889F078 /* SessionStoreTurns.swift */; };
+		D8263551DECB2E7EBCD66E3B /* testSessionRuntimeBadgesInConversationList.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */; };
 		DAAB5AD21F6B77F6D691B94F /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373EDA921B7F6B3F6B680140 /* ConversationStore.swift */; };
 		DDCFB91D621190F7BA26678D /* AppExternalLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28C291AC46CF73586F8764A /* AppExternalLinks.swift */; };
 		E158B34D71964DBF782D1DDF /* MimiRemoteApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B337007E06BFD01501A0C9BD /* MimiRemoteApp.swift */; };
@@ -150,6 +151,7 @@
 		F38D8C9DDF3FCC6EBBE20885 /* SessionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9975BE3B6F00A870817B17 /* SessionIndexStore.swift */; };
 		F3ABBC8502D690C76985F756 /* AgentAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF761429383D479BD96FC52 /* AgentAPIClient.swift */; };
 		F430ECB13EE142C8AB67D5DF /* ConversationTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730CE8CD91CC2F2DFB5E6FBA /* ConversationTimelineView.swift */; };
+		F52369AA62CB6C0A7664D4B0 /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 712B1CDEF343C4D9D338DDDC /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png */; };
 		F996F870AD345E2888F2913B /* ConversationProcessGrouper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C529DD917A76943BC8A1C09E /* ConversationProcessGrouper.swift */; };
 		FA451031EB72AE10C3552C3F /* AppExternalLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554F31B0074B97074AE97B31 /* AppExternalLinksTests.swift */; };
 		FAD77559CF6FDCD943849D7C /* CodexAppServerSessionClients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */; };
@@ -220,6 +222,7 @@
 		3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreSupport.swift; sourceTree = "<group>"; };
 		40A98707004C8DC4ED81CBCD /* ComposerVoiceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceSupport.swift; sourceTree = "<group>"; };
 		41787BD804E7C9AD16448E38 /* ComposerRequestCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerRequestCards.swift; sourceTree = "<group>"; };
+		433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionRuntimeBadgesInConversationList.1.png; sourceTree = "<group>"; };
 		469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionClients.swift; sourceTree = "<group>"; };
 		476737709E01875A7992BABB /* SkillModelPickerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillModelPickerSnapshotTests.swift; sourceTree = "<group>"; };
 		485CC79160188BE6A5022A81 /* DiffPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPanelView.swift; sourceTree = "<group>"; };
@@ -247,6 +250,7 @@
 		67866EABC0460FF9A4867E87 /* AppServerProtocolModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServerProtocolModels.swift; sourceTree = "<group>"; };
 		6C7C7C0DF7B33C596EBE5FC7 /* ConversationSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSnapshotTests.swift; sourceTree = "<group>"; };
 		6C892E2BB83F2EE5FDD6EDA4 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		712B1CDEF343C4D9D338DDDC /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png; sourceTree = "<group>"; };
 		730CE8CD91CC2F2DFB5E6FBA /* ConversationTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTimelineView.swift; sourceTree = "<group>"; };
 		7348A6FCD28C7489CC7097AD /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		73BF91C2135478711BB991B2 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -510,6 +514,8 @@
 				2328266C2B65106940564667 /* testMixedActivityAndImageConversationRendering.1.png */,
 				2E4A0A29797384D5BD5002D1 /* testProjectSessionDashboard.1.png */,
 				2ACC589478ECDD4A4FB9BEB0 /* testRichMarkdownConversationRendering.1.png */,
+				433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */,
+				712B1CDEF343C4D9D338DDDC /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png */,
 				26D33D121E5B1B664D27BCCD /* testUnifiedWorkbenchSidebarNavigationChrome.1.png */,
 				0AEF1C233E236BA44225FA2F /* testWorkspaceOpenCurrentDirectoryButton.1.png */,
 			);
@@ -732,6 +738,13 @@
 			path = State;
 			sourceTree = "<group>";
 		};
+		"TEMP_5769549F-4F4E-48D9-A2FD-8F06B9AC0CF5" /* .claude */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = .claude;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -841,7 +854,9 @@
 				0F2BC7AA12BEC9037307837A /* testMixedActivityAndImageConversationRendering.1.png in Resources */,
 				B2628282609AF897C62B6178 /* testProjectSessionDashboard.1.png in Resources */,
 				9CDA4F02261EE4460043EC2B /* testRichMarkdownConversationRendering.1.png in Resources */,
+				D8263551DECB2E7EBCD66E3B /* testSessionRuntimeBadgesInConversationList.1.png in Resources */,
 				6B9100C88D46D2BB9A294B6F /* testSkillCardsAndModelGridDarkAppearance.1.png in Resources */,
+				F52369AA62CB6C0A7664D4B0 /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png in Resources */,
 				3555D54084E26E1CD6667F85 /* testUnifiedWorkbenchSidebarNavigationChrome.1.png in Resources */,
 				F08F39B329A077D24D08FECF /* testWorkspaceOpenCurrentDirectoryButton.1.png in Resources */,
 			);
@@ -1015,7 +1030,7 @@
 				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=macosx*]" = AppIconMac;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Resources/MimiRemote-Catalyst.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 100059;
+				CURRENT_PROJECT_VERSION = 100063;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1126,7 +1141,7 @@
 				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=macosx*]" = AppIconMac;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Resources/MimiRemote-Catalyst.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 100059;
+				CURRENT_PROJECT_VERSION = 100063;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Resources/Info.plist;

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1796,6 +1796,32 @@ actor CodexAppServerSessionRuntime {
         try await ensureConnection().respond(to: request, result: userInputResponse(for: request, answers: answers))
     }
 
+    /// Stable per-install name for this client's resumable gateway session.
+    ///
+    /// One gateway connection carries every thread of a runtime — the URL's
+    /// `thread_id` is empty on the real connection — so the resident bridge
+    /// session it maps to is keyed to the app install, not to a thread. It
+    /// has to survive app restarts, because that is the case the resident
+    /// bridge exists for: close the app mid-task, come back an hour later,
+    /// and reattach to the session that kept running.
+    /// Minting is serialized: two connections coming up together must not each
+    /// generate a key and race to persist it, or one of them would connect
+    /// under a name that is not the one stored — and silently fail to find its
+    /// session on the next launch.
+    private static let gatewaySessionKeyLock = NSLock()
+
+    static func gatewaySessionKey(defaults: UserDefaults = .standard) -> String {
+        let storageKey = "appServer.gatewaySessionKey"
+        gatewaySessionKeyLock.lock()
+        defer { gatewaySessionKeyLock.unlock() }
+        if let stored = defaults.string(forKey: storageKey), !stored.isEmpty {
+            return stored
+        }
+        let minted = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        defaults.set(minted, forKey: storageKey)
+        return minted
+    }
+
     static func gatewayURL(endpoint: String, sessionID: SessionID, runtimeProvider: String = "codex") throws -> URL {
         // WebSocket 也必须复用 HTTP Endpoint 策略；ATS 不会替应用阻止自行构造的公网 ws:// 地址。
         let validatedEndpoint = try EndpointTransportPolicy.validatedEndpoint(endpoint)
@@ -1816,6 +1842,9 @@ actor CodexAppServerSessionRuntime {
         if runtime != "codex" {
             queryItems.append(URLQueryItem(name: "runtime", value: runtime))
         }
+        // 命名这条连接对应的常驻会话。不带它，网关只能按连接给一个隔离会话，
+        // 断线重连拿不回还在跑的 turn 和未应答的审批。
+        queryItems.append(URLQueryItem(name: "session", value: "\(gatewaySessionKey())-\(runtime)"))
         components.queryItems = queryItems
         guard let url = components.url else {
             throw AgentAPIError.invalidEndpoint
@@ -2141,6 +2170,10 @@ actor CodexAppServerSessionRuntime {
             }
             return
         }
+        if notification.method == "serverRequest/replay" {
+            redeliverReplayedServerRequests(notification)
+            return
+        }
         if notification.method == "deprecationNotice",
            approvalSessionID(from: notification.params?.objectValue ?? [:]) == nil {
             // deprecationNotice 是连接级通知，官方协议不带 threadId。直接 emit 会被路由层丢弃，
@@ -2195,6 +2228,53 @@ actor CodexAppServerSessionRuntime {
             return
         }
         emit(event)
+    }
+
+    /// Re-deliver the server requests a reconnect found still waiting.
+    ///
+    /// A bridge whose sessions outlive the connection keeps an approval
+    /// prompt pending across a disconnect — that is the whole point of it —
+    /// and lists the survivors in one notification as soon as we attach.
+    /// Each entry goes back through the live path, so a restored prompt is
+    /// bookkept and rendered exactly like the original was.
+    ///
+    /// `isStaleReplayedApproval` is deliberately not consulted here. That
+    /// check exists for app-servers that re-deliver zombie approvals from
+    /// turns they have long since moved past; this list is the bridge's own
+    /// not-yet-answered table, emptied the moment a request resolves or its
+    /// turn dies, so everything in it is live by construction. Running the
+    /// check would decline the very prompts the user came back to answer,
+    /// because a thread parked on an approval still reports itself as idle.
+    func redeliverReplayedServerRequests(_ notification: CodexAppServerNotification) {
+        for entry in notification.params?["outstanding"]?.arrayValue ?? [] {
+            guard let method = entry["method"]?.stringValue,
+                  let id = replayedServerRequestID(entry["id"]) else {
+                continue
+            }
+            let request = CodexAppServerServerRequest(id: id, method: method, params: entry["params"])
+            if isUserInputServerRequest(request) {
+                handleUserInputRequest(request)
+                continue
+            }
+            rememberPendingApprovalRequest(request)
+            guard let event = projector.project(request) else {
+                continue
+            }
+            emit(event)
+        }
+    }
+
+    /// The id travels back to the bridge verbatim when the user answers, so
+    /// keep its JSON type instead of coercing everything to a string.
+    func replayedServerRequestID(_ value: CodexAppServerJSONValue?) -> CodexAppServerRequestID? {
+        switch value {
+        case .string(let text):
+            return .string(text)
+        case .int(let number):
+            return .int(number)
+        default:
+            return nil
+        }
     }
 
     func handleUserInputRequest(_ request: CodexAppServerServerRequest) {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -434,6 +434,33 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(queryItems.first(where: { $0.name == "thread_id" })?.value, "thr_claude")
     }
 
+    // 真实连接的 thread_id 是空的（一条连接承载所有线程），所以能不能接回常驻会话
+    // 全看这个 session 键。它必须存在、跨调用稳定、且落在网关的字符集白名单里。
+    func testGatewayURLCarriesStableSessionKey() throws {
+        let first = try CodexAppServerSessionRuntime.gatewayURL(
+            endpoint: "http://127.0.0.1:8787", sessionID: "", runtimeProvider: "claude")
+        let second = try CodexAppServerSessionRuntime.gatewayURL(
+            endpoint: "http://127.0.0.1:8787", sessionID: "", runtimeProvider: "claude")
+
+        func sessionKey(_ url: URL) throws -> String {
+            let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+            return try XCTUnwrap(items.first(where: { $0.name == "session" })?.value)
+        }
+
+        let key = try sessionKey(first)
+        XCTAssertFalse(key.isEmpty)
+        XCTAssertEqual(key, try sessionKey(second), "同一安装的会话键必须稳定，否则每次重连都是新会话")
+        XCTAssertTrue(key.hasSuffix("-claude"))
+        XCTAssertLessThanOrEqual(key.count, 128)
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        XCTAssertNil(key.rangeOfCharacter(from: allowed.inverted), "会话键含网关会拒绝的字符：\(key)")
+
+        // 不同 runtime 各自一条常驻会话，不能互相串。
+        let codex = try CodexAppServerSessionRuntime.gatewayURL(
+            endpoint: "http://127.0.0.1:8787", sessionID: "")
+        XCTAssertNotEqual(try sessionKey(codex), key)
+    }
+
     func testRequestBuilderAllowsFullAccessSandboxWithApproval() throws {
         let project = AgentProject(id: "repo", name: "Repo", path: "/Users/me/repo")
         let builder = CodexAppServerRequestBuilder(allowlistedProjects: [project])

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -427,6 +427,72 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(final.content, "程序员相亲，对方问：你会浪漫吗？")
     }
 
+    // 关掉 App 一小时后回来：bridge 的会话还活着、turn 还停在审批上，attach 时用
+    // serverRequest/replay 把未应答的请求推回来。这条路必须绕开僵尸审批检查——
+    // Claude bridge 把停在审批上的线程仍报成 idle，走那个检查会把真正在等的提示
+    // 直接 decline 掉，用户看到的就是一个永远不动的任务。
+    func testDirectRuntimeRestoresReplayedServerRequestOnIdleReportingThread() async throws {
+        let project = AgentProject(id: "proj_replay", name: "Replay", path: "/tmp/replay")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+
+        let sessionTask = Task {
+            try await client.session(id: "thr_replay")
+        }
+
+        let initializeMessages = try await waitForFakeAppServerMessages(transport, count: 1)
+        let initialize = try decodeAppServerRequest(initializeMessages[0])
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: initialize.id)),"result":{"userAgent":"fake-codex","platformFamily":"macos"}}"#)
+
+        let readMessages = try await waitForFakeAppServerMessages(transport, count: 3)
+        let read = try decodeAppServerRequest(readMessages[2])
+        XCTAssertEqual(read.method, "thread/read")
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: read.id)),"result":{"thread":{"id":"thr_replay","sessionId":"thr_replay","preview":"等审批","ephemeral":false,"modelProvider":"anthropic","createdAt":1780490000,"updatedAt":1780490001,"status":{"type":"idle"},"path":null,"cwd":"/tmp/replay","cliVersion":"0.0.0","source":"claude","threadSource":"user","name":"等审批","turns":[]}}}"#)
+        _ = try await sessionTask.value
+
+        let socket = CodexAppServerSessionWebSocketClient(runtime: runtime)
+        var statuses: [WebSocketStatus] = []
+        var events: [AgentEvent] = []
+        socket.onStatus = { statuses.append($0) }
+        socket.onEvent = { events.append($0) }
+        socket.connect(sessionID: "thr_replay")
+
+        let resumeMessages = try await waitForFakeAppServerMessages(transport, count: 4)
+        let resume = try decodeAppServerRequest(resumeMessages[3])
+        XCTAssertEqual(resume.method, "thread/resume")
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: resume.id)),"result":{"thread":{"id":"thr_replay","sessionId":"thr_replay","preview":"等审批","ephemeral":false,"modelProvider":"anthropic","createdAt":1780490000,"updatedAt":1780490001,"status":{"type":"idle"},"path":null,"cwd":"/tmp/replay","cliVersion":"0.0.0","source":"claude","threadSource":"user","name":"等审批","turns":[]}}}"#)
+
+        for _ in 0..<200 where !statuses.contains(.connected) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(statuses.contains(.connected))
+
+        transport.enqueue(#"{"jsonrpc":"2.0","method":"serverRequest/replay","params":{"outstanding":[{"id":"req-abc","method":"item/commandExecution/requestApproval","params":{"threadId":"thr_replay","turnId":"turn_live","itemId":"cmd_live","command":"cargo install --path ."}}]}}"#)
+
+        for _ in 0..<200 where !events.contains(where: { if case .approvalRequest = $0 { return true } else { return false } }) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(events.contains {
+            if case .approvalRequest = $0 {
+                return true
+            }
+            return false
+        }, "重放的未应答审批应当重新弹出审批卡")
+
+        // 它是活的，不能被当成僵尸请求自动 decline 掉。
+        let sent = await transport.sentMessages()
+        XCTAssertFalse(sent.contains { $0.contains("\"decision\":\"decline\"") },
+                       "重放的审批不应被自动拒绝")
+
+        socket.disconnect()
+    }
+
     func testDirectRuntimeDropsStaleReplayedApprovalForIdleThread() async throws {
         let project = AgentProject(id: "proj_stale", name: "Stale", path: "/tmp/stale")
         let transport = FakeCodexAppServerTransport()

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -73,7 +73,7 @@ targets:
         "ENABLE_HARDENED_RUNTIME[sdk=macosx*]": "YES"
         # UI 文案统一由显式 L10n key 管理，关闭编译器自动提取，避免 Xcode 把技术字符串写回目录。
         SWIFT_EMIT_LOC_STRINGS: "NO"
-        CURRENT_PROJECT_VERSION: "100059"
+        CURRENT_PROJECT_VERSION: "100063"
         MARKETING_VERSION: "1.0"
   MimiRemoteTests:
     type: bundle.unit-test


### PR DESCRIPTION
## 说明

这是一个**记录性 PR**：对应的提交 `e6049e9` 已经直接提交并推送到 `main`（未经过 PR review），这里补开一个 PR 只是为了留下可读的 diff 和评审记录，不代表待合并的改动。

- base：`record/claude-session-lifecycle-base` = `664db1a`（e6049e9 的父提交，即改动前的状态）
- head：`record/claude-session-lifecycle` = `e6049e9`（已经在 main 上的那次提交，原始 hash）

## Summary
- Claude bridge 从每连接 spawn 一次 stdio 进程，改为单个常驻进程 + Unix socket（`internal/httpapi/claude_bridge_supervisor.go`），断线不再杀掉进行中的 turn。
- 网关 attach 握手支持按 `session`（缺省回退 `thread_id`）续传 replay 游标；attach 应答非 `resumed` 或序号回退时丢弃过期游标。
- Rust `bridge-core` 会话生命周期与 Codex app-server 语义对齐：`Session::begin_turn` / `TurnGuard` 让运行中的 turn 不被 reaper 回收；`AttachReservation` 消除 resolve→install 之间的竞态窗口；`publish_server_request` 把审批"登记为 outstanding"与"发到线上"合并成一步，避免重连时重复投递；新增 `busy_hard_ttl`（24h）兜底彻底不可达的忙会话，回收时真正 `cancel()` 唤醒等待方并释放 Claude 进程槽位，而不只是摘注册表索引。
- agentd 增加 `Router.Shutdown()`，进程退出时收口常驻 bridge，避免遗留孤儿进程树。
- iOS 端处理 `serverRequest/replay` 通知，让重连后仍处于审批等待态的 turn 能重新弹出审批卡，而不会被"过期重放"检查误判自动拒绝。

## Test plan
- [x] `cargo test --workspace`（282 passed）
- [x] `cargo clippy --workspace --all-targets`（无新增告警）
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./internal/httpapi/ ./cmd/...`
- [x] iOS `MimiRemoteTests`（CodexAppServerProtocolTests / ConversationDirectRuntimeHistoryTests / ConversationDataFlowTests）
- [ ] iPad 真机端到端验证（发任务 → 杀后台 → 等待 → 回来查看审批/结果）—— 用户正在自行部署验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)