### PR TITLE
feat: optimize runtime status and usage display

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/lifecycle.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/lifecycle.rs
@@ -5,9 +5,11 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use alleycat_codex_proto as p;
 use anyhow::Result;
+use tokio::time::timeout;
 
 use crate::state::ConnectionState;
 
@@ -75,8 +77,9 @@ pub fn handle_account_read(
 pub async fn handle_account_rate_limits_read(
     state: &Arc<ConnectionState>,
 ) -> p::GetAccountRateLimitsResponse {
-    const OAUTH_CACHE_SECS: i64 = 60;
+    const OAUTH_CACHE_SECS: i64 = 5 * 60;
     const OAUTH_RETRY_SECS: i64 = 15;
+    const OAUTH_REFRESH_BUDGET: Duration = Duration::from_secs(6);
     let now = chrono::Utc::now().timestamp();
     if let Some(snapshot) = state.cached_oauth_rate_limit(now, OAUTH_CACHE_SECS) {
         return p::GetAccountRateLimitsResponse {
@@ -84,32 +87,47 @@ pub async fn handle_account_rate_limits_read(
             rate_limits_by_limit_id: None,
         };
     }
-    // 设置页可能同时触发多次刷新。串行化首次 Keychain/API 查询，让后续请求
-    // 等待并复用缓存，避免后到的 unavailable 覆盖先到的成功结果。
-    let _refresh_guard = state.lock_oauth_rate_limit_refresh().await;
-    let now = chrono::Utc::now().timestamp();
-    if let Some(snapshot) = state.cached_oauth_rate_limit(now, OAUTH_CACHE_SECS) {
-        return p::GetAccountRateLimitsResponse {
-            rate_limits: snapshot,
-            rate_limits_by_limit_id: None,
-        };
-    }
-    if state.begin_oauth_rate_limit_refresh(now, OAUTH_RETRY_SECS) {
-        match crate::oauth_usage::fetch_rate_limit_snapshot(state.claude_pool().claude_bin()).await
-        {
-            Ok(snapshot) => {
-                state.store_oauth_rate_limit(snapshot.clone(), now);
-                return p::GetAccountRateLimitsResponse {
-                    rate_limits: snapshot,
-                    rate_limits_by_limit_id: None,
-                };
-            }
-            Err(err) => {
-                // OAuth 是展示增强能力；凭据缺失、过期或临时网络失败都必须安全
-                // 降级到官方事件缓存，不能影响 Claude 会话与发送链路。
-                tracing::debug!(error = %err, "Claude OAuth usage unavailable; falling back to observed events");
+    // 设置页和菜单栏可能同时触发刷新。包括等待 single-flight 锁在内，整条
+    // Keychain/OAuth 链路最多占用 6 秒；超时会取消隐藏的 Claude CLI/curl，
+    // 避免断开的菜单客户端在 bridge 内留下长达数十秒的工作。
+    let refresh_result = timeout(OAUTH_REFRESH_BUDGET, async {
+        let _refresh_guard = state.lock_oauth_rate_limit_refresh().await;
+        let now = chrono::Utc::now().timestamp();
+        if let Some(snapshot) = state.cached_oauth_rate_limit(now, OAUTH_CACHE_SECS) {
+            return Some(snapshot);
+        }
+        if state.begin_oauth_rate_limit_refresh(now, OAUTH_RETRY_SECS) {
+            match crate::oauth_usage::fetch_rate_limit_snapshot(state.claude_pool().claude_bin())
+                .await
+            {
+                Ok(snapshot) => {
+                    state.store_oauth_rate_limit(snapshot.clone(), chrono::Utc::now().timestamp());
+                    return Some(snapshot);
+                }
+                Err(err) => {
+                    // OAuth 是展示增强能力；凭据缺失、过期或临时网络失败都必须安全
+                    // 降级到官方事件缓存，不能影响 Claude 会话与发送链路。
+                    tracing::debug!(
+                        error = %err,
+                        "Claude OAuth usage unavailable; falling back to observed events"
+                    );
+                }
             }
         }
+        None
+    })
+    .await;
+    if let Ok(Some(snapshot)) = refresh_result {
+        return p::GetAccountRateLimitsResponse {
+            rate_limits: snapshot,
+            rate_limits_by_limit_id: None,
+        };
+    }
+    if refresh_result.is_err() {
+        tracing::debug!(
+            budget_secs = OAUTH_REFRESH_BUDGET.as_secs(),
+            "Claude OAuth usage refresh exceeded budget; falling back to observed events"
+        );
     }
 
     let infos: Vec<_> = state.caches().rate_limit_infos.into_values().collect();

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -48,6 +48,16 @@ type Router struct {
 	// 让菜单栏展示运行时长，而不是误用 agentd 或 Mac App 自身的存活时间。
 	runtimeProcessMu      sync.RWMutex
 	codexRuntimeStartedAt time.Time
+	// Codex 连接探测与额度读取共用一个 app-server 会话。额度偶发超时时保留最近一次
+	// 脱敏窗口，避免菜单把三个圆环整块移除；缓存只存百分比和重置时间，不含账号信息。
+	codexRuntimeQuotaMu        sync.RWMutex
+	codexRuntimeQuota          *runtimeRateLimits
+	codexRuntimeQuotaCheckedAt time.Time
+	// 菜单只为 Claude 额度等待很短时间；慢查询完成后把脱敏结果留在 Router，
+	// 下一轮状态刷新无需依赖已经断开的匿名 bridge connection。
+	claudeRuntimeQuotaMu        sync.RWMutex
+	claudeRuntimeQuota          *runtimeRateLimits
+	claudeRuntimeQuotaCheckedAt time.Time
 	// pairingClaims 只记录短期票据的签名和过期时间，不保存长期 Token。
 	// 状态仅需覆盖当前进程内的短期重放窗口，服务重启后丢失是可接受的 MVP 取舍。
 	pairingClaimsMu sync.Mutex

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -18,11 +18,14 @@ import (
 )
 
 const (
-	runtimeStatusRefreshTimeout = 42 * time.Second
-	runtimeStatusSuccessTTL     = time.Minute
+	runtimeStatusRefreshTimeout = 9 * time.Second
+	runtimeStatusSuccessTTL     = 5 * time.Minute
 	runtimeStatusFailureTTL     = 15 * time.Second
+	runtimeQuotaFallbackTTL     = 15 * time.Minute
 	codexRuntimeProbeTimeout    = 8 * time.Second
-	claudeRuntimeProbeTimeout   = 41 * time.Second
+	claudeRuntimeProbeTimeout   = 4 * time.Second
+	claudeRuntimeQuotaTimeout   = 2 * time.Second
+	claudeRuntimeQuotaHardLimit = 7 * time.Second
 )
 
 type runtimeConnectionState string
@@ -147,11 +150,60 @@ func (c *runtimeStatusSnapshotCache) Close() {
 
 func runtimeStatusHasFailure(response runtimeStatusResponse) bool {
 	for _, runtime := range response.Runtimes {
-		if runtime.State == runtimeStateUnavailable {
+		if runtime.State == runtimeStateUnavailable ||
+			runtime.Reason == "quota_refresh_in_progress" ||
+			runtime.RateLimits != nil &&
+				strings.EqualFold(runtime.RateLimits.Availability, "unavailable") {
 			return true
 		}
 	}
 	return false
+}
+
+func (r *Router) cachedCodexRuntimeQuota(now time.Time) *runtimeRateLimits {
+	r.codexRuntimeQuotaMu.RLock()
+	defer r.codexRuntimeQuotaMu.RUnlock()
+	if r.codexRuntimeQuota == nil ||
+		r.codexRuntimeQuotaCheckedAt.IsZero() ||
+		now.Sub(r.codexRuntimeQuotaCheckedAt) < 0 ||
+		now.Sub(r.codexRuntimeQuotaCheckedAt) >= runtimeQuotaFallbackTTL {
+		return nil
+	}
+	// runtimeRateLimits 归一化后只读；锁只保护整份缓存的替换。
+	return r.codexRuntimeQuota
+}
+
+func (r *Router) storeCodexRuntimeQuota(limits *runtimeRateLimits) {
+	if limits == nil {
+		return
+	}
+	r.codexRuntimeQuotaMu.Lock()
+	r.codexRuntimeQuota = limits
+	r.codexRuntimeQuotaCheckedAt = time.Now().UTC()
+	r.codexRuntimeQuotaMu.Unlock()
+}
+
+func (r *Router) cachedClaudeRuntimeQuota(now time.Time) *runtimeRateLimits {
+	r.claudeRuntimeQuotaMu.RLock()
+	defer r.claudeRuntimeQuotaMu.RUnlock()
+	if r.claudeRuntimeQuota == nil ||
+		r.claudeRuntimeQuotaCheckedAt.IsZero() ||
+		now.Sub(r.claudeRuntimeQuotaCheckedAt) < 0 ||
+		now.Sub(r.claudeRuntimeQuotaCheckedAt) >= runtimeStatusSuccessTTL {
+		return nil
+	}
+	// runtimeRateLimits 解码后只读；锁保护指针替换，字段本身不会再被修改。
+	return r.claudeRuntimeQuota
+}
+
+func (r *Router) storeClaudeRuntimeQuota(limits *runtimeRateLimits) {
+	if limits == nil || strings.EqualFold(limits.Availability, "unavailable") {
+		return
+	}
+	r.claudeRuntimeQuotaMu.Lock()
+	r.claudeRuntimeQuota = limits
+	r.claudeRuntimeQuotaCheckedAt = time.Now().UTC()
+	r.claudeRuntimeQuotaMu.Unlock()
 }
 
 // runtimeAccountStatus 只包含菜单栏需要的脱敏状态。账号邮箱、Token、Keychain
@@ -366,9 +418,18 @@ func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
 	var limits runtimeRateLimitsEnvelope
 	if err := rpc.call(ctx, "account/rateLimits/read", map[string]any{}, &limits); err == nil {
 		status.RateLimits = normalizeRuntimeRateLimits(limits, "codex")
-		if status.PlanType == "" && status.RateLimits != nil {
-			status.PlanType = status.RateLimits.PlanType
-		}
+		r.storeCodexRuntimeQuota(status.RateLimits)
+	}
+	if status.RateLimits == nil {
+		status.RateLimits = r.cachedCodexRuntimeQuota(time.Now().UTC())
+	}
+	if status.PlanType == "" && status.RateLimits != nil {
+		status.PlanType = status.RateLimits.PlanType
+	}
+	if status.RateLimits == nil && status.Reason == "" {
+		// 账号连接已经确认，额度缺失只触发短 TTL 后台重试，不能把 Codex
+		// 降级成断开；菜单会继续显示连接状态和已有的视觉占位。
+		status.Reason = "quota_refresh_in_progress"
 	}
 	return status
 }
@@ -444,7 +505,12 @@ func (r *Router) probeClaudeRuntime(ctx context.Context) runtimeAccountStatus {
 	if err != nil {
 		return status
 	}
-	defer conn.Close()
+	keepQuotaProbeAlive := false
+	defer func() {
+		if !keepQuotaProbeAlive {
+			_ = conn.Close()
+		}
+	}()
 
 	client := appserver.NewClient(conn, conn, appserver.ClientOptions{
 		ClientInfo: appserver.ClientInfo{
@@ -453,7 +519,11 @@ func (r *Router) probeClaudeRuntime(ctx context.Context) runtimeAccountStatus {
 			Version: r.version,
 		},
 	})
-	defer client.Close()
+	defer func() {
+		if !keepQuotaProbeAlive {
+			_ = client.Close()
+		}
+	}()
 	initialization, err := client.Initialize(ctx)
 	if err != nil {
 		return status
@@ -472,19 +542,80 @@ func (r *Router) probeClaudeRuntime(ctx context.Context) runtimeAccountStatus {
 		status.Reason = "api_key_configured_unverified"
 		return status
 	}
-
-	var limits runtimeRateLimitsEnvelope
-	if err := client.Call(ctx, "account/rateLimits/read", map[string]any{}, &limits); err == nil {
-		status.RateLimits = normalizeRuntimeRateLimits(limits, "claude")
-		if status.RateLimits != nil {
-			status.PlanType = status.RateLimits.PlanType
-		}
+	if cached := r.cachedClaudeRuntimeQuota(time.Now().UTC()); cached != nil {
+		applyClaudeRuntimeQuota(&status, cached)
+		return status
 	}
-	if runtimeRateLimitsShowAuthenticated(status.RateLimits) {
+
+	// 连接状态与额度是两种时效要求：本机 bridge 的 initialize 足以确认进程
+	// 可用，OAuth/Keychain/网络额度查询则可能很慢。菜单栏最多为额度等待 2 秒，
+	// 超时后先返回连接与版本；已发出的查询最多再存活 7 秒以填充 bridge 缓存，
+	// 供 15 秒后的补拉复用，不能在返回菜单结果时直接留下无界后台任务。
+	type quotaProbeResult struct {
+		limits runtimeRateLimitsEnvelope
+		err    error
+	}
+	quotaCtx, cancelQuota := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		claudeRuntimeQuotaHardLimit,
+	)
+	quotaResult := make(chan quotaProbeResult, 1)
+	go func() {
+		var limits runtimeRateLimitsEnvelope
+		err := client.Call(
+			quotaCtx,
+			"account/rateLimits/read",
+			map[string]any{},
+			&limits,
+		)
+		quotaResult <- quotaProbeResult{limits: limits, err: err}
+	}()
+	presentationTimer := time.NewTimer(claudeRuntimeQuotaTimeout)
+	defer presentationTimer.Stop()
+
+	select {
+	case result := <-quotaResult:
+		cancelQuota()
+		if result.err != nil {
+			return status
+		}
+		limits := normalizeRuntimeRateLimits(result.limits, "claude")
+		r.storeClaudeRuntimeQuota(limits)
+		applyClaudeRuntimeQuota(&status, limits)
+	case <-presentationTimer.C:
+		status.Reason = "quota_refresh_in_progress"
+		keepQuotaProbeAlive = true
+		go func() {
+			defer cancelQuota()
+			defer client.Close()
+			defer conn.Close()
+			select {
+			case result := <-quotaResult:
+				if result.err == nil {
+					r.storeClaudeRuntimeQuota(
+						normalizeRuntimeRateLimits(result.limits, "claude"),
+					)
+				}
+			case <-quotaCtx.Done():
+			}
+		}()
+	case <-ctx.Done():
+		cancelQuota()
+		return status
+	}
+	return status
+}
+
+func applyClaudeRuntimeQuota(status *runtimeAccountStatus, limits *runtimeRateLimits) {
+	if limits == nil {
+		return
+	}
+	status.RateLimits = limits
+	status.PlanType = limits.PlanType
+	if runtimeRateLimitsShowAuthenticated(limits) {
 		status.State = runtimeStateConnected
 		status.AuthMode = "oauth"
 	}
-	return status
 }
 
 func claudeAPIKeyConfigured(configured map[string]string) bool {

--- a/internal/httpapi/runtime_status_test.go
+++ b/internal/httpapi/runtime_status_test.go
@@ -64,6 +64,91 @@ func TestRuntimeStatusRequiresAuthAndReturnsSanitizedCodexSnapshot(t *testing.T)
 	}
 }
 
+func TestRuntimeStatusKeepsSlowCodexQuotaProbeOffRequestPath(t *testing.T) {
+	baseResponder := runtimeStatusCodexResponder(t)
+	upstreamURL, _, _ := fakeAppServerUpstream(t, func(
+		conn *websocket.Conn,
+		messageType int,
+		payload []byte,
+	) {
+		var frame struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(payload, &frame); err != nil {
+			t.Errorf("无法解析 fake app-server frame：%v", err)
+			return
+		}
+		if frame.Method == "account/rateLimits/read" {
+			// 覆盖本次回归：真实机器首次额度读取超过旧的 3 秒预算。
+			time.Sleep(3500 * time.Millisecond)
+		}
+		baseResponder(conn, messageType, payload)
+	})
+	handler, _ := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, nil)
+
+	startedAt := time.Now()
+	rec := httptest.NewRecorder()
+	req := authedRequest(t, http.MethodGet, "/api/runtime/status", nil)
+	req.RemoteAddr = "127.0.0.1:43210"
+	handler.ServeHTTP(rec, req)
+	if elapsed := time.Since(startedAt); elapsed >= 100*time.Millisecond {
+		t.Fatalf("慢 Codex 额度探测不能阻塞菜单请求：elapsed=%s", elapsed)
+	}
+	var first runtimeStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&first); err != nil {
+		t.Fatal(err)
+	}
+	if !first.Refreshing {
+		t.Fatalf("首次请求应立即返回后台刷新占位：%+v", first)
+	}
+
+	_, response := readRuntimeStatusEventually(t, handler)
+	codex := response.Runtimes[0]
+	if codex.RateLimits == nil || codex.RateLimits.Secondary == nil ||
+		codex.RateLimits.Secondary.UsedPercent == nil {
+		t.Fatalf("后台慢查询完成后必须恢复 Codex 圆环数据：%+v", codex)
+	}
+}
+
+func TestCodexRuntimeKeepsRecentQuotaOnTransientProbeFailure(t *testing.T) {
+	baseResponder := runtimeStatusCodexResponder(t)
+	var quotaCalls atomic.Int32
+	upstreamURL, _, _ := fakeAppServerUpstream(t, func(
+		conn *websocket.Conn,
+		messageType int,
+		payload []byte,
+	) {
+		var frame struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(payload, &frame); err != nil {
+			t.Errorf("无法解析 fake app-server frame：%v", err)
+			return
+		}
+		if frame.Method == "account/rateLimits/read" && quotaCalls.Add(1) > 1 {
+			_ = conn.Close()
+			return
+		}
+		baseResponder(conn, messageType, payload)
+	})
+	_, router := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, nil)
+
+	first := router.probeCodexRuntime(context.Background())
+	if first.RateLimits == nil || first.RateLimits.Secondary == nil {
+		t.Fatalf("首次探测应写入额度缓存：%+v", first)
+	}
+	second := router.probeCodexRuntime(context.Background())
+	if second.RateLimits == nil || second.RateLimits.Secondary == nil ||
+		second.RateLimits.Secondary.UsedPercent == nil ||
+		*second.RateLimits.Secondary.UsedPercent !=
+			*first.RateLimits.Secondary.UsedPercent {
+		t.Fatalf("临时失败时应保留最近一次圆环数据：first=%+v second=%+v", first, second)
+	}
+	if second.State != runtimeStateConnected {
+		t.Fatalf("额度临时失败不能降低 Codex 连接状态：%+v", second)
+	}
+}
+
 func TestRuntimeStatusDoesNotTreatServerRequestAsRPCResponse(t *testing.T) {
 	var rejectedServerRequest atomic.Bool
 	upstreamURL, _, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
@@ -222,6 +307,47 @@ while IFS= read -r line; do :; done
 	}
 }
 
+func TestRuntimeStatusDoesNotWaitForSlowClaudeQuotaProbe(t *testing.T) {
+	upstreamURL, _, _ := fakeAppServerUpstream(t, runtimeStatusCodexResponder(t))
+	bridgePath := writeTestBridge(t, `#!/bin/sh
+IFS= read -r initialize
+printf '{"id":1,"result":{"userAgent":"fake-claude"}}\n'
+IFS= read -r initialized
+IFS= read -r rate_limit
+sleep 4
+printf '{"id":2,"result":{"rateLimits":{"limitId":"claude","availability":"available"}}}\n'
+while IFS= read -r line; do :; done
+`)
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, func(cfg *config.Config) {
+		cfg.Claude.Enabled = true
+		cfg.Claude.BridgeBin = bridgePath
+		cfg.Claude.MaxConcurrentBridges = 3
+	})
+
+	startedAt := time.Now()
+	_, response := readRuntimeStatusEventually(t, handler)
+	if elapsed := time.Since(startedAt); elapsed >= 3*time.Second {
+		t.Fatalf("慢额度查询不能阻塞运行时连接状态：elapsed=%s", elapsed)
+	}
+	claude := response.Runtimes[1]
+	if claude.State != runtimeStateAvailable ||
+		claude.Version != "fake-claude" ||
+		claude.Reason != "quota_refresh_in_progress" {
+		t.Fatalf("额度超时时应先保留 Claude 连接与版本：%+v", claude)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cached := router.cachedClaudeRuntimeQuota(time.Now().UTC()); cached != nil {
+			if cached.Availability != "available" {
+				t.Fatalf("后台额度缓存异常：%+v", cached)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("慢额度查询完成后没有写入 Router 缓存")
+}
+
 func TestRuntimeVersionFromUserAgent(t *testing.T) {
 	tests := map[string]string{
 		"codex_cli_rs/0.146.0-alpha.3.1":  "0.146.0-alpha.3.1",
@@ -377,12 +503,89 @@ func TestRuntimeStatusCacheReturnsImmediatelyAndSingleFlightsRefresh(t *testing.
 	t.Fatal("runtime status cache 没有完成刷新")
 }
 
+func TestRuntimeStatusSuccessfulSnapshotStaysFreshForFiveMinutes(t *testing.T) {
+	base := time.Date(2026, time.July, 28, 2, 0, 0, 0, time.UTC)
+	now := base
+	var probes atomic.Int32
+	cache := newRuntimeStatusSnapshotCache(
+		func(context.Context) runtimeStatusResponse {
+			probes.Add(1)
+			checkedAt := now
+			return runtimeStatusResponse{
+				CheckedAt: &checkedAt,
+				Runtimes: []runtimeAccountStatus{{
+					ID: "codex", Title: "Codex", Enabled: true, State: runtimeStateConnected,
+				}},
+			}
+		},
+		func() runtimeStatusResponse { return runtimeStatusResponse{} },
+	)
+	cache.now = func() time.Time { return now }
+	defer cache.Close()
+
+	_ = cache.Snapshot()
+	deadline := time.Now().Add(time.Second)
+	for cache.Snapshot().Refreshing && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if probes.Load() != 1 {
+		t.Fatalf("首次快照探测次数异常：%d", probes.Load())
+	}
+
+	now = base.Add(4*time.Minute + 59*time.Second)
+	if snapshot := cache.Snapshot(); snapshot.Refreshing || snapshot.Stale {
+		t.Fatalf("5 分钟内的成功快照应直接复用：%+v", snapshot)
+	}
+	if probes.Load() != 1 {
+		t.Fatalf("5 分钟内不能重复探测：%d", probes.Load())
+	}
+
+	now = base.Add(5 * time.Minute)
+	if snapshot := cache.Snapshot(); !snapshot.Refreshing || !snapshot.Stale {
+		t.Fatalf("5 分钟后应后台刷新并继续返回旧快照：%+v", snapshot)
+	}
+}
+
+func TestRuntimeStatusUnavailableQuotaUsesFailureTTL(t *testing.T) {
+	response := runtimeStatusResponse{
+		Runtimes: []runtimeAccountStatus{{
+			ID:      "claude",
+			Title:   "Claude",
+			Enabled: true,
+			State:   runtimeStateAvailable,
+			RateLimits: &runtimeRateLimits{
+				Availability:      "unavailable",
+				UnavailableReason: "headless_statusline_unavailable",
+			},
+		}},
+	}
+	if !runtimeStatusHasFailure(response) {
+		t.Fatal("Claude 额度不可用应使用短失败 TTL，以便登录后自动重试")
+	}
+}
+
+func TestClaudeUnavailableQuotaIsNotCached(t *testing.T) {
+	router := &Router{}
+	router.storeClaudeRuntimeQuota(&runtimeRateLimits{
+		Availability:      "unavailable",
+		UnavailableReason: "headless_statusline_unavailable",
+	})
+	if cached := router.cachedClaudeRuntimeQuota(time.Now().UTC()); cached != nil {
+		t.Fatalf("不可用结果不能阻止后续 OAuth 额度重试：%+v", cached)
+	}
+
+	router.storeClaudeRuntimeQuota(&runtimeRateLimits{Availability: "available"})
+	if cached := router.cachedClaudeRuntimeQuota(time.Now().UTC()); cached == nil {
+		t.Fatal("可用 Claude 额度仍应进入短缓存")
+	}
+}
+
 func readRuntimeStatusEventually(
 	t *testing.T,
 	handler http.Handler,
 ) (*httptest.ResponseRecorder, runtimeStatusResponse) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for {
 		rec := httptest.NewRecorder()
 		req := authedRequest(t, http.MethodGet, "/api/runtime/status", nil)

--- a/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
+++ b/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
@@ -141,13 +141,21 @@ struct AgentRuntimeStatusSnapshot: Codable, Equatable, Sendable {
         guard let checkedDate else {
             return refreshing != true
         }
-        return now.timeIntervalSince(checkedDate) > 2 * 60
+        // 服务端成功快照缓存 5 分钟；本地多留 1 分钟容差，避免时钟/调度抖动
+        // 把服务端仍认可的数据提前染成“已过期”。
+        return now.timeIntervalSince(checkedDate) > 6 * 60
     }
 
     var hasRetryableFailure: Bool {
         runtimes.contains {
-            $0.enabled
-                && $0.state == .unavailable
+            guard $0.enabled else { return false }
+            if $0.reason == "quota_refresh_in_progress" {
+                return true
+            }
+            if $0.rateLimits?.availability?.lowercased() == "unavailable" {
+                return true
+            }
+            return $0.state == .unavailable
                 && $0.reason != "refresh_in_progress"
         }
     }

--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -7,6 +7,9 @@ private enum MenuBarLayout {
     static let symbolColumnWidth: CGFloat = 16
     static let symbolTextSpacing: CGFloat = 8
     static let textColumnLeading = sectionInset + symbolColumnWidth + symbolTextSpacing
+    // 同组操作使用固定高度，避免分隔线、悬停底色或文案状态造成视觉节奏跳动。
+    static let actionRowHeight: CGFloat = 40
+    static let actionDividerOpacity: Double = 0.28
 }
 
 struct MenuBarContentView: View {
@@ -75,7 +78,7 @@ struct MenuBarContentView: View {
                 }
 
                 Divider()
-                    .opacity(0.4)
+                    .opacity(MenuBarLayout.actionDividerOpacity)
                     .padding(.leading, MenuBarLayout.textColumnLeading)
 
                 MenuActionRow(
@@ -86,7 +89,7 @@ struct MenuBarContentView: View {
                 }
 
                 Divider()
-                    .opacity(0.4)
+                    .opacity(MenuBarLayout.actionDividerOpacity)
                     .padding(.leading, MenuBarLayout.textColumnLeading)
 
                 MenuActionRow(
@@ -99,7 +102,7 @@ struct MenuBarContentView: View {
 
                 if store.owner == .macApp {
                     Divider()
-                        .opacity(0.4)
+                        .opacity(MenuBarLayout.actionDividerOpacity)
                         .padding(.leading, MenuBarLayout.textColumnLeading)
 
                     MenuActionRow(
@@ -114,7 +117,7 @@ struct MenuBarContentView: View {
                 }
 
                 Divider()
-                    .opacity(0.4)
+                    .opacity(MenuBarLayout.actionDividerOpacity)
                     .padding(.leading, MenuBarLayout.textColumnLeading)
 
                 MenuActionRow(
@@ -138,7 +141,7 @@ struct MenuBarContentView: View {
             value: store.lifecycle
         )
         .task {
-            await store.refresh()
+            await store.refreshIfNeeded()
         }
     }
 
@@ -381,7 +384,7 @@ private struct MenuRuntimeSummary: View {
     var body: some View {
         let codex = runtime(id: "codex")
         let claude = runtime(id: "claude")
-        let usageItems = MenuRuntimePresentation.usageItems(codex: codex, claude: claude)
+        let usageSlots = MenuRuntimePresentation.usageSlots(codex: codex, claude: claude)
 
         VStack(alignment: .leading, spacing: 9) {
             HStack(spacing: 5) {
@@ -405,6 +408,12 @@ private struct MenuRuntimeSummary: View {
             .foregroundStyle(.secondary)
             .padding(.horizontal, MenuBarLayout.sectionInset)
 
+            if !usageSlots.isEmpty {
+                MenuRuntimeUsageOverview(slots: usageSlots)
+                    // 先展示额度总览，再展示各运行时详情，扫描顺序与信息层级一致。
+                    .padding(.horizontal, MenuBarLayout.sectionInset)
+            }
+
             MenuRuntimeRow(
                 runtime: codex,
                 fallbackTitle: "Codex",
@@ -424,16 +433,6 @@ private struct MenuRuntimeSummary: View {
                 isStale: isStale,
                 missingDetail: missingDetail
             )
-
-            if !usageItems.isEmpty {
-                MenuRuntimeUsageOverview(
-                    items: usageItems,
-                    expectedRingCount: claude?.enabled == true ? 3 : 1
-                )
-                // 额度卡是独立模块，不继承运行时行的图标/文字列缩进。
-                // 左右使用相同分区边距，保证卡片中心与菜单内容中心一致。
-                .padding(.horizontal, MenuBarLayout.sectionInset)
-            }
         }
     }
 
@@ -513,7 +512,7 @@ private struct MenuRuntimeRow: View {
 
                     Text(stateTitle)
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(stateColor)
+                        .foregroundStyle(stateTextColor)
 
                     if let accountLabel {
                         Text("· \(accountLabel)")
@@ -583,7 +582,9 @@ private struct MenuRuntimeRow: View {
 
     private var stateTitle: String {
         if runtime?.state == .disabled { return "未启用" }
-        if isStale { return "状态已过期" }
+        // stale-while-revalidate：有旧快照时继续展示最后已知连接状态，
+        // 刷新进度由分区标题承接，不把两行都降级成“过期”。
+        if isStale, !isRefreshing { return "状态已过期" }
         if isRefreshing, runtime?.reason == "refresh_in_progress" {
             return "正在刷新"
         }
@@ -625,7 +626,7 @@ private struct MenuRuntimeRow: View {
 
     private var stateColor: Color {
         if runtime?.state == .disabled { return .secondary }
-        if isStale { return .orange }
+        if isStale, !isRefreshing { return .orange }
         if isRefreshing, runtime?.reason == "refresh_in_progress" {
             return .secondary
         }
@@ -638,6 +639,16 @@ private struct MenuRuntimeRow: View {
         case .signedOut: return Color.orange
         case .disabled: return Color.secondary
         case .unavailable: return Color.red
+        }
+    }
+
+    private var stateTextColor: Color {
+        if isStale, !isRefreshing { return Color.orange.opacity(0.8) }
+        guard let runtime else { return .secondary }
+        switch runtime.state {
+        case .signedOut: return Color.orange.opacity(0.8)
+        case .unavailable: return Color.red.opacity(0.8)
+        case .connected, .available, .disabled: return .secondary
         }
     }
 
@@ -696,28 +707,18 @@ private struct MenuRuntimeRow: View {
 }
 
 private struct MenuRuntimeUsageOverview: View {
-    let items: [MenuRuntimeUsageItem]
-    let expectedRingCount: Int
+    let slots: [MenuRuntimeUsageSlot]
 
     var body: some View {
-        VStack(alignment: .center, spacing: 8) {
-            MenuRuntimeUsageRingsGraphic(
-                items: items,
-                expectedRingCount: expectedRingCount
-            )
-            // 圆环相对整个额度卡片居中，而不是相对左侧信息栏居中。
-            .frame(maxWidth: .infinity, alignment: .center)
+        HStack(alignment: .center, spacing: 14) {
+            MenuRuntimeUsageRingsGraphic(slots: slots)
+                .fixedSize()
 
-            HStack(alignment: .top, spacing: 4) {
-                ForEach(items) { item in
-                    MenuRuntimeUsageCompactColumn(item: item)
-                        .frame(maxWidth: .infinity, alignment: .top)
-                }
-            }
-            .frame(maxWidth: .infinity)
+            MenuRuntimeUsageInfoRows(slots: slots)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
         .background(
             Color.primary.opacity(0.04),
             in: RoundedRectangle(cornerRadius: 9, style: .continuous)
@@ -726,11 +727,10 @@ private struct MenuRuntimeUsageOverview: View {
     }
 }
 
-/// 与设置页一致的三层同心圆：Codex 长窗口、Claude 长窗口、Claude 短窗口。
-/// 菜单栏只缩小尺寸，不改变颜色、顺序和“剩余额度”语义。
+/// 三层同心圆依次表示 Codex 长窗口、Claude 长窗口、Claude 短窗口。
+/// 菜单栏降低强调色强度，避免小面积高饱和颜色在浅色材质上过度刺眼。
 private struct MenuRuntimeUsageRingsGraphic: View {
-    let items: [MenuRuntimeUsageItem]
-    let expectedRingCount: Int
+    let slots: [MenuRuntimeUsageSlot]
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let diameter: CGFloat = 74
@@ -738,12 +738,12 @@ private struct MenuRuntimeUsageRingsGraphic: View {
     private let ringStep: CGFloat = 20
 
     var body: some View {
-        let ringCount = min(max(expectedRingCount, items.count), 3)
+        let ringCount = min(slots.count, 3)
 
         ZStack(alignment: .center) {
             ForEach(0..<ringCount, id: \.self) { index in
                 let ringDiameter = diameter - CGFloat(index) * ringStep
-                let item = index < items.count ? items[index] : nil
+                let item = slots[index].item
 
                 ZStack {
                     Circle()
@@ -772,61 +772,92 @@ private struct MenuRuntimeUsageRingsGraphic: View {
 
     private func itemTint(_ item: MenuRuntimeUsageItem?) -> Color {
         guard let item else { return .secondary }
-        if item.isExhausted { return .red }
+        if item.isExhausted { return Color.red.opacity(0.82) }
         switch item.tintRole {
-        case .codexLong: return .pink
-        case .claudeLong: return .cyan
-        case .claudeShort: return .mimiPrimary
+        case .codexLong: return Color.pink.opacity(0.78)
+        case .claudeLong: return Color.cyan.opacity(0.72)
+        case .claudeShort: return Color.mimiPrimary.opacity(0.82)
         }
     }
 }
 
-private struct MenuRuntimeUsageCompactColumn: View {
-    let item: MenuRuntimeUsageItem
+private struct MenuRuntimeUsageInfoRows: View {
+    let slots: [MenuRuntimeUsageSlot]
 
     var body: some View {
-        VStack(alignment: .center, spacing: 2) {
+        Grid(alignment: .leading, horizontalSpacing: 4, verticalSpacing: 7) {
+            ForEach(slots) { slot in
+                MenuRuntimeUsageInfoRow(slot: slot)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct MenuRuntimeUsageInfoRow: View {
+    let slot: MenuRuntimeUsageSlot
+
+    var body: some View {
+        GridRow(alignment: .firstTextBaseline) {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Circle()
                     .fill(tint)
                     .frame(width: 6, height: 6)
                     .accessibilityHidden(true)
 
-                Text("\(item.providerName) · \(item.window.durationLabel)")
+                Text("\(slot.providerName) · \(slot.windowLabel)")
                     .font(.caption2.weight(.semibold))
                     .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
             }
+            .gridColumnAlignment(.leading)
 
             Text(valueText)
                 .font(.caption2.monospacedDigit().weight(.semibold))
-                .foregroundStyle(tint)
+                .foregroundStyle(valueColor)
                 .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .gridColumnAlignment(.trailing)
 
-            if let resetDate = item.window.resetDate {
-                Text("\(resetText(resetDate)) 重置")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-            }
+            Text(resetDetail)
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .gridColumnAlignment(.trailing)
         }
-        .frame(maxWidth: .infinity, alignment: .top)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(item.providerName) \(item.window.durationLabel)额度")
+        .accessibilityLabel("\(slot.providerName) \(slot.windowLabel)额度")
         .accessibilityValue(valueText)
     }
 
+    private var hasUsageValue: Bool {
+        slot.item?.window.remainingPercentText != nil || slot.item?.isExhausted == true
+    }
+
     private var valueText: String {
-        if item.isExhausted { return "已耗尽" }
-        return item.window.remainingPercentText.map { "剩余 \($0)" } ?? "等待刷新"
+        if slot.item?.isExhausted == true { return "已耗尽" }
+        return slot.item?.window.remainingPercentText.map { "剩余 \($0)" } ?? "等待额度"
+    }
+
+    private var resetDetail: String {
+        guard let resetDate = slot.item?.window.resetDate else { return "" }
+        return resetText(resetDate)
+    }
+
+    private var valueColor: Color {
+        if slot.item?.isExhausted == true {
+            return Color.red.opacity(0.8)
+        }
+        return hasUsageValue ? Color.primary.opacity(0.72) : .secondary
     }
 
     private var tint: Color {
-        if item.isExhausted { return .red }
-        switch item.tintRole {
-        case .codexLong: return .pink
-        case .claudeLong: return .cyan
-        case .claudeShort: return .mimiPrimary
+        if slot.item?.isExhausted == true { return Color.red.opacity(0.82) }
+        switch slot.tintRole {
+        case .codexLong: return Color.pink.opacity(0.78)
+        case .claudeLong: return Color.cyan.opacity(0.72)
+        case .claudeShort: return Color.mimiPrimary.opacity(0.82)
         }
     }
 
@@ -887,9 +918,14 @@ private struct MenuActionRow: View {
                 }
             }
             .padding(.horizontal, MenuBarLayout.sectionInset)
-            .frame(maxWidth: .infinity, minHeight: 35, alignment: .leading)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: MenuBarLayout.actionRowHeight,
+                maxHeight: MenuBarLayout.actionRowHeight,
+                alignment: .leading
+            )
             .background(
-                Color.primary.opacity(isHovered ? 0.075 : 0),
+                hoverBackgroundColor,
                 in: RoundedRectangle(cornerRadius: 8, style: .continuous)
             )
             .contentShape(Rectangle())
@@ -905,12 +941,21 @@ private struct MenuActionRow: View {
     }
 
     private var labelColor: Color {
-        role == .destructive ? Color(nsColor: .systemRed) : .primary
+        // 危险语义由电源图标与确认弹窗承接，文字保持普通层级，避免整行高饱和。
+        .primary
     }
 
     private var symbolColor: Color {
-        // 使用 macOS 语义化系统红，自动适配外观并符合用户对危险操作的既有认知。
-        role == .destructive ? Color(nsColor: .systemRed) : .secondary
+        // 保留危险操作语义，但减少高饱和红色在菜单底部形成“主按钮”的错觉。
+        role == .destructive ? Color(nsColor: .systemRed).opacity(0.62) : .secondary
+    }
+
+    private var hoverBackgroundColor: Color {
+        guard isHovered else { return .clear }
+        if role == .destructive {
+            return Color(nsColor: .systemRed).opacity(0.03)
+        }
+        return Color.primary.opacity(0.055)
     }
 }
 

--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuRuntimePresentation.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuRuntimePresentation.swift
@@ -15,6 +15,18 @@ struct MenuRuntimeUsageItem: Equatable, Identifiable {
     let tintRole: MenuRuntimeUsageTintRole
 }
 
+struct MenuRuntimeUsageSlot: Equatable, Identifiable {
+    let id: String
+    let providerName: String
+    let fallbackWindowLabel: String
+    let tintRole: MenuRuntimeUsageTintRole
+    let item: MenuRuntimeUsageItem?
+
+    var windowLabel: String {
+        item?.window.durationLabel ?? fallbackWindowLabel
+    }
+}
+
 enum MenuRuntimePresentation {
     static func versionText(for runtime: AgentRuntimeStatus?) -> String? {
         guard let runtime,
@@ -132,6 +144,47 @@ enum MenuRuntimePresentation {
             }
         }
         return Array(result.prefix(3))
+    }
+
+    /// 三个槽位固定对应三层圆环，额度暂不可用时也保留对应信息行。
+    /// 这样后台刷新只更新数值，不会让卡片高度和左右对齐发生跳变。
+    static func usageSlots(
+        codex: AgentRuntimeStatus?,
+        claude: AgentRuntimeStatus?
+    ) -> [MenuRuntimeUsageSlot] {
+        guard codex != nil || claude != nil else { return [] }
+        let items = usageItems(codex: codex, claude: claude)
+
+        var slots = [
+            MenuRuntimeUsageSlot(
+                id: "codex:long",
+                providerName: "Codex",
+                fallbackWindowLabel: "长周期",
+                tintRole: .codexLong,
+                item: items.first { $0.tintRole == .codexLong }
+            ),
+        ]
+        if claude?.enabled == true {
+            slots.append(
+                MenuRuntimeUsageSlot(
+                    id: "claude:long",
+                    providerName: "Claude",
+                    fallbackWindowLabel: "长周期",
+                    tintRole: .claudeLong,
+                    item: items.first { $0.tintRole == .claudeLong }
+                )
+            )
+            slots.append(
+                MenuRuntimeUsageSlot(
+                    id: "claude:short",
+                    providerName: "Claude",
+                    fallbackWindowLabel: "短周期",
+                    tintRole: .claudeShort,
+                    item: items.first { $0.tintRole == .claudeShort }
+                )
+            )
+        }
+        return slots
     }
 
     private struct UsageCandidate {

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -34,6 +34,7 @@ final class HostStore {
     private var monitorTask: Task<Void, Never>?
     private var runtimeStatusFollowUpTask: Task<Void, Never>?
     private var stopServiceAndQuitTask: Task<Void, Never>?
+    private var lastStatusRefreshAt: Date?
 
     init(
         agent: AgentCommandClient,
@@ -83,6 +84,11 @@ final class HostStore {
             await refreshHomebrewStatus()
         } else {
             await startMacAgentIfNeeded()
+        }
+        if owner == .macApp, runtimeStatusNeedsFollowUp {
+            // App 启动时就把服务端占位快照追到可展示结果，用户第一次展开
+            // 菜单时通常直接命中 Store，而不是从那一刻才开始 Provider 探测。
+            scheduleRuntimeStatusFollowUp()
         }
         startMonitoring()
     }
@@ -198,12 +204,25 @@ final class HostStore {
                 await startMacAgentIfNeeded()
             }
         }
-        if owner == .macApp,
-           status?.runtimeStatus?.refreshing == true
-            || status?.runtimeStatus?.hasRetryableFailure == true
-        {
+        if owner == .macApp, runtimeStatusNeedsFollowUp {
             scheduleRuntimeStatusFollowUp()
         }
+    }
+
+    /// MenuBarExtra 每次展开都会重建内容视图。短时间重复打开直接复用 Store
+    /// 中的状态，避免为同一份服务状态反复启动 agentd 子进程。
+    func refreshIfNeeded() async {
+        guard lifecycle != .loading, lifecycle != .starting else { return }
+        if let lastStatusRefreshAt,
+           Date().timeIntervalSince(lastStatusRefreshAt) < 30,
+           owner != .macApp || status?.runtimeStatus != nil
+        {
+            if owner == .macApp, runtimeStatusNeedsFollowUp {
+                scheduleRuntimeStatusFollowUp()
+            }
+            return
+        }
+        await refresh()
     }
 
     func refreshPairing(network: PairingNetwork? = nil) async {
@@ -527,6 +546,7 @@ final class HostStore {
             let current = try await agent.statusAt(binary)
             status = current
             doctor = current.doctor
+            lastStatusRefreshAt = Date()
             if !current.serviceOK {
                 lifecycle = .degraded(current.serviceError ?? "Homebrew 服务尚未就绪。")
             } else {
@@ -574,15 +594,54 @@ final class HostStore {
     }
 
     private func apply(_ current: AgentStatus) {
-        status = current
-        doctor = current.doctor
-        if current.serviceOK {
+        let resolved = preservingRuntimeSnapshotIfNeeded(in: current)
+        status = resolved
+        doctor = resolved.doctor
+        lastStatusRefreshAt = Date()
+        if resolved.serviceOK {
             lifecycle = .ready
-        } else if current.processOK {
-            lifecycle = .degraded(current.serviceError ?? firstBlockingIssue(in: current.doctor))
+        } else if resolved.processOK {
+            lifecycle = .degraded(
+                resolved.serviceError ?? firstBlockingIssue(in: resolved.doctor)
+            )
         } else {
             lifecycle = .stopped
         }
+    }
+
+    private func preservingRuntimeSnapshotIfNeeded(in current: AgentStatus) -> AgentStatus {
+        guard current.runtimeStatus == nil,
+              current.serviceOK,
+              let previousStatus = status,
+              previousStatus.endpoint == current.endpoint,
+              previousStatus.serverVersion == current.serverVersion,
+              let previousSnapshot = previousStatus.runtimeStatus
+        else {
+            return current
+        }
+        // status CLI 会并行读取 readyz 与 runtime endpoint。后者偶发超时时，
+        // 核心服务状态仍然有效；保留并显式标旧上次快照，避免运行时整块闪空。
+        let staleSnapshot = AgentRuntimeStatusSnapshot(
+            checkedAt: previousSnapshot.checkedAt,
+            runtimes: previousSnapshot.runtimes,
+            refreshing: previousSnapshot.refreshing,
+            stale: true
+        )
+        return AgentStatus(
+            processOK: current.processOK,
+            serviceOK: current.serviceOK,
+            processError: current.processError,
+            serviceError: current.serviceError,
+            version: current.version,
+            serverVersion: current.serverVersion,
+            endpoint: current.endpoint,
+            configPath: current.configPath,
+            projects: current.projects,
+            doctorOK: current.doctorOK,
+            doctor: current.doctor,
+            pairExpires: current.pairExpires,
+            runtimeStatus: staleSnapshot
+        )
     }
 
     private func firstBlockingIssue(in results: AgentDoctorResults) -> String {
@@ -632,10 +691,10 @@ final class HostStore {
             defer { runtimeStatusFollowUpTask = nil }
             // Provider 冷启动可能涉及 bridge 启动、OAuth 刷新和网络查询。
             // 菜单先展示缓存/refreshing，再在后台有界轮询，不能重新阻塞 readiness。
-            // 首次 unavailable 还会在服务端 15 秒失败 TTL 后重试一次；48 轮
-            // 足够覆盖两次最慢 42 秒 provider 刷新，同时避免永久轮询。
+            // 首次 unavailable/额度刷新还会在服务端 15 秒失败 TTL 后重试一次；
+            // 16 轮足够覆盖两次 9 秒 provider 预算，同时避免永久轮询。
             var didRetryUnavailable = false
-            for _ in 0..<48 {
+            for _ in 0..<16 {
                 let delay: Duration
                 if isRefreshingStatus {
                     delay = .seconds(2)
@@ -671,6 +730,11 @@ final class HostStore {
                 isRefreshingStatus = false
             }
         }
+    }
+
+    private var runtimeStatusNeedsFollowUp: Bool {
+        status?.runtimeStatus?.refreshing == true
+            || status?.runtimeStatus?.hasRetryableFailure == true
     }
 
     nonisolated static func runtimeStatusFollowUpDelay(

--- a/macos/MimiRemoteMac/Tests/AgentModelsTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentModelsTests.swift
@@ -103,8 +103,8 @@ final class AgentModelsTests: XCTestCase {
         )
         XCTAssertNil(runtimes[1].startedDate)
         let checkedDate = try XCTUnwrap(snapshot.checkedDate)
-        XCTAssertFalse(snapshot.isExpired(at: checkedDate.addingTimeInterval(60)))
-        XCTAssertTrue(snapshot.isExpired(at: checkedDate.addingTimeInterval(121)))
+        XCTAssertFalse(snapshot.isExpired(at: checkedDate.addingTimeInterval(5 * 60)))
+        XCTAssertTrue(snapshot.isExpired(at: checkedDate.addingTimeInterval(6 * 60 + 1)))
         XCTAssertEqual(runtimes[0].state, .connected)
         XCTAssertEqual(runtimes[0].effectivePlanType, "plus")
         let windows = try XCTUnwrap(runtimes[0].rateLimits).windows
@@ -227,8 +227,56 @@ final class AgentModelsTests: XCTestCase {
             refreshing: false,
             stale: false
         )
+        let quotaRefreshing = AgentRuntimeStatusSnapshot(
+            checkedAt: "2026-07-27T12:00:00Z",
+            runtimes: [
+                AgentRuntimeStatus(
+                    id: "claude",
+                    title: "Claude",
+                    enabled: true,
+                    state: .available,
+                    authMode: nil,
+                    planType: nil,
+                    reason: "quota_refresh_in_progress",
+                    rateLimits: nil
+                ),
+            ],
+            refreshing: false,
+            stale: false
+        )
+        let quotaUnavailable = AgentRuntimeStatusSnapshot(
+            checkedAt: "2026-07-27T12:00:00Z",
+            runtimes: [
+                AgentRuntimeStatus(
+                    id: "claude",
+                    title: "Claude",
+                    enabled: true,
+                    state: .available,
+                    authMode: nil,
+                    planType: nil,
+                    reason: nil,
+                    rateLimits: AgentRuntimeRateLimits(
+                        limitID: "claude",
+                        limitName: "Claude",
+                        planType: nil,
+                        reachedType: nil,
+                        availability: "unavailable",
+                        unavailableReason: "headless_statusline_unavailable",
+                        primary: nil,
+                        secondary: nil,
+                        hasCredits: nil,
+                        creditsUnlimited: nil,
+                        creditBalance: nil
+                    )
+                ),
+            ],
+            refreshing: false,
+            stale: false
+        )
 
         XCTAssertTrue(failed.hasRetryableFailure)
+        XCTAssertTrue(quotaRefreshing.hasRetryableFailure)
+        XCTAssertTrue(quotaUnavailable.hasRetryableFailure)
         XCTAssertEqual(
             HostStore.runtimeStatusFollowUpDelay(
                 snapshot: failed,

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -304,6 +304,95 @@ final class HostStoreTests: XCTestCase {
         XCTAssertEqual(store.owner, .macApp)
     }
 
+    func testMenuAppearanceReusesRecentBootstrapStatus() async {
+        let events = EventRecorder()
+        let current = AgentStatus(
+            processOK: Self.readyStatus.processOK,
+            serviceOK: Self.readyStatus.serviceOK,
+            processError: Self.readyStatus.processError,
+            serviceError: Self.readyStatus.serviceError,
+            version: Self.readyStatus.version,
+            serverVersion: Self.readyStatus.serverVersion,
+            endpoint: Self.readyStatus.endpoint,
+            configPath: Self.readyStatus.configPath,
+            projects: Self.readyStatus.projects,
+            doctorOK: Self.readyStatus.doctorOK,
+            doctor: Self.readyStatus.doctor,
+            pairExpires: Self.readyStatus.pairExpires,
+            runtimeStatus: AgentRuntimeStatusSnapshot(
+                checkedAt: "2026-07-28T02:00:00Z",
+                runtimes: [],
+                refreshing: false,
+                stale: false
+            )
+        )
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            status: {
+                events.append("status")
+                return current
+            }
+        )
+
+        await store.bootstrap()
+        await store.refreshIfNeeded()
+
+        XCTAssertEqual(events.values, ["status"])
+        XCTAssertEqual(store.lifecycle, .ready)
+    }
+
+    func testTransientMissingRuntimeStatusPreservesPreviousSnapshotAsStale() async {
+        let events = EventRecorder()
+        let snapshot = AgentRuntimeStatusSnapshot(
+            checkedAt: "2026-07-28T02:00:00Z",
+            runtimes: [
+                AgentRuntimeStatus(
+                    id: "codex",
+                    title: "Codex",
+                    enabled: true,
+                    state: .connected,
+                    authMode: "chatgpt",
+                    planType: "pro",
+                    reason: nil,
+                    rateLimits: nil
+                ),
+            ],
+            refreshing: false,
+            stale: false
+        )
+        let statusWithRuntime = AgentStatus(
+            processOK: Self.readyStatus.processOK,
+            serviceOK: Self.readyStatus.serviceOK,
+            processError: Self.readyStatus.processError,
+            serviceError: Self.readyStatus.serviceError,
+            version: Self.readyStatus.version,
+            serverVersion: Self.readyStatus.serverVersion,
+            endpoint: Self.readyStatus.endpoint,
+            configPath: Self.readyStatus.configPath,
+            projects: Self.readyStatus.projects,
+            doctorOK: Self.readyStatus.doctorOK,
+            doctor: Self.readyStatus.doctor,
+            pairExpires: Self.readyStatus.pairExpires,
+            runtimeStatus: snapshot
+        )
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            status: {
+                events.append("status")
+                return events.values.count == 1 ? statusWithRuntime : Self.readyStatus
+            }
+        )
+
+        await store.bootstrap()
+        await store.refresh()
+
+        XCTAssertEqual(events.values, ["status", "status"])
+        XCTAssertEqual(store.status?.runtimeStatus?.runtimes.map(\.id), ["codex"])
+        XCTAssertEqual(store.status?.runtimeStatus?.stale, true)
+    }
+
     private func makeStore(
         configExists: Bool,
         homebrewLoaded: Bool = false,

--- a/macos/MimiRemoteMac/Tests/MenuRuntimePresentationTests.swift
+++ b/macos/MimiRemoteMac/Tests/MenuRuntimePresentationTests.swift
@@ -111,6 +111,31 @@ final class MenuRuntimePresentationTests: XCTestCase {
         )
     }
 
+    func testUsageSlotsKeepThreeAlignedRowsWhileClaudeQuotaIsUnavailable() {
+        let codex = makeRuntime(
+            id: "codex",
+            title: "Codex",
+            state: .connected,
+            authMode: "chatgpt",
+            rateLimits: makeRateLimits(primaryUsed: 80, secondaryUsed: 42)
+        )
+        let claude = makeRuntime(
+            id: "claude",
+            title: "Claude",
+            state: .available,
+            authMode: "oauth"
+        )
+
+        let slots = MenuRuntimePresentation.usageSlots(codex: codex, claude: claude)
+
+        XCTAssertEqual(slots.map(\.id), ["codex:long", "claude:long", "claude:short"])
+        XCTAssertNotNil(slots[0].item)
+        XCTAssertNil(slots[1].item)
+        XCTAssertNil(slots[2].item)
+        XCTAssertEqual(slots[1].windowLabel, "长周期")
+        XCTAssertEqual(slots[2].windowLabel, "短周期")
+    }
+
     private func makeRuntime(
         id: String = "test",
         title: String = "Test",

--- a/scripts/check-source-size.sh
+++ b/scripts/check-source-size.sh
@@ -18,6 +18,9 @@ exception_reason() {
     ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift)
       printf '%s' '会话数据流回归矩阵，后续按流式事件、审批和附件场景拆分'
       ;;
+    ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift)
+      printf '%s' '运行时切换与消息流回归矩阵，后续按运行时选择和会话执行场景拆分'
+      ;;
     ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift)
       printf '%s' 'Workspace 历史回归矩阵，后续按目录解析与会话恢复场景拆分'
       ;;


### PR DESCRIPTION
## 改动内容

- 将 Mac 菜单栏运行时状态改为缓存优先、后台刷新，减少每次展开菜单时的等待。
- 增加 Claude OAuth 额度窗口获取与缓存，并统一映射 Codex、Claude 的额度数据。
- 在运行时详情上方展示三层同心圆额度总览，优化信息对齐、颜色饱和度和操作行节奏。
- 弱化退出操作的视觉刺激，同时保留电源图标和确认弹窗的危险语义。

## 原因

原实现会在菜单展开时同步等待运行时探测，Codex 和 Claude CLI/Bridge 的状态获取较慢；Claude 登录后也缺少稳定的额度展示。菜单中的高饱和状态色和不统一的操作行高度进一步影响扫描效率。

## 用户影响

- 菜单展开后可以立即展示最近一次状态，并在后台更新。
- Claude 登录用户可以看到 5 小时和 7 天额度窗口。
- 三个额度圆环固定保留并集中展示在运行时详情上方。
- 操作区高度、分隔线和危险操作配色更一致。

## 验证

- `go vet ./...`
- `go test ./... -count=1`
- `cargo test --locked -p alleycat-codex-proto -p alleycat-bridge-core -p alleycat-claude-bridge`
- Mac 单元测试
- Mac Release 本地构建与严格签名校验
- `scripts/check-packaging.sh`
- `scripts/check-public-repo-safety.sh`
