### PR TITLE
feat: track Codex Desktop sessions as read-only activity

### DIFF
--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -1,0 +1,430 @@
+package codexhistory
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/projects"
+)
+
+const (
+	defaultExternalActivityStaleAfter = 30 * time.Minute
+	externalActivityCandidateLimit    = 500
+	maxExternalActivityLineBytes      = 1 << 20
+)
+
+// ExternalActivity 是允许返回给移动端的最小只读快照。
+// 不包含 cwd、rollout 路径、prompt 或消息内容，避免把本机 Codex 状态库变成文件枚举接口。
+type ExternalActivity struct {
+	ThreadID     string    `json:"thread_id"`
+	ProjectID    string    `json:"project_id"`
+	Source       string    `json:"source"`
+	State        string    `json:"state"`
+	TurnID       string    `json:"turn_id,omitempty"`
+	Revision     string    `json:"revision"`
+	LastActivity time.Time `json:"last_activity_at"`
+}
+
+type ExternalActivityDiagnostics struct {
+	CandidateQueries int `json:"candidate_queries"`
+	FileScans        int `json:"file_scans"`
+	CacheHits        int `json:"cache_hits"`
+	MalformedLines   int `json:"malformed_lines"`
+	OversizedLines   int `json:"oversized_lines"`
+}
+
+type externalActivityCandidate struct {
+	ThreadID     string
+	CWD          string
+	Source       string
+	ThreadSource string
+	RolloutPath  string
+}
+
+type externalRolloutCacheEntry struct {
+	offset       int64
+	size         int64
+	modTime      time.Time
+	originator   string
+	metaThreadID string
+	metaCWD      string
+	threadSource string
+	active       bool
+	turnID       string
+}
+
+type externalRolloutRecord struct {
+	Timestamp string `json:"timestamp"`
+	Type      string `json:"type"`
+	Payload   struct {
+		ID           string `json:"id"`
+		CWD          string `json:"cwd"`
+		Originator   string `json:"originator"`
+		ThreadSource string `json:"thread_source"`
+		Type         string `json:"type"`
+		TurnID       string `json:"turn_id"`
+	} `json:"payload"`
+}
+
+// ExternalActivityTracker 按请求增量读取 rollout 尾部。它没有后台 goroutine，
+// agentd 空闲时不会持续扫盘；同一个文件未变化时只做一次 stat 并复用解析状态。
+type ExternalActivityTracker struct {
+	mu         sync.Mutex
+	store      ThreadStore
+	registry   *projects.Registry
+	staleAfter time.Duration
+	now        func() time.Time
+	stat       func(string) (os.FileInfo, error)
+	open       func(string) (*os.File, error)
+	query      func(string, string) ([]byte, error)
+
+	dbSignature dbSignature
+	dbCached    bool
+	candidates  []externalActivityCandidate
+	files       map[string]externalRolloutCacheEntry
+	diagnostics ExternalActivityDiagnostics
+}
+
+func NewExternalActivityTracker(db string, registry *projects.Registry) *ExternalActivityTracker {
+	return &ExternalActivityTracker{
+		store:      NewThreadStore(db),
+		registry:   registry,
+		staleAfter: defaultExternalActivityStaleAfter,
+		now:        time.Now,
+		stat:       os.Stat,
+		open:       os.Open,
+		query:      sqliteQueryFunc,
+		files:      map[string]externalRolloutCacheEntry{},
+	}
+}
+
+func NewDefaultExternalActivityTracker(registry *projects.Registry) *ExternalActivityTracker {
+	return NewExternalActivityTracker("", registry)
+}
+
+func (t *ExternalActivityTracker) Diagnostics() ExternalActivityDiagnostics {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.diagnostics
+}
+
+// Snapshot 只返回仍有外部 turn 运行证据的白名单项目线程。
+// terminal lifecycle 到达或文件超过 staleAfter 未更新后，该线程会从结果中消失。
+func (t *ExternalActivityTracker) Snapshot() ([]ExternalActivity, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.registry == nil {
+		return []ExternalActivity{}, nil
+	}
+	candidates, err := t.loadCandidates()
+	if err != nil {
+		return nil, err
+	}
+
+	now := t.now()
+	activities := make([]ExternalActivity, 0, len(candidates))
+	knownPaths := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		project, ok := t.registry.FindByPath(candidate.CWD)
+		if !ok {
+			continue
+		}
+		path := strings.TrimSpace(candidate.RolloutPath)
+		if path == "" {
+			continue
+		}
+		knownPaths[path] = struct{}{}
+		info, err := t.stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		entry, err := t.scanRollout(path, info)
+		if err != nil {
+			continue
+		}
+		if !isCodexDesktopOriginator(entry.originator) ||
+			entry.metaThreadID != candidate.ThreadID ||
+			!isTopLevelExternalThreadSource(entry.threadSource) ||
+			!entry.active ||
+			now.Sub(info.ModTime()) > t.staleAfter {
+			continue
+		}
+		// SQLite cwd 和 session_meta cwd 都必须落在同一个白名单项目中。
+		// 这样即使状态库里出现不一致路径，也不会跨项目泄露线程身份。
+		metaProject, ok := t.registry.FindByPath(entry.metaCWD)
+		if !ok || metaProject.ID != project.ID {
+			continue
+		}
+		activities = append(activities, ExternalActivity{
+			ThreadID:     candidate.ThreadID,
+			ProjectID:    project.ID,
+			Source:       "codex_desktop",
+			State:        "running",
+			TurnID:       entry.turnID,
+			Revision:     externalActivityRevision(info),
+			LastActivity: info.ModTime().UTC(),
+		})
+	}
+	for path := range t.files {
+		if _, ok := knownPaths[path]; !ok {
+			delete(t.files, path)
+		}
+	}
+	sort.Slice(activities, func(i, j int) bool {
+		if activities[i].LastActivity.Equal(activities[j].LastActivity) {
+			return activities[i].ThreadID < activities[j].ThreadID
+		}
+		return activities[i].LastActivity.After(activities[j].LastActivity)
+	})
+	return activities, nil
+}
+
+func (t *ExternalActivityTracker) loadCandidates() ([]externalActivityCandidate, error) {
+	db := t.store.databasePath()
+	signature, err := t.readDBSignature(db)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// 没有使用过 Codex 的旧主机可能尚未创建状态库。能力仍可安全声明，
+			// 此时返回空活动而不是让 iPad 每轮轮询都收到 503。
+			t.dbCached = false
+			t.candidates = nil
+			t.files = map[string]externalRolloutCacheEntry{}
+			return []externalActivityCandidate{}, nil
+		}
+		return nil, err
+	}
+	if t.dbCached && signature == t.dbSignature {
+		out := make([]externalActivityCandidate, len(t.candidates))
+		copy(out, t.candidates)
+		return out, nil
+	}
+
+	columns, edgeColumns, err := t.externalHistoryColumns(db)
+	if err != nil {
+		return nil, err
+	}
+	where := "1=1"
+	if columns["archived"] {
+		where = "archived=0"
+	}
+	where += " and " + interactiveSourcePredicate(columns)
+	where += " and " + nonSubagentPredicate(columns, edgeColumns)
+	if columns["thread_source"] {
+		where += " and coalesce(thread_source, 'user') = 'user'"
+	}
+	sourceExpr := optionalColumnExpr(columns, "source")
+	threadSourceExpr := optionalColumnExpr(columns, "thread_source")
+	rolloutPathExpr := optionalColumnExpr(columns, "rollout_path")
+	sql := "select id,cwd," + sourceExpr + "," + threadSourceExpr + "," + rolloutPathExpr +
+		" from threads where " + where + " order by updated_at_ms desc, id desc limit " +
+		strconv.Itoa(externalActivityCandidateLimit)
+	out, err := t.query(db, sql)
+	if err != nil {
+		return nil, err
+	}
+	t.diagnostics.CandidateQueries++
+	var rows []struct {
+		ID           string `json:"id"`
+		CWD          string `json:"cwd"`
+		Source       string `json:"source"`
+		ThreadSource string `json:"thread_source"`
+		RolloutPath  string `json:"rollout_path"`
+	}
+	if len(bytes.TrimSpace(out)) != 0 {
+		if err := json.Unmarshal(out, &rows); err != nil {
+			return nil, err
+		}
+	}
+	candidates := make([]externalActivityCandidate, 0, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.ID) == "" ||
+			strings.TrimSpace(row.CWD) == "" ||
+			strings.TrimSpace(row.RolloutPath) == "" ||
+			!isInteractiveSource(row.Source) ||
+			!isTopLevelExternalThreadSource(row.ThreadSource) {
+			continue
+		}
+		candidates = append(candidates, externalActivityCandidate{
+			ThreadID:     row.ID,
+			CWD:          row.CWD,
+			Source:       row.Source,
+			ThreadSource: row.ThreadSource,
+			RolloutPath:  row.RolloutPath,
+		})
+	}
+	t.dbSignature = signature
+	t.dbCached = true
+	t.candidates = candidates
+	result := make([]externalActivityCandidate, len(candidates))
+	copy(result, candidates)
+	return result, nil
+}
+
+func (t *ExternalActivityTracker) externalHistoryColumns(db string) (map[string]bool, map[string]bool, error) {
+	query := "select 'threads' as table_name, name from pragma_table_info('threads') " +
+		"union all select 'thread_spawn_edges' as table_name, name from pragma_table_info('thread_spawn_edges')"
+	out, err := t.query(db, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	var rows []struct {
+		TableName string `json:"table_name"`
+		Name      string `json:"name"`
+	}
+	if len(bytes.TrimSpace(out)) != 0 {
+		if err := json.Unmarshal(out, &rows); err != nil {
+			return nil, nil, err
+		}
+	}
+	columns := map[string]bool{}
+	edgeColumns := map[string]bool{}
+	for _, row := range rows {
+		switch row.TableName {
+		case "threads":
+			columns[row.Name] = true
+		case "thread_spawn_edges":
+			edgeColumns[row.Name] = true
+		}
+	}
+	if !columns["id"] || !columns["cwd"] || !columns["rollout_path"] || !columns["updated_at_ms"] {
+		return nil, nil, fmt.Errorf("Codex 状态库缺少外部活动跟踪所需字段")
+	}
+	return columns, edgeColumns, nil
+}
+
+func (t *ExternalActivityTracker) readDBSignature(db string) (dbSignature, error) {
+	info, err := t.stat(db)
+	if err != nil {
+		return dbSignature{}, err
+	}
+	signature := dbSignature{size: info.Size(), modTime: info.ModTime()}
+	if wal, err := t.stat(db + "-wal"); err == nil {
+		signature.walSize = wal.Size()
+		signature.walModTime = wal.ModTime()
+	}
+	return signature, nil
+}
+
+func (t *ExternalActivityTracker) scanRollout(path string, info os.FileInfo) (externalRolloutCacheEntry, error) {
+	entry, cached := t.files[path]
+	if cached && entry.size == info.Size() && entry.modTime.Equal(info.ModTime()) {
+		t.diagnostics.CacheHits++
+		return entry, nil
+	}
+	if !cached || info.Size() < entry.offset || info.ModTime().Before(entry.modTime) {
+		entry = externalRolloutCacheEntry{}
+	}
+
+	file, err := t.open(path)
+	if err != nil {
+		return entry, err
+	}
+	defer file.Close()
+	if _, err := file.Seek(entry.offset, io.SeekStart); err != nil {
+		return entry, err
+	}
+
+	t.diagnostics.FileScans++
+	reader := bufio.NewReaderSize(file, 64*1024)
+	committedOffset := entry.offset
+	var line []byte
+	lineBytes := int64(0)
+	oversized := false
+	for {
+		fragment, readErr := reader.ReadSlice('\n')
+		lineBytes += int64(len(fragment))
+		if !oversized {
+			if len(line)+len(fragment) <= maxExternalActivityLineBytes {
+				line = append(line, fragment...)
+			} else {
+				oversized = true
+				line = nil
+			}
+		}
+		switch {
+		case errors.Is(readErr, bufio.ErrBufferFull):
+			continue
+		case readErr == nil:
+			if oversized {
+				t.diagnostics.OversizedLines++
+			} else {
+				t.applyExternalRolloutLine(&entry, line)
+			}
+			committedOffset += lineBytes
+			line = nil
+			lineBytes = 0
+			oversized = false
+		case errors.Is(readErr, io.EOF):
+			// rollout 是 append-only JSONL。尾部半行留到下次追加后再解析，
+			// 不能提前提交 offset，否则会永久漏掉 lifecycle。
+			entry.offset = committedOffset
+			entry.size = info.Size()
+			entry.modTime = info.ModTime()
+			t.files[path] = entry
+			return entry, nil
+		default:
+			return entry, readErr
+		}
+	}
+}
+
+func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRolloutCacheEntry, line []byte) {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return
+	}
+	var record externalRolloutRecord
+	if err := json.Unmarshal(line, &record); err != nil {
+		t.diagnostics.MalformedLines++
+		return
+	}
+	switch record.Type {
+	case "session_meta":
+		entry.originator = strings.TrimSpace(record.Payload.Originator)
+		entry.metaThreadID = strings.TrimSpace(record.Payload.ID)
+		entry.metaCWD = strings.TrimSpace(record.Payload.CWD)
+		entry.threadSource = strings.TrimSpace(record.Payload.ThreadSource)
+	case "event_msg":
+		turnID := strings.TrimSpace(record.Payload.TurnID)
+		switch strings.TrimSpace(record.Payload.Type) {
+		case "task_started":
+			entry.active = true
+			entry.turnID = turnID
+		case "task_complete", "turn_aborted":
+			// 旧 turn 的迟到 terminal 不能终止已经开始的新 turn。
+			if turnID == "" || entry.turnID == "" || turnID == entry.turnID {
+				entry.active = false
+				entry.turnID = ""
+			}
+		}
+	}
+}
+
+func externalActivityRevision(info os.FileInfo) string {
+	return strconv.FormatInt(info.Size(), 36) + "-" + strconv.FormatInt(info.ModTime().UnixNano(), 36)
+}
+
+func isCodexDesktopOriginator(originator string) bool {
+	switch strings.ToLower(strings.TrimSpace(originator)) {
+	case "codex desktop", "codex_work_desktop":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTopLevelExternalThreadSource(source string) bool {
+	source = strings.ToLower(strings.TrimSpace(source))
+	return source == "" || source == "user"
+}

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -1,0 +1,266 @@
+package codexhistory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+	"github.com/gaixianggeng/mimi-remote/internal/projects"
+)
+
+func TestExternalActivityFiltersSourceAndProject(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	valid := fixture.writeRollout("valid", "Codex Desktop", fixture.projectDir,
+		externalEventLine("task_started", "turn-valid"))
+	legacyOrigin := fixture.writeRollout("cli", "codex_cli_rs", fixture.projectDir,
+		externalEventLine("task_started", "turn-cli"))
+	alternateOrigin := fixture.writeRollout("work-desktop", "codex_work_desktop", fixture.projectDir,
+		externalEventLine("task_started", "turn-work"))
+	outsideDir := t.TempDir()
+	outside := fixture.writeRollout("outside", "Codex Desktop", outsideDir,
+		externalEventLine("task_started", "turn-outside"))
+
+	fixture.rows = []externalActivityTestRow{
+		{ID: "valid", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: valid},
+		{ID: "cli", CWD: fixture.projectDir, Source: "cli", ThreadSource: "user", RolloutPath: legacyOrigin},
+		{ID: "work-desktop", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: alternateOrigin},
+		{ID: "outside", CWD: outsideDir, Source: "vscode", ThreadSource: "user", RolloutPath: outside},
+		{ID: "subagent", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "subagent", RolloutPath: valid},
+		{ID: "unsupported", CWD: fixture.projectDir, Source: "exec", ThreadSource: "user", RolloutPath: valid},
+	}
+
+	activities, err := fixture.tracker.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(activities) != 2 || activities[0].ProjectID != "demo" || activities[1].ProjectID != "demo" {
+		t.Fatalf("只应返回白名单项目的 Codex Desktop 顶层线程：%+v", activities)
+	}
+	ids := map[string]bool{}
+	for _, activity := range activities {
+		ids[activity.ThreadID] = true
+		if activity.Source != "codex_desktop" || activity.State != "running" || activity.Revision == "" {
+			t.Fatalf("外部活动字段异常：%+v", activity)
+		}
+	}
+	if !ids["valid"] || !ids["work-desktop"] {
+		t.Fatalf("缺少合法 Desktop 来源：%+v", activities)
+	}
+}
+
+func TestExternalActivityTracksStartCompleteAndAbortIncrementally(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	path := fixture.writeRollout("thread-1", "Codex Desktop", fixture.projectDir,
+		externalEventLine("task_started", "turn-1"))
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+
+	first := fixture.snapshot(t)
+	if len(first) != 1 || first[0].TurnID != "turn-1" {
+		t.Fatalf("task_started 应进入活动态：%+v", first)
+	}
+	firstRevision := first[0].Revision
+
+	fixture.appendLine(path, externalEventLine("task_complete", "turn-1"))
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("task_complete 应退出活动态：%+v", got)
+	}
+
+	fixture.appendLine(path, externalEventLine("task_started", "turn-2"))
+	second := fixture.snapshot(t)
+	if len(second) != 1 || second[0].TurnID != "turn-2" || second[0].Revision == firstRevision {
+		t.Fatalf("追加的新 turn 应增量解析并更新 revision：%+v", second)
+	}
+	// 旧 turn 的迟到 terminal 不能终止新 turn。
+	fixture.appendLine(path, externalEventLine("task_complete", "turn-1"))
+	if got := fixture.snapshot(t); len(got) != 1 || got[0].TurnID != "turn-2" {
+		t.Fatalf("迟到 terminal 不应终止当前 turn：%+v", got)
+	}
+	fixture.appendLine(path, externalEventLine("turn_aborted", "turn-2"))
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("turn_aborted 应退出活动态：%+v", got)
+	}
+}
+
+func TestExternalActivitySkipsMalformedJSONLAndReusesCache(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	path := fixture.writeRollout("thread-1", "Codex Desktop", fixture.projectDir,
+		"{broken-json",
+		externalEventLine("task_started", "turn-1"))
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+
+	if got := fixture.snapshot(t); len(got) != 1 {
+		t.Fatalf("损坏行不应阻断后续 lifecycle：%+v", got)
+	}
+	before := fixture.tracker.Diagnostics()
+	if got := fixture.snapshot(t); len(got) != 1 {
+		t.Fatalf("缓存复用后活动态不应变化：%+v", got)
+	}
+	after := fixture.tracker.Diagnostics()
+	if after.CandidateQueries != before.CandidateQueries ||
+		after.FileScans != before.FileScans ||
+		after.CacheHits <= before.CacheHits ||
+		after.MalformedLines != 1 {
+		t.Fatalf("未变化的 DB/rollout 应复用缓存：before=%+v after=%+v", before, after)
+	}
+}
+
+func TestExternalActivityExpiresAndLaterWritesReactivate(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 28, 15, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	path := fixture.writeRollout("thread-1", "Codex Desktop", fixture.projectDir,
+		externalEventLine("task_started", "turn-1"))
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+	old := now.Add(-31 * time.Minute)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("30 分钟无更新应降为非活动：%+v", got)
+	}
+
+	fixture.appendLine(path, `{"timestamp":"2026-07-28T14:30:01Z","type":"event_msg","payload":{"type":"agent_message"}}`)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.snapshot(t); len(got) != 1 || got[0].TurnID != "turn-1" {
+		t.Fatalf("仍在运行的旧 turn 后续写入应重新激活：%+v", got)
+	}
+}
+
+func TestExternalActivityWithoutStateDatabaseReturnsEmpty(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	if err := os.Remove(fixture.db); err != nil {
+		t.Fatal(err)
+	}
+
+	activities, err := fixture.tracker.Snapshot()
+	if err != nil {
+		t.Fatalf("尚未创建 Codex 状态库时不应让活动接口失败：%v", err)
+	}
+	if len(activities) != 0 {
+		t.Fatalf("没有状态库时应返回空活动：%+v", activities)
+	}
+}
+
+type externalActivityTestRow struct {
+	ID           string `json:"id"`
+	CWD          string `json:"cwd"`
+	Source       string `json:"source"`
+	ThreadSource string `json:"thread_source"`
+	RolloutPath  string `json:"rollout_path"`
+}
+
+type externalActivityTrackerFixture struct {
+	t          *testing.T
+	projectDir string
+	db         string
+	tracker    *ExternalActivityTracker
+	rows       []externalActivityTestRow
+}
+
+func newExternalActivityTrackerFixture(t *testing.T) *externalActivityTrackerFixture {
+	t.Helper()
+	projectDir := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registry, err := projects.NewRegistry([]config.ProjectConfig{{
+		ID: "demo", Name: "Demo", Path: projectDir,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := filepath.Join(t.TempDir(), "state_5.sqlite")
+	if err := os.WriteFile(db, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture := &externalActivityTrackerFixture{
+		t:          t,
+		projectDir: projectDir,
+		db:         db,
+		tracker:    NewExternalActivityTracker(db, registry),
+	}
+	fixture.tracker.query = func(_ string, query string) ([]byte, error) {
+		if strings.Contains(query, "pragma_table_info") {
+			return []byte(`[
+				{"table_name":"threads","name":"id"},
+				{"table_name":"threads","name":"cwd"},
+				{"table_name":"threads","name":"source"},
+				{"table_name":"threads","name":"thread_source"},
+				{"table_name":"threads","name":"rollout_path"},
+				{"table_name":"threads","name":"updated_at_ms"},
+				{"table_name":"threads","name":"archived"},
+				{"table_name":"thread_spawn_edges","name":"child_thread_id"}
+			]`), nil
+		}
+		return json.Marshal(fixture.rows)
+	}
+	return fixture
+}
+
+func (f *externalActivityTrackerFixture) writeRollout(threadID, originator, cwd string, lines ...string) string {
+	f.t.Helper()
+	path := filepath.Join(f.t.TempDir(), threadID+".jsonl")
+	meta := `{"timestamp":"2026-07-28T14:00:00Z","type":"session_meta","payload":{"id":` +
+		mustJSONQuote(f.t, threadID) + `,"cwd":` + mustJSONQuote(f.t, cwd) +
+		`,"originator":` + mustJSONQuote(f.t, originator) + `,"thread_source":"user"}}`
+	all := append([]string{meta}, lines...)
+	if err := os.WriteFile(path, []byte(strings.Join(all, "\n")+"\n"), 0o600); err != nil {
+		f.t.Fatal(err)
+	}
+	return path
+}
+
+func (f *externalActivityTrackerFixture) appendLine(path, line string) {
+	f.t.Helper()
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if _, err := file.WriteString(line + "\n"); err != nil {
+		file.Close()
+		f.t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *externalActivityTrackerFixture) snapshot(t *testing.T) []ExternalActivity {
+	t.Helper()
+	activities, err := f.tracker.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return activities
+}
+
+func externalEventLine(eventType, turnID string) string {
+	return `{"timestamp":"2026-07-28T14:00:01Z","type":"event_msg","payload":{"type":` +
+		strconvQuote(eventType) + `,"turn_id":` + strconvQuote(turnID) + `}}`
+}
+
+func mustJSONQuote(t *testing.T, value string) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func strconvQuote(value string) string {
+	data, _ := json.Marshal(value)
+	return string(data)
+}

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -180,6 +180,7 @@ type appServerChannelCapability struct {
 	Compact          bool `json:"compact"`
 	Review           bool `json:"review"`
 	RateLimits       bool `json:"rate_limits"`
+	ExternalActivity bool `json:"external_activity"`
 }
 
 type appServerChannelPolicy struct {
@@ -421,6 +422,7 @@ func (r *Router) appServerChannels(req *http.Request) []appServerChannel {
 			Compact:          true,
 			Review:           true,
 			RateLimits:       true,
+			ExternalActivity: true,
 		},
 		Policy: appServerChannelPolicy{
 			ApprovalPolicies: []string{"on-request", "on-failure"},

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -88,8 +88,9 @@ func TestAppServerConfigRequiresAuthAndReturnsSanitizedMetadata(t *testing.T) {
 		t.Fatalf("config metadata 应返回 Codex channel：%v", body)
 	}
 	capabilities, ok := channels[0].(map[string]any)["capabilities"].(map[string]any)
-	if !ok || capabilities["rename"] != true || capabilities["compact"] != true || capabilities["review"] != true {
-		t.Fatalf("Codex channel 应声明 rename/compact/review 能力：%v", channels[0])
+	if !ok || capabilities["rename"] != true || capabilities["compact"] != true ||
+		capabilities["review"] != true || capabilities["external_activity"] != true {
+		t.Fatalf("Codex channel 应声明 rename/compact/review/external_activity 能力：%v", channels[0])
 	}
 }
 
@@ -124,7 +125,8 @@ func TestAppServerConfigIncludesClaudeChannelWhenEnabled(t *testing.T) {
 		t.Fatalf("Claude bridge metadata 异常：%v", bridge)
 	}
 	capabilities := claude["capabilities"].(map[string]any)
-	if capabilities["rename"] != false || capabilities["compact"] != false || capabilities["review"] != false || capabilities["rate_limits"] != true {
+	if capabilities["rename"] != false || capabilities["compact"] != false || capabilities["review"] != false ||
+		capabilities["rate_limits"] != true || capabilities["external_activity"] != false {
 		t.Fatalf("Claude channel 不应声明 Codex 专属能力：%v", capabilities)
 	}
 	methods := claude["methods"].([]any)

--- a/internal/httpapi/external_activity.go
+++ b/internal/httpapi/external_activity.go
@@ -1,0 +1,46 @@
+package httpapi
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/codexhistory"
+)
+
+type externalActivitySource interface {
+	Snapshot() ([]codexhistory.ExternalActivity, error)
+}
+
+type externalActivityResponse struct {
+	Activities []codexhistory.ExternalActivity `json:"activities"`
+	ScannedAt  time.Time                       `json:"scanned_at"`
+}
+
+func (r *Router) externalActivityHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	if r.externalActivity == nil {
+		writeJSON(w, http.StatusOK, externalActivityResponse{
+			Activities: []codexhistory.ExternalActivity{},
+			ScannedAt:  time.Now().UTC(),
+		})
+		return
+	}
+	activities, err := r.externalActivity.Snapshot()
+	if err != nil {
+		// 错误响应不包含 SQLite/rollout 路径；详细路径只留在本机 agentd 日志。
+		log.Printf("external activity snapshot failed: %v", err)
+		http.Error(w, "external activity unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if activities == nil {
+		activities = []codexhistory.ExternalActivity{}
+	}
+	writeJSON(w, http.StatusOK, externalActivityResponse{
+		Activities: activities,
+		ScannedAt:  time.Now().UTC(),
+	})
+}

--- a/internal/httpapi/external_activity_test.go
+++ b/internal/httpapi/external_activity_test.go
@@ -1,0 +1,76 @@
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/codexhistory"
+)
+
+type stubExternalActivitySource struct {
+	activities []codexhistory.ExternalActivity
+	err        error
+}
+
+func (s stubExternalActivitySource) Snapshot() ([]codexhistory.ExternalActivity, error) {
+	return s.activities, s.err
+}
+
+func TestExternalActivityRequiresAuthAndReturnsSanitizedSnapshot(t *testing.T) {
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, "", nil)
+	router.externalActivity = stubExternalActivitySource{activities: []codexhistory.ExternalActivity{{
+		ThreadID:     "thread-1",
+		ProjectID:    "demo",
+		Source:       "codex_desktop",
+		State:        "running",
+		TurnID:       "turn-1",
+		Revision:     "revision-1",
+		LastActivity: time.Date(2026, 7, 28, 14, 0, 0, 0, time.UTC),
+	}}}
+
+	unauthorized := httptest.NewRecorder()
+	handler.ServeHTTP(unauthorized, httptest.NewRequest(http.MethodGet, "/api/app-server/external-activity", nil))
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("external activity 必须要求 Bearer Token，got=%d", unauthorized.Code)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, authedRequest(t, http.MethodGet, "/api/app-server/external-activity", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("external activity 应返回 200，got=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := decodeJSON(t, rec)
+	activities, ok := body["activities"].([]any)
+	if !ok || len(activities) != 1 {
+		t.Fatalf("活动响应异常：%v", body)
+	}
+	activity := activities[0].(map[string]any)
+	allowed := map[string]bool{
+		"thread_id": true, "project_id": true, "source": true, "state": true,
+		"turn_id": true, "revision": true, "last_activity_at": true,
+	}
+	for key := range activity {
+		if !allowed[key] {
+			t.Fatalf("活动响应包含非白名单字段 %q：%v", key, activity)
+		}
+	}
+	text := rec.Body.String()
+	if strings.Contains(text, "rollout") || strings.Contains(text, "\"cwd\"") || strings.Contains(text, "\"path\"") {
+		t.Fatalf("活动响应不应泄漏本机路径：%s", text)
+	}
+}
+
+func TestExternalActivityFailureIsRedacted(t *testing.T) {
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, "", nil)
+	router.externalActivity = stubExternalActivitySource{err: errors.New("/Users/private/.codex/state_5.sqlite: locked")}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, authedRequest(t, http.MethodGet, "/api/app-server/external-activity", nil))
+	if rec.Code != http.StatusServiceUnavailable || strings.Contains(rec.Body.String(), "/Users/private") {
+		t.Fatalf("错误响应应脱敏：code=%d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -38,6 +38,9 @@ type Router struct {
 	monitor        *relayMonitor
 	historyMedia   *appServerHistoryMediaStore
 	fileUploads    *fileUploadStore
+	// externalActivity 只读取同一 CODEX_HOME 内 Codex Desktop 的脱敏运行态。
+	// 它与本进程 app-server runtime 分离，不能被用于 resume、审批或中断外部 turn。
+	externalActivity externalActivitySource
 	// tailscalePathLookup 只在连接验证/测速时读取一次本机 Tailscale 状态。
 	// 使用可注入函数既避免常驻轮询，也让无 Tailscale 环境下的接口行为可测试。
 	tailscalePathLookup tailscaleNetworkPathLookup
@@ -127,6 +130,7 @@ func NewRouterWithRuntimeAndInstallationID(cfg config.Config, registry *projects
 		monitor:                     newRelayMonitor(),
 		historyMedia:                newAppServerHistoryMediaStore(),
 		fileUploads:                 newFileUploadStore(defaultFileUploadRoot()),
+		externalActivity:            codexhistory.NewDefaultExternalActivityTracker(registry),
 		tailscalePathLookup:         defaultTailscaleNetworkPathLookup,
 		gatewayThreads:              map[string]appServerGatewayAllowedThread{},
 		managedWorktrees:            map[string]managedWorktree{},
@@ -182,6 +186,7 @@ func NewRouterWithRuntimeAndInstallationID(cfg config.Config, registry *projects
 	mux.Handle("/api/voice/transcribe", r.auth.Middleware(http.HandlerFunc(r.voiceTranscribeHandler)))
 	mux.Handle("/api/runtime/status", r.auth.Middleware(http.HandlerFunc(r.runtimeStatusHandler)))
 	mux.Handle("/api/app-server/config", r.auth.Middleware(http.HandlerFunc(r.appServerConfigHandler)))
+	mux.Handle("/api/app-server/external-activity", r.auth.Middleware(http.HandlerFunc(r.externalActivityHandler)))
 	mux.Handle("/api/app-server/history-media/", r.auth.Middleware(http.HandlerFunc(r.appServerHistoryMediaHandler)))
 	mux.Handle("/api/app-server/ws", r.auth.Middleware(http.HandlerFunc(r.appServerGatewayWS)))
 	return logging(limitAPIRequestBodies(mux), r.monitor), r

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		388033847B02B31529D2BFCA /* ConversationProcessGrouperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF29C4EA9F4D0ECC4709B97 /* ConversationProcessGrouperTests.swift */; };
 		391A66E7F197E57DBA1239DF /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 6C892E2BB83F2EE5FDD6EDA4 /* Localizable.xcstrings */; };
 		3942D0F45FDBA6578D875940 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 2EBD11FEEFA3EA7C03993BE1 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png */; };
+		3A6B744D9E0860CE86A994D6 /* SessionStoreExternalActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735BE2C721373586AD49D470 /* SessionStoreExternalActivity.swift */; };
 		3B0E963BB2856F7CDD36EB67 /* MessageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CAFB1927C976C000C9E026 /* MessageStore.swift */; };
 		3E93414CD3560843DC67433E /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png in Resources */ = {isa = PBXBuildFile; fileRef = 9143CBABCA38B2E316A221BB /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png */; };
 		3F150075A258BDF73AFB8ED6 /* WorktreeManagementViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7A4F02C5EC7121D1BB6B9 /* WorktreeManagementViews.swift */; };
@@ -195,6 +196,7 @@
 		F6BD11C8457F7429102EC4C3 /* FileAttachmentPreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3474AF2F3AA856519A20B642 /* FileAttachmentPreparer.swift */; };
 		F996F870AD345E2888F2913B /* ConversationProcessGrouper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C529DD917A76943BC8A1C09E /* ConversationProcessGrouper.swift */; };
 		FA451031EB72AE10C3552C3F /* AppExternalLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554F31B0074B97074AE97B31 /* AppExternalLinksTests.swift */; };
+		FA5DDE779DCE06AAF45BBBD2 /* ExternalActivitySessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2791378963B2ED7657F13BD /* ExternalActivitySessionStoreTests.swift */; };
 		FAD77559CF6FDCD943849D7C /* CodexAppServerSessionClients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */; };
 		FBF4E996E64F7B7D637E1B79 /* LogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A2FAA4C2526405C2DDB750 /* LogStore.swift */; };
 		FC192D8EA361C1588BA2C2DF /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F63FE197E70AD192F429877 /* ThemeStore.swift */; };
@@ -313,6 +315,7 @@
 		712B1CDEF343C4D9D338DDDC /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png; sourceTree = "<group>"; };
 		730CE8CD91CC2F2DFB5E6FBA /* ConversationTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTimelineView.swift; sourceTree = "<group>"; };
 		7348A6FCD28C7489CC7097AD /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
+		735BE2C721373586AD49D470 /* SessionStoreExternalActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreExternalActivity.swift; sourceTree = "<group>"; };
 		73BF91C2135478711BB991B2 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		7587EB164AF1902FAD735D90 /* testExpandedWorkGroupRendering.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testExpandedWorkGroupRendering.1.png; sourceTree = "<group>"; };
 		760E3B9BE51D633691ED9C56 /* testCollapsedWorkGroupRendering.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCollapsedWorkGroupRendering.1.png; sourceTree = "<group>"; };
@@ -391,6 +394,7 @@
 		DCC3691375017B35F7E29234 /* testSkillCardsAndModelGridDarkAppearance.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSkillCardsAndModelGridDarkAppearance.1.png; sourceTree = "<group>"; };
 		DE04A73144E31515A65F5830 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E033E7A8267D3C3494835305 /* SessionContextModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContextModels.swift; sourceTree = "<group>"; };
+		E2791378963B2ED7657F13BD /* ExternalActivitySessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalActivitySessionStoreTests.swift; sourceTree = "<group>"; };
 		E4C85188C13516219753D4ED /* testComposerStatusTrayCrowdedState.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCrowdedState.1.png; sourceTree = "<group>"; };
 		E55DE1D530ABE8EE097ECB59 /* testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png; sourceTree = "<group>"; };
 		E5D0FB9DA0913B603240372D /* WorkspaceAppearanceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceAppearanceStore.swift; sourceTree = "<group>"; };
@@ -547,6 +551,7 @@
 				23CF7E66AAB73235912C1990 /* ConversationTurnQueueTests.swift */,
 				1F803BE24EB9F6963792C11C /* ConversationWorkspaceHistoryTests.swift */,
 				ECFE36A2B8257E443C9824FD /* DataURLImageDecoderTests.swift */,
+				E2791378963B2ED7657F13BD /* ExternalActivitySessionStoreTests.swift */,
 				F55F20982430C816BB70A7F5 /* FileAttachmentModelsTests.swift */,
 				E61B1FCD1B28FACE28547C86 /* FileUploadStoreTests.swift */,
 				2C2FCF65A5A23A9D87948F4F /* GitQuickPublishTests.swift */,
@@ -881,6 +886,7 @@
 				CD9975BE3B6F00A870817B17 /* SessionIndexStore.swift */,
 				82A5884CEA865140A301E6AC /* SessionStore.swift */,
 				97A0B761520F7AEF2F16D3DC /* SessionStoreConnection.swift */,
+				735BE2C721373586AD49D470 /* SessionStoreExternalActivity.swift */,
 				F84F0CC61CAE4D7C5D8D9233 /* SessionStoreHistory.swift */,
 				3369A709F1AC9D2CF790753C /* SessionStoreHostSwitching.swift */,
 				D78D8C49C36228C60EF5D096 /* SessionStoreLifecycleWorkspaces.swift */,
@@ -1103,6 +1109,7 @@
 				2EE9AF7AEF490C9B6832C118 /* ConversationTurnQueueTests.swift in Sources */,
 				7917AE82BBAC2F36217D9BC0 /* ConversationWorkspaceHistoryTests.swift in Sources */,
 				23AA3B5B65DB2FF5D2EFFD87 /* DataURLImageDecoderTests.swift in Sources */,
+				FA5DDE779DCE06AAF45BBBD2 /* ExternalActivitySessionStoreTests.swift in Sources */,
 				0209F743D168F03B03894AB0 /* FileAttachmentModelsTests.swift in Sources */,
 				229B4470F93272B55380AF28 /* FileUploadStoreTests.swift in Sources */,
 				4B4DDB0179C0326DBC0BBA00 /* GitQuickPublishTests.swift in Sources */,
@@ -1209,6 +1216,7 @@
 				5264A96AC8B711B42087FA3F /* SessionListView.swift in Sources */,
 				8F2DD1F690D1B12E159AE592 /* SessionStore.swift in Sources */,
 				C9ED41CB470AB37E7A45044C /* SessionStoreConnection.swift in Sources */,
+				3A6B744D9E0860CE86A994D6 /* SessionStoreExternalActivity.swift in Sources */,
 				C7B1A9AFF196C5B3D0A334B9 /* SessionStoreHistory.swift in Sources */,
 				31B351EE974251896BA43252 /* SessionStoreHostSwitching.swift in Sources */,
 				5B092289C5F40E2A9B3622B9 /* SessionStoreLifecycleWorkspaces.swift in Sources */,

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -13380,6 +13380,23 @@
         }
       }
     },
+    "ui.mac_observe_only" : {
+      "comment" : "Read-only status for a session currently running in Codex Desktop on the Mac.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac · Observe only"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac · 仅观察"
+          }
+        }
+      }
+    },
     "ui.mac_preparation" : {
       "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "extractionState" : "stale",

--- a/ios/MimiRemote/Sources/Core/API/AgentAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/AgentAPIClient.swift
@@ -301,6 +301,15 @@ struct AgentAPIClient {
         )
     }
 
+    func externalActivities(timeout: TimeInterval = 10) async throws -> ExternalActivityResponse {
+        try await request(
+            path: "/api/app-server/external-activity",
+            method: "GET",
+            body: Optional<Data>.none,
+            timeout: timeout
+        )
+    }
+
     func relayDiagnostics() async throws -> RelayDiagnosticsResponse {
         try await request(path: "/api/diagnostics/relay", method: "GET", body: Optional<Data>.none)
     }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
@@ -20,6 +20,10 @@ final class CodexAppServerSessionAPIClient: SessionStoreAPIClient {
         try await runtime.channelAvailable(runtimeProvider: runtimeProvider)
     }
 
+    func externalActivities() async throws -> ExternalActivityResponse? {
+        try await runtime.externalActivities()
+    }
+
     func capabilities(path: String?, forceReload: Bool) async throws -> CapabilityListResponse {
         try await runtime.capabilities(path: path, forceReload: forceReload)
     }
@@ -375,6 +379,7 @@ final class MultiRuntimeSessionAPIClient: SessionStoreAPIClient {
     }
 
     func projects() async throws -> [AgentProject] { try await codexClient.projects() }
+    func externalActivities() async throws -> ExternalActivityResponse? { try await codexClient.externalActivities() }
     func capabilities(path: String?, forceReload: Bool) async throws -> CapabilityListResponse {
         try await codexClient.capabilities(path: path, forceReload: forceReload)
     }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -165,6 +165,20 @@ actor CodexAppServerSessionRuntime {
         try await ensureConfig().projects
     }
 
+    func externalActivities() async throws -> ExternalActivityResponse? {
+        let config = try await ensureConfig()
+        let channel = config.channels.first { channel in
+            let channelRuntime = (channel.runtimeID ?? channel.id)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            return channelRuntime == "codex"
+        }
+        guard channel?.capabilities?["external_activity"] == true else {
+            return nil
+        }
+        return try await AgentAPIClient(endpoint: endpoint, token: token).externalActivities()
+    }
+
     func modelOptions() async throws -> [CodexAppServerModelOption] {
         let result = try await sendRecoveringFromStaleInitialization(
             CodexAppServerRequestBuilder(allowlistedProjects: try await projects()).modelList()

--- a/ios/MimiRemote/Sources/Core/Models/APIResponses.swift
+++ b/ios/MimiRemote/Sources/Core/Models/APIResponses.swift
@@ -132,6 +132,38 @@ struct CodexAppServerChannelMetadata: Codable, Hashable, Identifiable {
     }
 }
 
+struct ExternalSessionActivity: Codable, Hashable, Identifiable {
+    let threadID: SessionID
+    let projectID: String
+    let source: String
+    let state: String
+    let turnID: TurnID?
+    let revision: String
+    let lastActivityAt: Date
+
+    var id: SessionID { threadID }
+
+    enum CodingKeys: String, CodingKey {
+        case threadID = "thread_id"
+        case projectID = "project_id"
+        case source
+        case state
+        case turnID = "turn_id"
+        case revision
+        case lastActivityAt = "last_activity_at"
+    }
+}
+
+struct ExternalActivityResponse: Codable, Hashable {
+    let activities: [ExternalSessionActivity]
+    let scannedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case activities
+        case scannedAt = "scanned_at"
+    }
+}
+
 struct CodexAppServerChannelBridgeMetadata: Codable, Hashable {
     let name: String?
     let version: String?

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
@@ -339,6 +339,7 @@ struct ComposerStatusTray: View {
     let isGoalUpdating: Bool
     let goalErrorMessage: String?
     let isRefreshDisabled: Bool
+    let allowsTakeOver: Bool
     let onTakeOver: () -> Void
     let onRefreshUsage: () -> Void
     let onEditGoal: () -> Void
@@ -521,13 +522,15 @@ struct ComposerStatusTray: View {
                     .font(themeStore.uiFont(.caption, weight: .semibold))
                     .foregroundStyle(tokens.primaryText)
                     .lineLimit(1)
-                Button(action: onTakeOver) {
-                    Text(L10n.text("ui.take_over"))
+                if allowsTakeOver {
+                    Button(action: onTakeOver) {
+                        Text(L10n.text("ui.take_over"))
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .font(themeStore.uiFont(.caption, weight: .semibold))
+                    .foregroundStyle(tokens.accent)
                 }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
-                .font(themeStore.uiFont(.caption, weight: .semibold))
-                .foregroundStyle(tokens.accent)
             }
             .accessibilityElement(children: .combine)
             .accessibilityHint(notice)

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -728,6 +728,7 @@ struct ComposerView: View {
                 isGoalUpdating: sessionStore.isUpdatingThreadGoal,
                 goalErrorMessage: sessionStore.threadGoalErrorMessage,
                 isRefreshDisabled: sessionStore.isRefreshingSelectedSession || sessionStore.isLoading,
+                allowsTakeOver: sessionStore.selectedSessionAllowsTakeOver,
                 onTakeOver: {
                     sessionStore.takeOverSelectedSession()
                 },

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -442,7 +442,7 @@ struct SessionIndexRow: View {
                 SessionRuntimeBadge(session: session, compact: style == .sidebar)
 
                 if isExternalReadOnly {
-                    Text("Mac · \(L10n.text("ui.just_observe"))")
+                    Text(L10n.text("ui.mac_observe_only"))
                         .font(themeStore.uiFont(size: style == .sidebar ? 9 : 11, weight: .semibold))
                         .foregroundStyle(tokens.secondaryText)
                         .fixedSize(horizontal: true, vertical: false)

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -302,6 +302,7 @@ struct SessionListView: View {
                 isArchived: sessionStore.isSessionArchived(session.id),
                 reminder: sessionStore.sessionReminder(for: session.id),
                 isObserving: sessionStore.isSessionObserving(session),
+                isExternalReadOnly: sessionStore.isExternalReadOnlySession(session),
                 style: .library,
                 searchSnippet: sessionStore.sessionSearchSnippet(for: session.id)
             )
@@ -402,6 +403,7 @@ struct SessionIndexRow: View {
     let isArchived: Bool
     let reminder: SessionReminder?
     let isObserving: Bool
+    let isExternalReadOnly: Bool
     let style: SessionIndexRowStyle
     var searchSnippet: String? = nil
 
@@ -438,6 +440,13 @@ struct SessionIndexRow: View {
                 if reminder != nil { Image(systemName: "bell.fill").foregroundStyle(tokens.warning) }
 
                 SessionRuntimeBadge(session: session, compact: style == .sidebar)
+
+                if isExternalReadOnly {
+                    Text("Mac · \(L10n.text("ui.just_observe"))")
+                        .font(themeStore.uiFont(size: style == .sidebar ? 9 : 11, weight: .semibold))
+                        .foregroundStyle(tokens.secondaryText)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
 
                 Text(session.project.isEmpty ? session.dir : session.project)
                     .lineLimit(1)
@@ -589,7 +598,8 @@ private struct SessionRowActions: ViewModifier {
         let reminder = sessionStore.sessionReminder(for: session.id)
 
         content.contextMenu {
-            if sessionStore.isSessionObserving(session) {
+            if sessionStore.isSessionObserving(session),
+               !sessionStore.isExternalReadOnlySession(session) {
                 Button {
                     sessionStore.takeOverSession(session)
                 } label: {
@@ -650,6 +660,7 @@ private struct SessionRowActions: ViewModifier {
             } label: {
                 Label(isArchived ? L10n.text("ui.unarchive") : L10n.text("ui.archive"), systemImage: isArchived ? "archivebox.fill" : "archivebox")
             }
+            .disabled(sessionStore.isExternalReadOnlySession(session))
         }
         .sheet(item: $renameTarget) { target in
             SessionRenameSheet(session: target.session)

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -765,6 +765,7 @@ struct UnifiedWorkbenchShell: View {
                 isArchived: sessionStore.isSessionArchived(session.id),
                 reminder: sessionStore.sessionReminder(for: session.id),
                 isObserving: sessionStore.isSessionObserving(session),
+                isExternalReadOnly: sessionStore.isExternalReadOnlySession(session),
                 style: .sidebar
             )
         }

--- a/ios/MimiRemote/Sources/RootView.swift
+++ b/ios/MimiRemote/Sources/RootView.swift
@@ -109,6 +109,12 @@ struct RootView: View {
             }
             await sessionStore.pollSelectedProjectSessionsWhileVisible()
         }
+        .task(id: scenePhase == .active ? appStore.activeHostScope : nil) {
+            guard scenePhase == .active else {
+                return
+            }
+            await sessionStore.pollExternalActivitiesWhileVisible()
+        }
         .onChange(of: scenePhase) { _, phase in
             if phase == .background {
                 persistActiveHostRestoration()

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -38,6 +38,7 @@ final class SessionStore: ObservableObject {
             rebuildSessionIndexes()
         }
     }
+    @Published var externalActivityBySessionID: [SessionID: ExternalSessionActivity] = [:]
     @Published var remoteSessionSearchResults: [AgentSession] = [] {
         didSet {
             rebuildProjectSessionListSnapshots()
@@ -207,6 +208,7 @@ final class SessionStore: ObservableObject {
     let sessionListSleep: (UInt64) async -> Void
     let sessionSearchDebounceNanoseconds: UInt64
     let sessionSearchSleep: (UInt64) async throws -> Void
+    let externalActivitySleep: (UInt64) async -> Void
     var webSocket: (any SessionWebSocketClient)?
     var connectedSessionID: String?
     var connectedHostScope: HostScope?
@@ -224,6 +226,11 @@ final class SessionStore: ObservableObject {
     var networkRecoveryTask: Task<Void, Never>?
     var appLifecycleSuspendedSessionID: SessionID?
     var isAppInBackground = false
+    // 终态刷新期间 activity 已从服务端快照消失，但历史还没补齐；这段窗口仍必须保持只读，
+    // 防止旧的持久化 `.takenOver` 状态抢先触发 thread/resume。
+    var externalReadOnlySessionIDs: Set<SessionID> = []
+    var isRefreshingExternalActivity = false
+    var externalActivityCapabilityUnavailable = false
     var connectionChangeGeneration = 0
     var inFlightConnectionChangeGeneration: Int?
     var connectionSwitchTargetGeneration: Int?
@@ -304,6 +311,8 @@ final class SessionStore: ObservableObject {
     let runtimeEventFlushDelayNanoseconds: UInt64 = 80_000_000
     let sessionListConnectedPollingDelayNanoseconds: UInt64 = 60_000_000_000
     let sessionListDisconnectedPollingDelayNanoseconds: UInt64 = 8_000_000_000
+    let externalActivityDefaultPollingDelayNanoseconds: UInt64 = 8_000_000_000
+    let externalActivitySelectedPollingDelayNanoseconds: UInt64 = 5_000_000_000
     let sessionListFirstPageCacheTTL: TimeInterval = 2
     let sessionLibraryIndexPollingInterval: TimeInterval = 60
     let sessionListReconciliationDelayNanoseconds: UInt64 = 1_500_000_000
@@ -358,6 +367,9 @@ final class SessionStore: ObservableObject {
         sessionSearchDebounceNanoseconds: UInt64 = 300_000_000,
         sessionSearchSleep: @escaping (UInt64) async throws -> Void = { nanoseconds in
             try await Task.sleep(nanoseconds: nanoseconds)
+        },
+        externalActivitySleep: @escaping (UInt64) async -> Void = { nanoseconds in
+            try? await Task.sleep(nanoseconds: nanoseconds)
         }
     ) {
         self.appStore = appStore
@@ -463,6 +475,7 @@ final class SessionStore: ObservableObject {
         self.sessionListSleep = sessionListSleep
         self.sessionSearchDebounceNanoseconds = sessionSearchDebounceNanoseconds
         self.sessionSearchSleep = sessionSearchSleep
+        self.externalActivitySleep = externalActivitySleep
         self.dismissedHistorySavingsNoticeEndpoints = self.historySavingsNoticeStore.loadDismissedEndpoints()
         reloadSessionListPreferences()
         reloadSessionControlStates()
@@ -1183,6 +1196,9 @@ final class SessionStore: ObservableObject {
     }
 
     func controlState(for session: AgentSession) -> SessionControlState {
+        if isExternalReadOnlySession(session) {
+            return .observing
+        }
         if let state = sessionControlStateByID[session.id] {
             return state
         }
@@ -1195,6 +1211,9 @@ final class SessionStore: ObservableObject {
         }
         guard let session else {
             return true
+        }
+        guard !isExternalReadOnlySession(session) else {
+            return false
         }
         guard session.isRunning else {
             return true
@@ -1263,10 +1282,28 @@ final class SessionStore: ObservableObject {
         guard isSelectedSessionObserving else {
             return nil
         }
+        if let session = selectedSession, isExternalReadOnlySession(session) {
+            return "Mac · \(L10n.text("ui.just_observe"))"
+        }
         return L10n.text("ui.this_session_is_running_on_other_clients_the")
     }
 
+    var selectedSessionAllowsTakeOver: Bool {
+        guard let session = selectedSession else {
+            return false
+        }
+        return !isExternalReadOnlySession(session)
+    }
+
+    func isExternalReadOnlySession(_ session: AgentSession) -> Bool {
+        externalReadOnlySessionIDs.contains(session.id)
+    }
+
     func takeOverSession(_ session: AgentSession) {
+        guard !isExternalReadOnlySession(session) else {
+            setStatusMessage("Mac · \(L10n.text("ui.just_observe"))")
+            return
+        }
         setSessionControlState(.takenOver, sessionID: session.id)
         if session.id == selectedSessionID, session.isRunning {
             // 接管前消息区已经由 selectSession/刷新用 thread/read 快照兜底；backlog 走状态级

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -1283,7 +1283,7 @@ final class SessionStore: ObservableObject {
             return nil
         }
         if let session = selectedSession, isExternalReadOnlySession(session) {
-            return "Mac · \(L10n.text("ui.just_observe"))"
+            return L10n.text("ui.mac_observe_only")
         }
         return L10n.text("ui.this_session_is_running_on_other_clients_the")
     }
@@ -1301,7 +1301,7 @@ final class SessionStore: ObservableObject {
 
     func takeOverSession(_ session: AgentSession) {
         guard !isExternalReadOnlySession(session) else {
-            setStatusMessage("Mac · \(L10n.text("ui.just_observe"))")
+            setStatusMessage(L10n.text("ui.mac_observe_only"))
             return
         }
         setSessionControlState(.takenOver, sessionID: session.id)

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -8,6 +8,13 @@ extension SessionStore {
         replayBufferedEvents: Bool = true,
         allowNonRunning: Bool = false
     ) {
+        guard !isExternalReadOnlySession(session) else {
+            if connectedSessionID == session.id {
+                disconnectWebSocket()
+            }
+            setWebSocketStatus(.disconnected)
+            return
+        }
         guard connectionTermination == nil, !appStore.requiresRePairing else {
             setWebSocketStatus(.terminated(.credentialsInvalid))
             return
@@ -1848,6 +1855,10 @@ extension SessionStore {
         reloadSessionControlStates()
         reloadSessionReminders()
         foregroundActivityBySessionID = [:]
+        externalActivityBySessionID = [:]
+        externalReadOnlySessionIDs = []
+        isRefreshingExternalActivity = false
+        externalActivityCapabilityUnavailable = false
         runtimeActivityBySessionID = [:]
         locallyCompletedSessionIDs = []
         locallyCompletedGoalThreadIDs = []

--- a/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+// Codex Desktop 与 Mimi 的 app-server 是两个独立进程，runtime status 不能跨进程复用。
+// 这里消费 agentd 从 rollout 提炼出的只读活动层；所有消息仍走现有历史读取，不建立控制连接。
+extension SessionStore {
+    func externalActivityPollingDelayNanoseconds() -> UInt64 {
+        if let selectedSessionID,
+           externalActivityBySessionID[selectedSessionID] != nil {
+            return externalActivitySelectedPollingDelayNanoseconds
+        }
+        return externalActivityDefaultPollingDelayNanoseconds
+    }
+
+    func pollExternalActivitiesWhileVisible() async {
+        while !Task.isCancelled {
+            if connectionTermination != nil || appStore.requiresRePairing {
+                return
+            }
+#if DEBUG
+            if isDebugWorkbenchUISeedActive {
+                return
+            }
+#endif
+            if !isAppInBackground,
+               !isNetworkUnavailable,
+               appStore.isConfigured {
+                _ = await refreshExternalActivities()
+                if externalActivityCapabilityUnavailable {
+                    // 旧 agentd 没有该 capability 时结束本次前台轮询，不制造 404/配置请求噪音。
+                    return
+                }
+            }
+            let delay = externalActivityPollingDelayNanoseconds()
+            await externalActivitySleep(delay)
+        }
+    }
+
+    @discardableResult
+    func refreshExternalActivities(
+        client fixedClient: (any SessionStoreAPIClient)? = nil
+    ) async -> Bool {
+        guard !isRefreshingExternalActivity,
+              !isAppInBackground,
+              !isNetworkUnavailable,
+              appStore.isConfigured,
+              connectionTermination == nil,
+              !appStore.requiresRePairing else {
+            return false
+        }
+        isRefreshingExternalActivity = true
+        defer { isRefreshingExternalActivity = false }
+
+        let hostScope = appStore.activeHostScope
+        let client: any SessionStoreAPIClient
+        do {
+            client = try fixedClient ?? clientFactory()
+        } catch {
+            return false
+        }
+
+        do {
+            guard let response = try await client.externalActivities() else {
+                guard appStore.activeHostScope == hostScope else { return false }
+                // 同一主机降级到旧 agentd 时不能把上次缓存的 Mac 活动态永久留在“进行中”。
+                // 按空快照完成最后一次只读收尾，再停止本次前台轮询。
+                await applyExternalActivitySnapshot(
+                    [],
+                    client: client,
+                    hostScope: hostScope
+                )
+                guard appStore.activeHostScope == hostScope else { return false }
+                externalActivityCapabilityUnavailable = true
+                return false
+            }
+            guard appStore.activeHostScope == hostScope else {
+                return false
+            }
+            externalActivityCapabilityUnavailable = false
+            await applyExternalActivitySnapshot(
+                response.activities,
+                client: client,
+                hostScope: hostScope
+            )
+            return appStore.activeHostScope == hostScope
+        } catch {
+            guard appStore.activeHostScope == hostScope, !Task.isCancelled else {
+                return false
+            }
+            _ = terminateConnectionIfCredentialsInvalid(error)
+            // 短暂读取失败不清空上次活动态，否则列表会在“进行中/历史”之间来回抖动。
+            return false
+        }
+    }
+
+    func applyExternalActivitySnapshot(
+        _ activities: [ExternalSessionActivity],
+        client: any SessionStoreAPIClient,
+        hostScope: HostScope
+    ) async {
+        var nextByID: [SessionID: ExternalSessionActivity] = [:]
+        for activity in activities where activity.state.lowercased() == "running" {
+            guard workspacesByID[activity.projectID] != nil || projectsByID[activity.projectID] != nil else {
+                continue
+            }
+            nextByID[activity.threadID] = activity
+        }
+
+        let previousByID = externalActivityBySessionID
+        let activeIDs = Set(nextByID.keys)
+        // 上一次 terminal 最终刷新若因退后台被取消，externalActivityBySessionID 已经清空，
+        // 但只读 tombstone 会保留。把它重新纳入 removedIDs，下一次前台轮询即可续跑并清理。
+        let removedIDs = Set(previousByID.keys)
+            .union(externalReadOnlySessionIDs)
+            .subtracting(activeIDs)
+        externalReadOnlySessionIDs.formUnion(activeIDs)
+        externalReadOnlySessionIDs.formUnion(removedIDs)
+        externalActivityBySessionID = nextByID
+
+        for (sessionID, activity) in nextByID {
+            stopQueuedSessionMonitoring(sessionID: sessionID)
+            updateSession(sessionID) { session in
+                session.status = SessionStatus.running.rawValue
+                session.activeTurnID = activity.turnID
+                session.pendingApproval = nil
+                session.pendingUserInput = nil
+                session.updatedAt = max(session.updatedAt ?? .distantPast, activity.lastActivityAt)
+                session.recencyAt = max(session.recencyAt ?? .distantPast, activity.lastActivityAt)
+            }
+        }
+        if let selectedSessionID, activeIDs.contains(selectedSessionID) {
+            disconnectWebSocket()
+        }
+
+        // 先本地降级，确保 terminal/过期快照一到就从“进行中”移回“历史”；
+        // 随后的权威列表与最终历史读取负责补齐标题、消息和最新时间。
+        for sessionID in removedIDs {
+            updateSession(sessionID) { session in
+                session.status = SessionStatus.history.rawValue
+                session.activeTurnID = nil
+                session.pendingApproval = nil
+                session.pendingUserInput = nil
+            }
+            clearForegroundActivity(sessionID: sessionID)
+            clearRuntimeActivity(sessionID: sessionID)
+        }
+
+        let newOrMissingProjectIDs = Set(nextByID.values.compactMap { activity in
+            if previousByID[activity.threadID] == nil || sessionsByID[activity.threadID] == nil {
+                return activity.projectID
+            }
+            return nil
+        })
+        for projectID in newOrMissingProjectIDs {
+            guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
+            await refreshExternalActivityProject(
+                projectID: projectID,
+                client: client,
+                hostScope: hostScope
+            )
+        }
+
+        if let selectedSessionID,
+           let activity = nextByID[selectedSessionID],
+           previousByID[selectedSessionID]?.revision != activity.revision,
+           let session = sessionsByID[selectedSessionID] {
+            _ = await loadHistory(
+                for: session,
+                quiet: true,
+                loadMode: .full,
+                force: true
+            )
+        }
+
+        // terminal/过期必须做最后一次强制历史补拉。只读集合在所有 await 完成前保留，
+        // 即使磁盘里遗留 `.takenOver`，这段时间也不能触发 resume 或发送。
+        for sessionID in removedIDs {
+            guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
+            if selectedSessionID == sessionID, let session = sessionsByID[sessionID] {
+                _ = await loadHistory(
+                    for: session,
+                    quiet: true,
+                    loadMode: .full,
+                    force: true
+                )
+            }
+            let projectID = previousByID[sessionID]?.projectID ?? sessionsByID[sessionID]?.projectID
+            if let projectID {
+                await refreshExternalActivityProject(
+                    projectID: projectID,
+                    client: client,
+                    hostScope: hostScope
+                )
+            }
+        }
+        guard appStore.activeHostScope == hostScope else { return }
+        externalReadOnlySessionIDs.subtract(removedIDs)
+    }
+
+    func refreshExternalActivityProject(
+        projectID: String,
+        client: any SessionStoreAPIClient,
+        hostScope: HostScope
+    ) async {
+        guard let workspace = ensureWorkspaceForKnownProjectID(projectID) else {
+            return
+        }
+        do {
+            let page = try await client.sessionsPage(
+                workspace: workspace,
+                cursor: nil,
+                limit: Self.initialSessionPageLimit,
+                consistency: .authoritative
+            )
+            guard appStore.activeHostScope == hostScope, !Task.isCancelled else {
+                return
+            }
+            mergeSessionPage(sessions(page.sessions, in: workspace))
+            updateSessionPageState(projectID: projectID, page: page)
+            clearWorkspaceUnavailable(projectID)
+        } catch {
+            // 活动 API 已给出可靠运行态；列表补拉失败时保留已有行，下一次轮询继续重试未知线程。
+        }
+    }
+}

--- a/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
@@ -98,6 +98,7 @@ protocol SessionStoreAPIClient {
     func projects() async throws -> [AgentProject]
     func modelOptions() async throws -> [CodexAppServerModelOption]
     func runtimeChannelAvailable(runtimeProvider: String) async throws -> Bool
+    func externalActivities() async throws -> ExternalActivityResponse?
     func capabilities(path: String?, forceReload: Bool) async throws -> CapabilityListResponse
     func resolveWorkspace(path: String) async throws -> AgentWorkspace
     func createWorktree(path: String, name: String?, base: String?, branch: String?) async throws -> WorktreeCreateResponse
@@ -155,6 +156,12 @@ protocol SessionStoreAPIClient {
 }
 
 extension SessionStoreAPIClient {
+    func externalActivities() async throws -> ExternalActivityResponse? {
+        // 旧 agentd/iOS 测试客户端没有该能力时明确返回 nil；nil 表示“不支持”，
+        // 与新 agentd 返回 activities=[]（支持但当前无活动）不能混为一谈。
+        nil
+    }
+
     func runtimeChannelAvailable(runtimeProvider: String) async throws -> Bool {
         let value = runtimeProvider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return value.isEmpty || value == "codex" || value == "openai"

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -893,7 +893,7 @@ extension SessionStore {
     @discardableResult
     func toggleSessionArchivedRemote(_ session: AgentSession) async -> Bool {
         guard !isExternalReadOnlySession(session) else {
-            setStatusMessage("Mac · \(L10n.text("ui.just_observe"))")
+            setStatusMessage(L10n.text("ui.mac_observe_only"))
             return false
         }
         let shouldArchive = !archivedSessionIDs.contains(session.id)

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -892,6 +892,10 @@ extension SessionStore {
 
     @discardableResult
     func toggleSessionArchivedRemote(_ session: AgentSession) async -> Bool {
+        guard !isExternalReadOnlySession(session) else {
+            setStatusMessage("Mac · \(L10n.text("ui.just_observe"))")
+            return false
+        }
         let shouldArchive = !archivedSessionIDs.contains(session.id)
         let hostScope = appStore.activeHostScope
         toggleSessionArchived(session)
@@ -914,7 +918,8 @@ extension SessionStore {
     }
 
     func supportsCodexThreadManagement(_ session: AgentSession) -> Bool {
-        Self.normalizedRuntimeProvider(session.runtimeProvider ?? session.source) == "codex"
+        !isExternalReadOnlySession(session)
+            && Self.normalizedRuntimeProvider(session.runtimeProvider ?? session.source) == "codex"
     }
 
     @discardableResult

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -1316,7 +1316,23 @@ extension SessionStore {
         )
         let previewProjected = sessionApplyingListProjection(preserved)
         let monotonicRecency = sessionPreservingRecencyFloor(previewProjected)
-        return sessionApplyingRecentActivityProjection(monotonicRecency)
+        let recentProjected = sessionApplyingRecentActivityProjection(monotonicRecency)
+        return sessionApplyingExternalActivity(recentProjected)
+    }
+
+    func sessionApplyingExternalActivity(_ incoming: AgentSession) -> AgentSession {
+        guard let activity = externalActivityBySessionID[incoming.id],
+              activity.state == "running" else {
+            return incoming
+        }
+        var projected = incoming
+        projected.status = SessionStatus.running.rawValue
+        projected.activeTurnID = activity.turnID
+        projected.pendingApproval = nil
+        projected.pendingUserInput = nil
+        projected.updatedAt = max(incoming.updatedAt ?? .distantPast, activity.lastActivityAt)
+        projected.recencyAt = max(incoming.recencyAt ?? .distantPast, activity.lastActivityAt)
+        return projected
     }
 
     func sessionPreservingRecencyFloor(_ incoming: AgentSession) -> AgentSession {

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -577,7 +577,7 @@ extension SessionStore {
         runningDelivery: RunningTurnDelivery = .queued
     ) async -> Bool {
         if let session = selectedSession, isExternalReadOnlySession(session) {
-            threadGoalErrorMessage = "Mac · \(L10n.text("ui.just_observe"))"
+            threadGoalErrorMessage = L10n.text("ui.mac_observe_only")
             return false
         }
         let normalizedObjective = objective.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -667,7 +667,7 @@ extension SessionStore {
             return false
         }
         if let session = selectedSession, isExternalReadOnlySession(session) {
-            setErrorMessage("Mac · \(L10n.text("ui.just_observe"))")
+            setErrorMessage(L10n.text("ui.mac_observe_only"))
             return false
         }
         if let notice = selectedQuotaNotice, notice.blocksSending {
@@ -1733,7 +1733,7 @@ extension SessionStore {
         tokenBudget: Int64?
     ) async -> Bool {
         if let session = sessionsByID[threadID], isExternalReadOnlySession(session) {
-            threadGoalErrorMessage = "Mac · \(L10n.text("ui.just_observe"))"
+            threadGoalErrorMessage = L10n.text("ui.mac_observe_only")
             return false
         }
         let normalizedObjective = objective?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1792,7 +1792,7 @@ extension SessionStore {
             return
         }
         if let session = sessionsByID[sessionID], isExternalReadOnlySession(session) {
-            threadGoalErrorMessage = "Mac · \(L10n.text("ui.just_observe"))"
+            threadGoalErrorMessage = L10n.text("ui.mac_observe_only")
             return
         }
         isUpdatingThreadGoal = true

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -576,6 +576,10 @@ extension SessionStore {
         tokenBudget: Int64? = nil,
         runningDelivery: RunningTurnDelivery = .queued
     ) async -> Bool {
+        if let session = selectedSession, isExternalReadOnlySession(session) {
+            threadGoalErrorMessage = "Mac · \(L10n.text("ui.just_observe"))"
+            return false
+        }
         let normalizedObjective = objective.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedObjective.isEmpty else {
             threadGoalErrorMessage = L10n.text("ui.target_content_cannot_be_empty")
@@ -660,6 +664,10 @@ extension SessionStore {
         queuedIntent: QueuedTurnIntent? = nil
     ) async -> Bool {
         guard !payload.isEmpty else {
+            return false
+        }
+        if let session = selectedSession, isExternalReadOnlySession(session) {
+            setErrorMessage("Mac · \(L10n.text("ui.just_observe"))")
             return false
         }
         if let notice = selectedQuotaNotice, notice.blocksSending {
@@ -1724,6 +1732,10 @@ extension SessionStore {
         status: ThreadGoalStatus?,
         tokenBudget: Int64?
     ) async -> Bool {
+        if let session = sessionsByID[threadID], isExternalReadOnlySession(session) {
+            threadGoalErrorMessage = "Mac · \(L10n.text("ui.just_observe"))"
+            return false
+        }
         let normalizedObjective = objective?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let normalizedObjective, normalizedObjective.isEmpty {
             threadGoalErrorMessage = L10n.text("ui.target_content_cannot_be_empty")
@@ -1777,6 +1789,10 @@ extension SessionStore {
 
     func clearSelectedThreadGoal() async {
         guard let sessionID = selectedSessionID else {
+            return
+        }
+        if let session = sessionsByID[sessionID], isExternalReadOnlySession(session) {
+            threadGoalErrorMessage = "Mac · \(L10n.text("ui.just_observe"))"
             return
         }
         isUpdatingThreadGoal = true

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AgentAPIClientRequestTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AgentAPIClientRequestTests.swift
@@ -59,6 +59,9 @@ final class AgentAPIClientRequestTests: XCTestCase {
             .init("app-server config", path: "/api/app-server/config", method: "GET") { client in
                 _ = try await client.appServerConfig()
             },
+            .init("external activity", path: "/api/app-server/external-activity", method: "GET") { client in
+                _ = try await client.externalActivities()
+            },
             .init("relay diagnostics", path: "/api/diagnostics/relay", method: "GET") { client in
                 _ = try await client.relayDiagnostics()
             },

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -450,6 +450,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     let rateLimitsByRuntime: [String: RateLimitSummary]
     let rateLimitHandler: ((String) async throws -> RateLimitSummary?)?
     let threadSearchHandler: ((String, String?, Int?) async throws -> ThreadSearchPage)?
+    let externalActivityResponses: [ExternalActivityResponse?]
     var requestedProjectIDs: [String?] {
         requestLogLock.withLock { requestedProjectIDsStorage }
     }
@@ -498,6 +499,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     private(set) var worktreeListCallCount = 0
     private(set) var modelOptionsCallCount = 0
     private(set) var requestedRateLimitProviders: [String] = []
+    private(set) var externalActivityCallCount = 0
 
     init(
         projects: [AgentProject],
@@ -544,7 +546,8 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         runtimeChannelAvailability: [String: Bool] = [:],
         rateLimitsByRuntime: [String: RateLimitSummary] = [:],
         rateLimitHandler: ((String) async throws -> RateLimitSummary?)? = nil,
-        threadSearchHandler: ((String, String?, Int?) async throws -> ThreadSearchPage)? = nil
+        threadSearchHandler: ((String, String?, Int?) async throws -> ThreadSearchPage)? = nil,
+        externalActivityResponses: [ExternalActivityResponse?] = []
     ) {
         self.projectsResult = projects
         self.sessionsResult = sessions
@@ -594,10 +597,20 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         self.rateLimitsByRuntime = rateLimitsByRuntime
         self.rateLimitHandler = rateLimitHandler
         self.threadSearchHandler = threadSearchHandler
+        self.externalActivityResponses = externalActivityResponses
     }
 
     func projects() async throws -> [AgentProject] {
         projectsResult
+    }
+
+    func externalActivities() async throws -> ExternalActivityResponse? {
+        let index = min(externalActivityCallCount, max(0, externalActivityResponses.count - 1))
+        externalActivityCallCount += 1
+        guard !externalActivityResponses.isEmpty else {
+            return nil
+        }
+        return externalActivityResponses[index]
     }
 
     func modelOptions() async throws -> [CodexAppServerModelOption] {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
@@ -1047,6 +1047,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
             isGoalUpdating: false,
             goalErrorMessage: nil,
             isRefreshDisabled: false,
+            allowsTakeOver: true,
             onTakeOver: {},
             onRefreshUsage: {},
             onEditGoal: {},
@@ -1284,6 +1285,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                 isArchived: false,
                 reminder: nil,
                 isObserving: false,
+                isExternalReadOnly: false,
                 style: .library
             )
             SessionIndexRow(
@@ -1294,6 +1296,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                 isArchived: false,
                 reminder: nil,
                 isObserving: false,
+                isExternalReadOnly: false,
                 style: .library
             )
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
@@ -1,0 +1,340 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testExternalActivityResponseDecodesOnlyReadOnlyIdentityAndRevisionFields() throws {
+        let data = Data(#"""
+        {
+          "activities": [{
+            "thread_id": "thread-1",
+            "project_id": "project-1",
+            "source": "codex_desktop",
+            "state": "running",
+            "turn_id": "turn-1",
+            "revision": "rev-1",
+            "last_activity_at": "2026-07-28T14:00:00.123Z"
+          }],
+          "scanned_at": "2026-07-28T14:00:01Z"
+        }
+        """#.utf8)
+
+        let response = try AgentAPIClient.decoder.decode(ExternalActivityResponse.self, from: data)
+
+        XCTAssertEqual(response.activities.count, 1)
+        XCTAssertEqual(response.activities[0].threadID, "thread-1")
+        XCTAssertEqual(response.activities[0].projectID, "project-1")
+        XCTAssertEqual(response.activities[0].turnID, "turn-1")
+        XCTAssertEqual(response.activities[0].revision, "rev-1")
+    }
+
+    func testExternalActivityMovesSessionBetweenActiveAndHistoryAndDeduplicatesRevision() async throws {
+        let project = makeProject(id: "proj_external_activity")
+        let threadID = "thread-external"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "Mac 会话",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let firstActivity = makeExternalActivity(
+            threadID: threadID,
+            projectID: project.id,
+            turnID: "turn-1",
+            revision: "rev-1"
+        )
+        let revisedActivity = makeExternalActivity(
+            threadID: threadID,
+            projectID: project.id,
+            turnID: "turn-1",
+            revision: "rev-2"
+        )
+        let responses = [
+            ExternalActivityResponse(activities: [firstActivity], scannedAt: Date()),
+            ExternalActivityResponse(activities: [firstActivity], scannedAt: Date()),
+            ExternalActivityResponse(activities: [revisedActivity], scannedAt: Date()),
+            ExternalActivityResponse(activities: [], scannedAt: Date())
+        ].map(Optional.some)
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            workspacePages: [project.id: SessionsPage(sessions: [history])],
+            historyPages: [
+                threadID: HistoryMessagesPage(messages: [
+                    CodexHistoryMessage(role: "assistant", content: "Mac 输出", createdAt: Date())
+                ])
+            ],
+            externalActivityResponses: responses
+        )
+        let store = makeExternalActivityStore(project: project, session: history, client: client)
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+
+        let firstRefresh = await store.refreshExternalActivities(client: client)
+        XCTAssertTrue(firstRefresh)
+        let activePartition = SessionListPartition(sessions: store.sessions)
+        XCTAssertEqual(activePartition.active.map(\.id), [threadID])
+        XCTAssertTrue(activePartition.history.isEmpty)
+        XCTAssertEqual(store.sessionsByID[threadID]?.activeTurnID, "turn-1")
+        XCTAssertEqual(store.externalActivityPollingDelayNanoseconds(), 5_000_000_000)
+        XCTAssertEqual(client.requestedMessageSessionIDs.count, 1)
+
+        let duplicateRefresh = await store.refreshExternalActivities(client: client)
+        XCTAssertTrue(duplicateRefresh)
+        XCTAssertEqual(
+            client.requestedMessageSessionIDs.count,
+            1,
+            "相同 revision 不应重复拉取历史"
+        )
+
+        let revisedRefresh = await store.refreshExternalActivities(client: client)
+        XCTAssertTrue(revisedRefresh)
+        XCTAssertEqual(client.requestedMessageSessionIDs.count, 2)
+
+        let completedRefresh = await store.refreshExternalActivities(client: client)
+        XCTAssertTrue(completedRefresh)
+        let completedPartition = SessionListPartition(sessions: store.sessions)
+        XCTAssertTrue(completedPartition.active.isEmpty)
+        XCTAssertEqual(completedPartition.history.map(\.id), [threadID])
+        XCTAssertEqual(store.sessionsByID[threadID]?.status, SessionStatus.history.rawValue)
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.isExternalReadOnlySession(try XCTUnwrap(store.sessionsByID[threadID])))
+        XCTAssertEqual(store.externalActivityPollingDelayNanoseconds(), 8_000_000_000)
+        XCTAssertEqual(
+            client.requestedMessageSessionIDs.count,
+            3,
+            "terminal 快照应执行一次最终历史刷新"
+        )
+    }
+
+    func testExternalActivityOverridesLegacyTakenOverAndBlocksControlRPCs() async throws {
+        let project = makeProject(id: "proj_external_read_only")
+        let threadID = "thread-read-only"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "Mac 运行中",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            workspacePages: [project.id: SessionsPage(sessions: [history])],
+            externalActivityResponses: [
+                ExternalActivityResponse(
+                    activities: [makeExternalActivity(
+                        threadID: threadID,
+                        projectID: project.id,
+                        turnID: "turn-read-only",
+                        revision: "rev-read-only"
+                    )],
+                    scannedAt: Date()
+                )
+            ]
+        )
+        let socket = MockWebSocketClient()
+        let store = makeExternalActivityStore(
+            project: project,
+            session: history,
+            client: client,
+            socket: socket
+        )
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+        store.sessionControlStateByID[threadID] = .takenOver
+
+        let refresh = await store.refreshExternalActivities(client: client)
+        XCTAssertTrue(refresh)
+        let external = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertEqual(store.controlState(for: external), .observing)
+        XCTAssertFalse(store.canControlSession(external))
+        XCTAssertFalse(store.supportsCodexThreadManagement(external))
+        XCTAssertFalse(store.selectedSessionAllowsTakeOver)
+
+        store.takeOverSession(external)
+        store.connectWebSocket(external, allowNonRunning: true)
+        store.sendCtrlC()
+        let didSend = await store.sendTurn(CodexAppServerTurnPayload(prompt: "不要发送"))
+        let didGuide = await store.sendTurn(
+            CodexAppServerTurnPayload(prompt: "不要引导"),
+            runningDelivery: .guided
+        )
+        store.decideApproval(
+            ApprovalSummary(id: "approval-external", title: "不要审批", kind: "command", count: 1),
+            accept: true
+        )
+        XCTAssertFalse(didSend)
+        XCTAssertFalse(didGuide)
+        await store.stopSelectedSession()
+
+        // terminal 快照到达后，最终历史补拉会暂时把行降为 history，但只读 tombstone 仍在。
+        // 这一窗口也不能走“恢复历史会话并发送”的 createSession 分支。
+        store.updateSession(threadID) { session in
+            session.status = SessionStatus.history.rawValue
+            session.activeTurnID = nil
+        }
+        let didResume = await store.sendTurn(CodexAppServerTurnPayload(prompt: "不要恢复"))
+        XCTAssertFalse(didResume)
+
+        XCTAssertTrue(socket.connectedSessionIDs.isEmpty)
+        XCTAssertTrue(socket.sentTurns.isEmpty)
+        XCTAssertTrue(socket.sentGuidance.isEmpty)
+        XCTAssertTrue(socket.sentApprovals.isEmpty)
+        XCTAssertEqual(socket.sentCtrlCCount, 0)
+        XCTAssertTrue(client.createPayloads.isEmpty)
+    }
+
+    func testExternalActivityPollingStopsWhenOldAgentDDoesNotAdvertiseCapability() async {
+        let project = makeProject(id: "proj_external_legacy")
+        let history = makeSession(
+            id: "thread-legacy",
+            projectID: project.id,
+            title: "旧 agentd",
+            status: SessionStatus.history.rawValue,
+            source: "codex"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            externalActivityResponses: [nil]
+        )
+        var sleepCalls = 0
+        let store = makeExternalActivityStore(
+            project: project,
+            session: history,
+            client: client,
+            externalActivitySleep: { _ in sleepCalls += 1 }
+        )
+        let staleActivity = makeExternalActivity(
+            threadID: history.id,
+            projectID: project.id,
+            turnID: "turn-old-agent",
+            revision: "rev-old-agent"
+        )
+        store.externalActivityBySessionID[history.id] = staleActivity
+        store.externalReadOnlySessionIDs.insert(history.id)
+        store.updateSession(history.id) { session in
+            session.status = SessionStatus.running.rawValue
+            session.activeTurnID = staleActivity.turnID
+        }
+
+        await store.pollExternalActivitiesWhileVisible()
+
+        XCTAssertEqual(client.externalActivityCallCount, 1)
+        XCTAssertEqual(sleepCalls, 0)
+        XCTAssertTrue(store.externalActivityCapabilityUnavailable)
+        XCTAssertTrue(store.externalActivityBySessionID.isEmpty)
+        XCTAssertEqual(store.sessionsByID[history.id]?.status, SessionStatus.history.rawValue)
+        XCTAssertFalse(store.isExternalReadOnlySession(store.sessionsByID[history.id]!))
+    }
+
+    func testExternalActivityRetriesTerminalRefreshLeftByForegroundCancellation() async throws {
+        let project = makeProject(id: "proj_external_terminal_retry")
+        let threadID = "thread-terminal-retry"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "待完成刷新",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            workspacePages: [project.id: SessionsPage(sessions: [history])],
+            historyPages: [threadID: HistoryMessagesPage(messages: [])],
+            externalActivityResponses: [
+                ExternalActivityResponse(activities: [], scannedAt: Date())
+            ]
+        )
+        let store = makeExternalActivityStore(project: project, session: history, client: client)
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+        // 模拟上一次 apply 在清空 activity 后、最终补拉完成前因退后台被取消。
+        store.externalReadOnlySessionIDs.insert(threadID)
+
+        let refreshed = await store.refreshExternalActivities(client: client)
+
+        XCTAssertTrue(refreshed)
+        XCTAssertEqual(client.requestedMessageSessionIDs, [threadID])
+        XCTAssertFalse(store.isExternalReadOnlySession(try XCTUnwrap(store.sessionsByID[threadID])))
+    }
+
+    private func makeExternalActivity(
+        threadID: SessionID,
+        projectID: String,
+        turnID: TurnID,
+        revision: String
+    ) -> ExternalSessionActivity {
+        ExternalSessionActivity(
+            threadID: threadID,
+            projectID: projectID,
+            source: "codex_desktop",
+            state: "running",
+            turnID: turnID,
+            revision: revision,
+            lastActivityAt: Date(timeIntervalSince1970: 100)
+        )
+    }
+
+    private func makeExternalActivityStore(
+        project: AgentProject,
+        session: AgentSession,
+        client: MockSessionStoreClient,
+        socket: MockWebSocketClient = MockWebSocketClient(),
+        externalActivitySleep: @escaping (UInt64) async -> Void = { _ in }
+    ) -> SessionStore {
+        let suiteName = "ExternalActivitySessionStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let appStore = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
+        appStore.endpoint = "http://127.0.0.1:8787"
+        appStore.token = "test-token"
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: { socket },
+            externalActivitySleep: externalActivitySleep
+        )
+        store.setProjectsIfChanged([project])
+        store.setRecentWorkspacesIfChanged([AgentWorkspace(project: project)])
+        store.setSidebarProjectsIfChanged([project])
+        store.sessions = [historyAligned(session, project: project)]
+        return store
+    }
+
+    private func historyAligned(_ session: AgentSession, project: AgentProject) -> AgentSession {
+        AgentSession(
+            id: session.id,
+            projectID: project.id,
+            project: project.name,
+            dir: project.path,
+            title: session.title,
+            status: session.status,
+            source: session.source,
+            runtimeProvider: session.runtimeProvider,
+            resumeID: session.resumeID,
+            createdAt: session.createdAt,
+            updatedAt: session.updatedAt,
+            recencyAt: session.recencyAt,
+            preview: session.preview,
+            activeTurnID: session.activeTurnID
+        )
+    }
+}


### PR DESCRIPTION
## 背景

Codex Desktop 与 Mimi 的 agentd 使用不同 app-server 进程，thread/list 的运行态只对当前进程有效，因此 Mac 端发起的任务此前只能显示为历史或 notLoaded，iPad 无法可靠识别其真实运行态。

## 变更

- agentd 从 state_5.sqlite 和 rollout JSONL 识别 Codex Desktop 顶层会话，并增量缓存文件偏移与 revision。
- 新增经过认证且脱敏的 GET /api/app-server/external-activity，并在 Codex channel 声明 external_activity 能力。
- iPad 前台按 8 秒轮询，选中 Mac 会话时按 5 秒轮询，仅在 revision 变化时刷新历史。
- Mac 会话进入现有进行中分区并显示“Mac · 仅观察”；结束、中断或过期后最终刷新并返回历史。
- 外部活动强制只读，禁止发送、引导、审批、中断、接管、会话管理及 thread/resume。
- 兼容旧 agentd、旧 iOS、遗留 takenOver 状态和前后台取消后的恢复。

## 边界

- V1 仅覆盖同一台 Mac、同一 CODEX_HOME 的 Codex Desktop 会话。
- rollout 30 分钟无写入会降为非活动，后续写入可重新激活。
- 不接入 Remote Control，也不允许从 iPad 控制 Mac 正在执行的回合。

## 验证

- go test ./...
- Go 测试覆盖来源/项目过滤、开始/完成/中断、追加解析、损坏 JSONL、过期、缓存复用、认证和响应脱敏。
- iOS 模拟器通过 5 项外部活动测试和 5 项现有观察、接管、历史恢复回归。
- 使用真实 Codex Desktop 当前任务验证，能够从真实状态库和 rollout 识别活动线程。

## 待人工验收

- [ ] 安装到物理 iPad 后确认 8 秒进入进行中、选中后约 5 秒同步，以及完成或中断后 8 秒内返回历史。
