### PR TITLE
fix(macos): refresh agent registration after updates

### DIFF
--- a/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
@@ -2,6 +2,8 @@ import ServiceManagement
 
 struct ServiceManagementClient {
     var agentStatus: @MainActor () -> ServiceRegistrationState
+    var isAgentRegistrationCurrent: @MainActor () -> Bool
+    var markAgentRegistrationCurrent: @MainActor () -> Void
     var registerAgent: @MainActor () throws -> Void
     var unregisterAgent: @MainActor () async throws -> Void
     var mainAppStatus: @MainActor () -> ServiceRegistrationState
@@ -13,9 +15,23 @@ struct ServiceManagementClient {
 extension ServiceManagementClient {
     @MainActor
     static var live: ServiceManagementClient {
-        ServiceManagementClient(
+        let registrationRevision = currentAgentRegistrationRevision()
+        return ServiceManagementClient(
             agentStatus: {
                 registrationState(for: agentService.status)
+            },
+            isAgentRegistrationCurrent: {
+                guard let registrationRevision else { return true }
+                return UserDefaults.standard.string(
+                    forKey: agentRegistrationRevisionKey
+                ) == registrationRevision
+            },
+            markAgentRegistrationCurrent: {
+                guard let registrationRevision else { return }
+                UserDefaults.standard.set(
+                    registrationRevision,
+                    forKey: agentRegistrationRevisionKey
+                )
             },
             registerAgent: {
                 let service = agentService
@@ -26,7 +42,8 @@ extension ServiceManagementClient {
             unregisterAgent: {
                 let service = agentService
                 guard service.status != .notRegistered, service.status != .notFound else { return }
-                try service.unregister()
+                // 使用异步 API 等待系统真正终止旧进程；回调完成后才可安全重新注册。
+                try await service.unregister()
             },
             mainAppStatus: {
                 registrationState(for: SMAppService.mainApp.status)
@@ -40,7 +57,7 @@ extension ServiceManagementClient {
                 guard SMAppService.mainApp.status != .notRegistered,
                       SMAppService.mainApp.status != .notFound
                 else { return }
-                try SMAppService.mainApp.unregister()
+                try await SMAppService.mainApp.unregister()
             },
             openLoginItemsSettings: {
                 SMAppService.openSystemSettingsLoginItems()
@@ -51,6 +68,28 @@ extension ServiceManagementClient {
     @MainActor
     private static var agentService: SMAppService {
         SMAppService.agent(plistName: "com.gaixianggeng.mimi.mac.agentd.plist")
+    }
+
+    private static let agentRegistrationRevisionKey =
+        "MimiRemoteMac.agentRegistrationRevision"
+
+    /// SMAppService 不会自动刷新已登记的 LaunchAgent 可执行文件。正式发布的
+    /// build number 每次都会递增，因此用 App 版本与构建号识别需要重新注册的升级。
+    private static func currentAgentRegistrationRevision(
+        bundle: Bundle = .main
+    ) -> String? {
+        guard let version = bundle.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String,
+              let build = bundle.object(
+                  forInfoDictionaryKey: "CFBundleVersion"
+              ) as? String,
+              !version.isEmpty,
+              !build.isEmpty
+        else {
+            return nil
+        }
+        return "\(version)+\(build)"
     }
 
     @MainActor

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -111,9 +111,8 @@ final class HostStore {
             pairing = nextPairing
             pairingNetwork = nextPairing.network
             await enableLoginLaunchBestEffort()
-            try services.registerAgent()
             owner = .macApp
-            try await waitForMacAgentReady()
+            try await registerMacAgentAndWaitForReady()
         } catch {
             fail(error)
         }
@@ -142,9 +141,8 @@ final class HostStore {
             try await prepareAutomaticNetworkBeforeServiceStart()
             try await homebrew.stop()
             homebrewLoaded = false
-            try services.registerAgent()
             owner = .macApp
-            try await waitForMacAgentReady()
+            try await registerMacAgentAndWaitForReady()
         } catch {
             let takeoverError = error
             await rollbackAfterFailedTakeover(oldAgent: oldAgent, cause: takeoverError)
@@ -357,8 +355,7 @@ final class HostStore {
         defer { isBusy = false }
         do {
             try await unregisterMacAgentAndWait(endpoint: status?.endpoint)
-            try services.registerAgent()
-            try await waitForMacAgentReady()
+            try await registerMacAgentAndWaitForReady()
         } catch {
             fail(error)
         }
@@ -405,6 +402,14 @@ final class HostStore {
         case .enabled:
             owner = .macApp
             do {
+                if !services.isAgentRegistrationCurrent() {
+                    // Apple 要求 LaunchAgent 的 plist 或可执行文件更新后重新注册。
+                    // 先于状态命令处理，才能修复旧签名约束在进程启动前直接 SIGKILL 的升级。
+                    lifecycle = .starting
+                    try await unregisterMacAgentAndWait(endpoint: status?.endpoint)
+                    try await registerMacAgentAndWaitForReady()
+                    return
+                }
                 let current = try await agent.status()
                 status = current
                 doctor = current.doctor
@@ -413,8 +418,7 @@ final class HostStore {
                     // 启动阶段发现明确版本漂移时做一次受控换代，避免长期半更新。
                     lifecycle = .starting
                     try await unregisterMacAgentAndWait(endpoint: current.endpoint)
-                    try services.registerAgent()
-                    try await waitForMacAgentReady()
+                    try await registerMacAgentAndWaitForReady()
                 } else {
                     apply(current)
                 }
@@ -425,9 +429,8 @@ final class HostStore {
             lifecycle = .starting
             do {
                 try await prepareAutomaticNetworkBeforeServiceStart()
-                try services.registerAgent()
                 owner = .macApp
-                try await waitForMacAgentReady()
+                try await registerMacAgentAndWaitForReady()
             } catch {
                 fail(error)
             }
@@ -453,6 +456,13 @@ final class HostStore {
         }
         let detail = lastStatus?.serviceError ?? "服务在 15 秒内没有通过就绪检查。"
         throw AgentClientError.commandFailed(detail)
+    }
+
+    private func registerMacAgentAndWaitForReady() async throws {
+        try services.registerAgent()
+        try await waitForMacAgentReady()
+        // 只有新登记的进程真正通过就绪检查后才记账；失败时下次启动仍会重试迁移。
+        services.markAgentRegistrationCurrent()
     }
 
     private func waitForMacAgentUnregistered() async throws {
@@ -581,9 +591,8 @@ final class HostStore {
             try? await homebrew.stop()
         }
         do {
-            try services.registerAgent()
             owner = .macApp
-            try await waitForMacAgentReady()
+            try await registerMacAgentAndWaitForReady()
             homebrewLoaded = false
             lastError = "恢复 Homebrew 失败，已继续使用 App 服务：\(cause.localizedDescription)"
         } catch {
@@ -871,7 +880,11 @@ final class HostStore {
             version: { status.version }
         )
         let services = ServiceManagementClient(
-            agentStatus: { .enabled }, registerAgent: {}, unregisterAgent: {},
+            agentStatus: { .enabled },
+            isAgentRegistrationCurrent: { true },
+            markAgentRegistrationCurrent: {},
+            registerAgent: {},
+            unregisterAgent: {},
             mainAppStatus: { .enabled }, registerMainApp: {}, unregisterMainApp: {},
             openLoginItemsSettings: {}
         )

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -304,6 +304,49 @@ final class HostStoreTests: XCTestCase {
         XCTAssertEqual(store.owner, .macApp)
     }
 
+    func testBootstrapReregistersEnabledAgentWhenRegistrationRevisionIsStale() async {
+        let events = EventRecorder()
+        let registration = LaggingAgentRegistration()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registration.nextStatus() },
+            isAgentRegistrationCurrent: { false },
+            markAgentRegistrationCurrent: { events.append("mark-registration") },
+            registerAgent: { events.append("register-mac") },
+            unregisterAgent: { events.append("unregister-mac") }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, [
+            "unregister-mac", "register-mac", "mark-registration",
+        ])
+        XCTAssertEqual(store.lifecycle, .ready)
+        XCTAssertEqual(store.owner, .macApp)
+    }
+
+    func testBootstrapReusesEnabledAgentWhenRegistrationRevisionIsCurrent() async {
+        let events = EventRecorder()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            isAgentRegistrationCurrent: { true },
+            markAgentRegistrationCurrent: { events.append("mark-registration") },
+            status: {
+                events.append("status")
+                return Self.readyStatus
+            },
+            registerAgent: { events.append("register-mac") },
+            unregisterAgent: { events.append("unregister-mac") }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, ["status"])
+        XCTAssertEqual(store.lifecycle, .ready)
+        XCTAssertEqual(store.owner, .macApp)
+    }
+
     func testMenuAppearanceReusesRecentBootstrapStatus() async {
         let events = EventRecorder()
         let current = AgentStatus(
@@ -397,6 +440,8 @@ final class HostStoreTests: XCTestCase {
         configExists: Bool,
         homebrewLoaded: Bool = false,
         agentStatus: @escaping @MainActor () -> ServiceRegistrationState = { .notRegistered },
+        isAgentRegistrationCurrent: @escaping @MainActor () -> Bool = { true },
+        markAgentRegistrationCurrent: @escaping @MainActor () -> Void = {},
         status: @escaping @Sendable () async throws -> AgentStatus = {
             HostStoreTests.readyStatus
         },
@@ -425,6 +470,8 @@ final class HostStoreTests: XCTestCase {
         )
         let services = ServiceManagementClient(
             agentStatus: agentStatus,
+            isAgentRegistrationCurrent: isAgentRegistrationCurrent,
+            markAgentRegistrationCurrent: markAgentRegistrationCurrent,
             registerAgent: registerAgent,
             unregisterAgent: unregisterAgent,
             mainAppStatus: { .enabled },


### PR DESCRIPTION
## 目标

修复覆盖安装签名版 Mac App 后，旧的 `SMAppService` LaunchAgent 注册仍保留开发签名约束，导致 `agentd` 被 macOS 以 `Launch Constraint Violation` 循环杀死的问题。

## 方案

- 使用 App 版本与构建号记录已经验证成功的 LaunchAgent 注册版本。
- 发现系统服务已启用但注册版本过期时，先完整注销旧服务，再重新注册内嵌的新版 `agentd`。
- 改用 `SMAppService` 异步注销 API，等待旧进程终止后再注册。
- 仅在新 `agentd` 真正通过就绪检查后记录注册版本，失败时保留下次启动重试能力。
- 增加过期注册需要换代、当前注册直接复用的回归测试。

## 验证

- `xcodebuild ... test`
- `go vet ./...`
- `go test ./... -count=1`
- `cargo fmt --all -- --check`
- Claude bridge workspace tests
- packaging、source-size、third-party notices、public-repo safety 门禁
- 本地 `0.2.7` universal DMG 快照构建与安装包检查
