### PR TITLE
fix: 稳定 Claude Max 模型选择与新会话启动

### DIFF
--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -740,11 +740,21 @@ func TestValidateGatewayCollaborationModeAllowsOptionalModelOnlyWhenSafe(t *test
 			wantErr: "model",
 		},
 		{
-			name: "unknown effort is rejected",
+			name: "Claude max effort is allowed",
 			value: map[string]any{
 				"mode": "plan",
 				"settings": map[string]any{
 					"reasoning_effort":       "max",
+					"developer_instructions": nil,
+				},
+			},
+		},
+		{
+			name: "unknown effort is rejected",
+			value: map[string]any{
+				"mode": "plan",
+				"settings": map[string]any{
+					"reasoning_effort":       "turbo",
 					"developer_instructions": nil,
 				},
 			},

--- a/internal/httpapi/appserver_gateway_scope.go
+++ b/internal/httpapi/appserver_gateway_scope.go
@@ -268,7 +268,9 @@ func validateGatewayCollaborationMode(value any) error {
 			return fmt.Errorf("collaborationMode.settings.reasoning_effort 必须是字符串或 null")
 		}
 		switch text {
-		case "none", "minimal", "low", "medium", "high", "xhigh":
+		// max 是 Claude 原生 effort 的最高档；网关只做枚举校验，
+		// 具体模型是否支持该档位仍由 runtime 的 model/list 能力约束。
+		case "none", "minimal", "low", "medium", "high", "xhigh", "max":
 		default:
 			return fmt.Errorf("collaborationMode.settings.reasoning_effort 不支持：%s", text)
 		}

--- a/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
@@ -108,6 +108,11 @@ struct AgentSession: Identifiable, Codable, Hashable {
         status == "history"
     }
 
+    /// 新建页在首条消息前只保留本地草稿，不提前创建没有 rollout 的远端 thread。
+    var isLocalDraft: Bool {
+        source == "local" && status == "draft" && resumeID == nil
+    }
+
     var isRunning: Bool {
         status == "running" || status == "waiting_for_approval" || status == "waiting_for_input"
     }
@@ -379,6 +384,9 @@ extension AgentSession {
     func displayStatus(foregroundActivity: SessionForegroundActivity?) -> AgentSessionDisplayStatus {
         // 侧栏和对话顶部共用这套优先级，避免同一个会话在不同入口显示成两种状态。
         // 审批/输入是需要用户处理的状态，优先级高于流式输出；foreground activity 负责区分等待回复和正在回复。
+        if isLocalDraft {
+            return AgentSessionDisplayStatus(title: L10n.text("ui.new_session"), systemImage: "square.and.pencil", tone: .neutral, showsSpinner: false)
+        }
         if status == SessionStatus.waitingForApproval.rawValue || pendingApproval != nil {
             return AgentSessionDisplayStatus(title: L10n.text("ui.pending_approval"), systemImage: "checkmark.seal.fill", tone: .warning, showsSpinner: false)
         }

--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -1027,8 +1027,9 @@ struct CodexAppServerModelOption: Codable, Hashable, Identifiable {
             id: "gpt-5.6-sol",
             title: "GPT-5.6 Sol",
             description: "Detail and polish",
+            isDefault: true,
             supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
-            defaultReasoningEffort: "low"
+            defaultReasoningEffort: "xhigh"
         ),
         CodexAppServerModelOption(
             id: "gpt-5.6-terra",
@@ -1044,7 +1045,7 @@ struct CodexAppServerModelOption: Codable, Hashable, Identifiable {
             supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
             defaultReasoningEffort: "medium"
         ),
-        CodexAppServerModelOption(id: "gpt-5.5", title: "GPT-5.5", isDefault: true),
+        CodexAppServerModelOption(id: "gpt-5.5", title: "GPT-5.5"),
         CodexAppServerModelOption(id: "gpt-5-codex", title: "gpt-5-codex"),
         CodexAppServerModelOption(id: "gpt-5.1-codex", title: "gpt-5.1-codex"),
         CodexAppServerModelOption(id: "gpt-5", title: "gpt-5"),

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -133,6 +133,54 @@ struct ComposerDraftCache {
     }
 }
 
+struct ComposerModelSelectionSnapshot: Equatable {
+    var runtimeProvider: String?
+    var model: String?
+    var modelProvider: String?
+    var reasoningEffort: CodexAppServerReasoningEffort?
+    var serviceTier: String?
+
+    init(options: CodexAppServerTurnOptions) {
+        runtimeProvider = options.runtimeProvider
+        model = options.model
+        modelProvider = options.modelProvider
+        reasoningEffort = options.reasoningEffort
+        serviceTier = options.serviceTier
+    }
+
+    func apply(to options: inout CodexAppServerTurnOptions) {
+        options.runtimeProvider = runtimeProvider
+        options.model = model
+        options.modelProvider = modelProvider
+        options.reasoningEffort = reasoningEffort
+        options.serviceTier = serviceTier
+    }
+}
+
+struct ComposerModelSelectionCache {
+    private var snapshotsByScope: [ComposerDraftScopeKey: ComposerModelSelectionSnapshot] = [:]
+
+    mutating func save(_ snapshot: ComposerModelSelectionSnapshot, for scope: ComposerDraftScopeKey) {
+        guard scope != .none else {
+            return
+        }
+        // 模型偏好与正文是否为空无关；即使消息已经发出，也要在切回会话时恢复。
+        snapshotsByScope[scope] = snapshot
+    }
+
+    func snapshot(for scope: ComposerDraftScopeKey) -> ComposerModelSelectionSnapshot? {
+        snapshotsByScope[scope]
+    }
+
+    mutating func remove(scope: ComposerDraftScopeKey) {
+        snapshotsByScope.removeValue(forKey: scope)
+    }
+
+    mutating func removeAll() {
+        snapshotsByScope.removeAll(keepingCapacity: false)
+    }
+}
+
 enum ComposerPermissionMode: String, CaseIterable, Identifiable {
     case requestApproval
     case readOnly
@@ -461,6 +509,14 @@ struct ComposerState {
         voiceDraftBase = nil
         voiceLastRenderedDraft = nil
         voiceRealtimeManualSuffix = ""
+    }
+
+    func modelSelectionSnapshot() -> ComposerModelSelectionSnapshot {
+        ComposerModelSelectionSnapshot(options: turnOptions)
+    }
+
+    mutating func restoreModelSelectionSnapshot(_ snapshot: ComposerModelSelectionSnapshot) {
+        snapshot.apply(to: &turnOptions)
     }
 
     mutating func addAttachment(_ input: CodexAppServerUserInput) {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -250,6 +250,10 @@ struct ComposerView: View {
             // 每次确认文字或附件变化都写入稳定内存仓，视图突然重建时也能恢复最新草稿。
             sessionStore.saveComposerDraft(snapshot, for: activeComposerDraftScope)
         }
+        .onChange(of: composerState.modelSelectionSnapshot()) { _, snapshot in
+            // 模型偏好独立于正文保存；空输入、发送成功和视图重建都不能清掉会话选择。
+            sessionStore.saveComposerModelSelection(snapshot, for: activeComposerDraftScope)
+        }
         .onChange(of: sessionStore.latestFileUploadCompletion) { _, completion in
             guard let completion,
                   completion.targetScope == activeComposerDraftScope,
@@ -262,11 +266,19 @@ struct ComposerView: View {
             composerState.addAttachment(.uploadedFile(completion.attachment))
         }
         .onChange(of: selectedSessionRuntimeProviderForModelMenu) { _, _ in
+            // 会话 scope 的 onChange 可能稍晚到达。此时仍显示旧 Composer，不能先用新
+            // runtime 改写并保存旧会话的模型；scope 切换完成后会统一恢复并校验。
+            guard activeComposerDraftScope == currentComposerDraftScope else {
+                return
+            }
             clampModelSelectionToSelectedSessionRuntime()
             clampPermissionSelectionToSelectedSessionRuntime()
         }
         .onChange(of: modelOptionsForMenu) { _, _ in
             // model/list 刷新后能力元数据可能变化；立即清理当前模型已不支持的推理强度。
+            guard activeComposerDraftScope == currentComposerDraftScope else {
+                return
+            }
             clampModelSelectionToSelectedSessionRuntime()
         }
         .onChange(of: canUseGuidedFollowUp) { _, canGuide in
@@ -303,6 +315,10 @@ struct ComposerView: View {
         .onDisappear {
             synchronizeComposerTextBeforeDraftScopeChange()
             sessionStore.saveComposerDraft(composerState.draftSnapshot(), for: activeComposerDraftScope)
+            sessionStore.saveComposerModelSelection(
+                composerState.modelSelectionSnapshot(),
+                for: activeComposerDraftScope
+            )
             cancelVoiceInteraction(clearStatus: true)
             activeSkillQuery = nil
         }
@@ -435,12 +451,16 @@ struct ComposerView: View {
         )
         synchronizeComposerTextBeforeDraftScopeChange()
         let outgoingDraft = composerState.draftSnapshot()
+        let outgoingModelSelection = composerState.modelSelectionSnapshot()
         sessionStore.saveComposerDraft(outgoingDraft, for: previousScope)
+        sessionStore.saveComposerModelSelection(outgoingModelSelection, for: previousScope)
         if isOptimisticHandoff {
             // local:* 只是创建接口返回前的临时身份。服务端 ID 回来时迁移当前可见草稿，
-            // 避免用户正在输入的追加指令被新 scope 的空草稿覆盖。
+            // 避免用户正在输入的追加指令和模型选择被新 scope 的默认值覆盖。
             sessionStore.saveComposerDraft(outgoingDraft, for: nextScope)
+            sessionStore.saveComposerModelSelection(outgoingModelSelection, for: nextScope)
             sessionStore.removeComposerDraft(for: previousScope)
+            sessionStore.removeComposerModelSelection(for: previousScope)
         }
         cancelVoiceInteraction(clearStatus: true)
 
@@ -450,6 +470,8 @@ struct ComposerView: View {
         composerState.setSendMode(restoredSendMode)
         persistComposerSendMode(restoredSendMode, for: nextScope)
         composerState.restoreDraftSnapshot(sessionStore.composerDraft(for: nextScope))
+        restoreComposerModelSelection(for: nextScope)
+        clampModelSelectionToSelectedSessionRuntime()
         composerTextExternalRevision += 1
         guidedFollowUpEnabled = false
         measuredComposerTextHeight = 0
@@ -473,6 +495,19 @@ struct ComposerView: View {
 
     func persistComposerSendMode(_ mode: ComposerSendMode, for scope: ComposerDraftScopeKey) {
         sessionStore.saveComposerSendMode(mode, for: scope)
+    }
+
+    func restoreComposerModelSelection(for scope: ComposerDraftScopeKey) {
+        if let snapshot = sessionStore.composerModelSelection(for: scope) {
+            composerState.restoreModelSelectionSnapshot(snapshot)
+            return
+        }
+
+        let runtimeProvider = selectedSessionRuntimeProviderForModelMenu
+            ?? normalizedRuntimeProvider(composerState.turnOptions.runtimeProvider)
+        composerState.updateTurnOptions { options in
+            applyPreferredDefaultModel(runtimeProvider: runtimeProvider, to: &options)
+        }
     }
 
     func resetComposerSendModeAfterSubmit() {
@@ -1891,8 +1926,10 @@ struct ComposerView: View {
         guard let session = sessionStore.selectedSession else {
             return nil
         }
+        // 新建页已经选择了 runtime；本地草稿的 nil 是 Codex 的协议简写，不表示
+        // 可以再由模型菜单切换到 Claude。
         if session.source == "local", session.runtimeProvider == nil {
-            return nil
+            return "codex"
         }
         return normalizedRuntimeProvider(session.runtimeProvider ?? session.source)
     }
@@ -1902,6 +1939,12 @@ struct ComposerView: View {
             return
         }
         let runtimeChanged = normalizedRuntimeProvider(composerState.turnOptions.runtimeProvider) != runtimeProvider
+        let explicitModelID = composerState.turnOptions.model?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .appServerNilIfEmpty
+        let unsupportedModel = !developerModeEnabled &&
+            explicitModelID != nil &&
+            modelOption(matching: explicitModelID) == nil
         let normalizedEffort: CodexAppServerReasoningEffort?
         if developerModeEnabled {
             normalizedEffort = composerState.turnOptions.reasoningEffort.flatMap { effort in
@@ -1919,18 +1962,14 @@ struct ComposerView: View {
         let unsupportedServiceTier = runtimeProvider == "claude"
             && composerState.turnOptions.serviceTier?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
 
-        guard runtimeChanged || unsupportedEffort || unsupportedServiceTier else {
+        guard runtimeChanged || unsupportedModel || unsupportedEffort || unsupportedServiceTier else {
             return
         }
         composerState.updateTurnOptions { options in
-            if runtimeChanged {
-                options.runtimeProvider = payloadRuntimeProviderForSelectedSessionLock()
-                options.model = nil
-                options.modelProvider = nil
-                options.reasoningEffort = nil
-                if !developerModeEnabled {
-                    normalizeModelControlsForStandardComposer(&options)
-                }
+            if runtimeChanged || unsupportedModel {
+                // 切换 runtime 或目录刷新淘汰旧模型时，使用产品约定默认值：
+                // Codex 为 GPT-5.6 Sol/xhigh，Claude 为 Opus 5/high。
+                applyPreferredDefaultModel(runtimeProvider: runtimeProvider, to: &options)
             } else if unsupportedEffort {
                 options.reasoningEffort = normalizedEffort
             }
@@ -1938,6 +1977,40 @@ struct ComposerView: View {
                 options.serviceTier = nil
             }
         }
+    }
+
+    func applyPreferredDefaultModel(
+        runtimeProvider: String,
+        to options: inout CodexAppServerTurnOptions
+    ) {
+        guard let option = ModelReasoningGridCatalog.preferredDefaultOption(
+            runtimeProvider: runtimeProvider,
+            options: modelOptionsForMenu
+        ) else {
+            options.runtimeProvider = runtimeProvider == "codex" ? nil : runtimeProvider
+            options.model = nil
+            options.modelProvider = nil
+            options.reasoningEffort = nil
+            options.serviceTier = nil
+            return
+        }
+        let layout = ModelReasoningGridCatalog.layout(
+            runtimeProvider: runtimeProvider,
+            options: modelOptionsForMenu
+        )
+        let effort = ModelReasoningGridCatalog.preferredDefaultEffort(
+            runtimeProvider: runtimeProvider,
+            option: option,
+            layout: layout
+        )
+        ModelReasoningGridCatalog.applySelection(
+            option: option,
+            effort: effort,
+            preservesServerDefault: false,
+            fallbackRuntimeProvider: runtimeProvider == "codex" ? nil : runtimeProvider,
+            to: &options
+        )
+        options.serviceTier = nil
     }
 
     func supportsReasoningEffort(

--- a/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
@@ -86,6 +86,56 @@ enum ModelReasoningGridCatalog {
         .max
     ]
 
+    static func preferredDefaultOption(
+        runtimeProvider: String?,
+        options: [CodexAppServerModelOption]
+    ) -> CodexAppServerModelOption? {
+        let normalizedRuntime = CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider)
+        let runtimeOptions = options.filter {
+            !$0.hidden &&
+                CodexAppServerSessionRuntime.normalizedRuntimeProvider($0.runtimeProvider) == normalizedRuntime
+        }
+        let fallbackOptions = normalizedRuntime == "claude"
+            ? CodexAppServerModelOption.builtInClaudeFallback
+            : CodexAppServerModelOption.builtInFallback
+        let candidates = runtimeOptions.isEmpty ? fallbackOptions : runtimeOptions
+
+        if normalizedRuntime == "claude" {
+            // Bridge 可能返回稳定 alias `opus`，也可能返回带版本的 canonical id。
+            // 以产品名 Opus 5 匹配，避免服务端把其他模型标成默认后改变新会话体验。
+            if let opus = candidates.first(where: { option in
+                let model = option.model.lowercased()
+                let title = option.title.lowercased()
+                return model == "opus" ||
+                    model.contains("opus-5") ||
+                    title.contains("opus 5")
+            }) {
+                return opus
+            }
+        } else if let sol = candidates.first(where: {
+            $0.model.caseInsensitiveCompare("gpt-5.6-sol") == .orderedSame
+        }) {
+            return sol
+        }
+
+        // 账号尚未获得目标模型时不能发送目录外 ID；退回该 runtime 的可用默认项。
+        return candidates.first(where: \.isDefault) ?? candidates.first
+    }
+
+    static func preferredDefaultEffort(
+        runtimeProvider: String?,
+        option: CodexAppServerModelOption?,
+        layout: ModelReasoningGridLayout
+    ) -> CodexAppServerReasoningEffort? {
+        let normalizedRuntime = CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider)
+        let preferred: CodexAppServerReasoningEffort = normalizedRuntime == "claude" ? .high : .xhigh
+        return normalizedVisibleEffort(
+            option: option,
+            current: preferred,
+            layout: layout
+        )
+    }
+
     static func effectiveModelID(
         selectedModelID: String?,
         options: [CodexAppServerModelOption]

--- a/ios/MimiRemote/Sources/State/ConversationStore.swift
+++ b/ios/MimiRemote/Sources/State/ConversationStore.swift
@@ -179,6 +179,19 @@ final class ConversationStore: ObservableObject {
         touchConversationSession(scopedSessionID)
     }
 
+    /// 本地空草稿被放弃时立即释放消息与索引，避免失败过的首发内容留在不可见缓存中。
+    func reset(sessionID: String) {
+        let scopedSessionID = scopedSessionID(for: sessionID)
+        let messages = messagesByScopedSessionID[scopedSessionID] ?? []
+        clearConversationSessionState(scopedSessionID: scopedSessionID, messages: messages)
+        guard messagesByScopedSessionID[scopedSessionID] != nil else {
+            return
+        }
+        var next = messagesByScopedSessionID
+        next.removeValue(forKey: scopedSessionID)
+        messagesByScopedSessionID = next
+    }
+
     func setHistory(
         _ history: [CodexHistoryMessage],
         sessionID: String,

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -170,6 +170,9 @@ final class SessionStore: ObservableObject {
     // 草稿跟随 SessionStore 生命周期，避免窗口 resize 或详情页重建时随 ComposerView 的 @State 一起丢失。
     // 不使用 @Published，防止每次键入都触发整个工作台刷新。
     var composerDraftCache = ComposerDraftCache()
+    // 模型与推理强度按会话保留，但只存在当前连接的内存生命周期内。
+    // 与内容草稿分开后，空输入或发送成功也不会误删模型偏好。
+    var composerModelSelectionCache = ComposerModelSelectionCache()
 
     func storeCompletedFileUpload(_ attachment: UploadedFileAttachment, for scope: ComposerDraftScopeKey) {
         guard scope != .none else {
@@ -595,6 +598,23 @@ final class SessionStore: ObservableObject {
 
     func removeComposerDraft(for scope: ComposerDraftScopeKey) {
         composerDraftCache.remove(scope: scope)
+    }
+
+    func saveComposerModelSelection(
+        _ snapshot: ComposerModelSelectionSnapshot,
+        for scope: ComposerDraftScopeKey
+    ) {
+        composerModelSelectionCache.save(snapshot, for: scope)
+    }
+
+    func composerModelSelection(
+        for scope: ComposerDraftScopeKey
+    ) -> ComposerModelSelectionSnapshot? {
+        composerModelSelectionCache.snapshot(for: scope)
+    }
+
+    func removeComposerModelSelection(for scope: ComposerDraftScopeKey) {
+        composerModelSelectionCache.remove(scope: scope)
     }
 
     func composerSendModeForScopeActivation(
@@ -1042,6 +1062,9 @@ final class SessionStore: ObservableObject {
         guard let selectedSession else {
             return nil
         }
+        if selectedSession.isLocalDraft {
+            return L10n.text("ui.new_session")
+        }
         guard selectedSession.isRunning else {
             if selectedSession.isAppServerHistory {
                 return L10n.text("ui.history")
@@ -1073,12 +1096,12 @@ final class SessionStore: ObservableObject {
 
     /// 进行中的任务不能被“最近 8 条”截断；侧栏始终展示当前已加载索引里的全部运行态。
     var activeSessions: [AgentSession] {
-        Self.sortedSessions(sessions.filter { isListableSession($0) && $0.isRunning })
+        Self.sortedSessions(sessions.filter { isListableSession($0) && ($0.isRunning || $0.isLocalDraft) })
     }
 
     /// 历史区单独保留最近 8 条，避免运行任务占掉历史预览名额。
     var recentHistorySessions: [AgentSession] {
-        Array(Self.sortedSessions(sessions.filter { isListableSession($0) && !$0.isRunning }).prefix(8))
+        Array(Self.sortedSessions(sessions.filter { isListableSession($0) && !$0.isRunning && !$0.isLocalDraft }).prefix(8))
     }
 
     var filteredSidebarProjects: [AgentProject] {

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -15,6 +15,12 @@ extension SessionStore {
             setWebSocketStatus(.disconnected)
             return
         }
+        // 本地草稿尚无远端 thread id，任何 history/resume/WebSocket 请求都会把 local: id
+        // 误送给 app-server。首条消息创建真实 thread 后再按正常路径连接。
+        guard !session.isLocalDraft else {
+            disconnectWebSocket()
+            return
+        }
         guard connectionTermination == nil, !appStore.requiresRePairing else {
             setWebSocketStatus(.terminated(.credentialsInvalid))
             return
@@ -1737,6 +1743,7 @@ extension SessionStore {
         // endpoint 切换后 session/project ID 可能重复；旧 Mac 的草稿不能恢复到新连接。
         clearFileUploadsForConnectionChange()
         composerDraftCache.removeAll()
+        composerModelSelectionCache.removeAll()
         composerSendModeCache.removeAll()
         stopAllQueuedSessionMonitoring()
         queuedRunningTurnsBySessionID.removeAll()

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -24,6 +24,7 @@ extension SessionStore {
         resume: AgentSession?,
         clientMessageID: ClientMessageID? = nil,
         initialGoalObjective: String? = nil,
+        replacingLocalDraft localDraft: AgentSession? = nil,
         ifCurrent expectedSelectionLease: SessionSelectionLease? = nil
     ) async -> Bool {
         let createIntent = expectedSelectionLease ?? reserveSelectionIntent()
@@ -44,19 +45,39 @@ extension SessionStore {
             return false
         }
         projectID = workspace.id
+        if resume == nil, payload.isEmpty {
+            return createLocalDraftSession(
+                projectID: projectID,
+                runtimeProvider: payload.options.runtimeProvider,
+                ifCurrent: createIntent
+            )
+        }
+        let requestedLocalDraft = localDraft
+        let localDraft = requestedLocalDraft.flatMap { draft -> AgentSession? in
+            guard draft.isLocalDraft,
+                  draft.projectID == projectID,
+                  isSelectionLeaseCurrent(createIntent),
+                  sessionsByID[draft.id]?.isLocalDraft == true else {
+                return nil
+            }
+            return draft
+        }
+        if requestedLocalDraft != nil, localDraft == nil {
+            return false
+        }
         isLoading = true
         defer { isLoading = false }
         let prompt = payload.previewText
-        let optimisticSessionID = optimisticSessionID(
+        let optimisticSessionID = localDraft?.id ?? optimisticSessionID(
             projectID: projectID,
             resume: resume,
             clientMessageID: clientMessageID,
             prompt: prompt
-        ) ?? (resume == nil && payload.isEmpty ? "local:\(projectID):\(UUID().uuidString)" : nil)
+        )
         var optimisticSelectionLease: SessionSelectionLease?
         if let optimisticSessionID {
-            // 空会话也先发布本地占位，让 UI 立即离开创建弹窗；带首轮输入时继续用
-            // client_message_id 合并本地气泡，服务端确认后再迁移到真实 session_id。
+            // 本地草稿或带首轮输入的新会话先发布运行态占位；服务端确认后再用
+            // client_message_id 合并本地气泡并迁移到真实 session_id。
             if resume == nil {
                 upsert(makeOptimisticSession(
                     id: optimisticSessionID,
@@ -119,6 +140,8 @@ extension SessionStore {
                     // 真实 ID 的预览/最近活动投影当成孤儿清掉，造成新会话瞬间回跳或消失。
                     upsert(responseSession)
                     removeSession(optimisticSessionID)
+                    conversationStore.reset(sessionID: optimisticSessionID)
+                    logStore.reset(sessionID: optimisticSessionID)
                 }
             }
             upsert(responseSession)
@@ -244,8 +267,15 @@ extension SessionStore {
                     clearSessionListProjection(sessionID: optimisticSessionID, clientMessageID: clientMessageID)
                 }
                 clearSessionRecentActivityProjection(sessionID: optimisticSessionID, clientMessageID: clientMessageID)
-                updateSession(optimisticSessionID) { item in
-                    item.status = "failed"
+                if let localDraft {
+                    // 首发失败不销毁草稿，也不能把它改成普通 failed 会话；用户修正配置或
+                    // 网络恢复后应能直接重试，且重试仍然是 thread/start 而不是 thread/resume。
+                    upsert(localDraft)
+                    setSessionRecentActivityProjection(sessionID: localDraft.id, clientMessageID: nil)
+                } else {
+                    updateSession(optimisticSessionID) { item in
+                        item.status = "failed"
+                    }
                 }
                 clearForegroundActivity(sessionID: optimisticSessionID)
             }
@@ -267,6 +297,10 @@ extension SessionStore {
 
     @discardableResult
     func loadHistoryIfNeeded(for session: AgentSession) async -> Bool {
+        // 本地草稿没有服务端 thread，更没有 rollout；所有历史读取都必须短路。
+        if session.isLocalDraft {
+            return true
+        }
         if canReuseFreshEmptyHistory(for: session) {
             return true
         }
@@ -304,6 +338,9 @@ extension SessionStore {
         allowPolicyRetry: Bool = true,
         recoveryGeneration: UInt64? = nil
     ) async -> Bool {
+        if session.isLocalDraft {
+            return true
+        }
         if !force, canReuseLoadedHistory(for: session, loadMode: loadMode) {
             return true
         }
@@ -1247,6 +1284,11 @@ extension SessionStore {
         selectionLease: SessionSelectionLease
     ) async {
         guard isSelectionLeaseCurrent(selectionLease) else { return }
+        if session.isLocalDraft {
+            // 会话列表轮询可以保留选中的本地草稿，但绝不能为它读历史或建立订阅。
+            disconnectWebSocket()
+            return
+        }
         await loadHistoryIfNeeded(for: session)
         guard isSelectionLeaseCurrent(selectionLease) else { return }
         if session.isRunning {
@@ -1287,6 +1329,11 @@ extension SessionStore {
         guard generation == recoveryHistoryGeneration,
               let session = sessionsByID[sessionID] else {
             return false
+        }
+        if session.isLocalDraft {
+            reconciledRecoveryGenerationBySessionID[sessionID] = generation
+            recoveryHistorySucceededBySessionID[sessionID] = true
+            return true
         }
         let didLoad = await loadHistory(
             for: session,
@@ -1681,6 +1728,58 @@ extension SessionStore {
         return "local:\(projectID):\(clientMessageID)"
     }
 
+    @discardableResult
+    func createLocalDraftSession(
+        projectID: String,
+        runtimeProvider: String?,
+        ifCurrent selectionIntent: SessionSelectionLease
+    ) -> Bool {
+        guard isSelectionLeaseCurrent(selectionIntent) else {
+            return false
+        }
+        // 单窗口只保留一个尚未发送的草稿。切换工作区或再次点击新建时直接丢弃旧草稿，
+        // 避免侧栏积累永远无法从服务端恢复的 local:* 项。
+        discardLocalDraftSessions()
+        let draft = makeLocalDraftSession(
+            id: "local:\(projectID):\(UUID().uuidString)",
+            projectID: projectID,
+            runtimeProvider: runtimeProvider
+        )
+        upsert(draft)
+        setSessionRecentActivityProjection(sessionID: draft.id, clientMessageID: nil)
+        guard commitSelection(
+            projectID: projectID,
+            sessionID: draft.id,
+            reason: .userOpen,
+            ifCurrent: selectionIntent
+        ) != nil else {
+            discardLocalDraft(draft)
+            return false
+        }
+        insertExpandedProjectID(projectID)
+        disconnectWebSocket()
+        setStatusMessage(L10n.text("ui.session_started"))
+        setErrorMessage(nil)
+        return true
+    }
+
+    func makeLocalDraftSession(id: SessionID, projectID: String, runtimeProvider: String?) -> AgentSession {
+        let project = sidebarProjectsByID[projectID] ?? projectsByID[projectID]
+        return AgentSession(
+            id: id,
+            projectID: projectID,
+            project: project?.name ?? projectID,
+            dir: project?.path ?? "",
+            title: L10n.text("ui.new_session"),
+            status: "draft",
+            source: Self.optimisticSessionSource,
+            runtimeProvider: runtimeProvider,
+            resumeID: nil,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+    }
+
     func makeOptimisticSession(id: SessionID, projectID: String, prompt: String, runtimeProvider: String?) -> AgentSession {
         let project = sidebarProjectsByID[projectID] ?? projectsByID[projectID]
         let title = Self.promptTitle(prompt)
@@ -1698,6 +1797,22 @@ extension SessionStore {
             updatedAt: Date(),
             preview: prompt
         )
+    }
+
+    func discardLocalDraftSessions(except retainedSessionID: SessionID? = nil) {
+        let drafts = sessions.filter { $0.isLocalDraft && $0.id != retainedSessionID }
+        for draft in drafts {
+            discardLocalDraft(draft)
+        }
+    }
+
+    func discardLocalDraft(_ draft: AgentSession) {
+        guard draft.isLocalDraft else {
+            return
+        }
+        conversationStore.reset(sessionID: draft.id)
+        logStore.reset(sessionID: draft.id)
+        removeSession(draft.id)
     }
 
     func removeSession(_ id: SessionID) {

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -919,6 +919,7 @@ extension SessionStore {
 
     func supportsCodexThreadManagement(_ session: AgentSession) -> Bool {
         !isExternalReadOnlySession(session)
+            && !session.isLocalDraft
             && Self.normalizedRuntimeProvider(session.runtimeProvider ?? session.source) == "codex"
     }
 

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -323,6 +323,9 @@ extension SessionStore {
             sessionID: nil,
             reason: .invalidation
         )
+        if let previousSession, previousSession.isLocalDraft {
+            discardLocalDraft(previousSession)
+        }
         guard !wasAlreadyOnList else {
             return
         }
@@ -493,6 +496,11 @@ extension SessionStore {
                 unsubscribeThreadInBackground(previousSession.id)
             }
         }
+        if let previousSession,
+           previousSession.id != session.id,
+           previousSession.isLocalDraft {
+            discardLocalDraft(previousSession)
+        }
         stopQueuedSessionMonitoring(sessionID: session.id)
         revealProjectInSidebar(session.projectID)
         setErrorMessage(nil)
@@ -502,6 +510,11 @@ extension SessionStore {
         }
         conversationStore.retainSessionCache(sessionID: session.id)
         logStore.retainSessionCache(sessionID: session.id)
+        if session.isLocalDraft {
+            // 草稿只存在本机内存；选中时不读历史、不订阅 WebSocket。
+            disconnectWebSocket()
+            return true
+        }
 #if DEBUG
         guard !isDebugWorkbenchUISeedActive else {
             setStatusMessage(L10n.format("ui.debug_session_value_selected", session.title))
@@ -538,8 +551,8 @@ extension SessionStore {
         return true
     }
 
-    // 新建会话在点击瞬间就急切创建空线程并绑定 runtime；不传 runtimeProvider 时由默认模型
-    // 决定（当前是 Codex）。要开 Claude 会话必须在这里显式指定，事后无法把线程迁到另一条通道。
+    // 新建会话先创建本地草稿；runtime 选择随草稿保留，到首条消息发送时才原子执行
+    // thread/start + turn/start，避免空线程闲置后因没有 rollout 而无法恢复。
     func startNewSession(runtimeProvider: String? = nil) async {
         guard let selectedProjectID else {
             setErrorMessage(L10n.text("ui.please_select_the_project_first"))
@@ -629,8 +642,9 @@ extension SessionStore {
             return sent
         }
 
-        let resume = selectedSession
-        let projectID = resume?.projectID ?? selectedProjectID
+        let localDraft = selectedSession?.isLocalDraft == true ? selectedSession : nil
+        let resume = localDraft == nil ? selectedSession : nil
+        let projectID = localDraft?.projectID ?? resume?.projectID ?? selectedProjectID
         guard let projectID else {
             setErrorMessage(L10n.text("ui.please_select_the_project_first"))
             return false
@@ -640,7 +654,8 @@ extension SessionStore {
             payload: payload,
             resume: resume,
             clientMessageID: UUID().uuidString,
-            initialGoalObjective: normalizedObjective
+            initialGoalObjective: normalizedObjective,
+            replacingLocalDraft: localDraft
         )
         if started {
             setStatusMessage(L10n.text("ui.the_target_task_has_been_started"))
@@ -676,6 +691,16 @@ extension SessionStore {
         }
         let payload = runningDelivery == .queued ? await payloadResolvingRequiredModel(payload) : payload
         let prompt = payload.previewText
+
+        if let localDraft = selectedSession, localDraft.isLocalDraft {
+            return await createSession(
+                projectID: localDraft.projectID,
+                payload: payload,
+                resume: nil,
+                clientMessageID: UUID().uuidString,
+                replacingLocalDraft: localDraft
+            )
+        }
 
         let selectedSessionHasQueuedTurns = selectedSession.map {
             queuedRunningTurnsBySessionID[$0.id]?.isEmpty == false

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -955,7 +955,8 @@ final class CodexAppServerProtocolTests: XCTestCase {
             ModelReasoningGridCatalog.visibleEfforts(for: luna, layout: layout),
             [.medium, .high, .xhigh]
         )
-        XCTAssertEqual(sol.defaultReasoningEffort, "low")
+        XCTAssertEqual(sol.defaultReasoningEffort, "xhigh")
+        XCTAssertTrue(sol.isDefault)
         XCTAssertEqual(terra.defaultReasoningEffort, "medium")
         XCTAssertEqual(luna.defaultReasoningEffort, "medium")
         XCTAssertTrue(ModelReasoningGridCatalog.supports(.ultra, option: sol))
@@ -971,6 +972,136 @@ final class CodexAppServerProtocolTests: XCTestCase {
         )
         XCTAssertEqual(ModelReasoningGridCatalog.effortTitle(.max), "Max")
         XCTAssertEqual(ModelReasoningGridCatalog.effortTitle(.ultra), "Ultra")
+    }
+
+    func testPreferredCodexDefaultOverridesServerDefaultWithSolXHigh() throws {
+        let options = [
+            CodexAppServerModelOption(
+                id: "gpt-5.6-terra",
+                title: "GPT-5.6 Terra",
+                runtimeProvider: "codex",
+                isDefault: true,
+                supportedReasoningEfforts: ["medium", "high", "xhigh"]
+            ),
+            CodexAppServerModelOption(
+                id: "gpt-5.6-sol",
+                title: "GPT-5.6 Sol",
+                provider: "openai",
+                runtimeProvider: "codex",
+                supportedReasoningEfforts: ["medium", "high", "xhigh", "ultra"],
+                defaultReasoningEffort: "medium"
+            )
+        ]
+        let option = try XCTUnwrap(
+            ModelReasoningGridCatalog.preferredDefaultOption(
+                runtimeProvider: "codex",
+                options: options
+            )
+        )
+        let layout = ModelReasoningGridCatalog.layout(runtimeProvider: "codex", options: options)
+
+        XCTAssertEqual(option.model, "gpt-5.6-sol")
+        XCTAssertEqual(
+            ModelReasoningGridCatalog.preferredDefaultEffort(
+                runtimeProvider: "codex",
+                option: option,
+                layout: layout
+            ),
+            .xhigh
+        )
+    }
+
+    func testPreferredClaudeDefaultUsesCanonicalOpus5High() throws {
+        let options = [
+            CodexAppServerModelOption(
+                id: "claude-fable-5",
+                title: "Claude Fable 5",
+                runtimeProvider: "claude",
+                isDefault: true,
+                supportedReasoningEfforts: ["medium", "high", "xhigh", "max"]
+            ),
+            CodexAppServerModelOption(
+                id: "claude-opus-5",
+                title: "Claude Opus 5",
+                provider: "anthropic",
+                runtimeProvider: "claude",
+                supportedReasoningEfforts: ["medium", "high", "xhigh", "max"],
+                defaultReasoningEffort: "medium"
+            )
+        ]
+        let option = try XCTUnwrap(
+            ModelReasoningGridCatalog.preferredDefaultOption(
+                runtimeProvider: "claude",
+                options: options
+            )
+        )
+        let layout = ModelReasoningGridCatalog.layout(runtimeProvider: "claude", options: options)
+
+        XCTAssertEqual(option.model, "claude-opus-5")
+        XCTAssertEqual(
+            ModelReasoningGridCatalog.preferredDefaultEffort(
+                runtimeProvider: "claude",
+                option: option,
+                layout: layout
+            ),
+            .high
+        )
+    }
+
+    func testPreferredClaudeFallbackUsesOpusAliasHigh() throws {
+        let option = try XCTUnwrap(
+            ModelReasoningGridCatalog.preferredDefaultOption(
+                runtimeProvider: "claude",
+                options: []
+            )
+        )
+        let layout = ModelReasoningGridCatalog.layout(
+            runtimeProvider: "claude",
+            options: CodexAppServerModelOption.builtInClaudeFallback
+        )
+
+        XCTAssertEqual(option.model, "opus")
+        XCTAssertTrue(option.isDefault)
+        XCTAssertEqual(option.defaultReasoningEffort, "high")
+        XCTAssertEqual(
+            ModelReasoningGridCatalog.preferredDefaultEffort(
+                runtimeProvider: "claude",
+                option: option,
+                layout: layout
+            ),
+            .high
+        )
+    }
+
+    func testPreferredDefaultFallsBackToAvailableCatalogModel() throws {
+        let onlyAvailable = CodexAppServerModelOption(
+            id: "gpt-account-default",
+            title: "Account Default",
+            runtimeProvider: "codex",
+            isDefault: true,
+            supportedReasoningEfforts: ["medium"]
+        )
+        let option = try XCTUnwrap(
+            ModelReasoningGridCatalog.preferredDefaultOption(
+                runtimeProvider: "codex",
+                options: [onlyAvailable]
+            )
+        )
+        let layout = ModelReasoningGridCatalog.layout(
+            runtimeProvider: "codex",
+            options: [onlyAvailable]
+        )
+
+        XCTAssertEqual(option.model, "gpt-account-default")
+        XCTAssertEqual(
+            ModelReasoningGridCatalog.preferredDefaultEffort(
+                runtimeProvider: "codex",
+                option: option,
+                layout: layout
+            ),
+            .medium,
+            "账号没有 Sol 时必须使用目录内可发送组合，不能硬编码未授权模型"
+        )
     }
 
     func testEmptyReasoningMetadataUsesProviderSpecificFallback() {
@@ -1069,7 +1200,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
                 current: .max,
                 layout: layout
             ),
-            .medium
+            .xhigh
         )
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -413,6 +413,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     let workspacePages: [String: SessionsPage]
     let cursorPages: [String: SessionsPage]
     let createSessionResponse: CreateSessionResponse?
+    var createSessionResults: [Result<CreateSessionResponse, Error>]
     let sessionArchiveResults: [String: Result<Void, Error>]
     let sessionForkResults: [String: Result<AgentSession, Error>]
     let threadGoalSetResults: [String: Result<ThreadGoal, Error>]
@@ -510,6 +511,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         workspacePages: [String: SessionsPage] = [:],
         cursorPages: [String: SessionsPage] = [:],
         createSessionResponse: CreateSessionResponse? = nil,
+        createSessionResults: [Result<CreateSessionResponse, Error>] = [],
         sessionArchiveResults: [String: Result<Void, Error>] = [:],
         sessionForkResults: [String: Result<AgentSession, Error>] = [:],
         threadGoalSetResults: [String: Result<ThreadGoal, Error>] = [:],
@@ -557,6 +559,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         self.workspacePages = workspacePages
         self.cursorPages = cursorPages
         self.createSessionResponse = createSessionResponse
+        self.createSessionResults = createSessionResults
         self.sessionArchiveResults = sessionArchiveResults
         self.sessionForkResults = sessionForkResults
         self.threadGoalSetResults = threadGoalSetResults
@@ -986,6 +989,9 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
 
     func createSession(_ payload: CreateSessionRequest) async throws -> CreateSessionResponse {
         createPayloads.append(payload)
+        if !createSessionResults.isEmpty {
+            return try createSessionResults.removeFirst().get()
+        }
         guard let createSessionResponse else {
             throw MockError.unimplemented
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -2353,6 +2353,56 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertTrue(composerState.isGoalModeSelected)
     }
 
+    func testComposerModelSelectionCacheRestoresEachSessionIndependently() throws {
+        let codexScope = ComposerDraftScopeKey.session("thread-codex")
+        let claudeScope = ComposerDraftScopeKey.session("thread-claude")
+        var cache = ComposerModelSelectionCache()
+        var codexOptions = CodexAppServerTurnOptions.default
+        codexOptions.model = "gpt-5.6-sol"
+        codexOptions.modelProvider = "openai"
+        codexOptions.reasoningEffort = .xhigh
+        var claudeOptions = CodexAppServerTurnOptions.default
+        claudeOptions.runtimeProvider = "claude"
+        claudeOptions.model = "claude-opus-5"
+        claudeOptions.modelProvider = "anthropic"
+        claudeOptions.reasoningEffort = .high
+
+        cache.save(ComposerModelSelectionSnapshot(options: codexOptions), for: codexScope)
+        cache.save(ComposerModelSelectionSnapshot(options: claudeOptions), for: claudeScope)
+
+        var recreatedComposer = ComposerState()
+        recreatedComposer.restoreModelSelectionSnapshot(
+            try XCTUnwrap(cache.snapshot(for: claudeScope))
+        )
+        XCTAssertEqual(recreatedComposer.turnOptions.runtimeProvider, "claude")
+        XCTAssertEqual(recreatedComposer.turnOptions.model, "claude-opus-5")
+        XCTAssertEqual(recreatedComposer.turnOptions.reasoningEffort, .high)
+
+        recreatedComposer.restoreModelSelectionSnapshot(
+            try XCTUnwrap(cache.snapshot(for: codexScope))
+        )
+        XCTAssertEqual(recreatedComposer.turnOptions.runtimeProvider, codexOptions.runtimeProvider)
+        XCTAssertEqual(recreatedComposer.turnOptions.model, "gpt-5.6-sol")
+        XCTAssertEqual(recreatedComposer.turnOptions.reasoningEffort, .xhigh)
+    }
+
+    func testComposerModelSelectionCacheKeepsExplicitDefaultWhenDraftIsEmpty() throws {
+        let scope = ComposerDraftScopeKey.session("thread-server-default")
+        var cache = ComposerModelSelectionCache()
+        var options = CodexAppServerTurnOptions.default
+        options.model = nil
+        options.modelProvider = nil
+        options.reasoningEffort = .high
+        options.serviceTier = "priority"
+
+        cache.save(ComposerModelSelectionSnapshot(options: options), for: scope)
+
+        let restored = try XCTUnwrap(cache.snapshot(for: scope))
+        XCTAssertNil(restored.model, "显式选择服务端默认模型时必须保留 nil 语义")
+        XCTAssertEqual(restored.reasoningEffort, .high)
+        XCTAssertEqual(restored.serviceTier, "priority")
+    }
+
     func testComposerDraftCacheKeepsDraftsScopedToSessionOrNewProject() {
         let sessionScope = ComposerDraftScopeKey.current(selectedSessionID: "thread-a", selectedProjectID: "project-1")
         let newProjectScope = ComposerDraftScopeKey.current(selectedSessionID: nil, selectedProjectID: "project-1")
@@ -2479,6 +2529,32 @@ final class ConversationDataFlowTests: XCTestCase {
 
         sessionStore.removeComposerDraft(for: scope)
         XCTAssertEqual(sessionStore.composerDraft(for: scope), .empty)
+    }
+
+    func testSessionStoreRetainsComposerModelSelectionAcrossComposerRecreation() throws {
+        let sessionStore = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore()
+        )
+        let scope = ComposerDraftScopeKey.session("thread-model-recreation")
+        var options = CodexAppServerTurnOptions.default
+        options.runtimeProvider = "claude"
+        options.model = "opus"
+        options.modelProvider = "anthropic"
+        options.reasoningEffort = .high
+        let expected = ComposerModelSelectionSnapshot(options: options)
+
+        sessionStore.saveComposerModelSelection(expected, for: scope)
+
+        var recreatedComposer = ComposerState()
+        recreatedComposer.restoreModelSelectionSnapshot(
+            try XCTUnwrap(sessionStore.composerModelSelection(for: scope))
+        )
+        XCTAssertEqual(recreatedComposer.modelSelectionSnapshot(), expected)
+
+        sessionStore.removeComposerModelSelection(for: scope)
+        XCTAssertNil(sessionStore.composerModelSelection(for: scope))
     }
 
     /// 这些旧回归专注验证第一遍 activity/process 聚合；外层 work-group 语义由

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -1779,7 +1779,7 @@ extension ConversationDataFlowTests {
 
         XCTAssertTrue(accepted)
         let createPayload = try XCTUnwrap(client.createPayloads.first)
-        XCTAssertEqual(createPayload.turnOptions.model, "gpt-5.5")
+        XCTAssertEqual(createPayload.turnOptions.model, "gpt-5.6-sol")
         XCTAssertNil(createPayload.turnOptions.modelProvider)
         XCTAssertEqual(client.modelOptionsCallCount, 1)
     }
@@ -2175,12 +2175,12 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(failedMessage.sendStatus, .failed)
         XCTAssertTrue(payloadContainsInlineImage(failedMessage.turnPayload))
         XCTAssertEqual(failedMessage.turnPayload?.input, payload.input)
-        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-5.5")
+        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-5.6-sol")
 
         let retryTask = Task { await store.retryFailedUserMessage(failedMessage) }
         await client.waitForCreateRequestCount(2)
         XCTAssertEqual(client.createPayloads[1].input, payload.input)
-        XCTAssertEqual(client.createPayloads[1].turnOptions.model, "gpt-5.5")
+        XCTAssertEqual(client.createPayloads[1].turnOptions.model, "gpt-5.6-sol")
         XCTAssertTrue(client.createPayloads[1].input.contains { item in
             if case .image(let url, _) = item {
                 return url == "data:image/png;base64,AA=="
@@ -2349,7 +2349,7 @@ extension ConversationDataFlowTests {
         let sent = try XCTUnwrap(sockets[0].sentTurns.first)
         XCTAssertEqual(sent.clientMessageID, "client-rich-retry")
         XCTAssertEqual(sent.payload.input, payload.input)
-        XCTAssertEqual(sent.payload.options.model, "gpt-5.5")
+        XCTAssertEqual(sent.payload.options.model, "gpt-5.6-sol")
     }
 
     func testRunningSendKeepsInlineImagePayloadAfterAcceptedForPreview() async throws {
@@ -2392,7 +2392,7 @@ extension ConversationDataFlowTests {
         let clientMessageID = try XCTUnwrap(localEcho.clientMessageID)
         XCTAssertTrue(payloadContainsInlineImage(localEcho.turnPayload))
         XCTAssertEqual(localEcho.turnPayload?.input, payload.input)
-        XCTAssertEqual(localEcho.turnPayload?.options.model, "gpt-5.5")
+        XCTAssertEqual(localEcho.turnPayload?.options.model, "gpt-5.6-sol")
 
         sockets[0].onSendAccepted?(clientMessageID)
         let acceptedMessages = try await waitForConversationMessages(in: conversationStore, sessionID: running.id) { messages in

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
@@ -1493,7 +1493,7 @@ extension ConversationDataFlowTests {
 
         let failedMessage = try XCTUnwrap(conversationStore.messages(for: running.id).first { $0.clientMessageID == clientMessageID })
         XCTAssertEqual(failedMessage.turnPayload?.input, payload.input)
-        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-5.5")
+        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-5.6-sol")
         XCTAssertTrue(payloadContainsInlineImage(failedMessage.turnPayload))
         XCTAssertTrue(payloadContainsMention(failedMessage.turnPayload, name: "README"))
         let expectedError = "待发送消息结果不确定，请确认后重试：app-server 错误 -32000：no rollout found"

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -1479,18 +1479,18 @@ extension ConversationDataFlowTests {
         // upsert 只发布一次 sessions，同时必须重建派生索引；否则侧栏会继续显示旧排序。
         await store.startNewSession(in: project)
 
-        XCTAssertEqual(store.selectedSession?.id, created.id)
-        XCTAssertEqual(store.visibleSessions(forProjectID: project.id).map(\.id), [created.id, newer.id, older.id])
-        XCTAssertEqual(store.filteredSessions.map(\.id), [created.id, newer.id, older.id])
+        let draftID = try XCTUnwrap(store.selectedSession?.id)
+        XCTAssertTrue(store.selectedSession?.isLocalDraft == true)
+        XCTAssertEqual(client.createPayloads.count, 0)
+        XCTAssertEqual(store.visibleSessions(forProjectID: project.id).map(\.id), [draftID, newer.id, older.id])
+        XCTAssertEqual(store.filteredSessions.map(\.id), [draftID, newer.id, older.id])
     }
 
     func testStartingEmptyInteractiveSessionDoesNotAutoLoadHistory() async throws {
         let project = makeProject(id: "proj_1")
-        let created = makeSession(id: "sess_created_running", projectID: project.id, title: "刚创建", status: "running", source: "codex")
         let client = MockSessionStoreClient(
             projects: [project],
-            sessions: [created],
-            createSessionResponse: try makeCreateSessionResponse(session: created),
+            sessions: [],
             messagesError: AgentAPIError.server(status: 504, message: "thread/read timeout")
         )
         let conversationStore = ConversationStore()
@@ -1509,21 +1509,26 @@ extension ConversationDataFlowTests {
 
         await store.startNewSession(in: project)
 
-        XCTAssertEqual(client.createPayloads.count, 1)
+        let draftID = try XCTUnwrap(store.selectedSession?.id)
+        XCTAssertTrue(store.selectedSession?.isLocalDraft == true)
+        XCTAssertEqual(client.createPayloads.count, 0)
         XCTAssertTrue(client.requestedMessageSessionIDs.isEmpty)
-        XCTAssertEqual(store.selectedSession?.id, created.id)
         XCTAssertNil(store.selectedHistorySavingsNotice)
         XCTAssertNil(store.errorMessage)
-        XCTAssertEqual(conversationStore.messages(for: created.id).map(\.content), [L10n.text("ui.an_interactive_session_has_been_started")])
-        XCTAssertEqual(sockets.count, 1)
+        XCTAssertTrue(conversationStore.messages(for: draftID).isEmpty)
+        XCTAssertTrue(sockets.isEmpty)
 
-        // 回前台会再次 refreshAll；空 thread 已记录空快照后，不能在首个 turn 前读取不存在的 rollout。
+        // 模拟用户停留一段时间后的列表轮询/回前台：草稿必须保留，但不能产生任何远端请求。
         await store.refreshAll(autoAttach: true)
+        XCTAssertEqual(store.selectedSession?.id, draftID)
+        XCTAssertTrue(store.selectedSession?.isLocalDraft == true)
+        XCTAssertEqual(client.createPayloads.count, 0)
         XCTAssertTrue(client.requestedMessageSessionIDs.isEmpty)
+        XCTAssertTrue(sockets.isEmpty)
         XCTAssertNil(store.selectedHistorySavingsNotice)
     }
 
-    func testStartingEmptyInteractiveSessionPublishesOptimisticSessionBeforeBackendReturns() async throws {
+    func testEmptyLocalDraftSurvivesRefreshAndMigratesOnFirstMessage() async throws {
         let project = makeProject(id: "proj_empty_optimistic")
         let created = makeSession(
             id: "sess_empty_optimistic",
@@ -1532,33 +1537,54 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let client = DelayedCreateSessionClient(projects: [project], sessions: [])
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            projectSessions: [project.id: []],
+            createSessionResponse: try makeCreateSessionResponse(session: created),
+            messagesResult: []
+        )
+        let conversationStore = ConversationStore()
+        var sockets: [MockWebSocketClient] = []
         let store = SessionStore(
             appStore: AppStore(),
-            conversationStore: ConversationStore(),
+            conversationStore: conversationStore,
             logStore: LogStore(),
-            clientFactory: { client }
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
         )
 
-        let createTask = Task { await store.startNewSession(in: project) }
-        await client.waitForCreateRequestCount(1)
+        await store.startNewSession(in: project)
 
-        // 空会话也必须先发布本地占位，让弹窗可以立即关闭并进入会话页；不能等 thread/start 返回。
-        let optimisticSessionID = try XCTUnwrap(store.selectedSessionID)
-        XCTAssertTrue(optimisticSessionID.hasPrefix("local:"))
+        let draftID = try XCTUnwrap(store.selectedSessionID)
+        XCTAssertTrue(draftID.hasPrefix("local:"))
+        XCTAssertTrue(store.selectedSession?.isLocalDraft == true)
         XCTAssertEqual(store.selectedSession?.title, L10n.text("ui.new_session"))
         XCTAssertEqual(store.selectedSession?.source, "local")
+        XCTAssertEqual(client.createPayloads.count, 0)
         XCTAssertEqual(client.modelOptionsCallCount, 0, "空会话没有 turn/start，不应先请求 model/list")
 
-        client.resolveCreate(with: .success(try makeCreateSessionResponse(session: created)))
-        await createTask.value
+        // 模拟至少一次轮询后再首发，覆盖原来 idle thread/resume 报 no-rollout 的真实路径。
+        await store.refreshAll(autoAttach: true)
+        let didSend = await store.sendPrompt("轮询后发送第一条消息")
 
+        XCTAssertTrue(didSend)
+        XCTAssertEqual(client.createPayloads.count, 1)
+        let payload = try XCTUnwrap(client.createPayloads.first)
+        XCTAssertEqual(payload.resumeID, "", "本地草稿首发必须创建新 thread，不能 resume 不存在 rollout 的空 thread")
+        XCTAssertEqual(payload.prompt, "轮询后发送第一条消息")
         XCTAssertEqual(store.selectedSessionID, created.id)
-        XCTAssertFalse(store.sessions.contains { $0.id == optimisticSessionID })
+        XCTAssertFalse(store.sessions.contains { $0.id == draftID })
+        XCTAssertTrue(conversationStore.messages(for: draftID).isEmpty)
+        XCTAssertTrue(conversationStore.messages(for: created.id).contains { $0.content == "轮询后发送第一条消息" })
+        XCTAssertEqual(sockets.count, 1)
     }
 
-    // 回归：新建会话在创建瞬间就绑定 runtime。入口显式选择 Claude 时，createSession 请求必须
-    // 携带 runtimeProvider=claude，否则空线程会落在默认 Codex 通道上且事后无法迁移。
+    // 回归：新建草稿必须保留入口选择的 runtime，直到首条消息真正创建远端会话。
     func testWorkspaceSessionRuntimeChoicesExposeClaudeProviderOnlyWhenAvailable() {
         XCTAssertEqual(
             WorkspaceSessionRuntimeChoice.available(claudeChannelAvailable: false),
@@ -1613,17 +1639,31 @@ extension ConversationDataFlowTests {
 
         await store.startNewSession(in: project, runtimeProvider: "claude")
 
+        XCTAssertEqual(client.createPayloads.count, 0)
+        XCTAssertTrue(store.selectedSession?.isLocalDraft == true)
+        XCTAssertEqual(
+            CodexAppServerSessionRuntime.normalizedRuntimeProvider(store.selectedSession?.runtimeProvider),
+            "claude"
+        )
+
+        let didSendClaudePrompt = await store.sendPrompt("Claude 首条消息")
+        XCTAssertTrue(didSendClaudePrompt)
         XCTAssertEqual(client.createPayloads.count, 1)
         let payload = try XCTUnwrap(client.createPayloads.first)
         XCTAssertEqual(
             CodexAppServerSessionRuntime.normalizedRuntimeProvider(payload.turnOptions.runtimeProvider),
             "claude",
-            "显式 Claude 入口创建的空线程必须路由到 Claude runtime"
+            "显式 Claude 入口必须把草稿保存的 runtime 带到真正的首轮请求"
         )
         XCTAssertEqual(store.selectedSession?.id, created.id)
 
         // 默认入口保持 Codex 主线行为：不显式携带 claude runtimeProvider。
         await store.startNewSession(in: project)
+        XCTAssertTrue(store.selectedSession?.isLocalDraft == true)
+        XCTAssertNil(store.selectedSession?.runtimeProvider)
+        XCTAssertEqual(client.createPayloads.count, 1)
+        let didSendCodexPrompt = await store.sendPrompt("Codex 首条消息")
+        XCTAssertTrue(didSendCodexPrompt)
         XCTAssertEqual(client.createPayloads.count, 2)
         let defaultPayload = try XCTUnwrap(client.createPayloads.last)
         XCTAssertNotEqual(
@@ -1631,6 +1671,73 @@ extension ConversationDataFlowTests {
             "claude",
             "默认新建会话不能被 Claude 修复改变通道"
         )
+    }
+
+    func testLocalDraftFirstSendFailureCanRetryWithoutThreadResume() async throws {
+        let project = makeProject(id: "proj_draft_retry")
+        let created = makeSession(
+            id: "sess_draft_retry",
+            projectID: project.id,
+            title: "重试成功",
+            status: "running",
+            source: "codex"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            createSessionResults: [
+                .failure(AgentAPIError.server(status: 503, message: "temporary unavailable")),
+                .success(try makeCreateSessionResponse(session: created))
+            ],
+            messagesResult: []
+        )
+        let conversationStore = ConversationStore()
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        await store.startNewSession(in: project)
+        let draftID = try XCTUnwrap(store.selectedSessionID)
+
+        let didSendFirstAttempt = await store.sendPrompt("第一次发送")
+        XCTAssertFalse(didSendFirstAttempt)
+        XCTAssertEqual(store.selectedSessionID, draftID)
+        XCTAssertTrue(store.selectedSession?.isLocalDraft == true)
+        XCTAssertNotNil(store.errorMessage)
+        XCTAssertEqual(client.createPayloads.first?.resumeID, "")
+
+        let didSendRetry = await store.sendPrompt("重试发送")
+        XCTAssertTrue(didSendRetry)
+        XCTAssertEqual(client.createPayloads.map(\.resumeID), ["", ""])
+        XCTAssertEqual(store.selectedSessionID, created.id)
+        XCTAssertFalse(store.sessions.contains { $0.id == draftID })
+        XCTAssertTrue(conversationStore.messages(for: draftID).isEmpty)
+        XCTAssertTrue(conversationStore.messages(for: created.id).contains { $0.content == "重试发送" })
+        XCTAssertNil(store.errorMessage)
+    }
+
+    func testReturningToSessionListDiscardsUnsentLocalDraft() async throws {
+        let project = makeProject(id: "proj_draft_discard")
+        let client = MockSessionStoreClient(projects: [project], sessions: [])
+        let conversationStore = ConversationStore()
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        await store.startNewSession(in: project)
+        let draftID = try XCTUnwrap(store.selectedSessionID)
+        store.returnToSessionList()
+
+        XCTAssertNil(store.selectedSessionID)
+        XCTAssertFalse(store.sessions.contains { $0.id == draftID })
+        XCTAssertTrue(conversationStore.messages(for: draftID).isEmpty)
+        XCTAssertTrue(client.createPayloads.isEmpty)
     }
 
     func testSessionStoreUsesIDTieBreakerForMatchingBackendCursorOrder() async {


### PR DESCRIPTION
## 目标

稳定 Codex 与 Claude 的默认模型选择、会话级选择记忆，以及新会话首次发送流程。

## 根因

- 网关 reasoning effort 白名单缺少 max，无法完整转发 Claude Max 能力。
- 客户端直接依赖服务端默认模型，Codex 与 Claude 的推荐默认值不稳定。
- 新会话在用户首次输入前即创建远端 thread，失败重试与空草稿生命周期容易产生多余 resume/history 请求。
- Composer 重建后未可靠恢复每个会话自己的模型选择。

## 方案

- 网关允许 max reasoning effort，实际可选范围仍由运行时模型目录约束。
- Codex 优先 GPT-5.6 Sol / xhigh；Claude 优先 Opus 5 / high，并对可用模型做安全回退。
- 按会话缓存 Composer 模型与 reasoning effort。
- 新会话先创建本地草稿，首条消息再原子创建 thread/turn；失败可重试，返回列表时清理未发送草稿。
- 与 Mac 外部活动会话保护合并：外部只读会话和本地草稿都禁止 thread 管理及 WebSocket 误连接。

## 影响与风险

- 需要更新并重启 agentd，iOS 端需要重新构建或升级。
- 旧运行时不提供目标模型时会回退到目录中可用模型，不硬编码发送不存在的模型。
- 不改变现有远端会话恢复与 Mac 外部会话只读边界。

## 验证

- go test ./internal/httpapi
- iOS 定向测试 10 个：模型默认值与回退 4 个、会话模型缓存 3 个、本地草稿创建/重试/清理 3 个。
- Rebase 后冲突合并验证：Mac 外部会话只读保护与本地草稿保护同时生效。