### PR TITLE
fix(macos): tighten menu bar bottom spacing

### DIFF
--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -2,6 +2,9 @@ import AppKit
 import SwiftUI
 
 private enum MenuBarLayout {
+    static let contentInset: CGFloat = 12
+    // 底部操作已经有完整的 40pt 点击区域；收紧窗口底边留白，避免最后一行显得虚高。
+    static let bottomInset: CGFloat = 6
     // 状态信息、运行时和操作区共用同一列网格，避免不同区块的图标与文字左右漂移。
     static let sectionInset: CGFloat = 3
     static let symbolColumnWidth: CGFloat = 16
@@ -133,7 +136,9 @@ struct MenuBarContentView: View {
             }
             .padding(.top, 6)
         }
-        .padding(12)
+        .padding(.horizontal, MenuBarLayout.contentInset)
+        .padding(.top, MenuBarLayout.contentInset)
+        .padding(.bottom, MenuBarLayout.bottomInset)
         .frame(width: 340)
         .background(MenuBarWindowPositionGuard())
         .animation(


### PR DESCRIPTION
## 改动

- 将菜单栏弹窗的统一外边距拆分为水平、顶部与底部间距。
- 保持水平和顶部 `12pt`，将底部收紧为 `6pt`。

## 原因

“退出并停止服务”操作行本身已有完整的 `40pt` 点击区域，额外的底部留白会让最后一行显得虚高。

## 影响

只调整 Mac 菜单栏弹窗底部视觉间距，不改变服务生命周期、运行时状态或交互行为。

## 验证

- Release 构建通过。
- Packaging 门禁通过。
- 本地部署后 Codex、Claude 和 agentd 均正常运行。
- `git diff --check` 通过。

备注：Xcode `test` 动作会遇到仓库现有的测试 Bundle 签名顺序问题；正式 Release 构建路径不受影响。
