### PR TITLE
test(ios): align external activity timeout contract

### DIFF
--- a/ios/MimiRemote/Tests/MimiRemoteTests/AgentAPIClientRequestTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AgentAPIClientRequestTests.swift
@@ -59,7 +59,12 @@ final class AgentAPIClientRequestTests: XCTestCase {
             .init("app-server config", path: "/api/app-server/config", method: "GET") { client in
                 _ = try await client.appServerConfig()
             },
-            .init("external activity", path: "/api/app-server/external-activity", method: "GET") { client in
+            .init(
+                "external activity",
+                path: "/api/app-server/external-activity",
+                method: "GET",
+                timeout: 10
+            ) { client in
                 _ = try await client.externalActivities()
             },
             .init("relay diagnostics", path: "/api/diagnostics/relay", method: "GET") { client in


### PR DESCRIPTION
修正 external-activity 请求契约测试的超时期望：该轮询接口默认使用 10 秒，不沿用通用 20 秒。仅修改测试断言，不改变运行时行为。按实机验收决定，不等待模拟器回归。