### PR TITLE
MIM-10 修复运行中动态发送与停止切换

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		7380C6ED244A91FE8786269B /* QRCodeScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D29856557B35AE9C7C9B5EA /* QRCodeScannerSheet.swift */; };
 		74C33F1F00402E08A331ABBF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 11B71BA07C5D393BC0EA9FD4 /* PrivacyInfo.xcprivacy */; };
 		759158BB4175D405D74CD30A /* ConversationDirectRuntimeHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */; };
+		A10C0DE10000000000000002 /* ConversationTurnInterruptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10C0DE10000000000000001 /* ConversationTurnInterruptTests.swift */; };
 		76DD6A7B8D4D93D4385A615D /* AssistantTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA631A94730FC521FE15F6 /* AssistantTextNormalizer.swift */; };
 		77E8FB23786675B2947013E9 /* ConversationComposerSubmissionAndPendingInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F186EFB2A8BEC6E258B00D /* ConversationComposerSubmissionAndPendingInputTests.swift */; };
 		7813EDBB1DC23A88A94CAF56 /* ConversationRuntimeFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */; };
@@ -278,6 +279,7 @@
 		38004512B302AB5F8AD23644 /* testEmptyConversationState.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testEmptyConversationState.1.png; sourceTree = "<group>"; };
 		3CF761429383D479BD96FC52 /* AgentAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAPIClient.swift; sourceTree = "<group>"; };
 		3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeHistoryTests.swift; sourceTree = "<group>"; };
+		A10C0DE10000000000000001 /* ConversationTurnInterruptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTurnInterruptTests.swift; sourceTree = "<group>"; };
 		3DA20088DF3CC377CBB6D7B4 /* HostConnectionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConnectionSupport.swift; sourceTree = "<group>"; };
 		3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreSupport.swift; sourceTree = "<group>"; };
 		40A98707004C8DC4ED81CBCD /* ComposerVoiceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceSupport.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 				078AEE7E4BDAC1751244A05A /* ConversationDataFlowTestSupport.swift */,
 				3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */,
 				025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */,
+				A10C0DE10000000000000001 /* ConversationTurnInterruptTests.swift */,
 				FBF29C4EA9F4D0ECC4709B97 /* ConversationProcessGrouperTests.swift */,
 				033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */,
 				D9A1F29F52DC5CC790708ACC /* ConversationRuntimeTestSupport.swift */,
@@ -1103,6 +1106,7 @@
 				10BF43237408412ED651F5B4 /* ConversationDataFlowTests.swift in Sources */,
 				759158BB4175D405D74CD30A /* ConversationDirectRuntimeHistoryTests.swift in Sources */,
 				E790247242197F065BB1F1DE /* ConversationDirectRuntimeTests.swift in Sources */,
+				A10C0DE10000000000000002 /* ConversationTurnInterruptTests.swift in Sources */,
 				388033847B02B31529D2BFCA /* ConversationProcessGrouperTests.swift in Sources */,
 				7813EDBB1DC23A88A94CAF56 /* ConversationRuntimeFlowTests.swift in Sources */,
 				2B372F78E1EC09D8E4B7210F /* ConversationRuntimeTestSupport.swift in Sources */,

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
@@ -674,8 +674,8 @@ final class MultiRuntimeSessionWebSocketClient: SessionWebSocketClient {
     }
 
     @discardableResult
-    func sendCtrlC() -> Bool {
-        activeClient?.sendCtrlC() ?? false
+    func sendCtrlC(expectedTurnID: TurnID) -> Bool {
+        activeClient?.sendCtrlC(expectedTurnID: expectedTurnID) ?? false
     }
 
     @discardableResult
@@ -955,7 +955,7 @@ final class CodexAppServerSessionWebSocketClient: SessionWebSocketClient {
     }
 
     @discardableResult
-    func sendCtrlC() -> Bool {
+    func sendCtrlC(expectedTurnID: TurnID) -> Bool {
         guard let sessionID else {
             onControlFailure?(L10n.text("ui.direct_websocket_not_connected"))
             return false
@@ -963,7 +963,10 @@ final class CodexAppServerSessionWebSocketClient: SessionWebSocketClient {
         let failureHandler = onControlFailure
         Task { [runtime] in
             do {
-                try await runtime.interruptActiveTurn(sessionID: sessionID)
+                try await runtime.interruptActiveTurn(
+                    sessionID: sessionID,
+                    expectedTurnID: expectedTurnID
+                )
             } catch {
                 await MainActor.run {
                     failureHandler?(error.localizedDescription)

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1911,8 +1911,26 @@ actor CodexAppServerSessionRuntime {
         }
     }
 
-    func interruptActiveTurn(sessionID: SessionID) async throws {
-        guard let turnID = contextsBySessionID[sessionID]?.activeTurnID else {
+    func interruptActiveTurn(
+        sessionID: SessionID,
+        expectedTurnID: TurnID? = nil
+    ) async throws {
+        let cachedTurnID = contextsBySessionID[sessionID]?.activeTurnID
+        if let expectedTurnID,
+           let cachedTurnID,
+           cachedTurnID != expectedTurnID,
+           let session = contextsBySessionID[sessionID]?.session {
+            // Store 与 runtime 已观察到不同的 active turn 时，宁可拒绝旧控制命令，
+            // 也不能误停用户刚开始的新一轮。
+            throw CodexAppServerSessionRuntimeError.activeTurnConflict(
+                session: session,
+                activeTurnID: cachedTurnID
+            )
+        }
+        // SessionStore 是当前 Composer 的交互事实来源。列表/历史刷新可能先把 runtime
+        // 的局部缓存清空，但 Store 仍握有用户实际看到的 turn ID；把它作为安全回退，
+        // 避免控制命令尚未发出就误报 missingActiveTurn。
+        guard let turnID = cachedTurnID ?? expectedTurnID else {
             throw CodexAppServerSessionRuntimeError.missingActiveTurn(sessionID)
         }
         let spec = CodexAppServerRequestBuilder(allowlistedProjects: try await projects()).turnInterrupt(threadID: sessionID, turnID: turnID)

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
@@ -23,7 +23,7 @@ protocol SessionWebSocketClient: AnyObject {
     func sendInput(_ text: String, clientMessageID: ClientMessageID?) -> Bool
     func sendTurn(_ payload: CodexAppServerTurnPayload, clientMessageID: ClientMessageID?) -> Bool
     func sendGuidance(_ payload: CodexAppServerTurnPayload, clientMessageID: ClientMessageID?, expectedTurnID: TurnID) -> Bool
-    func sendCtrlC() -> Bool
+    func sendCtrlC(expectedTurnID: TurnID) -> Bool
     func sendApprovalDecision(approvalID: String, decision: String, message: String?) -> Bool
     func sendUserInputResponse(requestID: String, answers: [String: [String]]) -> Bool
     func acknowledgeAppliedEvent(_ event: AgentEvent)

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -542,13 +542,16 @@ extension ComposerView {
 
     @ViewBuilder
     func sendButton(showLabels: Bool) -> some View {
-        if showsTurnStopButton {
-            stopCurrentReplyButton
-                .transition(.scale(scale: 0.88).combined(with: .opacity))
-        } else {
-            submitDraftButton(showLabels: showLabels)
-                .transition(.scale(scale: 0.88).combined(with: .opacity))
+        Group {
+            if primaryComposerAction == .stopCurrentReply {
+                stopCurrentReplyButton
+                    .transition(.scale(scale: 0.88).combined(with: .opacity))
+            } else {
+                submitDraftButton(showLabels: showLabels)
+                    .transition(.scale(scale: 0.88).combined(with: .opacity))
+            }
         }
+        .animation(composerMotionAnimation, value: primaryComposerAction)
     }
 
     func submitDraftButton(showLabels: Bool) -> some View {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -4,10 +4,10 @@ enum ComposerPrimaryAction: Equatable {
     case submit
     case stopCurrentReply
 
-    static func resolve(hasDraftContent: Bool, canStopCurrentReply: Bool) -> ComposerPrimaryAction {
-        // 运行中只有空草稿才把主操作让给“停止”。一旦用户已经准备好下一条消息，
-        // 发送/排队必须优先可达，提交清空草稿后按钮会自然恢复为停止。
-        canStopCurrentReply && !hasDraftContent ? .stopCurrentReply : .submit
+    static func resolve(canSubmitDraft: Bool, canStopCurrentReply: Bool) -> ComposerPrimaryAction {
+        // 运行中只有草稿此刻确实可提交时，发送/排队才抢占主按钮。
+        // 上传、加载或额度限制暂时阻塞提交时保留“停止”，同时不丢弃用户草稿。
+        canStopCurrentReply && !canSubmitDraft ? .stopCurrentReply : .submit
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+enum ComposerPrimaryAction: Equatable {
+    case submit
+    case stopCurrentReply
+
+    static func resolve(hasDraftContent: Bool, canStopCurrentReply: Bool) -> ComposerPrimaryAction {
+        // 运行中只有空草稿才把主操作让给“停止”。一旦用户已经准备好下一条消息，
+        // 发送/排队必须优先可达，提交清空草稿后按钮会自然恢复为停止。
+        canStopCurrentReply && !hasDraftContent ? .stopCurrentReply : .submit
+    }
+}
+
 struct SubmittedComposerDraft {
     let text: String
     let attachments: [CodexAppServerUserInput]

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -841,7 +841,7 @@ struct ComposerView: View {
 
     var primaryComposerAction: ComposerPrimaryAction {
         ComposerPrimaryAction.resolve(
-            hasDraftContent: hasComposerContentForSubmit,
+            canSubmitDraft: canSubmitDraft,
             canStopCurrentReply: showsTurnStopButton
         )
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -839,6 +839,13 @@ struct ComposerView: View {
             sessionStore.canControlSession(session)
     }
 
+    var primaryComposerAction: ComposerPrimaryAction {
+        ComposerPrimaryAction.resolve(
+            hasDraftContent: hasComposerContentForSubmit,
+            canStopCurrentReply: showsTurnStopButton
+        )
+    }
+
     var canInterruptSelectedSession: Bool {
         guard showsTurnStopButton else {
             return false

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -1433,14 +1433,14 @@ extension SessionStore {
         guard let session = selectedSession, session.isRunning, canControlSession(session) else {
             return
         }
-        guard session.activeTurnID != nil else {
+        guard let activeTurnID = session.activeTurnID else {
             setStatusMessage(L10n.text("ui.there_are_currently_no_active_rounds_to_interrupt"))
             return
         }
         guard let socket = readyWebSocket(for: session) else {
             return
         }
-        if !socket.sendCtrlC() {
+        if !socket.sendCtrlC(expectedTurnID: activeTurnID) {
             setErrorMessage(L10n.text("ui.failed_to_stop_current_reply_websocket_not_connected"))
             return
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -68,6 +68,33 @@ extension ConversationDataFlowTests {
         )
     }
 
+    func testComposerPrimaryActionKeepsRunningTurnSubmissionReachable() {
+        XCTAssertEqual(
+            ComposerPrimaryAction.resolve(
+                hasDraftContent: false,
+                canStopCurrentReply: true
+            ),
+            .stopCurrentReply,
+            "运行中且没有可提交草稿时，主操作应是停止当前回复"
+        )
+        XCTAssertEqual(
+            ComposerPrimaryAction.resolve(
+                hasDraftContent: true,
+                canStopCurrentReply: true
+            ),
+            .submit,
+            "用户输入下一条消息后，发送/排队必须重新成为主操作"
+        )
+        XCTAssertEqual(
+            ComposerPrimaryAction.resolve(
+                hasDraftContent: false,
+                canStopCurrentReply: false
+            ),
+            .submit,
+            "非运行状态仍保留普通发送按钮，并由按钮自身表达禁用状态"
+        )
+    }
+
     func testComposerStateCanSubmitWithStandardModeSanitizedOptions() throws {
         var composerState = ComposerState()
         composerState.draft = "用标准模式提交"

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -68,26 +68,26 @@ extension ConversationDataFlowTests {
         )
     }
 
-    func testComposerPrimaryActionKeepsRunningTurnSubmissionReachable() {
+    func testComposerPrimaryActionKeepsRunningTurnSubmissionAndStopReachable() {
         XCTAssertEqual(
             ComposerPrimaryAction.resolve(
-                hasDraftContent: false,
+                canSubmitDraft: false,
                 canStopCurrentReply: true
             ),
             .stopCurrentReply,
-            "运行中且没有可提交草稿时，主操作应是停止当前回复"
+            "运行中且草稿为空或暂时不可提交时，停止当前回复必须保持可达"
         )
         XCTAssertEqual(
             ComposerPrimaryAction.resolve(
-                hasDraftContent: true,
+                canSubmitDraft: true,
                 canStopCurrentReply: true
             ),
             .submit,
-            "用户输入下一条消息后，发送/排队必须重新成为主操作"
+            "用户准备好可提交的下一条消息后，发送/排队必须重新成为主操作"
         )
         XCTAssertEqual(
             ComposerPrimaryAction.resolve(
-                hasDraftContent: false,
+                canSubmitDraft: false,
                 canStopCurrentReply: false
             ),
             .submit,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -79,6 +79,7 @@ final class MockWebSocketClient: SessionWebSocketClient {
     private(set) var sentTurns: [(payload: CodexAppServerTurnPayload, clientMessageID: ClientMessageID?)] = []
     private(set) var sentGuidance: [(payload: CodexAppServerTurnPayload, clientMessageID: ClientMessageID?, expectedTurnID: TurnID)] = []
     private(set) var sentCtrlCCount = 0
+    private(set) var sentCtrlCTurnIDs: [TurnID] = []
     private(set) var sentApprovals: [(approvalID: String, decision: String, message: String?)] = []
     private(set) var sentUserInputResponses: [(requestID: String, answers: [String: [String]])] = []
     private(set) var disconnectCallCount = 0
@@ -123,8 +124,9 @@ final class MockWebSocketClient: SessionWebSocketClient {
         return sendGuidanceResult
     }
 
-    func sendCtrlC() -> Bool {
+    func sendCtrlC(expectedTurnID: TurnID) -> Bool {
         sentCtrlCCount += 1
+        sentCtrlCTurnIDs.append(expectedTurnID)
         return sendCtrlCResult
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -357,56 +357,6 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(requests.filter { $0.method == "thread/turns/list" }.count, 2)
     }
 
-    func testTurnInterruptUsesExpectedTurnWhenRuntimeCacheIsMissing() async throws {
-        let project = AgentProject(
-            id: "proj_interrupt_expected_turn",
-            name: "Interrupt Expected Turn",
-            path: "/tmp/interrupt-expected-turn"
-        )
-        let transport = FakeCodexAppServerTransport()
-        let runtime = CodexAppServerSessionRuntime(
-            endpoint: "http://127.0.0.1:8787",
-            token: "outer-token",
-            transportFactory: { transport },
-            turnInterruptRecoveryDelaysNanoseconds: [],
-            configProvider: {
-                makeDirectAppServerConfig(
-                    project: project,
-                    allowedMethods: ["initialize", "initialized", "turn/interrupt"]
-                )
-            }
-        )
-
-        let interruptTask = Task {
-            try await runtime.interruptActiveTurn(
-                sessionID: "thr_interrupt_expected_turn",
-                expectedTurnID: "turn_from_composer"
-            )
-        }
-        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
-        transportResponse(
-            transport,
-            id: initialize.id,
-            result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#
-        )
-        let interruptRequest = try await waitForFakeAppServerRequest(
-            transport,
-            method: "turn/interrupt",
-            after: 1
-        )
-        XCTAssertEqual(
-            interruptRequest.params?.objectValue?["threadId"]?.stringValue,
-            "thr_interrupt_expected_turn"
-        )
-        XCTAssertEqual(
-            interruptRequest.params?.objectValue?["turnId"]?.stringValue,
-            "turn_from_composer"
-        )
-        transportResponse(transport, id: interruptRequest.id, result: #"{}"#)
-
-        try await interruptTask.value
-    }
-
     func testTargetedInterruptRecoveryWorksWithoutCachedActiveTurnAndProtectsNewerTurn() async {
         let runtime = CodexAppServerSessionRuntime(
             endpoint: "http://127.0.0.1:8787",

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -357,6 +357,56 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(requests.filter { $0.method == "thread/turns/list" }.count, 2)
     }
 
+    func testTurnInterruptUsesExpectedTurnWhenRuntimeCacheIsMissing() async throws {
+        let project = AgentProject(
+            id: "proj_interrupt_expected_turn",
+            name: "Interrupt Expected Turn",
+            path: "/tmp/interrupt-expected-turn"
+        )
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            turnInterruptRecoveryDelaysNanoseconds: [],
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "turn/interrupt"]
+                )
+            }
+        )
+
+        let interruptTask = Task {
+            try await runtime.interruptActiveTurn(
+                sessionID: "thr_interrupt_expected_turn",
+                expectedTurnID: "turn_from_composer"
+            )
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#
+        )
+        let interruptRequest = try await waitForFakeAppServerRequest(
+            transport,
+            method: "turn/interrupt",
+            after: 1
+        )
+        XCTAssertEqual(
+            interruptRequest.params?.objectValue?["threadId"]?.stringValue,
+            "thr_interrupt_expected_turn"
+        )
+        XCTAssertEqual(
+            interruptRequest.params?.objectValue?["turnId"]?.stringValue,
+            "turn_from_composer"
+        )
+        transportResponse(transport, id: interruptRequest.id, result: #"{}"#)
+
+        try await interruptTask.value
+    }
+
     func testTargetedInterruptRecoveryWorksWithoutCachedActiveTurnAndProtectsNewerTurn() async {
         let runtime = CodexAppServerSessionRuntime(
             endpoint: "http://127.0.0.1:8787",

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnInterruptTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnInterruptTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testTurnInterruptUsesExpectedTurnWhenRuntimeCacheIsMissing() async throws {
+        let project = AgentProject(
+            id: "proj_interrupt_expected_turn",
+            name: "Interrupt Expected Turn",
+            path: "/tmp/interrupt-expected-turn"
+        )
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            turnInterruptRecoveryDelaysNanoseconds: [],
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "turn/interrupt"]
+                )
+            }
+        )
+
+        let interruptTask = Task {
+            try await runtime.interruptActiveTurn(
+                sessionID: "thr_interrupt_expected_turn",
+                expectedTurnID: "turn_from_composer"
+            )
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#
+        )
+        let interruptRequest = try await waitForFakeAppServerRequest(
+            transport,
+            method: "turn/interrupt",
+            after: 1
+        )
+        XCTAssertEqual(
+            interruptRequest.params?.objectValue?["threadId"]?.stringValue,
+            "thr_interrupt_expected_turn"
+        )
+        XCTAssertEqual(
+            interruptRequest.params?.objectValue?["turnId"]?.stringValue,
+            "turn_from_composer"
+        )
+        transportResponse(transport, id: interruptRequest.id, result: #"{}"#)
+
+        try await interruptTask.value
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
@@ -915,6 +915,7 @@ extension ConversationDataFlowTests {
         store.interruptSelectedTurn()
 
         XCTAssertEqual(sockets[0].sentCtrlCCount, 1)
+        XCTAssertEqual(sockets[0].sentCtrlCTurnIDs, ["turn_ctrl_c"])
         XCTAssertEqual(store.statusMessage, L10n.text("ui.stopping_current_reply"))
         XCTAssertNil(store.errorMessage)
 


### PR DESCRIPTION
## 变更内容

- 会话正在回复且输入框为空时，主按钮显示停止。
- 正在回复时输入文字或添加附件，主按钮动态切换为发送，支持继续引导或排队。
- 草稿发送或清空后，仍在回复则恢复停止按钮。
- 中断请求携带 Store 已知的 active turn ID，修复运行中偶发“没有可中断的 active turn”误报。
- 增加按钮状态、队列顺序、历史状态保护和中断回退测试。

## 根因

原实现只根据“当前是否正在回复”决定主按钮，导致运行期间发送入口被停止按钮完全占用。同时中断逻辑仅依赖 Runtime 的瞬时 active turn 缓存；Store 明明持有有效 turn ID 时，缓存缺失仍会误判为无法中断。

## 验证

- 基于最新 `main` 迁移，无 rebase 冲突。
- MIM-10 定向测试：5 passed / 0 failed。
- 最新 `main` + MIM-10 模拟器 Debug 主程序编译成功，0 warning / 0 error。
- 测试目标 build-for-testing 编译成功。
- 实体 iPad mini 覆盖安装与启动成功。

## 范围

- 仅包含 MIM-10。
- 不包含 MIM-7 语音准备态修改。
- 不修改 `main` 的角色素材、本地化或 Mac Catalyst 连接功能。
