### PR TITLE
fix: 修复 installation ID 与旧 Profile 数据迁移

### DIFF
--- a/internal/config/installation_identity.go
+++ b/internal/config/installation_identity.go
@@ -17,8 +17,9 @@ const (
 
 // LoadOrCreateInstallationID 读取 agentd 的稳定安装身份。
 //
-// 身份与可变的 endpoint、Token 和配置文件分离：缺失时只创建一次；已有文件只要
-// 格式、类型或权限异常就直接失败，绝不能静默生成新身份并让移动端误认成另一台 Mac。
+// 身份与可变的 endpoint、Token 和配置文件分离：缺失时只创建一次；已有普通文件
+// 内容合法但权限不符时只收紧为 0600，类型或格式异常仍直接失败。任何情况下都不能
+// 静默生成新身份并让移动端误认成另一台 Mac。
 func LoadOrCreateInstallationID() (string, error) {
 	dir, err := UserConfigDir()
 	if err != nil {
@@ -117,9 +118,6 @@ func readInstallationID(path string) (string, error) {
 	if !pathInfo.Mode().IsRegular() {
 		return "", fmt.Errorf("安装身份必须是普通文件，不能是目录或符号链接：%s", path)
 	}
-	if pathInfo.Mode().Perm() != installationIDFileMode {
-		return "", fmt.Errorf("安装身份文件权限必须是 0600，实际为 %04o：%s", pathInfo.Mode().Perm(), path)
-	}
 
 	file, err := os.Open(path)
 	if err != nil {
@@ -130,11 +128,58 @@ func readInstallationID(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("读取安装身份文件状态失败：%w", err)
 	}
-	if !openedInfo.Mode().IsRegular() || openedInfo.Mode().Perm() != installationIDFileMode || !os.SameFile(pathInfo, openedInfo) {
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(pathInfo, openedInfo) {
 		return "", fmt.Errorf("安装身份文件在读取期间发生变化，拒绝继续启动")
 	}
 
 	// 只接受固定 36 字节 UUID 和一个换行，限制读取长度也避免异常文件造成无界分配。
+	installationID, err := readCanonicalInstallationID(file, path)
+	if err != nil {
+		return "", err
+	}
+
+	if openedInfo.Mode().Perm() != installationIDFileMode {
+		// 只在内容已经验证为现有合法身份后修复权限；直接操作已核验的文件描述符，
+		// 避免对路径二次 chmod 时被符号链接或并发替换劫持。
+		if err := file.Chmod(installationIDFileMode); err != nil {
+			return "", fmt.Errorf(
+				"收紧安装身份文件权限失败（实际为 %04o）：%s：%w",
+				openedInfo.Mode().Perm(),
+				path,
+				err,
+			)
+		}
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return "", fmt.Errorf("重新校验安装身份失败：%w", err)
+		}
+		recheckedID, err := readCanonicalInstallationID(file, path)
+		if err != nil {
+			return "", err
+		}
+		if recheckedID != installationID {
+			return "", fmt.Errorf("安装身份文件在权限修复期间发生变化，拒绝继续启动")
+		}
+	}
+
+	finalOpenedInfo, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("确认安装身份文件状态失败：%w", err)
+	}
+	finalPathInfo, err := os.Lstat(path)
+	if err != nil {
+		return "", fmt.Errorf("确认安装身份文件路径失败：%w", err)
+	}
+	if !finalPathInfo.Mode().IsRegular() ||
+		!finalOpenedInfo.Mode().IsRegular() ||
+		finalOpenedInfo.Mode().Perm() != installationIDFileMode ||
+		finalPathInfo.Mode().Perm() != installationIDFileMode ||
+		!os.SameFile(finalPathInfo, finalOpenedInfo) {
+		return "", fmt.Errorf("安装身份文件在读取期间发生变化，拒绝继续启动")
+	}
+	return installationID, nil
+}
+
+func readCanonicalInstallationID(file io.Reader, path string) (string, error) {
 	raw, err := io.ReadAll(io.LimitReader(file, 38))
 	if err != nil {
 		return "", fmt.Errorf("读取安装身份失败：%w", err)

--- a/internal/config/installation_identity_test.go
+++ b/internal/config/installation_identity_test.go
@@ -73,7 +73,7 @@ func TestLoadOrCreateInstallationIDRejectsCorruptionWithoutReplacement(t *testin
 	}
 }
 
-func TestLoadOrCreateInstallationIDRejectsUnsafePermissionAndSymlink(t *testing.T) {
+func TestLoadOrCreateInstallationIDRepairsPermissionAndRejectsSymlink(t *testing.T) {
 	valid := "00112233-4455-4677-8899-aabbccddeeff\n"
 
 	t.Run("permission", func(t *testing.T) {
@@ -81,15 +81,44 @@ func TestLoadOrCreateInstallationIDRejectsUnsafePermissionAndSymlink(t *testing.
 		if err := os.WriteFile(path, []byte(valid), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := loadOrCreateInstallationID(path, bytes.NewReader(make([]byte, 16))); err == nil || !strings.Contains(err.Error(), "0600") {
-			t.Fatalf("宽松权限必须 fail closed：%v", err)
+		got, err := loadOrCreateInstallationID(path, bytes.NewReader(make([]byte, 16)))
+		if err != nil {
+			t.Fatalf("合法身份应自动收紧权限：%v", err)
+		}
+		if got != strings.TrimSpace(valid) {
+			t.Fatalf("权限修复不能轮换安装身份：got=%q", got)
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("合法身份权限应收紧为 0600：%04o", info.Mode().Perm())
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(raw) != valid {
+			t.Fatalf("权限修复不能改写内容：%q", raw)
+		}
+	})
+
+	t.Run("damaged content with unsafe permission", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), installationIDFileName)
+		const damaged = "not-an-installation-id\n"
+		if err := os.WriteFile(path, []byte(damaged), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadOrCreateInstallationID(path, bytes.NewReader(make([]byte, 16))); err == nil {
+			t.Fatal("格式损坏不能因权限可修复而放行")
 		}
 		info, err := os.Lstat(path)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if info.Mode().Perm() != 0o644 {
-			t.Fatalf("加载器不能静默修复或替换异常权限：%04o", info.Mode().Perm())
+			t.Fatalf("内容损坏时不能先修改文件：%04o", info.Mode().Perm())
 		}
 	})
 

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -177,16 +177,17 @@ struct WorkspaceRootView: View {
             }
         }
         .task(id: appStore.activeHostScope) {
-            appearanceStore.migrateLegacyValueIfNeeded(
-                profileID: appStore.activeHostScope.profileID,
-                endpoint: appStore.endpoint,
-                profiles: appStore.connectionProfiles
-            )
+            migrateLegacyWorkspaceAppearance()
             synchronizeSelection()
             // 每次进入工作区都做轻量目录同步，同时执行旧版自动候选数据清理；
             // 该请求不改变当前会话和 WebSocket，上层选择保持稳定。
             await refreshCatalog()
             synchronizeSelection()
+        }
+        .onChange(of: appStore.connectionProfiles) { _, _ in
+            // 这里只重试本地偏好迁移，不重新请求目录。删除或修改重复 endpoint 后，
+            // 当前 Profile 一旦成为唯一匹配，就应立即恢复旧版自定义 emoji。
+            migrateLegacyWorkspaceAppearance()
         }
         .task {
             // 两个新建入口先稳定渲染；Claude 通道能力独立在后台刷新，不能让网络往返
@@ -240,6 +241,14 @@ struct WorkspaceRootView: View {
             Text(L10n.text("ui.removing_a_directory_only_removes_it_from_the_workspace"))
         }
         .background(tokens.background.ignoresSafeArea())
+    }
+
+    private func migrateLegacyWorkspaceAppearance() {
+        appearanceStore.migrateLegacyValueIfNeeded(
+            profileID: appStore.activeHostScope.profileID,
+            endpoint: appStore.endpoint,
+            profiles: appStore.connectionProfiles
+        )
     }
 
     private func navigationContent(tokens: ThemeTokens) -> some View {

--- a/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
@@ -64,6 +64,9 @@ extension SessionStore {
     func deleteConnectionProfile(id: String) async throws {
         try await appStore.deleteConnectionProfile(id: id)
         purgeConnectionProfileData(profileID: id)
+        // 删除重复 endpoint 的非当前 Profile 后，旧版 endpoint 数据可能刚刚变为唯一可归属。
+        // 立即重载本地 Store，避免必须切换 Mac 或手动刷新后才恢复最近工作区等偏好。
+        reloadRecentWorkspaces()
     }
 
     /// 当前 Mac 与非当前 Mac 共用同一条清理路径。先完成 Keychain 提交，再退役连接和清理

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -2769,4 +2769,65 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(migratedAfterResolution.pinnedSessionIDs, ["legacy-session"])
     }
 
+    func testDeletingAmbiguousProfileImmediatelyMigratesCurrentRecentWorkspaces() async throws {
+        let suiteName = "RecentWorkspaceStoreTests.DeleteAmbiguousProfile.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let endpoint = "http://shared-mac.local:8787"
+        let current = ConnectionProfile(
+            id: "mac-a",
+            displayName: "Mac A",
+            endpoint: endpoint,
+            lastSuccessfulAt: nil
+        )
+        let duplicate = ConnectionProfile(
+            id: "mac-b",
+            displayName: "Mac B",
+            endpoint: endpoint + "/",
+            lastSuccessfulAt: nil
+        )
+        defaults.set(
+            try JSONEncoder().encode([current, duplicate]),
+            forKey: "agentd.connectionProfiles.v1"
+        )
+        defaults.set(current.id, forKey: "agentd.activeConnectionProfileID.v1")
+        defaults.set(current.endpoint, forKey: "agentd.endpoint")
+
+        let keychain = TestKeychainOperations()
+        keychain.setData(Data("token-a".utf8), account: "agentd-profile.mac-a")
+        keychain.setData(Data("token-b".utf8), account: "agentd-profile.mac-b")
+        let appStore = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: keychain)
+        )
+        let workspace = AgentWorkspace(
+            id: "legacy-project",
+            name: "旧工作区",
+            path: "/legacy/project"
+        )
+        let recentWorkspaceStore = makeRecentWorkspaceStore(
+            workspaces: [workspace],
+            endpoint: endpoint
+        )
+        let sessionStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: recentWorkspaceStore,
+            clientFactory: {
+                MockSessionStoreClient(projects: [], sessions: [])
+            }
+        )
+
+        sessionStore.reloadRecentWorkspaces()
+        XCTAssertTrue(sessionStore.recentWorkspaces.isEmpty)
+
+        try await sessionStore.deleteConnectionProfile(id: duplicate.id)
+
+        XCTAssertEqual(sessionStore.recentWorkspaces.map(\.id), [workspace.id])
+        XCTAssertEqual(recentWorkspaceStore.load(profileID: current.id).map(\.id), [workspace.id])
+    }
+
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceAppearanceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceAppearanceStoreTests.swift
@@ -87,6 +87,46 @@ final class WorkspaceAppearanceStoreTests: XCTestCase {
         XCTAssertNil(store.customEmoji(profileID: "mac-b", projectID: "project-1"))
     }
 
+    func testLegacyEndpointEmojiRetriesAfterAmbiguityResolves() throws {
+        let key = "agentd.workspaceAppearancePreferences.v1"
+        let endpoint = "http://shared-mac.local:8787"
+        let legacy = [
+            "byEndpoint": [
+                endpoint: [
+                    "project-1": "🧑‍💻"
+                ]
+            ]
+        ]
+        defaults.set(try JSONSerialization.data(withJSONObject: legacy), forKey: key)
+        let current = ConnectionProfile(
+            id: "mac-a",
+            displayName: "Mac A",
+            endpoint: endpoint,
+            lastSuccessfulAt: nil
+        )
+        let duplicate = ConnectionProfile(
+            id: "mac-b",
+            displayName: "Mac B",
+            endpoint: endpoint + "/",
+            lastSuccessfulAt: nil
+        )
+        let store = WorkspaceAppearanceStore(defaults: defaults)
+
+        store.migrateLegacyValueIfNeeded(
+            profileID: current.id,
+            endpoint: current.endpoint,
+            profiles: [current, duplicate]
+        )
+        XCTAssertNil(store.customEmoji(profileID: current.id, projectID: "project-1"))
+
+        store.migrateLegacyValueIfNeeded(
+            profileID: current.id,
+            endpoint: current.endpoint,
+            profiles: [current]
+        )
+        XCTAssertEqual(store.customEmoji(profileID: current.id, projectID: "project-1"), "🧑‍💻")
+    }
+
     func testCustomEmojiAcceptsOneGraphemeAndRejectsPlainText() {
         XCTAssertEqual(WorkspaceAppearanceStore.normalizedEmoji("  🌈  "), "🌈")
         XCTAssertEqual(WorkspaceAppearanceStore.normalizedEmoji("⚾️"), "⚾️")


### PR DESCRIPTION
## 目标

修复 installation ID 权限异常时的身份稳定性，并让旧 endpoint 维度的工作区与外观数据在 Profile 歧义消除后完成迁移。

## 根因

- installation ID 文件内容有效但权限过宽时，旧逻辑可能把权限问题当作身份损坏处理。
- 多个 Profile 指向同一规范化 endpoint 时迁移会正确暂停，但删除重复 Profile 后缺少立即重试入口。

## 方案

- 有效 installation ID 遇到宽松权限时原地修复为 0600，不轮换身份。
- 损坏文件与符号链接继续 fail closed，保持安全边界。
- Profile 歧义解除后重新触发旧 recent workspaces、session preferences 和 workspace emoji 迁移。
- 删除重复 Profile 后立即刷新当前 Profile 的迁移结果。

## 影响与风险

- 需要更新并重启 agentd，iOS 端需要重新构建或升级。
- 不读取或迁移 Token；只处理 installation ID 文件权限及非敏感本地偏好。
- 歧义仍存在时继续不迁移，避免把旧数据错误归属到任意一台 Mac。

## 验证

- go test ./internal/config
- iOS 定向测试 2 个：删除歧义 Profile 后即时迁移、emoji 在歧义解除后重试。
- 分支已 rebase 到最新 origin/main，diff 检查通过。