### PR TITLE
[MIM-5] 收口 Worktree 并修复本地化与测试崩溃

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -31973,6 +31973,366 @@
         }
       }
     },
+    "ui.workspace_character_bull_demon_king" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bull Demon King"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "牛魔王"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_erlang_shen" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlang Shen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "二郎神"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_golden_horn_king" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Golden Horn King"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金角大王"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_guanyin" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guanyin"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "观音菩萨"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_jade_emperor" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jade Emperor"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "玉皇大帝"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_nezha" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nezha"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "哪吒"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_princess_iron_fan" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Princess Iron Fan"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "铁扇公主"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_queen_womens_kingdom" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queen of the Women's Kingdom"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "女儿国国王"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_red_boy" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Red Boy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "红孩儿"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_sha_wujing" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sha Wujing"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沙悟净"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_silver_horn_king" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silver Horn King"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "银角大王"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_spider_demon" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spider Demon"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蜘蛛精"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_sun_wukong" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sun Wukong"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "孙悟空"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_taishang_laojun" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taishang Laojun"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "太上老君"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_tang_sanzang" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tang Sanzang"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唐僧"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_tathagata" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tathagata"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如来佛祖"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_white_bone_demon" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "White Bone Demon"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "白骨精"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_white_dragon_horse" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "White Dragon Horse"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "白龙马"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_yellow_robed_demon" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yellow-Robed Demon"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黄袍怪"
+          }
+        }
+      }
+    },
+    "ui.workspace_character_zhu_bajie" : {
+      "comment" : "Display name for a built-in Journey to the West workspace character.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zhu Bajie"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "猪八戒"
+          }
+        }
+      }
+    },
     "ui.workspace_changes" : {
       "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations" : {

--- a/ios/MimiRemote/Sources/State/WorkspaceAppearanceStore.swift
+++ b/ios/MimiRemote/Sources/State/WorkspaceAppearanceStore.swift
@@ -5,33 +5,38 @@ import Foundation
 struct WorkspaceCharacterIcon: Identifiable, Equatable, Sendable {
     let id: String
     let assetName: String
-    let name: String
+    let nameKey: String
+
+    /// 角色 ID 和资源名需要保持稳定，展示名则跟随 App 当前语言动态解析。
+    var name: String {
+        L10n.text(nameKey)
+    }
 }
 
 /// 工作区角色图标是当前设备的展示偏好，不属于远端项目配置，也不参与会话状态同步。
 @MainActor
 final class WorkspaceAppearanceStore: ObservableObject {
     static let builtInCharacters = [
-        WorkspaceCharacterIcon(id: "sun-wukong", assetName: "WorkspaceCharacterSunWukong", name: "孙悟空"),
-        WorkspaceCharacterIcon(id: "tang-sanzang", assetName: "WorkspaceCharacterTangSanzang", name: "唐僧"),
-        WorkspaceCharacterIcon(id: "zhu-bajie", assetName: "WorkspaceCharacterZhuBajie", name: "猪八戒"),
-        WorkspaceCharacterIcon(id: "sha-wujing", assetName: "WorkspaceCharacterShaWujing", name: "沙悟净"),
-        WorkspaceCharacterIcon(id: "white-dragon-horse", assetName: "WorkspaceCharacterWhiteDragonHorse", name: "白龙马"),
-        WorkspaceCharacterIcon(id: "guanyin", assetName: "WorkspaceCharacterGuanyin", name: "观音菩萨"),
-        WorkspaceCharacterIcon(id: "tathagata", assetName: "WorkspaceCharacterTathagata", name: "如来佛祖"),
-        WorkspaceCharacterIcon(id: "jade-emperor", assetName: "WorkspaceCharacterJadeEmperor", name: "玉皇大帝"),
-        WorkspaceCharacterIcon(id: "taishang-laojun", assetName: "WorkspaceCharacterTaishangLaojun", name: "太上老君"),
-        WorkspaceCharacterIcon(id: "nezha", assetName: "WorkspaceCharacterNezha", name: "哪吒"),
-        WorkspaceCharacterIcon(id: "erlang-shen", assetName: "WorkspaceCharacterErlangShen", name: "二郎神"),
-        WorkspaceCharacterIcon(id: "bull-demon-king", assetName: "WorkspaceCharacterBullDemonKing", name: "牛魔王"),
-        WorkspaceCharacterIcon(id: "princess-iron-fan", assetName: "WorkspaceCharacterPrincessIronFan", name: "铁扇公主"),
-        WorkspaceCharacterIcon(id: "red-boy", assetName: "WorkspaceCharacterRedBoy", name: "红孩儿"),
-        WorkspaceCharacterIcon(id: "white-bone-demon", assetName: "WorkspaceCharacterWhiteBoneDemon", name: "白骨精"),
-        WorkspaceCharacterIcon(id: "spider-demon", assetName: "WorkspaceCharacterSpiderDemon", name: "蜘蛛精"),
-        WorkspaceCharacterIcon(id: "yellow-robed-demon", assetName: "WorkspaceCharacterYellowRobedDemon", name: "黄袍怪"),
-        WorkspaceCharacterIcon(id: "golden-horn-king", assetName: "WorkspaceCharacterGoldenHornKing", name: "金角大王"),
-        WorkspaceCharacterIcon(id: "silver-horn-king", assetName: "WorkspaceCharacterSilverHornKing", name: "银角大王"),
-        WorkspaceCharacterIcon(id: "queen-womens-kingdom", assetName: "WorkspaceCharacterQueenWomensKingdom", name: "女儿国国王")
+        WorkspaceCharacterIcon(id: "sun-wukong", assetName: "WorkspaceCharacterSunWukong", nameKey: "ui.workspace_character_sun_wukong"),
+        WorkspaceCharacterIcon(id: "tang-sanzang", assetName: "WorkspaceCharacterTangSanzang", nameKey: "ui.workspace_character_tang_sanzang"),
+        WorkspaceCharacterIcon(id: "zhu-bajie", assetName: "WorkspaceCharacterZhuBajie", nameKey: "ui.workspace_character_zhu_bajie"),
+        WorkspaceCharacterIcon(id: "sha-wujing", assetName: "WorkspaceCharacterShaWujing", nameKey: "ui.workspace_character_sha_wujing"),
+        WorkspaceCharacterIcon(id: "white-dragon-horse", assetName: "WorkspaceCharacterWhiteDragonHorse", nameKey: "ui.workspace_character_white_dragon_horse"),
+        WorkspaceCharacterIcon(id: "guanyin", assetName: "WorkspaceCharacterGuanyin", nameKey: "ui.workspace_character_guanyin"),
+        WorkspaceCharacterIcon(id: "tathagata", assetName: "WorkspaceCharacterTathagata", nameKey: "ui.workspace_character_tathagata"),
+        WorkspaceCharacterIcon(id: "jade-emperor", assetName: "WorkspaceCharacterJadeEmperor", nameKey: "ui.workspace_character_jade_emperor"),
+        WorkspaceCharacterIcon(id: "taishang-laojun", assetName: "WorkspaceCharacterTaishangLaojun", nameKey: "ui.workspace_character_taishang_laojun"),
+        WorkspaceCharacterIcon(id: "nezha", assetName: "WorkspaceCharacterNezha", nameKey: "ui.workspace_character_nezha"),
+        WorkspaceCharacterIcon(id: "erlang-shen", assetName: "WorkspaceCharacterErlangShen", nameKey: "ui.workspace_character_erlang_shen"),
+        WorkspaceCharacterIcon(id: "bull-demon-king", assetName: "WorkspaceCharacterBullDemonKing", nameKey: "ui.workspace_character_bull_demon_king"),
+        WorkspaceCharacterIcon(id: "princess-iron-fan", assetName: "WorkspaceCharacterPrincessIronFan", nameKey: "ui.workspace_character_princess_iron_fan"),
+        WorkspaceCharacterIcon(id: "red-boy", assetName: "WorkspaceCharacterRedBoy", nameKey: "ui.workspace_character_red_boy"),
+        WorkspaceCharacterIcon(id: "white-bone-demon", assetName: "WorkspaceCharacterWhiteBoneDemon", nameKey: "ui.workspace_character_white_bone_demon"),
+        WorkspaceCharacterIcon(id: "spider-demon", assetName: "WorkspaceCharacterSpiderDemon", nameKey: "ui.workspace_character_spider_demon"),
+        WorkspaceCharacterIcon(id: "yellow-robed-demon", assetName: "WorkspaceCharacterYellowRobedDemon", nameKey: "ui.workspace_character_yellow_robed_demon"),
+        WorkspaceCharacterIcon(id: "golden-horn-king", assetName: "WorkspaceCharacterGoldenHornKing", nameKey: "ui.workspace_character_golden_horn_king"),
+        WorkspaceCharacterIcon(id: "silver-horn-king", assetName: "WorkspaceCharacterSilverHornKing", nameKey: "ui.workspace_character_silver_horn_king"),
+        WorkspaceCharacterIcon(id: "queen-womens-kingdom", assetName: "WorkspaceCharacterQueenWomensKingdom", nameKey: "ui.workspace_character_queen_womens_kingdom")
     ]
 
     private typealias Storage = ProfileScopedStorage<[String: String]>

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -686,8 +686,10 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [first, second])
         )
         let socket = MockWebSocketClient()
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -730,8 +732,10 @@ extension ConversationDataFlowTests {
             projects: [firstProject, secondProject],
             page: SessionsPage(sessions: [first])
         )
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1487,6 +1487,7 @@ extension ConversationDataFlowTests {
         )
         let client = CodexAppServerSessionAPIClient(runtime: runtime)
         let appStore = AppStore()
+        appStore.token = "test-token"
         let conversationStore = ConversationStore()
         let logStore = LogStore()
         let contextStore = SessionContextStore()
@@ -1599,8 +1600,10 @@ extension ConversationDataFlowTests {
         )
         let client = CodexAppServerSessionAPIClient(runtime: runtime)
         let conversationStore = ConversationStore()
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -616,8 +616,11 @@ extension ConversationDataFlowTests {
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
         let conversationStore = ConversationStore()
+        let appStore = AppStore()
+        // 测试必须自行建立认证前置条件，不能依赖其他用例残留在 Keychain 的令牌。
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -632,8 +635,9 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
+        let socket = try XCTUnwrap(sockets.first)
         XCTAssertEqual(sockets.count, 1)
-        sockets[0].emitStatus(.connected)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
 
         client.page = SessionsPage(sessions: [staleHistory])
@@ -646,10 +650,10 @@ extension ConversationDataFlowTests {
 
         XCTAssertTrue(sent)
         XCTAssertEqual(sockets.count, 1)
-        XCTAssertTrue(sockets[0].sentTurns.isEmpty)
+        XCTAssertTrue(socket.sentTurns.isEmpty)
         XCTAssertFalse(conversationStore.messages(for: running.id).contains { $0.content == "已继续这个历史会话。" })
 
-        sockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+        socket.emitEvent(.turnCompleted(AgentEventMetadata(
             seq: 1,
             sessionID: running.id,
             turnID: "turn-long-running",
@@ -659,8 +663,8 @@ extension ConversationDataFlowTests {
             revision: nil,
             createdAt: nil
         )))
-        try await waitForSentTurnCount(1, socket: sockets[0])
-        XCTAssertEqual(sockets[0].sentTurns.first?.payload.textPrompt, "继续当前长任务")
+        try await waitForSentTurnCount(1, socket: socket)
+        XCTAssertEqual(socket.sentTurns.first?.payload.textPrompt, "继续当前长任务")
     }
 
     func testWebSocketReconnectKeepsSubscriptionWhenSnapshotIsNoLongerRunning() async throws {
@@ -1011,8 +1015,10 @@ extension ConversationDataFlowTests {
         let running = makeSession(id: "sess_goal_running", projectID: project.id, title: "运行中", status: "running", source: "codex")
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -1026,14 +1032,15 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
 
         let payload = CodexAppServerTurnPayload(prompt: "修复 iPad 目标入口")
         let accepted = await store.startGoalTurn(payload: payload, objective: "  修复 iPad 目标入口  ")
 
         XCTAssertTrue(accepted)
-        try await waitForSentTurnCount(1, socket: sockets[0])
+        try await waitForSentTurnCount(1, socket: socket)
         XCTAssertEqual(client.requestedThreadGoalSets, [
             RequestedThreadGoalSet(
                 threadID: running.id,
@@ -1042,8 +1049,8 @@ extension ConversationDataFlowTests {
                 tokenBudget: nil
             )
         ])
-        XCTAssertEqual(sockets[0].sentTurns.count, 1)
-        XCTAssertEqual(sockets[0].sentTurns.first?.payload.textPrompt, "修复 iPad 目标入口")
+        XCTAssertEqual(socket.sentTurns.count, 1)
+        XCTAssertEqual(socket.sentTurns.first?.payload.textPrompt, "修复 iPad 目标入口")
     }
 
     func testQueuedGoalRemainsActiveAfterItsTurnCompletes() async throws {
@@ -1058,8 +1065,10 @@ extension ConversationDataFlowTests {
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -1073,7 +1082,8 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
 
         let accepted = await store.startGoalTurn(
@@ -1081,10 +1091,10 @@ extension ConversationDataFlowTests {
             objective: "执行排队目标"
         )
         XCTAssertTrue(accepted)
-        XCTAssertTrue(sockets[0].sentTurns.isEmpty)
+        XCTAssertTrue(socket.sentTurns.isEmpty)
         XCTAssertNil(store.selectedThreadGoal, "排队目标在前一 turn 完成前不能提前改写 thread goal")
 
-        sockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+        socket.emitEvent(.turnCompleted(AgentEventMetadata(
             seq: 1,
             sessionID: running.id,
             turnID: "turn_before_goal",
@@ -1094,13 +1104,13 @@ extension ConversationDataFlowTests {
             revision: nil,
             createdAt: nil
         )))
-        try await waitForSentTurnCount(1, socket: sockets[0])
+        try await waitForSentTurnCount(1, socket: socket)
         try await waitForSelectedThreadGoalStatus(.active, store: store)
         XCTAssertEqual(store.selectedThreadGoal?.status, .active)
-        sockets[0].onSendAccepted?(sockets[0].sentTurns[0].clientMessageID)
+        socket.onSendAccepted?(try XCTUnwrap(socket.sentTurns.first).clientMessageID)
         try await Task.sleep(nanoseconds: 60_000_000)
 
-        sockets[0].emitEvent(.turnStarted(AgentEventMetadata(
+        socket.emitEvent(.turnStarted(AgentEventMetadata(
             seq: 2,
             sessionID: running.id,
             turnID: "turn_goal",
@@ -1111,7 +1121,7 @@ extension ConversationDataFlowTests {
             createdAt: nil
         )))
         try await waitForSelectedActiveTurnID("turn_goal", store: store)
-        sockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+        socket.emitEvent(.turnCompleted(AgentEventMetadata(
             seq: 3,
             sessionID: running.id,
             turnID: "turn_goal",
@@ -1942,8 +1952,10 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [second])
         let conversationStore = ConversationStore()
         let socket = MockWebSocketClient()
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -2006,8 +2018,10 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [history, second])
         let conversationStore = ConversationStore()
         let socket = MockWebSocketClient()
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -2103,8 +2117,10 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [history])
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -515,6 +515,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1
         )
         let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -966,6 +967,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1
         )
         let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1394,8 +1396,10 @@ extension ConversationDataFlowTests {
             )
         ], sessionID: running.id)
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -1412,7 +1416,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(client.requestedMessageSessionIDs, [running.id])
         XCTAssertEqual(client.requestedMessageCursors, [nil])
         XCTAssertEqual(sockets.count, 1)
-        XCTAssertEqual(sockets[0].replayBufferedEventsByConnect, [false])
+        XCTAssertEqual(try XCTUnwrap(sockets.first).replayBufferedEventsByConnect, [false])
         XCTAssertEqual(conversationStore.messages(for: running.id).suffix(refreshedHistory.count).map(\.content), refreshedHistory.map(\.content))
     }
 
@@ -1449,6 +1453,7 @@ extension ConversationDataFlowTests {
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         let appStore = AppStore()
+        appStore.token = "test-token"
         let conversationStore = ConversationStore()
         conversationStore.activate(profileID: appStore.activeHostScope.profileID)
         conversationStore.appendSystem("等待补充信息：\(request.title)", sessionID: running.id, kind: .userInput)
@@ -1471,15 +1476,16 @@ extension ConversationDataFlowTests {
         for _ in 0..<50 where sockets.isEmpty {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
+        let socket = try XCTUnwrap(sockets.first)
         XCTAssertEqual(sockets.count, 1)
-        sockets[0].emitStatus(.connected)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
 
         store.respondToUserInput(request, answers: ["scope": ["后端", "只做最小闭环"]])
 
-        XCTAssertEqual(sockets[0].sentUserInputResponses.count, 1)
-        XCTAssertEqual(sockets[0].sentUserInputResponses.first?.requestID, "input-1")
-        XCTAssertEqual(sockets[0].sentUserInputResponses.first?.answers["scope"], ["后端", "只做最小闭环"])
+        XCTAssertEqual(socket.sentUserInputResponses.count, 1)
+        XCTAssertEqual(socket.sentUserInputResponses.first?.requestID, "input-1")
+        XCTAssertEqual(socket.sentUserInputResponses.first?.answers["scope"], ["后端", "只做最小闭环"])
         XCTAssertTrue(store.isUserInputResponsePending(request))
         XCTAssertEqual(store.selectedSession?.status, "running")
         XCTAssertNil(store.selectedSession?.pendingUserInput)
@@ -1490,7 +1496,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.selectedSession?.status, "running")
         XCTAssertNil(store.selectedSession?.pendingUserInput)
 
-        sockets[0].onUserInputResponseFailure?("input-1", "request expired")
+        socket.onUserInputResponseFailure?("input-1", "request expired")
         try await waitForSelectedSessionStatus("waiting_for_input", store: store)
 
         XCTAssertEqual(store.selectedSession?.pendingUserInput, request)
@@ -1527,8 +1533,10 @@ extension ConversationDataFlowTests {
             CodexHistoryMessage(id: "rollout:1", role: "assistant", content: "已加载", createdAt: Date(timeIntervalSince1970: 1))
         ], sessionID: history.id)
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: [history]) },
@@ -1738,6 +1746,7 @@ extension ConversationDataFlowTests {
             resumeID: "browsed-session"
         )
         let appStore = AppStore()
+        appStore.token = "test-token"
         let recentStore = makeRecentWorkspaceStore(
             workspaces: [],
             endpoint: appStore.endpoint

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -1546,8 +1546,10 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -2119,8 +2121,10 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -2135,7 +2139,8 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
 
         let didSend = await store.sendPrompt("iPad 继续下一步")
@@ -2159,8 +2164,10 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -2175,7 +2182,8 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
         let didSend = await store.sendPrompt("iPad 新输入")
         XCTAssertTrue(didSend)
@@ -2210,8 +2218,10 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -2226,7 +2236,8 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
         let didSend = await store.sendPrompt("iPad 新输入")
         XCTAssertTrue(didSend)
@@ -2263,8 +2274,10 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -2280,7 +2293,8 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
 
         let didSend = await store.sendPrompt("会失败的新输入")
@@ -2300,12 +2314,19 @@ extension ConversationDataFlowTests {
             source: "codex",
             preview: "旧摘要"
         )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [running])
+        )
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        // 显式配置认证，保证该测试可独立运行，不读取前序测试留下的 Keychain 状态。
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
-            clientFactory: { MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: []) },
+            clientFactory: { client },
             webSocketFactory: {
                 let socket = MockWebSocketClient()
                 sockets.append(socket)
@@ -2317,9 +2338,10 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
-        sockets[0].emitEvent(.messageCompleted(
+        socket.emitEvent(.messageCompleted(
             AgentMessage(id: "assistant-final", sessionID: running.id, role: .assistant, content: "助手最终回复摘要", revision: 1),
             AgentEventMetadata(seq: 1, sessionID: running.id, turnID: "turn-1", itemID: "item-1", messageID: "assistant-final", clientMessageID: nil, revision: 1, createdAt: nil)
         ))
@@ -2362,8 +2384,10 @@ extension ConversationDataFlowTests {
         let project = makeProject(id: "proj_takeover")
         let running = makeSession(id: "sess_takeover", projectID: project.id, title: "接管运行中", status: "running", source: "codex")
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: []) },
@@ -2378,12 +2402,13 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
 
         let didSend = await store.sendPrompt("接管后发送")
         XCTAssertTrue(didSend)
-        XCTAssertEqual(sockets[0].sentTurns.map { $0.payload.previewText }, ["接管后发送"])
+        XCTAssertEqual(socket.sentTurns.map { $0.payload.previewText }, ["接管后发送"])
     }
 
     func testHistorySessionContinueMarksTakenOver() async throws {
@@ -2463,8 +2488,10 @@ extension ConversationDataFlowTests {
         )
         var sockets: [MockWebSocketClient] = []
         let conversationStore = ConversationStore()
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -2502,8 +2529,10 @@ extension ConversationDataFlowTests {
             preview: "用户可见摘要"
         )
         var sockets: [MockWebSocketClient] = []
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: []) },
@@ -2518,9 +2547,10 @@ extension ConversationDataFlowTests {
         await store.refreshAll(autoAttach: false)
         store.takeOverSession(running)
         await store.selectSession(running)
-        sockets[0].emitStatus(.connected)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: store)
-        sockets[0].emitEvent(.logDelta(
+        socket.emitEvent(.logDelta(
             LogDelta(text: "tool output should stay in log", stream: "stdout"),
             AgentEventMetadata(seq: 1, sessionID: running.id, turnID: "turn-1", itemID: "cmd-1", messageID: nil, clientMessageID: nil, revision: 1, createdAt: nil)
         ))
@@ -2784,8 +2814,10 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [first, second])
         )
         let socket = MockWebSocketClient()
+        let appStore = AppStore()
+        appStore.token = "test-token"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceAppearanceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceAppearanceStoreTests.swift
@@ -34,6 +34,17 @@ final class WorkspaceAppearanceStoreTests: XCTestCase {
         )
     }
 
+    func testBuiltInCharacterNamesHaveEnglishAndChineseLocalizations() {
+        for character in WorkspaceAppearanceStore.builtInCharacters {
+            let englishName = L10n.text(character.nameKey, language: .english)
+            let chineseName = L10n.text(character.nameKey, language: .simplifiedChinese)
+
+            XCTAssertNotEqual(englishName, character.nameKey, "缺少英文角色名：\(character.id)")
+            XCTAssertNotEqual(chineseName, character.nameKey, "缺少中文角色名：\(character.id)")
+            XCTAssertNotEqual(englishName, chineseName, "中英文角色名不应共用未翻译文案：\(character.id)")
+        }
+    }
+
     func testDefaultCharacterIsStableForProfileAndProject() {
         let first = WorkspaceAppearanceStore(defaults: defaults)
         let value = first.defaultCharacterID(profileID: "mac-a", projectID: "project-1")


### PR DESCRIPTION
## 目标

收口 MIM-5 盘点期间发现的 iOS CI 阻断和 XCTest 崩溃，确保本分支可独立验证并安全进入 main。

## 变更

- 将 20 个工作区角色名称改为稳定本地化 key，补齐英语和简体中文，并增加本地化覆盖测试。
- 修复会话测试对其他用例 Keychain 残留令牌的隐式依赖；需要 WebSocket 的 fixture 现在显式配置认证。
- 将用户崩溃日志涉及的 `sockets[0]` 等关键访问改为 `XCTUnwrap`，避免缺少前置条件时直接终止测试宿主。
- MIM-5 盘点出的独立未完成工作已拆为 MIM-6、MIM-7，已合并内容对应的旧 Worktree 已清理。

## 根因

工作区角色名称仍硬编码中文，触发 iOS localization CI。部分会话测试没有自行配置认证，单测顺序或 Keychain 状态变化时 WebSocket 不会创建，随后数组下标访问触发 `EXC_BREAKPOINT / Index out of range`。

## 验证

- `scripts/test-conversation-regressions.sh`：通过
- `scripts/test-ios-localization-smoke.sh`：通过
- `ConversationDataFlowTests`：548/548 通过
- iOS 全量功能测试：837 通过、39 跳过；另有 5 个既有快照因当前 3x 模拟器与仓库 2x 基准尺寸不同而失败，不在 CI 核心回归选择范围内
- `go test ./... -count=1`：通过
- localization / String Catalog / source size / public repo safety / `git diff --check`：通过
- iPhone 17 Pro 模拟器构建、启动和 UI 语义快照：通过

Linear: MIM-5