### PR TITLE
feat(mac): show Codex and Claude runtime status

### DIFF
--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -391,8 +391,12 @@ func runStatus(args []string) error {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
 	configPath := fs.String("config", config.DefaultPath(), "配置文件路径")
 	asJSON := fs.Bool("json", false, "输出 JSON")
+	includeRuntime := fs.Bool("runtime", false, "附加本机 Codex / Claude 运行时状态")
 	if err := fs.Parse(args[1:]); err != nil {
 		return err
+	}
+	if *includeRuntime && !*asJSON {
+		return errors.New("status --runtime 只能与 --json 一起使用")
 	}
 	if err := prepareDefaultConfigMigration(fs, *configPath, os.Stderr); err != nil {
 		return err
@@ -403,13 +407,35 @@ func runStatus(args []string) error {
 		return err
 	}
 	result := agentsetup.ResultFromConfig(context.Background(), *configPath, cfg)
+	loopbackEndpoint := loopbackServiceEndpoint(result.Endpoint)
+	type runtimeStatusResult struct {
+		payload map[string]any
+		err     error
+	}
+	var runtimeStatusCh chan runtimeStatusResult
+	if *includeRuntime {
+		runtimeStatusCh = make(chan runtimeStatusResult, 1)
+		go func() {
+			payload, fetchErr := fetchServiceRuntimeStatus(
+				context.Background(),
+				loopbackEndpoint,
+				result.Token,
+				2*time.Second,
+			)
+			runtimeStatusCh <- runtimeStatusResult{payload: payload, err: fetchErr}
+		}()
+	}
 	serviceStatus := probeAgentServiceStatus(
 		context.Background(),
-		loopbackServiceEndpoint(result.Endpoint),
+		loopbackEndpoint,
 		result.Token,
 		version,
 		2*time.Second,
 	)
+	var runtimeStatus runtimeStatusResult
+	if runtimeStatusCh != nil {
+		runtimeStatus = <-runtimeStatusCh
+	}
 	doctorResults := doctor.Results{
 		OK:      false,
 		Version: version,
@@ -443,6 +469,11 @@ func runStatus(args []string) error {
 	status["doctor_ok"] = doctorResults.OK
 	status["doctor"] = doctorResults
 	status["pair_expires"] = result.PairExpiresAt
+	// 旧版本 agentd 没有 runtime status endpoint。升级/接管过程中保持 status
+	// 兼容，只在成功拿到脱敏快照时附加字段，不让展示增强阻断服务状态。
+	if runtimeStatusCh != nil && runtimeStatus.err == nil {
+		status["runtime_status"] = runtimeStatus.payload
+	}
 	if *asJSON {
 		return printJSON(status)
 	}
@@ -1774,6 +1805,96 @@ func healthCheckURL(endpoint string) (string, error) {
 
 func readyCheckURL(endpoint string) (string, error) {
 	return serviceCheckURL(endpoint, "/api/readyz")
+}
+
+func runtimeStatusURL(endpoint string) (string, error) {
+	return serviceCheckURL(endpoint, "/api/runtime/status")
+}
+
+func fetchServiceRuntimeStatus(
+	ctx context.Context,
+	endpoint string,
+	token string,
+	timeout time.Duration,
+) (map[string]any, error) {
+	target, err := runtimeStatusURL(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, err
+	}
+	if value := strings.TrimSpace(token); value != "" {
+		req.Header.Set("Authorization", "Bearer "+value)
+	}
+	client := http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("runtime status HTTP %d", resp.StatusCode)
+	}
+	var payload map[string]any
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, 256*1024))
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("runtime status 响应不是有效 JSON：%w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("runtime status 响应包含多个 JSON 值")
+		}
+		return nil, fmt.Errorf("runtime status 响应包含畸形尾部数据：%w", err)
+	}
+	if err := validateRuntimeStatusPayload(payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func validateRuntimeStatusPayload(payload map[string]any) error {
+	rawRuntimes, ok := payload["runtimes"]
+	if !ok {
+		return errors.New("runtime status 响应缺少 runtimes")
+	}
+	runtimes, ok := rawRuntimes.([]any)
+	if !ok {
+		return errors.New("runtime status 响应的 runtimes 不是数组")
+	}
+	for index, rawRuntime := range runtimes {
+		runtime, ok := rawRuntime.(map[string]any)
+		if !ok {
+			return fmt.Errorf("runtime status 响应的 runtimes[%d] 不是对象", index)
+		}
+		for _, key := range []string{"id", "title", "state"} {
+			value, ok := runtime[key].(string)
+			if !ok || strings.TrimSpace(value) == "" {
+				return fmt.Errorf("runtime status 响应的 runtimes[%d].%s 无效", index, key)
+			}
+		}
+		if _, ok := runtime["enabled"].(bool); !ok {
+			return fmt.Errorf("runtime status 响应的 runtimes[%d].enabled 无效", index)
+		}
+	}
+	for _, key := range []string{"refreshing", "stale"} {
+		if value, exists := payload[key]; exists {
+			if _, ok := value.(bool); !ok {
+				return fmt.Errorf("runtime status 响应的 %s 不是布尔值", key)
+			}
+		}
+	}
+	if value, exists := payload["checked_at"]; exists {
+		if _, ok := value.(string); !ok {
+			return errors.New("runtime status 响应的 checked_at 不是字符串")
+		}
+	}
+	return nil
 }
 
 func serviceCheckURL(endpoint string, path string) (string, error) {

--- a/cmd/agentd/main_test.go
+++ b/cmd/agentd/main_test.go
@@ -923,6 +923,157 @@ func TestAgentStatusTextSeparatesProcessAndCodexAndRedactsToken(t *testing.T) {
 	}
 }
 
+func TestStatusRuntimeEnrichmentRequiresJSON(t *testing.T) {
+	err := runStatus([]string{"status", "--runtime"})
+	if err == nil || !strings.Contains(err.Error(), "--json") {
+		t.Fatalf("status --runtime 必须拒绝无 JSON 的调用：%v", err)
+	}
+}
+
+func TestStatusOnlyRequestsRuntimeWhenExplicitlyEnabled(t *testing.T) {
+	clearAgentdEnvForMainTest(t)
+	const token = "status-runtime-opt-in-token-0123456789"
+	var runtimeRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/api/readyz":
+			if req.Header.Get("Authorization") != "Bearer "+token {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(doctor.Results{
+				OK: true, Version: version, Checks: []doctor.Check{},
+			})
+		case "/api/runtime/status":
+			runtimeRequests.Add(1)
+			if req.Header.Get("Authorization") != "Bearer "+token {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`{"refreshing":false,"stale":false,"runtimes":[]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, "config.json")
+	upstreamTokenPath := filepath.Join(root, "app-server-token")
+	projectPath := filepath.Join(root, "project")
+	if err := os.Mkdir(projectPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(upstreamTokenPath, []byte("upstream-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Listen: strings.TrimPrefix(server.URL, "http://"),
+		Auth:   config.AuthConfig{Token: token},
+		Runtime: config.RuntimeConfig{
+			Type: "codex_app_server",
+		},
+		AppServer: config.AppServerConfig{
+			Transport:   "ws",
+			Managed:     true,
+			Listen:      "ws://127.0.0.1:4222",
+			WSTokenFile: upstreamTokenPath,
+		},
+		Codex: config.CodexConfig{Bin: "/bin/true"},
+		Session: config.SessionConfig{
+			OutputBufferBytes: 128 * 1024,
+		},
+		Projects: []config.ProjectConfig{{
+			ID: "test", Name: "Test", Path: projectPath,
+		}},
+		WorktreesRoot: filepath.Join(root, "worktrees"),
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := captureMainCommandOutput(t, func() error {
+		return runStatus([]string{"status", "--config", configPath, "--json"})
+	}); err != nil {
+		t.Fatalf("core status 失败：%v", err)
+	}
+	if runtimeRequests.Load() != 0 {
+		t.Fatalf("默认 status --json 不得触发额度探测：requests=%d", runtimeRequests.Load())
+	}
+
+	if _, _, err := captureMainCommandOutput(t, func() error {
+		return runStatus([]string{"status", "--config", configPath, "--json", "--runtime"})
+	}); err != nil {
+		t.Fatalf("runtime-enriched status 失败：%v", err)
+	}
+	if runtimeRequests.Load() != 1 {
+		t.Fatalf("显式 --runtime 应只请求一次缓存接口：requests=%d", runtimeRequests.Load())
+	}
+}
+
+func TestFetchServiceRuntimeStatusUsesBearerAndStrictJSON(t *testing.T) {
+	const token = "runtime-status-secret"
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests.Add(1)
+		if req.URL.Path != "/api/runtime/status" {
+			t.Errorf("runtime status 路径错误：%s", req.URL.Path)
+		}
+		if req.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"checked_at":"2026-07-27T12:00:00Z","runtimes":[{"id":"codex","title":"Codex","enabled":true,"state":"connected"}]}`))
+	}))
+	defer server.Close()
+
+	payload, err := fetchServiceRuntimeStatus(context.Background(), server.URL, token, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload["checked_at"] != "2026-07-27T12:00:00Z" {
+		t.Fatalf("runtime status payload 异常：%v", payload)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("runtime status 应只请求一次：requests=%d", requests.Load())
+	}
+
+	if _, err := fetchServiceRuntimeStatus(context.Background(), server.URL, "wrong-token", time.Second); err == nil ||
+		!strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("runtime status 必须使用 Bearer Token：%v", err)
+	}
+}
+
+func TestFetchServiceRuntimeStatusRejectsTrailingJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(`{"runtimes":[]} {"unexpected":true}`))
+	}))
+	defer server.Close()
+
+	if _, err := fetchServiceRuntimeStatus(context.Background(), server.URL, "", time.Second); err == nil ||
+		!strings.Contains(err.Error(), "多个 JSON 值") {
+		t.Fatalf("runtime status 必须拒绝尾随 JSON：%v", err)
+	}
+}
+
+func TestFetchServiceRuntimeStatusRejectsMissingRequiredShape(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	if _, err := fetchServiceRuntimeStatus(context.Background(), server.URL, "", time.Second); err == nil ||
+		!strings.Contains(err.Error(), "缺少 runtimes") {
+		t.Fatalf("runtime status 必须拒绝缺少最小结构的 200 响应：%v", err)
+	}
+}
+
 func TestWaitForServiceReadyUsesBearerAndReadyz(t *testing.T) {
 	const token = "ready-secret"
 	const expectedVersion = "1.2.3"

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -41,6 +41,9 @@ type Router struct {
 	tailscalePathLookup tailscaleNetworkPathLookup
 	// upstreamReadiness 对高频 readyz 轮询做短 TTL + single-flight，避免每 300ms 都创建 WebSocket。
 	upstreamReadiness *appServerReadinessProbe
+	// runtimeStatus 只服务本机菜单栏。额度探测可能访问 OAuth/Keychain 和 provider，
+	// 必须后台 single-flight 刷新，不能阻塞 readiness 或并发创建无上限连接。
+	runtimeStatus *runtimeStatusSnapshotCache
 	// pairingClaims 只记录短期票据的签名和过期时间，不保存长期 Token。
 	// 状态仅需覆盖当前进程内的短期重放窗口，服务重启后丢失是可接受的 MVP 取舍。
 	pairingClaimsMu sync.Mutex
@@ -104,6 +107,7 @@ func NewRouterWithRuntime(cfg config.Config, registry *projects.Registry, manage
 	}
 	r.refreshClaudeBridgeProbe(false)
 	r.upstreamReadiness = newAppServerReadinessProbe(r.probeAppServerUpstream)
+	r.runtimeStatus = newRuntimeStatusSnapshotCache(r.refreshRuntimeStatus, r.runtimeStatusPlaceholder)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", r.healthz)
@@ -143,6 +147,7 @@ func NewRouterWithRuntime(cfg config.Config, registry *projects.Registry, manage
 	mux.Handle("/api/git/pull-request", r.auth.Middleware(http.HandlerFunc(r.gitPullRequestHandler)))
 	mux.Handle("/api/git/pull-request/status", r.auth.Middleware(http.HandlerFunc(r.gitPullRequestStatusHandler)))
 	mux.Handle("/api/voice/transcribe", r.auth.Middleware(http.HandlerFunc(r.voiceTranscribeHandler)))
+	mux.Handle("/api/runtime/status", r.auth.Middleware(http.HandlerFunc(r.runtimeStatusHandler)))
 	mux.Handle("/api/app-server/config", r.auth.Middleware(http.HandlerFunc(r.appServerConfigHandler)))
 	mux.Handle("/api/app-server/history-media/", r.auth.Middleware(http.HandlerFunc(r.appServerHistoryMediaHandler)))
 	mux.Handle("/api/app-server/ws", r.auth.Middleware(http.HandlerFunc(r.appServerGatewayWS)))
@@ -157,6 +162,7 @@ func (r *Router) Shutdown() {
 	if r == nil {
 		return
 	}
+	r.runtimeStatus.Close()
 	r.claudeBridge.shutdown()
 }
 

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"sort"
@@ -353,10 +354,27 @@ func applyCodexAccount(status *runtimeAccountStatus, response runtimeAccountResp
 		}
 		return
 	}
-	status.State = runtimeStateConnected
-	status.Reason = ""
 	status.AuthMode = normalizeAuthMode(response.Account.Type)
 	status.PlanType = rawScalarString(response.Account.PlanType)
+	switch status.AuthMode {
+	case "chatgpt":
+		// 托管 ChatGPT 账户由 Codex 负责 OAuth 与刷新，account/read 返回账户
+		// 即可作为已登录证据。
+		status.State = runtimeStateConnected
+		status.Reason = ""
+	case "api_key":
+		// account/read 只证明 Key 已存入 Codex，不会主动验证 Key 是否有效。
+		status.State = runtimeStateAvailable
+		status.Reason = "api_key_configured_unverified"
+	case "bedrock":
+		// Bedrock credentialSource 只说明选中的凭据来源，AWS 凭据链可能仍不可用。
+		status.State = runtimeStateAvailable
+		status.Reason = "bedrock_credentials_configured_unverified"
+	default:
+		// 新增认证类型默认不宣称已连接；拿到实际认证证据后再提升状态。
+		status.State = runtimeStateAvailable
+		status.Reason = "account_configured_unverified"
+	}
 }
 
 func (r *Router) probeClaudeRuntime(ctx context.Context) runtimeAccountStatus {
@@ -583,21 +601,49 @@ func (c *runtimeWebSocketRPC) call(ctx context.Context, method string, params an
 		}
 		var frame struct {
 			ID     json.RawMessage     `json:"id"`
+			Method string              `json:"method"`
 			Result json.RawMessage     `json:"result"`
 			Error  *appserver.RPCError `json:"error"`
 		}
-		if json.Unmarshal(payload, &frame) != nil ||
-			strings.TrimSpace(string(frame.ID)) != strconv.FormatInt(id, 10) {
+		if json.Unmarshal(payload, &frame) != nil {
+			continue
+		}
+		if strings.TrimSpace(frame.Method) != "" {
+			// App Server 是双向 JSON-RPC。状态探针不拥有外部 Token 等宿主能力，
+			// 因此不能处理服务端 request；返回标准错误后继续等待原调用的响应，
+			// 避免相同 id 的服务端 request 被误判成成功 response。
+			if runtimeRPCFrameHasID(frame.ID) {
+				if err := c.write(ctx, map[string]any{
+					"id": frame.ID,
+					"error": map[string]any{
+						"code":    -32601,
+						"message": "runtime status client does not support server requests",
+					},
+				}); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if strings.TrimSpace(string(frame.ID)) != strconv.FormatInt(id, 10) {
 			continue
 		}
 		if frame.Error != nil {
 			return frame.Error
 		}
-		if result == nil || len(frame.Result) == 0 {
+		if len(frame.Result) == 0 {
+			return errors.New("app-server RPC 响应缺少 result 或 error")
+		}
+		if result == nil {
 			return nil
 		}
 		return json.Unmarshal(frame.Result, result)
 	}
+}
+
+func runtimeRPCFrameHasID(id json.RawMessage) bool {
+	value := strings.TrimSpace(string(id))
+	return value != "" && value != "null"
 }
 
 func (c *runtimeWebSocketRPC) notify(ctx context.Context, method string, params any) error {

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -1,0 +1,629 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
+)
+
+const (
+	runtimeStatusRefreshTimeout = 42 * time.Second
+	runtimeStatusSuccessTTL     = time.Minute
+	runtimeStatusFailureTTL     = 15 * time.Second
+	codexRuntimeProbeTimeout    = 8 * time.Second
+	claudeRuntimeProbeTimeout   = 41 * time.Second
+)
+
+type runtimeConnectionState string
+
+const (
+	runtimeStateConnected   runtimeConnectionState = "connected"
+	runtimeStateAvailable   runtimeConnectionState = "available"
+	runtimeStateSignedOut   runtimeConnectionState = "signed_out"
+	runtimeStateDisabled    runtimeConnectionState = "disabled"
+	runtimeStateUnavailable runtimeConnectionState = "unavailable"
+)
+
+type runtimeStatusResponse struct {
+	CheckedAt  *time.Time             `json:"checked_at,omitempty"`
+	Refreshing bool                   `json:"refreshing"`
+	Stale      bool                   `json:"stale"`
+	Runtimes   []runtimeAccountStatus `json:"runtimes"`
+}
+
+type runtimeStatusSnapshotCache struct {
+	mu sync.Mutex
+
+	probe       func(context.Context) runtimeStatusResponse
+	placeholder func() runtimeStatusResponse
+	now         func() time.Time
+	timeout     time.Duration
+	successTTL  time.Duration
+	failureTTL  time.Duration
+
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	hasResult  bool
+	snapshot   runtimeStatusResponse
+	refreshing bool
+	closed     bool
+}
+
+func newRuntimeStatusSnapshotCache(
+	probe func(context.Context) runtimeStatusResponse,
+	placeholder func() runtimeStatusResponse,
+) *runtimeStatusSnapshotCache {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &runtimeStatusSnapshotCache{
+		probe:       probe,
+		placeholder: placeholder,
+		now:         time.Now,
+		timeout:     runtimeStatusRefreshTimeout,
+		successTTL:  runtimeStatusSuccessTTL,
+		failureTTL:  runtimeStatusFailureTTL,
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+}
+
+func (c *runtimeStatusSnapshotCache) Snapshot() runtimeStatusResponse {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	if c.hasResult {
+		ttl := c.successTTL
+		if runtimeStatusHasFailure(c.snapshot) {
+			ttl = c.failureTTL
+		}
+		if c.snapshot.CheckedAt != nil {
+			age := now.Sub(*c.snapshot.CheckedAt)
+			if age >= 0 && age < ttl {
+				response := c.snapshot
+				response.Refreshing = c.refreshing
+				response.Stale = false
+				return response
+			}
+		}
+	}
+	if !c.refreshing && !c.closed {
+		c.refreshing = true
+		c.wg.Add(1)
+		go c.refresh()
+	}
+	if c.hasResult {
+		response := c.snapshot
+		response.Refreshing = c.refreshing
+		response.Stale = true
+		return response
+	}
+	response := c.placeholder()
+	response.Refreshing = c.refreshing
+	return response
+}
+
+func (c *runtimeStatusSnapshotCache) refresh() {
+	defer c.wg.Done()
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeout)
+	response := c.probe(ctx)
+	cancel()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refreshing = false
+	if c.closed || c.ctx.Err() != nil {
+		return
+	}
+	c.snapshot = response
+	c.hasResult = true
+}
+
+func (c *runtimeStatusSnapshotCache) Close() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	c.cancel()
+	c.mu.Unlock()
+	c.wg.Wait()
+}
+
+func runtimeStatusHasFailure(response runtimeStatusResponse) bool {
+	for _, runtime := range response.Runtimes {
+		if runtime.State == runtimeStateUnavailable {
+			return true
+		}
+	}
+	return false
+}
+
+// runtimeAccountStatus 只包含菜单栏需要的脱敏状态。账号邮箱、Token、Keychain
+// 内容和上游原始错误都不能进入这个结构，避免 status CLI 或日志扩大凭据暴露面。
+type runtimeAccountStatus struct {
+	ID         string                 `json:"id"`
+	Title      string                 `json:"title"`
+	Enabled    bool                   `json:"enabled"`
+	State      runtimeConnectionState `json:"state"`
+	AuthMode   string                 `json:"auth_mode,omitempty"`
+	PlanType   string                 `json:"plan_type,omitempty"`
+	Reason     string                 `json:"reason,omitempty"`
+	RateLimits *runtimeRateLimits     `json:"rate_limits,omitempty"`
+}
+
+type runtimeRateLimits struct {
+	LimitID           string                  `json:"limit_id,omitempty"`
+	LimitName         string                  `json:"limit_name,omitempty"`
+	PlanType          string                  `json:"plan_type,omitempty"`
+	ReachedType       string                  `json:"reached_type,omitempty"`
+	Availability      string                  `json:"availability,omitempty"`
+	UnavailableReason string                  `json:"unavailable_reason,omitempty"`
+	Primary           *runtimeRateLimitWindow `json:"primary,omitempty"`
+	Secondary         *runtimeRateLimitWindow `json:"secondary,omitempty"`
+	HasCredits        *bool                   `json:"has_credits,omitempty"`
+	CreditsUnlimited  *bool                   `json:"credits_unlimited,omitempty"`
+	CreditBalance     string                  `json:"credit_balance,omitempty"`
+}
+
+type runtimeRateLimitWindow struct {
+	UsedPercent       *float64 `json:"used_percent,omitempty"`
+	WindowDurationMin *int64   `json:"window_duration_mins,omitempty"`
+	ResetsAt          *int64   `json:"resets_at,omitempty"`
+}
+
+type runtimeAccountResponse struct {
+	Account *struct {
+		Type     string          `json:"type"`
+		PlanType json.RawMessage `json:"planType"`
+	} `json:"account"`
+	RequiresOpenAIAuth bool `json:"requiresOpenAIAuth"`
+}
+
+type runtimeRateLimitsEnvelope struct {
+	RateLimits        *runtimeRateLimitWire           `json:"rateLimits"`
+	RateLimitsByLimit map[string]runtimeRateLimitWire `json:"rateLimitsByLimitId"`
+}
+
+type runtimeRateLimitWire struct {
+	LimitID           string                      `json:"limitId"`
+	LimitName         string                      `json:"limitName"`
+	PlanType          json.RawMessage             `json:"planType"`
+	ReachedType       json.RawMessage             `json:"rateLimitReachedType"`
+	Availability      string                      `json:"availability"`
+	UnavailableReason string                      `json:"unavailableReason"`
+	Primary           *runtimeRateLimitWindowWire `json:"primary"`
+	Secondary         *runtimeRateLimitWindowWire `json:"secondary"`
+	Credits           *struct {
+		HasCredits bool            `json:"hasCredits"`
+		Unlimited  bool            `json:"unlimited"`
+		Balance    json.RawMessage `json:"balance"`
+	} `json:"credits"`
+}
+
+type runtimeRateLimitWindowWire struct {
+	UsedPercent       *float64 `json:"usedPercent"`
+	WindowDurationMin *int64   `json:"windowDurationMins"`
+	ResetsAt          *int64   `json:"resetsAt"`
+}
+
+func (r *Router) runtimeStatusHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	if !runtimeStatusLoopbackRequest(req) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	writeJSON(w, http.StatusOK, r.runtimeStatus.Snapshot())
+}
+
+func (r *Router) refreshRuntimeStatus(ctx context.Context) runtimeStatusResponse {
+	codexResult := make(chan runtimeAccountStatus, 1)
+	claudeResult := make(chan runtimeAccountStatus, 1)
+	go func() {
+		probeCtx, cancel := context.WithTimeout(ctx, codexRuntimeProbeTimeout)
+		defer cancel()
+		codexResult <- r.probeCodexRuntime(probeCtx)
+	}()
+	go func() {
+		probeCtx, cancel := context.WithTimeout(ctx, claudeRuntimeProbeTimeout)
+		defer cancel()
+		claudeResult <- r.probeClaudeRuntime(probeCtx)
+	}()
+
+	codex := <-codexResult
+	claude := <-claudeResult
+	checkedAt := time.Now().UTC()
+	return runtimeStatusResponse{
+		CheckedAt: &checkedAt,
+		Runtimes: []runtimeAccountStatus{
+			codex,
+			claude,
+		},
+	}
+}
+
+func (r *Router) runtimeStatusPlaceholder() runtimeStatusResponse {
+	claude := runtimeAccountStatus{
+		ID:      "claude",
+		Title:   "Claude",
+		Enabled: r.cfg.Claude.Enabled,
+		State:   runtimeStateUnavailable,
+		Reason:  "refresh_in_progress",
+	}
+	if !r.cfg.Claude.Enabled {
+		claude.State = runtimeStateDisabled
+		claude.Reason = "disabled"
+	}
+	return runtimeStatusResponse{
+		Runtimes: []runtimeAccountStatus{
+			{
+				ID:      "codex",
+				Title:   "Codex",
+				Enabled: true,
+				State:   runtimeStateUnavailable,
+				Reason:  "refresh_in_progress",
+			},
+			claude,
+		},
+	}
+}
+
+func runtimeStatusLoopbackRequest(req *http.Request) bool {
+	remote := strings.TrimSpace(req.RemoteAddr)
+	host, _, err := net.SplitHostPort(remote)
+	if err != nil {
+		host = strings.Trim(remote, "[]")
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
+	status := runtimeAccountStatus{
+		ID:      "codex",
+		Title:   "Codex",
+		Enabled: true,
+		State:   runtimeStateUnavailable,
+		Reason:  "upstream_unavailable",
+	}
+	upstreamURL, err := r.appServerUpstreamWebSocketURL()
+	if err != nil {
+		return status
+	}
+	headers, err := r.appServerUpstreamHeaders()
+	if err != nil {
+		return status
+	}
+	dialer := websocket.Dialer{HandshakeTimeout: codexRuntimeProbeTimeout}
+	conn, response, err := dialer.DialContext(ctx, upstreamURL, headers)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		return status
+	}
+	defer conn.Close()
+
+	rpc := runtimeWebSocketRPC{conn: conn}
+	if err := rpc.initialize(ctx); err != nil {
+		return status
+	}
+	status.State = runtimeStateAvailable
+	status.Reason = ""
+
+	var account runtimeAccountResponse
+	if err := rpc.call(ctx, "account/read", map[string]any{"refreshToken": false}, &account); err != nil {
+		status.Reason = "account_unavailable"
+	} else {
+		applyCodexAccount(&status, account)
+	}
+
+	var limits runtimeRateLimitsEnvelope
+	if err := rpc.call(ctx, "account/rateLimits/read", map[string]any{}, &limits); err == nil {
+		status.RateLimits = normalizeRuntimeRateLimits(limits, "codex")
+		if status.PlanType == "" && status.RateLimits != nil {
+			status.PlanType = status.RateLimits.PlanType
+		}
+	}
+	return status
+}
+
+func applyCodexAccount(status *runtimeAccountStatus, response runtimeAccountResponse) {
+	if response.Account == nil {
+		if response.RequiresOpenAIAuth {
+			status.State = runtimeStateSignedOut
+			status.Reason = "not_authenticated"
+		}
+		return
+	}
+	status.State = runtimeStateConnected
+	status.Reason = ""
+	status.AuthMode = normalizeAuthMode(response.Account.Type)
+	status.PlanType = rawScalarString(response.Account.PlanType)
+}
+
+func (r *Router) probeClaudeRuntime(ctx context.Context) runtimeAccountStatus {
+	status := runtimeAccountStatus{
+		ID:      "claude",
+		Title:   "Claude",
+		Enabled: r.cfg.Claude.Enabled,
+		State:   runtimeStateDisabled,
+		Reason:  "disabled",
+	}
+	if !r.cfg.Claude.Enabled {
+		return status
+	}
+	status.State = runtimeStateUnavailable
+	status.Reason = "bridge_unavailable"
+	r.refreshClaudeBridgeProbeIfStale()
+	probe := r.claudeBridgeProbe()
+	if !probe.Healthy {
+		return status
+	}
+	bin := firstNonEmpty(probe.Path, strings.TrimSpace(r.cfg.Claude.BridgeBin))
+	ensureResult := make(chan error, 1)
+	go func() {
+		_, err := r.claudeBridge.ensure(bin, r.cfg.Claude.Args, r.cfg.Claude.Env)
+		ensureResult <- err
+	}()
+	select {
+	case <-ctx.Done():
+		return status
+	case err := <-ensureResult:
+		if err != nil {
+			return status
+		}
+	}
+	if ctx.Err() != nil {
+		return status
+	}
+	conn, _, err := r.claudeBridge.dial()
+	if err != nil {
+		return status
+	}
+	defer conn.Close()
+
+	client := appserver.NewClient(conn, conn, appserver.ClientOptions{
+		ClientInfo: appserver.ClientInfo{
+			Name:    "mimi_remote_mac_status",
+			Title:   "Mimi Remote Mac",
+			Version: r.version,
+		},
+	})
+	defer client.Close()
+	if _, err := client.Initialize(ctx); err != nil {
+		return status
+	}
+	status.State = runtimeStateAvailable
+	status.Reason = ""
+
+	if claudeAPIKeyConfigured(r.cfg.Claude.Env) {
+		// bridge 只会收到 cfg.Claude.Env 中显式配置的 API Key。Key 的存在表示
+		// “已配置”而不是“已验证”。API Key 是按量计费身份，不能查询并混入
+		// 同一台 Mac 上残留的 OAuth 订阅额度。
+		status.AuthMode = "api_key"
+		status.Reason = "api_key_configured_unverified"
+		return status
+	}
+
+	var limits runtimeRateLimitsEnvelope
+	if err := client.Call(ctx, "account/rateLimits/read", map[string]any{}, &limits); err == nil {
+		status.RateLimits = normalizeRuntimeRateLimits(limits, "claude")
+		if status.RateLimits != nil {
+			status.PlanType = status.RateLimits.PlanType
+		}
+	}
+	if runtimeRateLimitsShowAuthenticated(status.RateLimits) {
+		status.State = runtimeStateConnected
+		status.AuthMode = "oauth"
+	}
+	return status
+}
+
+func claudeAPIKeyConfigured(configured map[string]string) bool {
+	return strings.TrimSpace(configured["ANTHROPIC_API_KEY"]) != ""
+}
+
+func runtimeRateLimitsShowAuthenticated(limits *runtimeRateLimits) bool {
+	if limits == nil {
+		return false
+	}
+	if strings.EqualFold(limits.Availability, "available") || strings.TrimSpace(limits.PlanType) != "" {
+		return true
+	}
+	return limits.Primary != nil && limits.Primary.UsedPercent != nil ||
+		limits.Secondary != nil && limits.Secondary.UsedPercent != nil
+}
+
+func normalizeRuntimeRateLimits(
+	envelope runtimeRateLimitsEnvelope,
+	preferredID string,
+) *runtimeRateLimits {
+	var wire *runtimeRateLimitWire
+	if item, ok := envelope.RateLimitsByLimit[preferredID]; ok {
+		wire = &item
+	} else if len(envelope.RateLimitsByLimit) > 0 {
+		keys := make([]string, 0, len(envelope.RateLimitsByLimit))
+		for key := range envelope.RateLimitsByLimit {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		item := envelope.RateLimitsByLimit[keys[0]]
+		wire = &item
+	} else {
+		wire = envelope.RateLimits
+	}
+	if wire == nil {
+		return nil
+	}
+	normalized := &runtimeRateLimits{
+		LimitID:           strings.TrimSpace(wire.LimitID),
+		LimitName:         strings.TrimSpace(wire.LimitName),
+		PlanType:          rawScalarString(wire.PlanType),
+		ReachedType:       rawScalarString(wire.ReachedType),
+		Availability:      strings.TrimSpace(wire.Availability),
+		UnavailableReason: strings.TrimSpace(wire.UnavailableReason),
+		Primary:           normalizeRuntimeRateLimitWindow(wire.Primary),
+		Secondary:         normalizeRuntimeRateLimitWindow(wire.Secondary),
+	}
+	if wire.Credits != nil {
+		hasCredits := wire.Credits.HasCredits
+		unlimited := wire.Credits.Unlimited
+		normalized.HasCredits = &hasCredits
+		normalized.CreditsUnlimited = &unlimited
+		normalized.CreditBalance = rawScalarString(wire.Credits.Balance)
+	}
+	if normalized.LimitID == "" && normalized.LimitName == "" &&
+		normalized.PlanType == "" && normalized.ReachedType == "" &&
+		normalized.Availability == "" && normalized.UnavailableReason == "" &&
+		normalized.Primary == nil && normalized.Secondary == nil &&
+		normalized.HasCredits == nil && normalized.CreditBalance == "" {
+		return nil
+	}
+	return normalized
+}
+
+func normalizeRuntimeRateLimitWindow(wire *runtimeRateLimitWindowWire) *runtimeRateLimitWindow {
+	if wire == nil {
+		return nil
+	}
+	if wire.UsedPercent == nil && wire.WindowDurationMin == nil && wire.ResetsAt == nil {
+		return nil
+	}
+	return &runtimeRateLimitWindow{
+		UsedPercent:       wire.UsedPercent,
+		WindowDurationMin: wire.WindowDurationMin,
+		ResetsAt:          wire.ResetsAt,
+	}
+}
+
+func rawScalarString(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return strings.TrimSpace(text)
+	}
+	var number json.Number
+	if json.Unmarshal(raw, &number) == nil {
+		return number.String()
+	}
+	return ""
+}
+
+func normalizeAuthMode(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "chatgpt":
+		return "chatgpt"
+	case "apikey", "api_key", "api-key":
+		return "api_key"
+	case "amazonbedrock", "amazon_bedrock", "bedrock":
+		return "bedrock"
+	default:
+		return value
+	}
+}
+
+type runtimeWebSocketRPC struct {
+	conn   *websocket.Conn
+	nextID int64
+}
+
+func (c *runtimeWebSocketRPC) initialize(ctx context.Context) error {
+	var result map[string]any
+	if err := c.call(ctx, "initialize", map[string]any{
+		"clientInfo": map[string]any{
+			"name":    "mimi_remote_mac_status",
+			"title":   "Mimi Remote Mac",
+			"version": "0.1.0",
+		},
+		"capabilities": map[string]any{},
+	}, &result); err != nil {
+		return err
+	}
+	return c.notify(ctx, "initialized", map[string]any{})
+}
+
+func (c *runtimeWebSocketRPC) call(ctx context.Context, method string, params any, result any) error {
+	c.nextID++
+	id := c.nextID
+	if err := c.write(ctx, map[string]any{
+		"id":     id,
+		"method": method,
+		"params": params,
+	}); err != nil {
+		return err
+	}
+	for {
+		if err := setRuntimeWebSocketDeadline(ctx, c.conn.SetReadDeadline); err != nil {
+			return err
+		}
+		_, payload, err := c.conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		var frame struct {
+			ID     json.RawMessage     `json:"id"`
+			Result json.RawMessage     `json:"result"`
+			Error  *appserver.RPCError `json:"error"`
+		}
+		if json.Unmarshal(payload, &frame) != nil ||
+			strings.TrimSpace(string(frame.ID)) != strconv.FormatInt(id, 10) {
+			continue
+		}
+		if frame.Error != nil {
+			return frame.Error
+		}
+		if result == nil || len(frame.Result) == 0 {
+			return nil
+		}
+		return json.Unmarshal(frame.Result, result)
+	}
+}
+
+func (c *runtimeWebSocketRPC) notify(ctx context.Context, method string, params any) error {
+	return c.write(ctx, map[string]any{
+		"method": method,
+		"params": params,
+	})
+}
+
+func (c *runtimeWebSocketRPC) write(ctx context.Context, payload any) error {
+	if err := setRuntimeWebSocketDeadline(ctx, c.conn.SetWriteDeadline); err != nil {
+		return err
+	}
+	return c.conn.WriteJSON(payload)
+}
+
+func setRuntimeWebSocketDeadline(
+	ctx context.Context,
+	set func(time.Time) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(codexRuntimeProbeTimeout)
+	}
+	return set(deadline)
+}

--- a/internal/httpapi/runtime_status_test.go
+++ b/internal/httpapi/runtime_status_test.go
@@ -1,0 +1,325 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+func TestRuntimeStatusRequiresAuthAndReturnsSanitizedCodexSnapshot(t *testing.T) {
+	upstreamURL, _, connections := fakeAppServerUpstream(t, runtimeStatusCodexResponder(t))
+	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, nil)
+
+	unauthorized := httptest.NewRecorder()
+	handler.ServeHTTP(unauthorized, httptest.NewRequest(http.MethodGet, "/api/runtime/status", nil))
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("runtime status 必须要求 Bearer Token，got=%d body=%s", unauthorized.Code, unauthorized.Body.String())
+	}
+	if connections.Load() != 0 {
+		t.Fatalf("未授权请求不能连接 provider upstream，connections=%d", connections.Load())
+	}
+
+	rec, response := readRuntimeStatusEventually(t, handler)
+	if strings.Contains(rec.Body.String(), "owner@example.com") ||
+		strings.Contains(rec.Body.String(), "test-upstream-token") {
+		t.Fatalf("runtime status 不得泄露邮箱或 upstream token：%s", rec.Body.String())
+	}
+
+	if len(response.Runtimes) != 2 {
+		t.Fatalf("应始终返回 Codex 和 Claude 两行：%+v", response.Runtimes)
+	}
+	if response.CheckedAt == nil || response.Stale || response.Refreshing {
+		t.Fatalf("完成后的 runtime status 必须是带时间的新鲜快照：%+v", response)
+	}
+	codex := response.Runtimes[0]
+	if codex.ID != "codex" || codex.State != runtimeStateConnected ||
+		codex.AuthMode != "chatgpt" || codex.PlanType != "plus" {
+		t.Fatalf("Codex 账号状态异常：%+v", codex)
+	}
+	if codex.RateLimits == nil || codex.RateLimits.Primary == nil ||
+		codex.RateLimits.Primary.UsedPercent == nil ||
+		*codex.RateLimits.Primary.UsedPercent != 62.5 ||
+		codex.RateLimits.Primary.WindowDurationMin == nil ||
+		*codex.RateLimits.Primary.WindowDurationMin != 300 {
+		t.Fatalf("Codex 额度窗口归一化异常：%+v", codex.RateLimits)
+	}
+	claude := response.Runtimes[1]
+	if claude.ID != "claude" || claude.Enabled || claude.State != runtimeStateDisabled {
+		t.Fatalf("未启用 Claude 应保留灰态行：%+v", claude)
+	}
+}
+
+func TestRuntimeStatusUsesClaudeOAuthUsageAsAuthenticatedEvidence(t *testing.T) {
+	upstreamURL, _, _ := fakeAppServerUpstream(t, runtimeStatusCodexResponder(t))
+	bridgePath := writeTestBridge(t, `#!/bin/sh
+IFS= read -r initialize
+printf '{"id":1,"result":{"userAgent":"fake-claude"}}\n'
+IFS= read -r initialized
+IFS= read -r rate_limit
+printf '{"id":2,"result":{"rateLimits":{"limitId":"claude","limitName":"Claude","planType":"pro","availability":"available","primary":{"usedPercent":25,"windowDurationMins":300,"resetsAt":1780494300},"secondary":{"usedPercent":40,"windowDurationMins":10080,"resetsAt":1781099100}}}}\n'
+while IFS= read -r line; do :; done
+`)
+	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridgePath
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+
+	_, response := readRuntimeStatusEventually(t, handler)
+	claude := response.Runtimes[1]
+	if claude.ID != "claude" || claude.State != runtimeStateConnected ||
+		claude.AuthMode != "oauth" || claude.PlanType != "pro" {
+		t.Fatalf("Claude OAuth 连接状态异常：%+v", claude)
+	}
+	if claude.RateLimits == nil || claude.RateLimits.Secondary == nil ||
+		claude.RateLimits.Secondary.WindowDurationMin == nil ||
+		*claude.RateLimits.Secondary.WindowDurationMin != 10_080 {
+		t.Fatalf("Claude 周额度窗口异常：%+v", claude.RateLimits)
+	}
+}
+
+func TestRuntimeStatusDoesNotMixConfiguredClaudeAPIKeyWithOAuthQuota(t *testing.T) {
+	upstreamURL, _, _ := fakeAppServerUpstream(t, runtimeStatusCodexResponder(t))
+	bridgePath := writeTestBridge(t, `#!/bin/sh
+IFS= read -r initialize
+printf '{"id":1,"result":{"userAgent":"fake-claude"}}\n'
+IFS= read -r initialized
+IFS= read -r rate_limit
+printf '{"id":2,"result":{"rateLimits":{"limitId":"claude","planType":"pro","availability":"available","primary":{"usedPercent":25,"windowDurationMins":300}}}}\n'
+while IFS= read -r line; do :; done
+`)
+	const apiKey = "configured-api-key-must-not-leak"
+	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridgePath
+		cfg.Claude.MaxConcurrentBridges = 3
+		if cfg.Claude.Env == nil {
+			cfg.Claude.Env = map[string]string{}
+		}
+		cfg.Claude.Env["ANTHROPIC_API_KEY"] = apiKey
+	})
+
+	rec, response := readRuntimeStatusEventually(t, handler)
+	claude := response.Runtimes[1]
+	if claude.State != runtimeStateAvailable || claude.AuthMode != "api_key" ||
+		claude.PlanType != "" || claude.RateLimits != nil ||
+		claude.Reason != "api_key_configured_unverified" {
+		t.Fatalf("API Key 应仅标记已配置，不得混入 OAuth 套餐额度：%+v", claude)
+	}
+	if strings.Contains(rec.Body.String(), apiKey) {
+		t.Fatalf("runtime status 不得泄露 Claude API Key：%s", rec.Body.String())
+	}
+}
+
+func TestRuntimeStatusIgnoresParentClaudeAPIKeyNotPassedToBridge(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "parent-only-key-must-not-leak")
+	upstreamURL, _, _ := fakeAppServerUpstream(t, runtimeStatusCodexResponder(t))
+	bridgePath := writeTestBridge(t, `#!/bin/sh
+IFS= read -r initialize
+printf '{"id":1,"result":{"userAgent":"fake-claude"}}\n'
+IFS= read -r initialized
+IFS= read -r rate_limit
+printf '{"id":2,"result":{"rateLimits":{"limitId":"claude","availability":"unavailable","unavailableReason":"headless_statusline_unavailable"}}}\n'
+while IFS= read -r line; do :; done
+`)
+	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridgePath
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+
+	rec, response := readRuntimeStatusEventually(t, handler)
+	claude := response.Runtimes[1]
+	if claude.State != runtimeStateAvailable || claude.AuthMode != "" {
+		t.Fatalf("未传给 bridge 的父进程 API Key 不能作为连接证据：%+v", claude)
+	}
+	if strings.Contains(rec.Body.String(), "parent-only-key-must-not-leak") {
+		t.Fatalf("runtime status 不得泄露父进程 API Key：%s", rec.Body.String())
+	}
+}
+
+func TestRuntimeStatusRejectsNonLoopbackWithoutStartingProviderProbe(t *testing.T) {
+	upstreamURL, _, connections := fakeAppServerUpstream(t, runtimeStatusCodexResponder(t))
+	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, nil)
+
+	rec := httptest.NewRecorder()
+	req := authedRequest(t, http.MethodGet, "/api/runtime/status", nil)
+	req.RemoteAddr = "100.64.0.8:43210"
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("远端 runtime status 必须拒绝，got=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if connections.Load() != 0 {
+		t.Fatalf("远端请求不能启动 provider probe：connections=%d", connections.Load())
+	}
+}
+
+func TestRuntimeStatusCacheReturnsImmediatelyAndSingleFlightsRefresh(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var probes atomic.Int32
+	cache := newRuntimeStatusSnapshotCache(
+		func(ctx context.Context) runtimeStatusResponse {
+			if probes.Add(1) == 1 {
+				close(started)
+			}
+			select {
+			case <-ctx.Done():
+			case <-release:
+			}
+			checkedAt := time.Now().UTC()
+			return runtimeStatusResponse{
+				CheckedAt: &checkedAt,
+				Runtimes: []runtimeAccountStatus{{
+					ID: "codex", Title: "Codex", Enabled: true, State: runtimeStateConnected,
+				}},
+			}
+		},
+		func() runtimeStatusResponse {
+			return runtimeStatusResponse{
+				Runtimes: []runtimeAccountStatus{{
+					ID: "codex", Title: "Codex", Enabled: true,
+					State: runtimeStateUnavailable, Reason: "refresh_in_progress",
+				}},
+			}
+		},
+	)
+	defer cache.Close()
+
+	start := time.Now()
+	first := cache.Snapshot()
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("缓存 miss 不得等待 provider：%s", elapsed)
+	}
+	if !first.Refreshing || first.CheckedAt != nil {
+		t.Fatalf("首次请求应立即返回 refreshing 占位：%+v", first)
+	}
+	<-started
+	for range 20 {
+		if snapshot := cache.Snapshot(); !snapshot.Refreshing {
+			t.Fatalf("刷新未释放前必须保持 refreshing：%+v", snapshot)
+		}
+	}
+	if probes.Load() != 1 {
+		t.Fatalf("并发快照必须 single-flight：probes=%d", probes.Load())
+	}
+	close(release)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := cache.Snapshot()
+		if !snapshot.Refreshing {
+			if snapshot.Stale || snapshot.CheckedAt == nil {
+				t.Fatalf("刷新结果必须新鲜：%+v", snapshot)
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("runtime status cache 没有完成刷新")
+}
+
+func readRuntimeStatusEventually(
+	t *testing.T,
+	handler http.Handler,
+) (*httptest.ResponseRecorder, runtimeStatusResponse) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		rec := httptest.NewRecorder()
+		req := authedRequest(t, http.MethodGet, "/api/runtime/status", nil)
+		req.RemoteAddr = "127.0.0.1:43210"
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("runtime status 应返回 200，got=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var response runtimeStatusResponse
+		if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+			t.Fatalf("runtime status 响应无法解析：%v", err)
+		}
+		if !response.Refreshing {
+			return rec, response
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("runtime status 后台刷新超时：%+v", response)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func runtimeStatusCodexResponder(t *testing.T) func(*websocket.Conn, int, []byte) {
+	t.Helper()
+	return func(conn *websocket.Conn, messageType int, payload []byte) {
+		var frame struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.Unmarshal(payload, &frame); err != nil {
+			t.Errorf("无法解析 fake app-server frame：%v", err)
+			return
+		}
+		var result any
+		switch frame.Method {
+		case "initialize":
+			result = map[string]any{"userAgent": "fake-codex"}
+		case "initialized":
+			return
+		case "account/read":
+			result = map[string]any{
+				"account": map[string]any{
+					"type":     "chatgpt",
+					"email":    "owner@example.com",
+					"planType": "plus",
+				},
+				"requiresOpenAIAuth": true,
+			}
+		case "account/rateLimits/read":
+			result = map[string]any{
+				"rateLimitsByLimitId": map[string]any{
+					"codex": map[string]any{
+						"limitId":   "codex",
+						"limitName": "Codex",
+						"planType":  "plus",
+						"primary": map[string]any{
+							"usedPercent":        62.5,
+							"windowDurationMins": 300,
+							"resetsAt":           1_780_494_300,
+						},
+						"secondary": map[string]any{
+							"usedPercent":        30,
+							"windowDurationMins": 10_080,
+							"resetsAt":           1_781_099_100,
+						},
+						"credits": map[string]any{
+							"hasCredits": true,
+							"unlimited":  false,
+							"balance":    "12.34",
+						},
+					},
+				},
+			}
+		default:
+			t.Errorf("fake app-server 收到未知方法：%s", frame.Method)
+			return
+		}
+		response, err := json.Marshal(map[string]any{
+			"id":     frame.ID,
+			"result": result,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if err := conn.WriteMessage(messageType, response); err != nil {
+			t.Errorf("fake app-server 写响应失败：%v", err)
+		}
+	}
+}

--- a/internal/httpapi/runtime_status_test.go
+++ b/internal/httpapi/runtime_status_test.go
@@ -58,6 +58,131 @@ func TestRuntimeStatusRequiresAuthAndReturnsSanitizedCodexSnapshot(t *testing.T)
 	}
 }
 
+func TestRuntimeStatusDoesNotTreatServerRequestAsRPCResponse(t *testing.T) {
+	var rejectedServerRequest atomic.Bool
+	upstreamURL, _, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var frame struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Error  *struct {
+				Code int `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(payload, &frame); err != nil {
+			t.Errorf("无法解析 runtime status RPC frame：%v", err)
+			return
+		}
+		if frame.Method == "" {
+			if frame.Error != nil && frame.Error.Code == -32601 {
+				rejectedServerRequest.Store(true)
+			}
+			return
+		}
+
+		var result any
+		switch frame.Method {
+		case "initialize":
+			result = map[string]any{"userAgent": "fake-codex"}
+		case "initialized":
+			return
+		case "account/read":
+			// 双向 JSON-RPC 的 request/response id namespace 相互独立。
+			// 服务端 request 故意复用当前客户端 request id，验证客户端不会误判。
+			if err := conn.WriteJSON(map[string]any{
+				"id":     frame.ID,
+				"method": "account/chatgptAuthTokens/refresh",
+				"params": map[string]any{"reason": "unauthorized"},
+			}); err != nil {
+				t.Errorf("写入服务端 request 失败：%v", err)
+				return
+			}
+			result = map[string]any{
+				"account": map[string]any{
+					"type":     "chatgpt",
+					"planType": "plus",
+				},
+				"requiresOpenaiAuth": true,
+			}
+		case "account/rateLimits/read":
+			result = map[string]any{}
+		default:
+			t.Errorf("fake app-server 收到未知方法：%s", frame.Method)
+			return
+		}
+		response, err := json.Marshal(map[string]any{
+			"id":     frame.ID,
+			"result": result,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if err := conn.WriteMessage(messageType, response); err != nil {
+			t.Errorf("fake app-server 写响应失败：%v", err)
+		}
+	})
+	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, nil)
+
+	_, response := readRuntimeStatusEventually(t, handler)
+	codex := response.Runtimes[0]
+	if codex.State != runtimeStateConnected || codex.AuthMode != "chatgpt" {
+		t.Fatalf("服务端 request 不能吞掉 account/read 响应：%+v", codex)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if rejectedServerRequest.Load() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("runtime status 客户端没有拒绝不支持的服务端 request")
+}
+
+func TestApplyCodexAccountDoesNotClaimUnverifiedCredentialsAreConnected(t *testing.T) {
+	testCases := []struct {
+		name       string
+		account    string
+		wantMode   string
+		wantReason string
+	}{
+		{
+			name:       "API key",
+			account:    `{"account":{"type":"apiKey"},"requiresOpenaiAuth":true}`,
+			wantMode:   "api_key",
+			wantReason: "api_key_configured_unverified",
+		},
+		{
+			name:       "Bedrock",
+			account:    `{"account":{"type":"amazonBedrock","credentialSource":"awsManaged"},"requiresOpenaiAuth":false}`,
+			wantMode:   "bedrock",
+			wantReason: "bedrock_credentials_configured_unverified",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var response runtimeAccountResponse
+			if err := json.Unmarshal([]byte(testCase.account), &response); err != nil {
+				t.Fatal(err)
+			}
+			status := runtimeAccountStatus{
+				ID:      "codex",
+				Title:   "Codex",
+				Enabled: true,
+				State:   runtimeStateUnavailable,
+			}
+
+			applyCodexAccount(&status, response)
+
+			if status.State != runtimeStateAvailable ||
+				status.AuthMode != testCase.wantMode ||
+				status.Reason != testCase.wantReason {
+				t.Fatalf("未验证凭据不能标记为 connected：%+v", status)
+			}
+		})
+	}
+}
+
 func TestRuntimeStatusUsesClaudeOAuthUsageAsAuthenticatedEvidence(t *testing.T) {
 	upstreamURL, _, _ := fakeAppServerUpstream(t, runtimeStatusCodexResponder(t))
 	bridgePath := writeTestBridge(t, `#!/bin/sh
@@ -279,7 +404,7 @@ func runtimeStatusCodexResponder(t *testing.T) func(*websocket.Conn, int, []byte
 					"email":    "owner@example.com",
 					"planType": "plus",
 				},
-				"requiresOpenAIAuth": true,
+				"requiresOpenaiAuth": true,
 			}
 		case "account/rateLimits/read":
 			result = map[string]any{

--- a/macos/MimiRemoteMac/MimiRemoteMac.xcodeproj/project.pbxproj
+++ b/macos/MimiRemoteMac/MimiRemoteMac.xcodeproj/project.pbxproj
@@ -24,11 +24,13 @@
 		7DA4ACD2AA9E502238AC5228 /* AgentLogClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34FFFDD49F996F5FB064A2 /* AgentLogClient.swift */; };
 		9190117090B67A3342D6120D /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE4D38858D995BC12D0856A /* QRCodeView.swift */; };
 		9381140D2855654A9E07746E /* StatusComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4847134E49077F02AF8BBE /* StatusComponents.swift */; };
+		AD199C3299AE46CEBBFBD8F4 /* MenuRuntimePresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */; };
 		B0007C75D28B779DE9DE6270 /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE170A943EDB5164E2CD95 /* PairingView.swift */; };
 		B4E72BE5C26B15E8255D9F2B /* HealthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF645CF76E8BD94261F54A9 /* HealthClient.swift */; };
 		D888FADCD970DD7E91DBFF45 /* AgentCommandClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BFD44EAEE64300C32946C4 /* AgentCommandClient.swift */; };
 		DE712EF3822095AC7465834A /* MacSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8B42F16AE872A2164A2C14 /* MacSettingsView.swift */; };
 		E315A720A10E9DC2DEC52514 /* AgentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7976BAA1C4222A9CE0CF24 /* AgentModels.swift */; };
+		EB40EB38AC0DD1E7C9C3B21E /* MenuRuntimePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78765A951C28D21B18CCFAF /* MenuRuntimePresentation.swift */; };
 		F0B1F99A2045339CB960772E /* AgentCommandClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA410B972FDE86680731233 /* AgentCommandClientTests.swift */; };
 		F496A4E680E86AEC0F3AB5E9 /* MimiRemoteMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0665418B45A53032B38134E3 /* MimiRemoteMacApp.swift */; };
 /* End PBXBuildFile section */
@@ -64,7 +66,9 @@
 		8BE4D38858D995BC12D0856A /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
 		8DA7DA1200E8FF88D5E0DDF2 /* DiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsView.swift; sourceTree = "<group>"; };
 		95CEFC2080963A6433B43217 /* MenuBarWindowPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarWindowPlacementTests.swift; sourceTree = "<group>"; };
+		A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRuntimePresentationTests.swift; sourceTree = "<group>"; };
 		A1A62A4B02D2D4B3685ED5AD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B78765A951C28D21B18CCFAF /* MenuRuntimePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRuntimePresentation.swift; sourceTree = "<group>"; };
 		C187C502CDCBC251CB35D863 /* MimiRemoteMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MimiRemoteMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC34FFFDD49F996F5FB064A2 /* AgentLogClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLogClient.swift; sourceTree = "<group>"; };
 		DC7976BAA1C4222A9CE0CF24 /* AgentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentModels.swift; sourceTree = "<group>"; };
@@ -150,6 +154,7 @@
 				F9B97C2451CBB1E2B78D009C /* AgentModelsTests.swift */,
 				01F22A0DD397F37B0B0E8849 /* HostStoreTests.swift */,
 				95CEFC2080963A6433B43217 /* MenuBarWindowPlacementTests.swift */,
+				A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -158,6 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				414A74A2A5A2877C1A9CB604 /* MenuBarContentView.swift */,
+				B78765A951C28D21B18CCFAF /* MenuRuntimePresentation.swift */,
 			);
 			path = MenuBar;
 			sourceTree = "<group>";
@@ -359,6 +365,7 @@
 				642F9E49711F073D72016DF1 /* HostStore.swift in Sources */,
 				DE712EF3822095AC7465834A /* MacSettingsView.swift in Sources */,
 				0233FB757655D673A1588B25 /* MenuBarContentView.swift in Sources */,
+				EB40EB38AC0DD1E7C9C3B21E /* MenuRuntimePresentation.swift in Sources */,
 				F496A4E680E86AEC0F3AB5E9 /* MimiRemoteMacApp.swift in Sources */,
 				73569A6C33D94DEE3D9141F3 /* OnboardingView.swift in Sources */,
 				B0007C75D28B779DE9DE6270 /* PairingView.swift in Sources */,
@@ -378,6 +385,7 @@
 				2D3D7AD1F48F6D665E50089E /* AgentModelsTests.swift in Sources */,
 				2D88E2B17C680EC02E71EAB5 /* HostStoreTests.swift in Sources */,
 				11399EBAD3569F1EA7DC3A55 /* MenuBarWindowPlacementTests.swift in Sources */,
+				AD199C3299AE46CEBBFBD8F4 /* MenuRuntimePresentationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/MimiRemoteMac/Scripts/embed-agentd.sh
+++ b/macos/MimiRemoteMac/Scripts/embed-agentd.sh
@@ -33,7 +33,7 @@ fi
 
 go_version="$(GOTOOLCHAIN=local "$go_binary" env GOVERSION)"
 if [[ "$go_version" != go1.25.* ]]; then
-  echo "Mimi Remote Mac 构建失败：agentd 需要 Go 1.25，当前为 $go_version。" >&2
+  echo "Mimi Remote Mac 构建失败：agentd 需要 Go 1.25，当前为 ${go_version}。" >&2
   exit 1
 fi
 
@@ -48,7 +48,7 @@ for architecture in "${architectures[@]}"; do
     arm64) go_arch=arm64 ;;
     x86_64) go_arch=amd64 ;;
     *)
-      echo "Mimi Remote Mac 构建失败：不支持架构 $architecture。" >&2
+      echo "Mimi Remote Mac 构建失败：不支持架构 ${architecture}。" >&2
       exit 1
       ;;
   esac

--- a/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
+++ b/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
@@ -104,6 +104,197 @@ struct DoctorFixResults: Codable, Equatable, Sendable {
     let results: AgentDoctorResults
 }
 
+struct AgentRuntimeStatusSnapshot: Codable, Equatable, Sendable {
+    let checkedAt: String?
+    let runtimes: [AgentRuntimeStatus]
+    let refreshing: Bool?
+    let stale: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case checkedAt = "checked_at"
+        case runtimes
+        case refreshing
+        case stale
+    }
+
+    init(
+        checkedAt: String?,
+        runtimes: [AgentRuntimeStatus],
+        refreshing: Bool? = nil,
+        stale: Bool? = nil
+    ) {
+        self.checkedAt = checkedAt
+        self.runtimes = runtimes
+        self.refreshing = refreshing
+        self.stale = stale
+    }
+
+    var checkedDate: Date? {
+        guard let checkedAt = checkedAt?.trimmedNonEmpty else { return nil }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: checkedAt) ?? ISO8601DateFormatter().date(from: checkedAt)
+    }
+
+    func isExpired(at now: Date = Date()) -> Bool {
+        if stale == true { return true }
+        guard let checkedDate else {
+            return refreshing != true
+        }
+        return now.timeIntervalSince(checkedDate) > 2 * 60
+    }
+
+    var hasRetryableFailure: Bool {
+        runtimes.contains {
+            $0.enabled
+                && $0.state == .unavailable
+                && $0.reason != "refresh_in_progress"
+        }
+    }
+}
+
+enum AgentRuntimeConnectionState: String, Codable, Equatable, Sendable {
+    case connected
+    case available
+    case signedOut = "signed_out"
+    case disabled
+    case unavailable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        // 服务端新增状态时 fail closed，但不要让整个 agent status 解码失败。
+        self = AgentRuntimeConnectionState(rawValue: raw) ?? .unavailable
+    }
+}
+
+struct AgentRuntimeStatus: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let enabled: Bool
+    let state: AgentRuntimeConnectionState
+    let authMode: String?
+    let planType: String?
+    let reason: String?
+    let rateLimits: AgentRuntimeRateLimits?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case enabled
+        case state
+        case authMode = "auth_mode"
+        case planType = "plan_type"
+        case reason
+        case rateLimits = "rate_limits"
+    }
+
+    var effectivePlanType: String? {
+        planType?.trimmedNonEmpty ?? rateLimits?.planType?.trimmedNonEmpty
+    }
+}
+
+struct AgentRuntimeRateLimits: Codable, Equatable, Sendable {
+    let limitID: String?
+    let limitName: String?
+    let planType: String?
+    let reachedType: String?
+    let availability: String?
+    let unavailableReason: String?
+    let primary: AgentRuntimeRateLimitWindow?
+    let secondary: AgentRuntimeRateLimitWindow?
+    let hasCredits: Bool?
+    let creditsUnlimited: Bool?
+    let creditBalance: String?
+
+    enum CodingKeys: String, CodingKey {
+        case limitID = "limit_id"
+        case limitName = "limit_name"
+        case planType = "plan_type"
+        case reachedType = "reached_type"
+        case availability
+        case unavailableReason = "unavailable_reason"
+        case primary
+        case secondary
+        case hasCredits = "has_credits"
+        case creditsUnlimited = "credits_unlimited"
+        case creditBalance = "credit_balance"
+    }
+
+    var windows: [AgentRuntimeRateLimitWindow] {
+        [primary, secondary]
+            .compactMap { $0 }
+            .sorted {
+                ($0.windowDurationMins ?? Int64.max) < ($1.windowDurationMins ?? Int64.max)
+            }
+    }
+
+    var isExhausted: Bool {
+        if reachedType?.trimmedNonEmpty != nil {
+            return true
+        }
+        return windows.contains { ($0.usedPercent ?? 0) >= 100 }
+    }
+}
+
+struct AgentRuntimeRateLimitWindow: Codable, Equatable, Sendable {
+    let usedPercent: Double?
+    let windowDurationMins: Int64?
+    let resetsAt: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case usedPercent = "used_percent"
+        case windowDurationMins = "window_duration_mins"
+        case resetsAt = "resets_at"
+    }
+
+    var remainingFraction: Double? {
+        usedPercent.map { min(max(1 - $0 / 100, 0), 1) }
+    }
+
+    var remainingPercentText: String? {
+        remainingFraction.map { fraction in
+            let percent = fraction * 100
+            if abs(percent.rounded() - percent) < 0.0001 {
+                return "\(Int(percent.rounded()))%"
+            }
+            return String(format: "%.1f%%", percent)
+        }
+    }
+
+    var durationLabel: String {
+        guard let minutes = windowDurationMins, minutes > 0 else {
+            return "额度窗口"
+        }
+        if minutes.isMultiple(of: 24 * 60) {
+            return "\(minutes / (24 * 60))d"
+        }
+        if minutes.isMultiple(of: 60) {
+            return "\(minutes / 60)h"
+        }
+        return "\(minutes)m"
+    }
+
+    var resetDate: Date? {
+        guard let resetsAt, resetsAt > 0 else { return nil }
+        let seconds = resetsAt > 10_000_000_000
+            ? TimeInterval(resetsAt) / 1_000
+            : TimeInterval(resetsAt)
+        return Date(timeIntervalSince1970: seconds)
+    }
+
+    var isExhausted: Bool {
+        (usedPercent ?? 0) >= 100
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}
+
 struct AgentStatus: Codable, Equatable, Sendable {
     let processOK: Bool
     let serviceOK: Bool
@@ -116,6 +307,7 @@ struct AgentStatus: Codable, Equatable, Sendable {
     let doctorOK: Bool
     let doctor: AgentDoctorResults
     let pairExpires: String?
+    let runtimeStatus: AgentRuntimeStatusSnapshot?
 
     enum CodingKeys: String, CodingKey {
         case processOK = "process_ok"
@@ -129,6 +321,60 @@ struct AgentStatus: Codable, Equatable, Sendable {
         case doctorOK = "doctor_ok"
         case doctor
         case pairExpires = "pair_expires"
+        case runtimeStatus = "runtime_status"
+    }
+
+    init(
+        processOK: Bool,
+        serviceOK: Bool,
+        processError: String?,
+        serviceError: String?,
+        version: String,
+        endpoint: String,
+        configPath: String,
+        projects: Int,
+        doctorOK: Bool,
+        doctor: AgentDoctorResults,
+        pairExpires: String?,
+        runtimeStatus: AgentRuntimeStatusSnapshot? = nil
+    ) {
+        self.processOK = processOK
+        self.serviceOK = serviceOK
+        self.processError = processError
+        self.serviceError = serviceError
+        self.version = version
+        self.endpoint = endpoint
+        self.configPath = configPath
+        self.projects = projects
+        self.doctorOK = doctorOK
+        self.doctor = doctor
+        self.pairExpires = pairExpires
+        self.runtimeStatus = runtimeStatus
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        processOK = try container.decode(Bool.self, forKey: .processOK)
+        serviceOK = try container.decode(Bool.self, forKey: .serviceOK)
+        processError = try container.decodeIfPresent(String.self, forKey: .processError)
+        serviceError = try container.decodeIfPresent(String.self, forKey: .serviceError)
+        version = try container.decode(String.self, forKey: .version)
+        endpoint = try container.decode(String.self, forKey: .endpoint)
+        configPath = try container.decode(String.self, forKey: .configPath)
+        projects = try container.decode(Int.self, forKey: .projects)
+        doctorOK = try container.decode(Bool.self, forKey: .doctorOK)
+        doctor = try container.decode(AgentDoctorResults.self, forKey: .doctor)
+        pairExpires = try container.decodeIfPresent(String.self, forKey: .pairExpires)
+        do {
+            runtimeStatus = try container.decodeIfPresent(
+                AgentRuntimeStatusSnapshot.self,
+                forKey: .runtimeStatus
+            )
+        } catch {
+            // runtime_status 是菜单栏增强字段。混合版本或局部协议漂移时只丢弃
+            // 该快照，不能让健康检查、迁移和服务控制一起解码失败。
+            runtimeStatus = nil
+        }
     }
 }
 

--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -571,27 +571,10 @@ private struct MenuRuntimeRow: View {
     }
 
     private var detailText: String {
-        guard let runtime else {
-            return missingDetail
-        }
-        if runtime.reason == "refresh_in_progress" {
-            return "正在后台获取连接与额度状态…"
-        }
-        if runtime.authMode == "api_key",
-           runtime.state == .available || runtime.state == .connected
-        {
-            return "API Key 已配置（按量计费），将在首次请求时验证有效性。"
-        }
-        switch runtime.state {
-        case .disabled:
-            return "可在设置中启用 Claude 实验通道。"
-        case .signedOut:
-            return "请在这台 Mac 上完成登录。"
-        case .unavailable:
-            return "运行时暂不可用，请刷新或运行诊断。"
-        case .connected, .available:
-            return "尚未获取到额度数据。"
-        }
+        MenuRuntimePresentation.detailText(
+            for: runtime,
+            missingDetail: missingDetail
+        )
     }
 
     private var stateColor: Color {

--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -7,13 +7,12 @@ struct MenuBarContentView: View {
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
     @State private var confirmsQuit = false
-    @State private var isRefreshing = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             MenuStatusHeader(
                 lifecycle: store.lifecycle,
-                isRefreshing: isRefreshing || store.isBusy,
+                isRefreshing: store.isRefreshingStatus || store.isBusy,
                 refresh: refreshStatus
             )
 
@@ -24,6 +23,17 @@ struct MenuBarContentView: View {
 
                 MenuConnectionSummary(status: status, owner: store.owner)
                     .padding(.vertical, 9)
+
+                Divider()
+                    .opacity(0.45)
+
+                MenuRuntimeSummary(
+                    snapshot: status.runtimeStatus,
+                    serviceAvailable: status.serviceOK,
+                    owner: store.owner,
+                    lifecycle: store.lifecycle
+                )
+                .padding(.vertical, 9)
 
                 Divider()
                     .opacity(0.45)
@@ -133,12 +143,7 @@ struct MenuBarContentView: View {
     }
 
     private func refreshStatus() {
-        guard !isRefreshing else { return }
-        isRefreshing = true
-        Task {
-            await store.refresh()
-            isRefreshing = false
-        }
+        Task { await store.refresh() }
     }
 
     private func presentWindow(_ window: AppWindow) {
@@ -332,6 +337,401 @@ private struct MenuMetadataRow<Content: View>: View {
             Spacer(minLength: 0)
         }
         .accessibilityElement(children: .combine)
+    }
+}
+
+private struct MenuRuntimeSummary: View {
+    let snapshot: AgentRuntimeStatusSnapshot?
+    let serviceAvailable: Bool
+    let owner: ServiceOwner
+    let lifecycle: HostLifecycleState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 5) {
+                Text("AI 运行时")
+                    .font(.caption2.weight(.semibold))
+                    .textCase(.uppercase)
+
+                Spacer(minLength: 4)
+
+                if snapshot?.refreshing == true {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .accessibilityLabel("正在刷新运行时状态")
+                }
+
+                if let snapshotStatusText {
+                    Text(snapshotStatusText)
+                        .font(.caption2)
+                }
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 3)
+
+            MenuRuntimeRow(
+                runtime: runtime(id: "codex"),
+                fallbackTitle: "Codex",
+                systemImage: "chevron.left.forwardslash.chevron.right",
+                serviceAvailable: serviceAvailable,
+                isRefreshing: snapshot?.refreshing == true,
+                isStale: isStale,
+                missingDetail: missingDetail
+            )
+
+            MenuRuntimeRow(
+                runtime: runtime(id: "claude"),
+                fallbackTitle: "Claude",
+                systemImage: "sparkles",
+                serviceAvailable: serviceAvailable,
+                isRefreshing: snapshot?.refreshing == true,
+                isStale: isStale,
+                missingDetail: missingDetail
+            )
+        }
+    }
+
+    private func runtime(id: String) -> AgentRuntimeStatus? {
+        snapshot?.runtimes.first { $0.id == id }
+    }
+
+    private var isStale: Bool {
+        guard serviceAvailable, lifecycleAllowsFreshStatus else { return true }
+        return snapshot?.isExpired() == true
+    }
+
+    private var lifecycleAllowsFreshStatus: Bool {
+        switch lifecycle {
+        case .ready, .migrationRequired:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private var missingDetail: String {
+        if owner == .homebrew {
+            return "升级或迁移到新版 Mac App 后可显示运行时状态。"
+        }
+        if !serviceAvailable {
+            return "Mac 服务不可用。"
+        }
+        return "运行时状态暂不可获取，请刷新或运行诊断。"
+    }
+
+    private var snapshotStatusText: String? {
+        if snapshot?.refreshing == true {
+            return snapshot?.checkedDate == nil ? "正在首次获取" : "后台刷新"
+        }
+        if isStale, snapshot != nil {
+            return "状态可能已过期"
+        }
+        if let checkedDate = snapshot?.checkedDate {
+            return "更新于 \(checkedDate.formatted(date: .omitted, time: .shortened))"
+        }
+        if owner == .homebrew {
+            return "需要升级"
+        }
+        return nil
+    }
+}
+
+private struct MenuRuntimeRow: View {
+    let runtime: AgentRuntimeStatus?
+    let fallbackTitle: String
+    let systemImage: String
+    let serviceAvailable: Bool
+    let isRefreshing: Bool
+    let isStale: Bool
+    let missingDetail: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: systemImage)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(stateColor)
+                .frame(width: 16, height: 19)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(runtime?.title ?? fallbackTitle)
+                        .font(.callout.weight(.semibold))
+
+                    Spacer(minLength: 4)
+
+                    Circle()
+                        .fill(stateColor)
+                        .frame(width: 6, height: 6)
+                        .accessibilityHidden(true)
+
+                    Text(stateTitle)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(stateColor)
+
+                    if let accountLabel {
+                        Text("· \(accountLabel)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if !usageWindows.isEmpty {
+                    HStack(alignment: .top, spacing: 6) {
+                        ForEach(usageWindows) { item in
+                            MenuRuntimeQuotaWindow(item: item)
+                        }
+                    }
+                }
+
+                if let quotaNoticeText {
+                    Text(quotaNoticeText)
+                        .font(.caption2.weight(quotaIsExhausted ? .semibold : .regular))
+                        .foregroundStyle(quotaIsExhausted ? Color.red : Color.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if let creditSummary {
+                    Text(creditSummary)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if usageWindows.isEmpty, quotaNoticeText == nil, creditSummary == nil {
+                    Text(detailText)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(.horizontal, 3)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var usageWindows: [MenuRuntimeQuotaWindowItem] {
+        guard let limits = runtime?.rateLimits else { return [] }
+        let reached = limits.reachedType?.lowercased() ?? ""
+        var result: [MenuRuntimeQuotaWindowItem] = []
+        if let primary = limits.primary,
+           primary.usedPercent != nil || primary.resetsAt != nil || primary.windowDurationMins != nil
+        {
+            result.append(MenuRuntimeQuotaWindowItem(
+                id: "primary",
+                window: primary,
+                isExhausted: primary.isExhausted || reached.contains("primary")
+            ))
+        }
+        if let secondary = limits.secondary,
+           secondary.usedPercent != nil || secondary.resetsAt != nil || secondary.windowDurationMins != nil
+        {
+            result.append(MenuRuntimeQuotaWindowItem(
+                id: "secondary",
+                window: secondary,
+                isExhausted: secondary.isExhausted || reached.contains("secondary")
+            ))
+        }
+        return result
+    }
+
+    private var stateTitle: String {
+        if runtime?.state == .disabled { return "未启用" }
+        if isStale { return "状态已过期" }
+        if isRefreshing, runtime?.reason == "refresh_in_progress" {
+            return "正在刷新"
+        }
+        guard let runtime else {
+            return serviceAvailable ? "状态未知" : "不可用"
+        }
+        switch runtime.state {
+        case .connected: return "已连接"
+        case .available: return "运行时可用"
+        case .signedOut: return "未登录"
+        case .disabled: return "未启用"
+        case .unavailable: return "不可用"
+        }
+    }
+
+    private var accountLabel: String? {
+        if runtime?.authMode == "api_key" {
+            return "API Key"
+        }
+        if let plan = runtime?.effectivePlanType {
+            return formattedAccountValue(plan)
+        }
+        guard let authMode = runtime?.authMode else { return nil }
+        switch authMode {
+        case "api_key": return "API Key"
+        case "chatgpt": return "ChatGPT"
+        case "oauth": return "OAuth"
+        case "bedrock": return "Bedrock"
+        default: return formattedAccountValue(authMode)
+        }
+    }
+
+    private var detailText: String {
+        guard let runtime else {
+            return missingDetail
+        }
+        if runtime.reason == "refresh_in_progress" {
+            return "正在后台获取连接与额度状态…"
+        }
+        if runtime.authMode == "api_key",
+           runtime.state == .available || runtime.state == .connected
+        {
+            return "API Key 已配置（按量计费），将在首次请求时验证有效性。"
+        }
+        switch runtime.state {
+        case .disabled:
+            return "可在设置中启用 Claude 实验通道。"
+        case .signedOut:
+            return "请在这台 Mac 上完成登录。"
+        case .unavailable:
+            return "运行时暂不可用，请刷新或运行诊断。"
+        case .connected, .available:
+            return "尚未获取到额度数据。"
+        }
+    }
+
+    private var stateColor: Color {
+        if runtime?.state == .disabled { return .secondary }
+        if isStale { return .orange }
+        if isRefreshing, runtime?.reason == "refresh_in_progress" {
+            return .secondary
+        }
+        guard let runtime else {
+            return serviceAvailable ? .secondary : .red
+        }
+        switch runtime.state {
+        case .connected: return Color.mimiPrimary
+        case .available: return Color.blue
+        case .signedOut: return Color.orange
+        case .disabled: return Color.secondary
+        case .unavailable: return Color.red
+        }
+    }
+
+    private var quotaIsExhausted: Bool {
+        runtime?.rateLimits?.isExhausted == true
+    }
+
+    private var quotaNoticeText: String? {
+        guard let limits = runtime?.rateLimits else { return nil }
+        if limits.isExhausted {
+            return "额度已耗尽，等待窗口重置。"
+        }
+        switch limits.availability?.lowercased() {
+        case "partial":
+            return "仅显示已观测到的额度窗口。"
+        case "unavailable":
+            return "额度暂不可获取。"
+        default:
+            return nil
+        }
+    }
+
+    private var creditSummary: String? {
+        guard runtime?.authMode != "api_key", let limits = runtime?.rateLimits else {
+            return nil
+        }
+        if limits.creditsUnlimited == true {
+            return "Credits 无限"
+        }
+        if let balance = limits.creditBalance?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !balance.isEmpty
+        {
+            return "Credits 余额 \(balance)"
+        }
+        if limits.hasCredits == false {
+            return "Credits 未启用"
+        }
+        if limits.hasCredits == true {
+            return "Credits 可用"
+        }
+        return nil
+    }
+
+    private func formattedAccountValue(_ raw: String) -> String {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return raw }
+        switch value.lowercased() {
+        case "plus": return "Plus"
+        case "pro": return "Pro"
+        case "team": return "Team"
+        case "business": return "Business"
+        case "enterprise": return "Enterprise"
+        default: return value
+        }
+    }
+}
+
+private struct MenuRuntimeQuotaWindowItem: Identifiable {
+    let id: String
+    let window: AgentRuntimeRateLimitWindow
+    let isExhausted: Bool
+}
+
+private struct MenuRuntimeQuotaWindow: View {
+    let item: MenuRuntimeQuotaWindowItem
+
+    private var window: AgentRuntimeRateLimitWindow {
+        item.window
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(window.durationLabel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 2)
+                Text(valueText)
+                    .font(.caption2.monospacedDigit().weight(.medium))
+                    .foregroundStyle(item.isExhausted ? Color.red : Color.primary)
+            }
+
+            if item.isExhausted || window.remainingFraction != nil {
+                let progress = item.isExhausted ? 0 : (window.remainingFraction ?? 0)
+                ProgressView(value: progress)
+                    .progressViewStyle(.linear)
+                    .tint(item.isExhausted ? Color.red : progressColor(progress))
+                    .accessibilityLabel("\(window.durationLabel)额度")
+                    .accessibilityValue(valueText)
+            }
+
+            if let resetDate = window.resetDate {
+                Text("\(resetText(resetDate)) 重置")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            item.isExhausted ? Color.red.opacity(0.07) : Color.primary.opacity(0.045),
+            in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+        )
+    }
+
+    private var valueText: String {
+        if item.isExhausted { return "已耗尽" }
+        return window.remainingPercentText.map { "剩余 \($0)" } ?? "等待刷新"
+    }
+
+    private func progressColor(_ remaining: Double) -> Color {
+        if remaining <= 0.05 { return .red }
+        if remaining <= 0.2 { return .orange }
+        return .mimiPrimary
+    }
+
+    private func resetText(_ date: Date) -> String {
+        if Calendar.current.isDateInToday(date) {
+            return date.formatted(date: .omitted, time: .shortened)
+        }
+        return date.formatted(date: .abbreviated, time: .shortened)
     }
 }
 

--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuRuntimePresentation.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuRuntimePresentation.swift
@@ -1,0 +1,35 @@
+enum MenuRuntimePresentation {
+    static func detailText(
+        for runtime: AgentRuntimeStatus?,
+        missingDetail: String
+    ) -> String {
+        guard let runtime else {
+            return missingDetail
+        }
+        if runtime.reason == "refresh_in_progress" {
+            return "正在后台获取连接与额度状态…"
+        }
+        // 认证类型与状态必须同时匹配，避免把其他已连接账户误显示成 API Key。
+        let isConfiguredAPIKey = runtime.authMode == "api_key"
+            && (runtime.state == .available || runtime.state == .connected)
+        if isConfiguredAPIKey {
+            return "API Key 已配置（按量计费），将在首次请求时验证有效性。"
+        }
+        if runtime.reason == "bedrock_credentials_configured_unverified" {
+            return "Bedrock 凭据来源已配置，将在首次请求时验证有效性。"
+        }
+        if runtime.reason == "account_configured_unverified" {
+            return "账户已配置，但尚未验证凭据是否有效。"
+        }
+        switch runtime.state {
+        case .disabled:
+            return "可在设置中启用 Claude 实验通道。"
+        case .signedOut:
+            return "请在这台 Mac 上完成登录。"
+        case .unavailable:
+            return "运行时暂不可用，请刷新或运行诊断。"
+        case .connected, .available:
+            return "尚未获取到额度数据。"
+        }
+    }
+}

--- a/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
@@ -76,14 +76,14 @@ extension AgentCommandClient {
                 let binary = try requireEmbeddedBinary()
                 return try decode(AgentStatus.self, from: try await execute(
                     binary: binary,
-                    arguments: ["status", "--json"],
+                    arguments: statusArguments(includeRuntime: true),
                     timeout: .seconds(8)
                 ))
             },
             statusAt: { binary in
                 try decode(AgentStatus.self, from: try await execute(
                     binary: binary,
-                    arguments: ["status", "--json"],
+                    arguments: statusArguments(includeRuntime: false),
                     timeout: .seconds(8)
                 ))
             },
@@ -142,6 +142,14 @@ extension AgentCommandClient {
             // 文件预览和会话产物可能位于 ~/.codex 等目录，浏览权限默认覆盖当前用户 Home。
             "--browse-root", browseRoot.path,
         ]
+    }
+
+    static func statusArguments(includeRuntime: Bool) -> [String] {
+        var arguments = ["status", "--json"]
+        if includeRuntime {
+            arguments.append("--runtime")
+        }
+        return arguments
     }
 }
 

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -74,6 +74,9 @@ actor ProcessExecutor {
 
         let stdout = try await stdoutRead
         let stderr = try await stderrRead
+        if Task.isCancelled {
+            throw CancellationError()
+        }
         if stdout.exceededLimit || stderr.exceededLimit {
             throw ProcessExecutorError.outputTooLarge
         }

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -14,6 +14,7 @@ final class HostStore {
     private(set) var recentLogs: [String] = []
     private(set) var appliedFixes: [String] = []
     private(set) var isBusy = false
+    private(set) var isRefreshingStatus = false
     private(set) var homebrewLoaded = false
     private(set) var launchesAtLogin = false
     var lastError: String?
@@ -29,6 +30,7 @@ final class HostStore {
     private let logs: AgentLogClient
     private var didBootstrap = false
     private var monitorTask: Task<Void, Never>?
+    private var runtimeStatusFollowUpTask: Task<Void, Never>?
 
     init(
         agent: AgentCommandClient,
@@ -169,7 +171,9 @@ final class HostStore {
     }
 
     func refresh() async {
-        guard !isBusy else { return }
+        guard !isBusy, !isRefreshingStatus else { return }
+        isRefreshingStatus = true
+        defer { isRefreshingStatus = false }
         switch owner {
         case .homebrew:
             await refreshHomebrewStatus()
@@ -186,6 +190,12 @@ final class HostStore {
             } else {
                 await startMacAgentIfNeeded()
             }
+        }
+        if owner == .macApp,
+           status?.runtimeStatus?.refreshing == true
+            || status?.runtimeStatus?.hasRetryableFailure == true
+        {
+            scheduleRuntimeStatusFollowUp()
         }
     }
 
@@ -438,6 +448,8 @@ final class HostStore {
         case .enabled:
             do {
                 apply(try await agent.status())
+            } catch is CancellationError {
+                return
             } catch {
                 fail(error)
             }
@@ -464,6 +476,8 @@ final class HostStore {
             } else {
                 lifecycle = .migrationRequired
             }
+        } catch is CancellationError {
+            return
         } catch {
             fail(error)
         }
@@ -555,6 +569,67 @@ final class HostStore {
         }
     }
 
+    private func scheduleRuntimeStatusFollowUp() {
+        guard runtimeStatusFollowUpTask == nil else { return }
+        runtimeStatusFollowUpTask = Task { [weak self] in
+            guard let self else { return }
+            defer { runtimeStatusFollowUpTask = nil }
+            // Provider 冷启动可能涉及 bridge 启动、OAuth 刷新和网络查询。
+            // 菜单先展示缓存/refreshing，再在后台有界轮询，不能重新阻塞 readiness。
+            // 首次 unavailable 还会在服务端 15 秒失败 TTL 后重试一次；48 轮
+            // 足够覆盖两次最慢 42 秒 provider 刷新，同时避免永久轮询。
+            var didRetryUnavailable = false
+            for _ in 0..<48 {
+                let delay: Duration
+                if isRefreshingStatus {
+                    delay = .seconds(2)
+                } else if let nextDelay = Self.runtimeStatusFollowUpDelay(
+                    snapshot: status?.runtimeStatus,
+                    didRetryUnavailable: didRetryUnavailable
+                ) {
+                    delay = nextDelay
+                } else {
+                    return
+                }
+                do {
+                    try await Task.sleep(for: delay)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled, owner == .macApp, !isBusy else { return }
+                guard !isRefreshingStatus else { continue }
+
+                guard Self.runtimeStatusFollowUpDelay(
+                    snapshot: status?.runtimeStatus,
+                    didRetryUnavailable: didRetryUnavailable
+                ) != nil else {
+                    return
+                }
+                if status?.runtimeStatus?.refreshing != true,
+                   status?.runtimeStatus?.hasRetryableFailure == true
+                {
+                    didRetryUnavailable = true
+                }
+                isRefreshingStatus = true
+                await refreshMacAgentStatus()
+                isRefreshingStatus = false
+            }
+        }
+    }
+
+    nonisolated static func runtimeStatusFollowUpDelay(
+        snapshot: AgentRuntimeStatusSnapshot?,
+        didRetryUnavailable: Bool
+    ) -> Duration? {
+        if snapshot?.refreshing == true {
+            return .seconds(2)
+        }
+        if !didRetryUnavailable, snapshot?.hasRetryableFailure == true {
+            return .seconds(15)
+        }
+        return nil
+    }
+
     private func fail(_ error: Error) {
         lastError = error.localizedDescription
         lifecycle = .failed(error.localizedDescription)
@@ -575,7 +650,72 @@ final class HostStore {
             projects: 12,
             doctorOK: true,
             doctor: doctor,
-            pairExpires: nil
+            pairExpires: nil,
+            runtimeStatus: AgentRuntimeStatusSnapshot(
+                checkedAt: "2026-07-27T12:00:00Z",
+                runtimes: [
+                    AgentRuntimeStatus(
+                        id: "codex",
+                        title: "Codex",
+                        enabled: true,
+                        state: .connected,
+                        authMode: "chatgpt",
+                        planType: "plus",
+                        reason: nil,
+                        rateLimits: AgentRuntimeRateLimits(
+                            limitID: "codex",
+                            limitName: "Codex",
+                            planType: "plus",
+                            reachedType: nil,
+                            availability: "available",
+                            unavailableReason: nil,
+                            primary: AgentRuntimeRateLimitWindow(
+                                usedPercent: 62,
+                                windowDurationMins: 300,
+                                resetsAt: Int64(Date().addingTimeInterval(80 * 60).timeIntervalSince1970)
+                            ),
+                            secondary: AgentRuntimeRateLimitWindow(
+                                usedPercent: 31,
+                                windowDurationMins: 10_080,
+                                resetsAt: Int64(Date().addingTimeInterval(4 * 24 * 60 * 60).timeIntervalSince1970)
+                            ),
+                            hasCredits: true,
+                            creditsUnlimited: false,
+                            creditBalance: "12.34"
+                        )
+                    ),
+                    AgentRuntimeStatus(
+                        id: "claude",
+                        title: "Claude",
+                        enabled: true,
+                        state: .connected,
+                        authMode: "oauth",
+                        planType: "pro",
+                        reason: nil,
+                        rateLimits: AgentRuntimeRateLimits(
+                            limitID: "claude",
+                            limitName: "Claude",
+                            planType: "pro",
+                            reachedType: nil,
+                            availability: "available",
+                            unavailableReason: nil,
+                            primary: AgentRuntimeRateLimitWindow(
+                                usedPercent: 24,
+                                windowDurationMins: 300,
+                                resetsAt: Int64(Date().addingTimeInterval(3 * 60 * 60).timeIntervalSince1970)
+                            ),
+                            secondary: AgentRuntimeRateLimitWindow(
+                                usedPercent: 48,
+                                windowDurationMins: 10_080,
+                                resetsAt: Int64(Date().addingTimeInterval(5 * 24 * 60 * 60).timeIntervalSince1970)
+                            ),
+                            hasCredits: nil,
+                            creditsUnlimited: nil,
+                            creditBalance: nil
+                        )
+                    ),
+                ]
+            )
         )
         let agent = AgentCommandClient(
             configExists: { lifecycle != .notConfigured },

--- a/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
@@ -14,4 +14,37 @@ final class AgentCommandClientTests: XCTestCase {
             "--browse-root", "/test-user",
         ])
     }
+
+    func testStatusOnlyRequestsRuntimeFromBundledAgent() {
+        XCTAssertEqual(
+            AgentCommandClient.statusArguments(includeRuntime: true),
+            ["status", "--json", "--runtime"]
+        )
+        XCTAssertEqual(
+            AgentCommandClient.statusArguments(includeRuntime: false),
+            ["status", "--json"]
+        )
+    }
+
+    func testProcessCancellationIsReportedAsCancellation() async {
+        let executor = ProcessExecutor()
+        let task = Task {
+            try await executor.run(
+                executable: URL(filePath: "/bin/sleep"),
+                arguments: ["5"],
+                timeout: .seconds(10)
+            )
+        }
+        try? await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("取消后不应返回成功结果")
+        } catch is CancellationError {
+            // 视图关闭导致的正常取消不能被 HostStore 当成服务故障。
+        } catch {
+            XCTFail("取消应保留 CancellationError 语义，实际为 \(error)")
+        }
+    }
 }

--- a/macos/MimiRemoteMac/Tests/AgentModelsTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentModelsTests.swift
@@ -39,6 +39,201 @@ final class AgentModelsTests: XCTestCase {
         XCTAssertTrue(status.doctor.ok)
     }
 
+    func testStatusPayloadDecodesSanitizedRuntimeAccountsAndQuotaWindows() throws {
+        let raw = Data(#"""
+        {
+          "process_ok": true,
+          "service_ok": true,
+          "version": "0.1.0",
+          "endpoint": "http://127.0.0.1:8787",
+          "config_path": "/tmp/config.json",
+          "projects": 2,
+          "doctor_ok": true,
+          "doctor": {"ok": true, "version": "0.1.0", "listen": "127.0.0.1:8787", "checks": []},
+          "runtime_status": {
+            "checked_at": "2026-07-27T12:00:00Z",
+            "runtimes": [
+              {
+                "id": "codex",
+                "title": "Codex",
+                "enabled": true,
+                "state": "connected",
+                "auth_mode": "chatgpt",
+                "plan_type": "plus",
+                "rate_limits": {
+                  "limit_id": "codex",
+                  "availability": "available",
+                  "primary": {
+                    "used_percent": 62.5,
+                    "window_duration_mins": 300,
+                    "resets_at": 1780494300
+                  },
+                  "secondary": {
+                    "used_percent": 30,
+                    "window_duration_mins": 10080,
+                    "resets_at": 1781099100
+                  }
+                }
+              },
+              {
+                "id": "claude",
+                "title": "Claude",
+                "enabled": false,
+                "state": "disabled",
+                "reason": "disabled"
+              }
+            ]
+          }
+        }
+        """#.utf8)
+
+        let status = try JSONDecoder().decode(AgentStatus.self, from: raw)
+        let snapshot = try XCTUnwrap(status.runtimeStatus)
+        let runtimes = snapshot.runtimes
+        XCTAssertEqual(runtimes.map(\.id), ["codex", "claude"])
+        let checkedDate = try XCTUnwrap(snapshot.checkedDate)
+        XCTAssertFalse(snapshot.isExpired(at: checkedDate.addingTimeInterval(60)))
+        XCTAssertTrue(snapshot.isExpired(at: checkedDate.addingTimeInterval(121)))
+        XCTAssertEqual(runtimes[0].state, .connected)
+        XCTAssertEqual(runtimes[0].effectivePlanType, "plus")
+        let windows = try XCTUnwrap(runtimes[0].rateLimits).windows
+        XCTAssertEqual(windows.map(\.durationLabel), ["5h", "7d"])
+        XCTAssertEqual(windows[0].remainingPercentText, "37.5%")
+        XCTAssertEqual(windows[1].remainingPercentText, "70%")
+        XCTAssertEqual(runtimes[1].state, .disabled)
+    }
+
+    func testUnknownRuntimeStateFailsClosedWithoutBreakingAgentStatusDecode() throws {
+        let raw = Data(#"""
+        {
+          "process_ok": true,
+          "service_ok": true,
+          "version": "0.1.0",
+          "endpoint": "http://127.0.0.1:8787",
+          "config_path": "/tmp/config.json",
+          "projects": 1,
+          "doctor_ok": true,
+          "doctor": {"ok": true, "version": "0.1.0", "listen": "127.0.0.1:8787", "checks": []},
+          "runtime_status": {
+            "checked_at": "2026-07-27T12:00:00Z",
+            "runtimes": [{"id":"codex","title":"Codex","enabled":true,"state":"future_state"}]
+          }
+        }
+        """#.utf8)
+
+        let status = try JSONDecoder().decode(AgentStatus.self, from: raw)
+        XCTAssertEqual(status.runtimeStatus?.runtimes.first?.state, .unavailable)
+    }
+
+    func testRuntimeQuotaRecognizesReachedStateAndCredits() {
+        let limits = AgentRuntimeRateLimits(
+            limitID: "codex",
+            limitName: "Codex",
+            planType: "plus",
+            reachedType: "primary",
+            availability: "partial",
+            unavailableReason: nil,
+            primary: AgentRuntimeRateLimitWindow(
+                usedPercent: nil,
+                windowDurationMins: 300,
+                resetsAt: 1_780_494_300
+            ),
+            secondary: nil,
+            hasCredits: true,
+            creditsUnlimited: false,
+            creditBalance: "12.34"
+        )
+
+        XCTAssertTrue(limits.isExhausted)
+        XCTAssertEqual(limits.creditBalance, "12.34")
+        XCTAssertEqual(limits.availability, "partial")
+    }
+
+    func testRefreshingSnapshotWithoutCheckedDateIsNotMarkedExpired() {
+        let snapshot = AgentRuntimeStatusSnapshot(
+            checkedAt: nil,
+            runtimes: [],
+            refreshing: true,
+            stale: false
+        )
+
+        XCTAssertFalse(snapshot.isExpired())
+    }
+
+    func testMalformedRuntimeSnapshotDoesNotBreakCoreStatusDecode() throws {
+        let raw = Data(#"""
+        {
+          "process_ok": true,
+          "service_ok": true,
+          "version": "0.1.0",
+          "endpoint": "http://127.0.0.1:8787",
+          "config_path": "/tmp/config.json",
+          "projects": 1,
+          "doctor_ok": true,
+          "doctor": {"ok": true, "version": "0.1.0", "listen": "127.0.0.1:8787", "checks": []},
+          "runtime_status": {}
+        }
+        """#.utf8)
+
+        let status = try JSONDecoder().decode(AgentStatus.self, from: raw)
+
+        XCTAssertTrue(status.serviceOK)
+        XCTAssertNil(status.runtimeStatus)
+    }
+
+    func testRuntimeFailureRetryOnlyAppliesToEnabledUnavailableProvider() {
+        let failed = AgentRuntimeStatusSnapshot(
+            checkedAt: "2026-07-27T12:00:00Z",
+            runtimes: [
+                AgentRuntimeStatus(
+                    id: "claude",
+                    title: "Claude",
+                    enabled: true,
+                    state: .unavailable,
+                    authMode: nil,
+                    planType: nil,
+                    reason: "bridge_unavailable",
+                    rateLimits: nil
+                ),
+            ],
+            refreshing: false,
+            stale: false
+        )
+        let disabled = AgentRuntimeStatusSnapshot(
+            checkedAt: "2026-07-27T12:00:00Z",
+            runtimes: [
+                AgentRuntimeStatus(
+                    id: "claude",
+                    title: "Claude",
+                    enabled: false,
+                    state: .disabled,
+                    authMode: nil,
+                    planType: nil,
+                    reason: "disabled",
+                    rateLimits: nil
+                ),
+            ],
+            refreshing: false,
+            stale: false
+        )
+
+        XCTAssertTrue(failed.hasRetryableFailure)
+        XCTAssertEqual(
+            HostStore.runtimeStatusFollowUpDelay(
+                snapshot: failed,
+                didRetryUnavailable: false
+            ),
+            .seconds(15)
+        )
+        XCTAssertNil(
+            HostStore.runtimeStatusFollowUpDelay(
+                snapshot: failed,
+                didRetryUnavailable: true
+            )
+        )
+        XCTAssertFalse(disabled.hasRetryableFailure)
+    }
+
     func testLifecyclePresentationIsStable() {
         XCTAssertEqual(HostLifecycleState.ready.title, "服务可用")
         XCTAssertEqual(HostLifecycleState.failed("boom").detail, "boom")

--- a/macos/MimiRemoteMac/Tests/MenuRuntimePresentationTests.swift
+++ b/macos/MimiRemoteMac/Tests/MenuRuntimePresentationTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import MimiRemoteMac
+
+final class MenuRuntimePresentationTests: XCTestCase {
+    func testConnectedNonAPIKeyRuntimeDoesNotUseAPIKeyDetail() {
+        for authMode in ["chatgpt", "oauth"] {
+            let runtime = makeRuntime(state: .connected, authMode: authMode)
+
+            XCTAssertEqual(
+                MenuRuntimePresentation.detailText(
+                    for: runtime,
+                    missingDetail: "缺失"
+                ),
+                "尚未获取到额度数据。",
+                "\(authMode) 已连接状态不能显示为 API Key"
+            )
+        }
+    }
+
+    func testConnectedAPIKeyRuntimeUsesAPIKeyDetail() {
+        let runtime = makeRuntime(state: .connected, authMode: "api_key")
+
+        XCTAssertEqual(
+            MenuRuntimePresentation.detailText(
+                for: runtime,
+                missingDetail: "缺失"
+            ),
+            "API Key 已配置（按量计费），将在首次请求时验证有效性。"
+        )
+    }
+
+    private func makeRuntime(
+        state: AgentRuntimeConnectionState,
+        authMode: String
+    ) -> AgentRuntimeStatus {
+        AgentRuntimeStatus(
+            id: "test",
+            title: "Test",
+            enabled: true,
+            state: state,
+            authMode: authMode,
+            planType: nil,
+            reason: nil,
+            rateLimits: nil
+        )
+    }
+}


### PR DESCRIPTION
## 改动内容

- 新增 Codex 与 Claude runtime 状态探针，统一返回脱敏后的账户、认证方式和额度窗口。
- 在 Mac 菜单栏展示连接状态、套餐、额度、余额和刷新结果。
- 按认证证据区分“已连接”和“已配置待验证”，避免 API Key、Bedrock 凭据被误报为已连接。
- 正确处理 Codex App Server 的双向 JSON-RPC 请求，拒绝探针不支持的服务端请求并继续等待原响应。
- 抽离菜单栏 runtime 文案决策，补充 ChatGPT、OAuth、API Key 和同 ID 服务端请求回归测试。

## 原因与影响

此前 Mac 端只能判断 agent 服务是否可用，无法直接观察 Codex/Claude 的登录和额度状态。同时，`account/read` 对 API Key 与 Bedrock 只证明配置存在，不代表凭据已经验证；双向 JSON-RPC 的服务端请求也可能与客户端请求复用相同 ID。

合并后，菜单栏能提供更准确、脱敏且可刷新的 runtime 状态，不会把未验证凭据或其他已连接账户错误显示为 API Key。

## 验证

- `go test ./...`
- `go test -race ./internal/httpapi ./cmd/agentd`
- macOS 完整测试：28 个测试全部通过
- `xcodegen generate --spec project.yml`
- `git diff --check`

源码体积门禁仍被仓库中 3 个既有超限文件阻塞，本 PR 修改文件均未触发体积限制。
