### PR TITLE
MIM-19 统一 iOS 编译设备与执行入口

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "ios/MimiRemote/**"
+      - "scripts/ios-dev.sh"
       - "scripts/test-conversation-regressions.sh"
       - "scripts/test-ios-localization-smoke.sh"
       - "scripts/check-ios-localization.sh"
@@ -16,11 +17,13 @@ on:
       - "docs/support.md"
       - "docs/terms-of-use.md"
       - ".github/workflows/ios-ci.yml"
+      - ".xcodebuildmcp/config.yaml"
   push:
     branches:
       - main
     paths:
       - "ios/MimiRemote/**"
+      - "scripts/ios-dev.sh"
       - "scripts/test-conversation-regressions.sh"
       - "scripts/test-ios-localization-smoke.sh"
       - "scripts/check-ios-localization.sh"
@@ -33,6 +36,7 @@ on:
       - "docs/support.md"
       - "docs/terms-of-use.md"
       - ".github/workflows/ios-ci.yml"
+      - ".xcodebuildmcp/config.yaml"
   workflow_dispatch:
     inputs:
       publish_app_store:
@@ -73,6 +77,29 @@ jobs:
           go version
           xcodebuild -version
           xcrun simctl list devices available
+
+      - name: Resolve one CI simulator
+        shell: bash
+        run: |
+          simulator_id="$(
+            xcrun simctl list devices available -j | ruby -rjson -e '
+              entries = JSON.parse(STDIN.read).fetch("devices").flat_map do |runtime, devices|
+                version = runtime.scan(/\d+/).map(&:to_i)
+                devices.map do |device|
+                  next unless device["isAvailable"] && device["name"].match?(/iPad|iPhone/)
+                  family_rank = device["name"].start_with?("iPad") ? 1 : 0
+                  [version, family_rank, device["name"], device["udid"]]
+                end.compact
+              end
+              chosen = entries.max_by { |version, family_rank, name, _udid| [version, family_rank, name] }
+              print chosen.last if chosen
+            '
+          )"
+          if [[ -z "$simulator_id" ]]; then
+            echo "No available iOS Simulator on the runner." >&2
+            exit 1
+          fi
+          echo "IOS_TEST_DESTINATION=platform=iOS Simulator,id=$simulator_id" >> "$GITHUB_ENV"
 
       - name: Check network security policy
         run: bash ./scripts/check-ios-network-security.sh

--- a/.xcodebuildmcp/config.yaml
+++ b/.xcodebuildmcp/config.yaml
@@ -1,0 +1,9 @@
+schemaVersion: 1
+sessionDefaults:
+  projectPath: ./ios/MimiRemote/MimiRemote.xcodeproj
+  scheme: MimiRemote
+  configuration: Debug
+  simulatorName: iPad Pro 13-inch (M5)
+  useLatestOS: true
+  derivedDataPath: ./ios/MimiRemote/build/dev-simulator-derived
+  bundleId: com.gaixianggeng.mimi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# 项目协作约定
+
+## Linear 问题归档与执行
+
+### 目标
+
+- Linear 是本项目的问题账本和状态看板，Codex 是主要的问题输入与执行入口。
+- Linear 工作区使用 `Gai Studio`，团队使用 `Mimi`，Issue 前缀为 `MIM`。
+- 用户不需要先打开 Linear；在 Codex 中报告 case、Bug、UI 问题、逻辑问题或发送问题截图即可。
+- 一个可独立验收、独立合并的用户结果对应一张 Issue；不要按文件、代码修改点或聊天轮次拆分 Issue。
+
+### 自动归档触发条件
+
+- 当用户针对本仓库发送问题截图、复现步骤，或明确描述一个可操作的 case、Bug、UI 问题、逻辑问题、改进点时，视为已授权使用 Linear MCP 在 `Mimi` 团队查重并创建或更新 Issue。
+- 如果用户只是在询问概念、讨论方案、要求解释代码，或描述一个明显的假设例子，不自动创建 Issue。
+- 如果用户明确说“进入问题收集模式”或说明还会连续发送多个问题，在用户说“收集结束”前只按 `B1`、`B2`、`B3` 编号确认，不创建 Issue、不修改代码、不创建分支；收到“收集结束”后再统一查重、合并或拆分并归档。
+- 如果当前已经有关联的 Linear Issue，新问题属于同一用户结果、同一根因或同一验收范围，优先更新原 Issue，不重复创建。
+
+### 归档流程
+
+1. 优先使用 Linear MCP 查询和写入，不通过浏览器手工操作，除非 MCP 缺少所需能力。
+2. 创建前搜索标题、描述和相关关键词，检查是否存在重复或高度相关的未完成 Issue。
+3. 有明确重复项时，更新原 Issue 的证据、复现信息或验收标准，并返回原 Issue ID 和链接。
+4. 没有重复项时创建新 Issue，默认指派给当前用户。
+5. 新 Issue 默认状态：
+   - 问题明确、具备复现信息、可以执行：`Todo`
+   - 只是想法、证据不足、暂不确定是否处理：`Backlog`
+   - 用户在同一条消息中明确要求立即修复或开始处理：`In Progress`
+6. 根据内容自动选择标签：
+   - 缺陷：`Bug`
+   - 新能力：`Feature`
+   - 体验或实现优化：`Improvement`
+   - 按影响范围补充 `UI`、`iOS`、`Mac/agentd`、`Release`
+7. 除非用户明确给出优先级、截止时间、Project 或 Cycle，不自行设置这些字段，也不为了完整性引入额外项目结构。
+8. 禁止静默创建或更新 Linear Issue。每次发生 Linear 写入后，都必须在当前 Codex 回复中明确告知用户。
+9. 完成归档后按实际结果返回：
+   - 新建成功：`已创建`、Issue ID、标题、状态、标签、链接，以及“仅归档”或“已开始处理”的结论。
+   - 命中已有问题：`未重复创建，已更新`、原 Issue ID、更新内容摘要和链接。
+   - 创建或更新失败：明确说明`未写入 Linear`、失败原因和建议的下一步；不得假装已经成功。
+   - 一次创建或更新多张 Issue：使用简短列表或表格逐项返回结果，不能只给总数。
+
+### Issue 内容要求
+
+- 标题描述用户可感知的结果或问题，不使用“修改某文件”“调整某函数”这类实现动作作为标题。
+- 描述至少包含：
+  - `目标`
+  - `现状与证据`
+  - `复现步骤`（可复现时）
+  - `实际结果`
+  - `期望结果`
+  - `验收标准`
+  - `实现边界`
+- 从截图中提取界面、状态和错误信息作为证据；如果当前工具不能把截图直接上传到 Linear，就在描述中准确记录可见证据，不虚构附件。
+- 截图、日志或描述中包含访问码、Token、账号、用户数据或其他敏感信息时，先脱敏再写入 Linear。
+- 信息不足时仍可先创建 Backlog Issue，但必须标记未知项，不猜测根因、优先级或复现条件。
+
+### 是否立即处理
+
+- 默认行为是“先归档，不修改代码”。仅报告 case、发送截图或描述问题，不等于授权立即实现。
+- 只有用户明确表达“处理”“修复”“开始做”“直接改”“现在解决”等执行意图时，才开始修改代码。
+- 用户在报告问题的同一条消息中已经明确要求处理时，先查重并创建或关联 Issue，设为 `In Progress`，随后直接继续实现，不停下来等待二次确认。
+- 问题大小用于决定组织方式和给出处理建议，不单独构成开始修改代码的授权：
+  - 当前 Issue 内的小修正：更新原 Issue 并在当前 Codex 任务中继续，不新建 Issue 或任务。
+  - 可独立验收、需要独立分支或 PR：创建独立 Issue。
+  - 范围较大、包含多个独立结果：先创建一个父 Issue 或提出拆分建议；创建多个子 Issue 前先让用户确认拆分方案。
+- 默认同时最多保持 2 张独立 Issue 为 `In Progress`。准备开始第三张时，先指出当前进行中的任务并让用户决定暂停或继续。
+
+### 开发、PR 与完成状态
+
+- 一张正在执行的 Issue 对应一个主要 Codex 任务和一个主要 Worktree；不要为同一 Issue 的分析、实现、测试和修正反复开启新任务。
+- 分支名称使用 `codex/mim-<编号>-<简短英文描述>`，例如 `codex/mim-12-fix-access-code-resume`。
+- PR 标题或分支名称必须包含 `MIM-<编号>`，确保 GitHub 与 Linear 自动关联。
+- 开始实现时状态为 `In Progress`；PR 创建、等待测试或等待合并时使用 `Verify`；PR 合并到受保护的 `main` 后才进入 `Done`。
+- 完成前在 Issue 中回写 Branch / Worktree、Commit / PR、测试结果、运行态验证和发布结果。
+- `Done` 的最低条件是：相关改动已进入并推送 `main`、必要验证或发布已完成、临时 Worktree 已清理。
+
+## iOS 日常构建与模拟器标准
+
+### 默认链路
+
+- 日常开发、编译、单测和 UI 调试固定使用 `iPad Pro 13-inch (M5)` Simulator、`MimiRemote` Scheme 和 `Debug` 配置。
+- 命令行统一通过 `bash ./scripts/ios-dev.sh` 执行：
+  - 编译：`bash ./scripts/ios-dev.sh build`
+  - 编译测试产物：`bash ./scripts/ios-dev.sh build-for-testing`
+  - 运行单测：`bash ./scripts/ios-dev.sh test`
+  - 构建、安装并启动：`bash ./scripts/ios-dev.sh run`
+- 默认 DerivedData 固定为 `ios/MimiRemote/build/dev-simulator-derived`，避免不同入口重复创建缓存。
+- 目标 Simulator 不存在或不可用时必须明确失败，不得静默回退到任意已启动设备、列表第一台设备或实体机。
+
+### XcodeBuildMCP
+
+- 第一次构建、运行或测试前先读取 session defaults；仓库的 `.xcodebuildmcp/config.yaml` 已固定 project、scheme、configuration、simulator name 和 DerivedData。
+- 日常任务只使用 Simulator workflow，不调用实体机构建、安装或启动工具。
+- 不把本机 Simulator UDID 写入仓库；通过固定设备名和最新可用 OS 解析本机 UDID。
+
+### 设备用途
+
+- `iPad Pro 13-inch (M5)` 是唯一日常默认目标。
+- `iPhone 17 Pro` 只用于明确的 iPhone 布局验收，`iPhone 17e` 只用于小屏兼容验收。切换时显式设置 `IOS_SIMULATOR_NAME`，完成后恢复默认 iPad。
+- 实体机只用于相机、通知、Keychain、Tailscale/弱网、性能以及发布前验证；使用 Xcode 或 `bash ./scripts/deploy-ipad.sh` 显式执行，不参与普通代码编译。
+- Simulator 通过不代表真机专项验收完成，真机结果也不替代日常 Simulator 回归。
+
+### 运行约束
+
+- Xcode、Codex、XcodeBuildMCP 的构建与测试串行执行，同一时间只运行一条 `xcodebuild` 链路。
+- 日常只保留一台已启动 Simulator；统一脚本在切换前关闭其他已启动 Simulator，但不会创建、擦除或删除设备。
+- 创建新设备前先检查现有设备并优先复用；不得为每次任务创建临时 Simulator。
+- 测试结束后关闭不再使用的设备。遇到 CoreSimulator 阻塞时，先停止构建并重启现有 Simulator 服务，不通过继续创建设备绕过。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,26 +78,31 @@
 
 ### 默认链路
 
-- 日常开发、编译、单测和 UI 调试固定使用 `iPad Pro 13-inch (M5)` Simulator、`MimiRemote` Scheme 和 `Debug` 配置。
+- 日常 `build` / `run` 采用确定性自动选择：优先 available、paired、USB 连接的 iOS/iPadOS 真机；没有可用 USB 真机时使用 `iPad Pro 13-inch (M5)` Simulator。
+- 同时连接多台 USB 真机时优先名为 `iPad Pro` 的设备；仍无法唯一确定时明确失败并要求设置 `IOS_DEVICE_ID`，不得随机选择。
+- `build-for-testing`、`test` 和 CI 固定使用 `iPad Pro 13-inch (M5)` Simulator，避免真机签名、设备数据和快照环境干扰测试。
+- 所有入口固定使用 `MimiRemote` Scheme 和 `Debug` 配置。
 - 命令行统一通过 `bash ./scripts/ios-dev.sh` 执行：
+  - 查看本次目标：`bash ./scripts/ios-dev.sh target`
   - 编译：`bash ./scripts/ios-dev.sh build`
   - 编译测试产物：`bash ./scripts/ios-dev.sh build-for-testing`
   - 运行单测：`bash ./scripts/ios-dev.sh test`
   - 构建、安装并启动：`bash ./scripts/ios-dev.sh run`
-- 默认 DerivedData 固定为 `ios/MimiRemote/build/dev-simulator-derived`，避免不同入口重复创建缓存。
-- 目标 Simulator 不存在或不可用时必须明确失败，不得静默回退到任意已启动设备、列表第一台设备或实体机。
+- Simulator DerivedData 固定为 `ios/MimiRemote/build/dev-simulator-derived`，真机 DerivedData 固定为 `ios/MimiRemote/build/dev-device-derived`。
+- 显式设置 `IOS_TARGET_MODE=device|simulator`、`IOS_DEVICE_ID` 或 `IOS_SIMULATOR_ID` 时，显式选择优先于自动规则。
 
 ### XcodeBuildMCP
 
-- 第一次构建、运行或测试前先读取 session defaults；仓库的 `.xcodebuildmcp/config.yaml` 已固定 project、scheme、configuration、simulator name 和 DerivedData。
-- 日常任务只使用 Simulator workflow，不调用实体机构建、安装或启动工具。
-- 不把本机 Simulator UDID 写入仓库；通过固定设备名和最新可用 OS 解析本机 UDID。
+- 第一次构建、运行或测试前先执行 `bash ./scripts/ios-dev.sh target` 并读取 session defaults。
+- 仓库的 `.xcodebuildmcp/config.yaml` 固定的是 Simulator fallback 和测试默认值；自动规则选中真机时，使用 device workflow 或统一脚本，不得继续沿用 Simulator defaults。
+- 不把本机真机或 Simulator UDID 写入仓库；每次从当前连接状态解析，显式覆盖只通过本机环境变量传入。
 
 ### 设备用途
 
-- `iPad Pro 13-inch (M5)` 是唯一日常默认目标。
+- available、paired、USB 连接的真机是日常 `build` / `run` 第一优先级；仅通过本地网络可见或历史配对的设备不算“连接到电脑”。
+- 没有可用 USB 真机时，`iPad Pro 13-inch (M5)` 是唯一 Simulator fallback。
 - `iPhone 17 Pro` 只用于明确的 iPhone 布局验收，`iPhone 17e` 只用于小屏兼容验收。切换时显式设置 `IOS_SIMULATOR_NAME`，完成后恢复默认 iPad。
-- 实体机只用于相机、通知、Keychain、Tailscale/弱网、性能以及发布前验证；使用 Xcode 或 `bash ./scripts/deploy-ipad.sh` 显式执行，不参与普通代码编译。
+- 相机、通知、Keychain、Tailscale/弱网、性能以及发布前验证仍必须使用真机；自动 fallback 到 Simulator 时不得把这些专项验证标记为完成。
 - Simulator 通过不代表真机专项验收完成，真机结果也不替代日常 Simulator 回归。
 
 ### 运行约束
@@ -105,8 +110,8 @@
 - Xcode、Codex、XcodeBuildMCP 的构建与测试串行执行，同一时间只运行一条 `xcodebuild` 链路。
 - 日常只保留一台已启动 Simulator；统一脚本在切换前关闭其他已启动 Simulator，但不会创建、擦除或删除设备。
 - 只执行 `build` 或 `build-for-testing` 时不要求预先启动 Simulator；不要为了纯编译主动开机。
-- 连续开发、调试 UI 或运行测试期间保持默认 iPad Simulator 开启，避免在同一开发时段反复启动和关闭。
-- 预计一小时内还会继续开发时可以保持开启；长时间不用、当天开发结束、准备让 Mac 合盖过夜前关闭 Simulator。
+- 使用 Simulator 连续开发、调试 UI 或运行测试期间保持默认 iPad 开启，避免在同一开发时段反复启动和关闭。
+- 使用 Simulator 且预计一小时内还会继续开发时可以保持开启；长时间不用、当天开发结束、准备让 Mac 合盖过夜前关闭。
 - 切换到兼容性设备前先关闭当前 Simulator；iPhone 验收结束后关闭 iPhone，后续开发再恢复默认 iPad。
 - 创建新设备前先检查现有设备并优先复用；不得为每次任务创建临时 Simulator。
 - 遇到高 CPU、安装卡住、Mac 睡眠恢复后状态异常或 CoreSimulator 阻塞时，先停止构建，关闭并重新启动现有 Simulator；不擦除主力设备，也不通过继续创建设备绕过。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,5 +104,9 @@
 
 - Xcode、Codex、XcodeBuildMCP 的构建与测试串行执行，同一时间只运行一条 `xcodebuild` 链路。
 - 日常只保留一台已启动 Simulator；统一脚本在切换前关闭其他已启动 Simulator，但不会创建、擦除或删除设备。
+- 只执行 `build` 或 `build-for-testing` 时不要求预先启动 Simulator；不要为了纯编译主动开机。
+- 连续开发、调试 UI 或运行测试期间保持默认 iPad Simulator 开启，避免在同一开发时段反复启动和关闭。
+- 预计一小时内还会继续开发时可以保持开启；长时间不用、当天开发结束、准备让 Mac 合盖过夜前关闭 Simulator。
+- 切换到兼容性设备前先关闭当前 Simulator；iPhone 验收结束后关闭 iPhone，后续开发再恢复默认 iPad。
 - 创建新设备前先检查现有设备并优先复用；不得为每次任务创建临时 Simulator。
-- 测试结束后关闭不再使用的设备。遇到 CoreSimulator 阻塞时，先停止构建并重启现有 Simulator 服务，不通过继续创建设备绕过。
+- 遇到高 CPU、安装卡住、Mac 睡眠恢复后状态异常或 CoreSimulator 阻塞时，先停止构建，关闭并重新启动现有 Simulator；不擦除主力设备，也不通过继续创建设备绕过。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,14 +37,10 @@ xcodegen generate \
   --spec ios/MimiRemote/project.yml \
   --project ios/MimiRemote
 
-xcodebuild \
-  -project ios/MimiRemote/MimiRemote.xcodeproj \
-  -scheme MimiRemote \
-  -configuration Debug \
-  -sdk iphoneos \
-  CODE_SIGNING_ALLOWED=NO \
-  build-for-testing
+bash ./scripts/ios-dev.sh build-for-testing
 ```
+
+本地默认固定使用 `iPad Pro 13-inch (M5)` Simulator。只有明确的兼容性测试才通过 `IOS_SIMULATOR_NAME` 切换 iPhone；真机部署使用独立的 `scripts/deploy-ipad.sh`。
 
 Claude bridge 改动至少运行：
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ xcodegen generate \
 bash ./scripts/ios-dev.sh build-for-testing
 ```
 
-本地默认固定使用 `iPad Pro 13-inch (M5)` Simulator。只有明确的兼容性测试才通过 `IOS_SIMULATOR_NAME` 切换 iPhone；真机部署使用独立的 `scripts/deploy-ipad.sh`。
+日常 `build` / `run` 优先使用 available、paired、USB 连接的真机，没有可用真机时回退到 `iPad Pro 13-inch (M5)` Simulator。`build-for-testing`、`test` 与 CI 固定使用 Simulator；兼容性测试通过 `IOS_TARGET_MODE=simulator` 和 `IOS_SIMULATOR_NAME` 显式切换。
 
 Claude bridge 改动至少运行：
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ open ios/MimiRemote/MimiRemote.xcodeproj
 
 In Xcode, select the `MimiRemote` scheme, your development team, and an iPhone or iPad target, then Run. On first launch, scan the QR code printed by `agentd up` or `agentd pair`. The QR code is a short-lived, single-use pairing ticket, not a long-lived token. Manual connection is available as a fallback.
 
-Command-line build verification uses the repository's fixed `iPad Pro 13-inch (M5)` Simulator target:
+Command-line `build` and `run` prefer an available, paired USB iOS device and fall back to the fixed `iPad Pro 13-inch (M5)` Simulator. Tests and CI remain Simulator-only:
 
 ```bash
 bash ./scripts/ios-dev.sh build-for-testing

--- a/README.md
+++ b/README.md
@@ -245,16 +245,10 @@ open ios/MimiRemote/MimiRemote.xcodeproj
 
 In Xcode, select the `MimiRemote` scheme, your development team, and an iPhone or iPad target, then Run. On first launch, scan the QR code printed by `agentd up` or `agentd pair`. The QR code is a short-lived, single-use pairing ticket, not a long-lived token. Manual connection is available as a fallback.
 
-Command-line build verification:
+Command-line build verification uses the repository's fixed `iPad Pro 13-inch (M5)` Simulator target:
 
 ```bash
-xcodebuild \
-  -project ios/MimiRemote/MimiRemote.xcodeproj \
-  -scheme MimiRemote \
-  -configuration Debug \
-  -sdk iphoneos \
-  CODE_SIGNING_ALLOWED=NO \
-  build-for-testing
+bash ./scripts/ios-dev.sh build-for-testing
 ```
 
 ### 3. Build the backend from source (optional)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -347,16 +347,10 @@ xcodegen generate \
   --spec ios/MimiRemote/project.yml \
   --project ios/MimiRemote
 
-xcodebuild \
-  -project ios/MimiRemote/MimiRemote.xcodeproj \
-  -scheme MimiRemote \
-  -configuration Debug \
-  -sdk iphoneos \
-  CODE_SIGNING_ALLOWED=NO \
-  build-for-testing
+bash ./scripts/ios-dev.sh build-for-testing
 ```
 
-iOS 工程结构、Catalyst 和真机验收见 [iOS 开发说明](ios/MimiRemote/README.md)。
+日常开发固定使用 `iPad Pro 13-inch (M5)` Simulator、Debug 配置和共享 DerivedData；iPhone 与真机只在明确的兼容性或硬件验收中使用。iOS 工程结构、运行命令、Catalyst 和真机验收见 [iOS 开发说明](ios/MimiRemote/README.md)。
 
 ### Claude bridge
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -350,7 +350,7 @@ xcodegen generate \
 bash ./scripts/ios-dev.sh build-for-testing
 ```
 
-日常开发固定使用 `iPad Pro 13-inch (M5)` Simulator、Debug 配置和共享 DerivedData；iPhone 与真机只在明确的兼容性或硬件验收中使用。iOS 工程结构、运行命令、Catalyst 和真机验收见 [iOS 开发说明](ios/MimiRemote/README.md)。
+日常 `build` / `run` 优先使用 available、paired、USB 连接的真机，没有可用真机时才使用固定 iPad Simulator；测试与 CI 始终使用 Simulator。iOS 工程结构、运行命令、Catalyst 和真机验收见 [iOS 开发说明](ios/MimiRemote/README.md)。
 
 ### Claude bridge
 

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -96,13 +96,7 @@ xcodegen generate \
   --spec ios/MimiRemote/project.yml \
   --project ios/MimiRemote
 
-xcodebuild \
-  -project ios/MimiRemote/MimiRemote.xcodeproj \
-  -scheme MimiRemote \
-  -configuration Debug \
-  -sdk iphoneos \
-  CODE_SIGNING_ALLOWED=NO \
-  build-for-testing
+bash ./scripts/ios-dev.sh build-for-testing
 ```
 
 Mimi TestFlight 使用本机 `git testflight-push`：先推送并核对远端 commit，再在干净 worktree 中归档、上传和内部组分发，不依赖 GitHub Actions。其他 CI 与公开 Release workflows 保持不变。

--- a/ios/MimiRemote/README.md
+++ b/ios/MimiRemote/README.md
@@ -147,6 +147,14 @@ IOS_SIMULATOR_NAME="iPhone 17e" bash ./scripts/ios-dev.sh run
 
 XcodeBuildMCP 会从仓库根目录的 `.xcodebuildmcp/config.yaml` 读取同一套 project、scheme、Simulator 和 DerivedData 默认值，不需要把本机 Simulator UDID 写入仓库。
 
+Simulator 开关采用“开发时保持一台、结束后关闭”的标准：
+
+- 只运行 `build` 或 `build-for-testing` 时无需预先启动 Simulator。
+- 连续开发、调试 UI 或运行测试期间保持默认 iPad 开启，不在同一开发时段反复开关。
+- 预计一小时内还会继续时可以保持开启；长时间不用、当天开发结束或准备让 Mac 合盖过夜前关闭。
+- 切换 iPhone 兼容性目标前先关闭 iPad；验收结束后关闭 iPhone，后续开发恢复默认 iPad。
+- 出现高 CPU、安装卡住或睡眠恢复异常时，关闭并重新启动现有 Simulator；不要擦除主力设备或创建新设备绕过问题。
+
 Mac Catalyst 使用同一套 SwiftUI 源码和 iPad 缩放界面，不增加 Mac 专用功能。生成工程后，可在 Apple Silicon Mac 上验证独立 Catalyst 构建：
 
 ```bash

--- a/ios/MimiRemote/README.md
+++ b/ios/MimiRemote/README.md
@@ -14,7 +14,7 @@ xcodegen generate \
 open ios/MimiRemote/MimiRemote.xcodeproj
 ```
 
-Select the `MimiRemote` scheme in Xcode. Daily development uses the repository's fixed `iPad Pro 13-inch (M5)` Simulator target; physical devices are reserved for hardware and release validation. Build the Mac service first with Codex CLI signed in, run `agentd up`, then scan its short-lived pairing QR code in the app. For a command-line build check:
+Select the `MimiRemote` scheme in Xcode and configure your development team for physical-device builds. Daily `build` and `run` prefer an available, paired USB iOS device and fall back to the fixed `iPad Pro 13-inch (M5)` Simulator; tests and CI remain Simulator-only. Build the Mac service first with Codex CLI signed in, run `agentd up`, then scan its short-lived pairing QR code in the app. For a command-line test build check:
 
 ```bash
 bash ./scripts/ios-dev.sh build-for-testing
@@ -117,7 +117,13 @@ cd "$HOME/code/mimi-remote"
 xcodegen generate --spec ios/MimiRemote/project.yml --project ios/MimiRemote
 ```
 
-日常开发统一使用 `iPad Pro 13-inch (M5)` Simulator、`MimiRemote` Scheme 和 Debug 配置。脚本会复用 `ios/MimiRemote/build/dev-simulator-derived`，切换前关闭其他已启动 Simulator；默认目标不存在时直接失败，不会回退到实体机或其他设备。
+日常 `build` / `run` 会先检测 available、paired、USB 连接的真机：只有一台时使用它；多台时优先名为 `iPad Pro` 的设备；仍无法唯一确定时明确失败。没有可用 USB 真机时才使用 `iPad Pro 13-inch (M5)` Simulator。`build-for-testing`、`test` 和 CI 始终固定 Simulator。
+
+先查看本次实际目标：
+
+```bash
+bash ./scripts/ios-dev.sh target
+```
 
 命令行验证 Swift 代码可编译：
 
@@ -141,16 +147,18 @@ bash ./scripts/ios-dev.sh run
 只有明确验证 iPhone 布局时才覆盖目标；完成后恢复默认 iPad：
 
 ```bash
-IOS_SIMULATOR_NAME="iPhone 17 Pro" bash ./scripts/ios-dev.sh run
-IOS_SIMULATOR_NAME="iPhone 17e" bash ./scripts/ios-dev.sh run
+IOS_TARGET_MODE=simulator IOS_SIMULATOR_NAME="iPhone 17 Pro" bash ./scripts/ios-dev.sh run
+IOS_TARGET_MODE=simulator IOS_SIMULATOR_NAME="iPhone 17e" bash ./scripts/ios-dev.sh run
 ```
 
-XcodeBuildMCP 会从仓库根目录的 `.xcodebuildmcp/config.yaml` 读取同一套 project、scheme、Simulator 和 DerivedData 默认值，不需要把本机 Simulator UDID 写入仓库。
+需要显式覆盖自动规则时，使用 `IOS_TARGET_MODE=device|simulator`、`IOS_DEVICE_ID` 或 `IOS_SIMULATOR_ID`。真机和 Simulator 分别复用 `ios/MimiRemote/build/dev-device-derived` 与 `ios/MimiRemote/build/dev-simulator-derived`。
+
+XcodeBuildMCP 会从仓库根目录的 `.xcodebuildmcp/config.yaml` 读取 Simulator fallback 和测试默认值。执行日常 `build` / `run` 前先运行 `bash ./scripts/ios-dev.sh target`；如果选中真机，应使用 device workflow 或统一脚本，不能继续沿用 Simulator defaults。
 
 Simulator 开关采用“开发时保持一台、结束后关闭”的标准：
 
-- 只运行 `build` 或 `build-for-testing` 时无需预先启动 Simulator。
-- 连续开发、调试 UI 或运行测试期间保持默认 iPad 开启，不在同一开发时段反复开关。
+- 只运行 `build` 或 `build-for-testing` 时无需预先启动 Simulator；USB 真机构建也不会为此启动 Simulator。
+- 使用 Simulator 连续开发、调试 UI 或运行测试期间保持默认 iPad 开启，不在同一开发时段反复开关。
 - 预计一小时内还会继续时可以保持开启；长时间不用、当天开发结束或准备让 Mac 合盖过夜前关闭。
 - 切换 iPhone 兼容性目标前先关闭 iPad；验收结束后关闭 iPhone，后续开发恢复默认 iPad。
 - 出现高 CPU、安装卡住或睡眠恢复异常时，关闭并重新启动现有 Simulator；不要擦除主力设备或创建新设备绕过问题。
@@ -178,7 +186,7 @@ Catalyst 产物使用独立的 Mac `Info.plist`、App Sandbox 权限和标准 Ma
 
 同机连接有一条轻量优化链路：当 `agentd` 配置为具体的 Tailscale 或局域网 IP 时，服务端会同时监听相同端口的 `127.0.0.1`，不会扩大到 `0.0.0.0`。Catalyst 冷启动先探测 `http://127.0.0.1:8787/healthz`，再用当前 Mac 档案已经保存的 Token 验证本机链路；验证成功后本次运行优先走 loopback，但档案身份和缓存仍使用原 Tailscale Endpoint。首次配对仍需扫描二维码或输入访问码，本机健康检查不会返回 Token。手动填写私网 HTTP 地址时省略端口会自动补为 `8787`。
 
-真机运行仅用于相机、通知、Keychain、Tailscale/弱网、性能和发布前验证：
+自动规则选中真机时，`bash ./scripts/ios-dev.sh run` 会完成构建、安装和启动。也可以显式使用真机部署入口：
 
 1. 用 Xcode 打开 `ios/MimiRemote/MimiRemote.xcodeproj`。
 2. 选择 `MimiRemote` scheme。

--- a/ios/MimiRemote/README.md
+++ b/ios/MimiRemote/README.md
@@ -14,16 +14,10 @@ xcodegen generate \
 open ios/MimiRemote/MimiRemote.xcodeproj
 ```
 
-Select the `MimiRemote` scheme, your development team, and an iPhone/iPad target in Xcode. Build the Mac service first with Codex CLI signed in, run `agentd up`, then scan its short-lived pairing QR code in the app. For a command-line build check:
+Select the `MimiRemote` scheme in Xcode. Daily development uses the repository's fixed `iPad Pro 13-inch (M5)` Simulator target; physical devices are reserved for hardware and release validation. Build the Mac service first with Codex CLI signed in, run `agentd up`, then scan its short-lived pairing QR code in the app. For a command-line build check:
 
 ```bash
-xcodebuild \
-  -project ios/MimiRemote/MimiRemote.xcodeproj \
-  -scheme MimiRemote \
-  -configuration Debug \
-  -sdk iphoneos \
-  CODE_SIGNING_ALLOWED=NO \
-  build-for-testing
+bash ./scripts/ios-dev.sh build-for-testing
 ```
 
 The detailed engineering and operational reference below is currently in Chinese.
@@ -123,29 +117,35 @@ cd "$HOME/code/mimi-remote"
 xcodegen generate --spec ios/MimiRemote/project.yml --project ios/MimiRemote
 ```
 
+日常开发统一使用 `iPad Pro 13-inch (M5)` Simulator、`MimiRemote` Scheme 和 Debug 配置。脚本会复用 `ios/MimiRemote/build/dev-simulator-derived`，切换前关闭其他已启动 Simulator；默认目标不存在时直接失败，不会回退到实体机或其他设备。
+
 命令行验证 Swift 代码可编译：
 
 ```bash
-xcodebuild \
-  -project ios/MimiRemote/MimiRemote.xcodeproj \
-  -scheme MimiRemote \
-  -configuration Debug \
-  -sdk iphoneos \
-  CODE_SIGNING_ALLOWED=NO \
-  clean build
+bash ./scripts/ios-dev.sh build
 ```
 
 测试 target 编译：
 
 ```bash
-xcodebuild \
-  -project ios/MimiRemote/MimiRemote.xcodeproj \
-  -scheme MimiRemote \
-  -configuration Debug \
-  -sdk iphoneos \
-  CODE_SIGNING_ALLOWED=NO \
-  clean build-for-testing
+bash ./scripts/ios-dev.sh build-for-testing
 ```
+
+运行全部单测，或构建、安装并启动 App：
+
+```bash
+bash ./scripts/ios-dev.sh test
+bash ./scripts/ios-dev.sh run
+```
+
+只有明确验证 iPhone 布局时才覆盖目标；完成后恢复默认 iPad：
+
+```bash
+IOS_SIMULATOR_NAME="iPhone 17 Pro" bash ./scripts/ios-dev.sh run
+IOS_SIMULATOR_NAME="iPhone 17e" bash ./scripts/ios-dev.sh run
+```
+
+XcodeBuildMCP 会从仓库根目录的 `.xcodebuildmcp/config.yaml` 读取同一套 project、scheme、Simulator 和 DerivedData 默认值，不需要把本机 Simulator UDID 写入仓库。
 
 Mac Catalyst 使用同一套 SwiftUI 源码和 iPad 缩放界面，不增加 Mac 专用功能。生成工程后，可在 Apple Silicon Mac 上验证独立 Catalyst 构建：
 
@@ -170,7 +170,7 @@ Catalyst 产物使用独立的 Mac `Info.plist`、App Sandbox 权限和标准 Ma
 
 同机连接有一条轻量优化链路：当 `agentd` 配置为具体的 Tailscale 或局域网 IP 时，服务端会同时监听相同端口的 `127.0.0.1`，不会扩大到 `0.0.0.0`。Catalyst 冷启动先探测 `http://127.0.0.1:8787/healthz`，再用当前 Mac 档案已经保存的 Token 验证本机链路；验证成功后本次运行优先走 loopback，但档案身份和缓存仍使用原 Tailscale Endpoint。首次配对仍需扫描二维码或输入访问码，本机健康检查不会返回 Token。手动填写私网 HTTP 地址时省略端口会自动补为 `8787`。
 
-真机运行：
+真机运行仅用于相机、通知、Keychain、Tailscale/弱网、性能和发布前验证：
 
 1. 用 Xcode 打开 `ios/MimiRemote/MimiRemote.xcodeproj`。
 2. 选择 `MimiRemote` scheme。

--- a/scripts/deploy-ipad.sh
+++ b/scripts/deploy-ipad.sh
@@ -10,6 +10,7 @@ DEVICE_ID="${DEVICE_ID:-}"
 BUNDLE_ID="${BUNDLE_ID:-com.gaixianggeng.mimi}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-120}"
 DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$ROOT_DIR/ios/MimiRemote/build/deploy-derived}"
+SKIP_INSTALL="${SKIP_INSTALL:-0}"
 SKIP_LAUNCH="${SKIP_LAUNCH:-0}"
 REFRESH_INSTALL="${REFRESH_INSTALL:-0}"
 ALLOW_PROVISIONING_UPDATES="${ALLOW_PROVISIONING_UPDATES:-1}"
@@ -66,6 +67,9 @@ fi
 if [[ ${#SIGNING_ARGS[@]} -gt 0 ]]; then
   XCODEBUILD_ARGS+=("${SIGNING_ARGS[@]}")
 fi
+if [[ $# -gt 0 ]]; then
+  XCODEBUILD_ARGS+=("$@")
+fi
 XCODEBUILD_ARGS+=(build)
 
 xcodebuild "${XCODEBUILD_ARGS[@]}"
@@ -73,6 +77,11 @@ xcodebuild "${XCODEBUILD_ARGS[@]}"
 if [[ ! -d "$APP_PATH" ]]; then
   echo "构建成功但找不到产物：$APP_PATH" >&2
   exit 1
+fi
+
+if [[ "$SKIP_INSTALL" == "1" ]]; then
+  echo "==> 已跳过安装，真机构建产物：$APP_PATH"
+  exit 0
 fi
 
 if [[ "$REFRESH_INSTALL" == "1" ]]; then

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -5,9 +5,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_PATH="${PROJECT_PATH:-$ROOT_DIR/ios/MimiRemote/MimiRemote.xcodeproj}"
 SCHEME="${SCHEME:-MimiRemote}"
 CONFIGURATION="${CONFIGURATION:-Debug}"
+TARGET_MODE="${IOS_TARGET_MODE:-auto}"
 SIMULATOR_NAME="${IOS_SIMULATOR_NAME:-iPad Pro 13-inch (M5)}"
 SIMULATOR_ID="${IOS_SIMULATOR_ID:-}"
+DEVICE_NAME="${IOS_DEVICE_NAME:-${DEVICE_NAME:-iPad Pro}}"
+DEVICE_ID="${IOS_DEVICE_ID:-${DEVICE_ID:-}}"
 DERIVED_DATA_PATH="${IOS_DERIVED_DATA_PATH:-$ROOT_DIR/ios/MimiRemote/build/dev-simulator-derived}"
+DEVICE_DERIVED_DATA_PATH="${IOS_DEVICE_DERIVED_DATA_PATH:-$ROOT_DIR/ios/MimiRemote/build/dev-device-derived}"
 BUNDLE_ID="${BUNDLE_ID:-com.gaixianggeng.mimi}"
 
 usage() {
@@ -16,20 +20,27 @@ usage() {
   bash ./scripts/ios-dev.sh [build|build-for-testing|test|run]
   bash ./scripts/ios-dev.sh destination
   bash ./scripts/ios-dev.sh prepare
+  bash ./scripts/ios-dev.sh target
   bash ./scripts/ios-dev.sh derived-data-path
 
 默认目标：
-  Simulator: iPad Pro 13-inch (M5)
+  build/run: USB 真机优先，没有可用真机时使用 iPad Pro 13-inch (M5) Simulator
+  test:      固定使用 iPad Pro 13-inch (M5) Simulator
   Scheme:    MimiRemote
   Config:    Debug
 
 可选覆盖：
+  IOS_TARGET_MODE         auto（默认）、device 或 simulator
+  IOS_DEVICE_NAME         多台 USB 真机时优先的设备名，默认 iPad Pro
+  IOS_DEVICE_ID           用 UDID 明确选择 USB 真机
   IOS_SIMULATOR_NAME      明确选择另一台 Simulator，用于兼容性测试
   IOS_SIMULATOR_ID        用 UDID 明确选择 Simulator，优先于名称
   IOS_TEST_DESTINATION    CI 使用的完整 destination，必须包含 Simulator UDID
   IOS_DERIVED_DATA_PATH   覆盖固定的 DerivedData 目录
+  IOS_DEVICE_DERIVED_DATA_PATH 覆盖真机构建的固定 DerivedData 目录
 
-脚本不会创建、擦除 Simulator，也不会回退到任意可用设备。
+脚本只把 available、paired、USB 连接的 iOS/iPadOS 设备视为真机候选。
+不会创建、擦除 Simulator，也不会随机选择多台真机。
 EOF
 }
 
@@ -63,6 +74,56 @@ available_simulator_id() {
     '
 }
 
+available_physical_device() {
+  xcrun devicectl list devices --json-output - --quiet --timeout 5 | \
+    IOS_REQUESTED_DEVICE_ID="$DEVICE_ID" IOS_REQUESTED_DEVICE_NAME="$DEVICE_NAME" ruby -rjson -e '
+      requested_id = ENV.fetch("IOS_REQUESTED_DEVICE_ID", "")
+      requested_name = ENV.fetch("IOS_REQUESTED_DEVICE_NAME")
+      devices = JSON.parse(STDIN.read).fetch("result").fetch("devices")
+      candidates = devices.map do |device|
+        properties = device.fetch("properties", {})
+        connection = properties.fetch("connection", {})
+        hardware = properties.fetch("hardware", {})
+        state = properties.fetch("state", {})
+        next unless hardware["platform"] == "iOS" && hardware["reality"] == "physical"
+        next unless connection["transportType"] == "wired"
+        next unless connection["state"] == "connected" && connection["pairingState"] == "paired"
+
+        udid = hardware["udid"]
+        name = state["name"]
+        next if udid.to_s.empty? || name.to_s.empty?
+        [udid, name]
+      end.compact
+
+      if !requested_id.empty?
+        chosen = candidates.find { |udid, _name| udid == requested_id }
+        unless chosen
+          warn "找不到可用的 USB 真机：#{requested_id}"
+          exit 4
+        end
+        puts chosen.join("\t")
+        exit
+      end
+
+      preferred = candidates.select { |_udid, name| name == requested_name }
+      if preferred.length == 1
+        puts preferred.first.join("\t")
+      elsif preferred.length > 1
+        warn "存在多台同名 USB 真机：#{requested_name}，请设置 IOS_DEVICE_ID。"
+        preferred.each { |udid, name| warn "- #{name}: #{udid}" }
+        exit 2
+      elsif candidates.length == 1
+        puts candidates.first.join("\t")
+      elsif candidates.empty?
+        exit 3
+      else
+        warn "检测到多台 USB 真机，但没有唯一的 #{requested_name}。请设置 IOS_DEVICE_ID。"
+        candidates.each { |udid, name| warn "- #{name}: #{udid}" }
+        exit 2
+      end
+    '
+}
+
 resolve_destination() {
   if [[ -n "${IOS_TEST_DESTINATION:-}" ]]; then
     if [[ "$IOS_TEST_DESTINATION" != *"platform=iOS Simulator"* || "$IOS_TEST_DESTINATION" != *"id="* ]]; then
@@ -88,6 +149,49 @@ resolve_destination() {
   fi
 
   printf 'platform=iOS Simulator,id=%s\n' "$resolved_id"
+}
+
+resolve_build_target() {
+  local effective_mode="$TARGET_MODE"
+  local device_record device_status simulator_destination simulator_id
+
+  if [[ -z "${IOS_TARGET_MODE:-}" ]]; then
+    if [[ -n "${IOS_TEST_DESTINATION:-}" || -n "${IOS_SIMULATOR_ID:-}" || -n "${IOS_SIMULATOR_NAME:-}" ]]; then
+      effective_mode="simulator"
+    elif [[ -n "$DEVICE_ID" || -n "${IOS_DEVICE_NAME:-}" ]]; then
+      effective_mode="device"
+    fi
+  fi
+
+  case "$effective_mode" in
+    simulator)
+      simulator_destination="$(resolve_destination)"
+      simulator_id="$(simulator_id_from_destination "$simulator_destination")"
+      printf 'simulator\t%s\t%s\n' "$simulator_id" "$SIMULATOR_NAME"
+      ;;
+    auto|device)
+      if device_record="$(available_physical_device)"; then
+        printf 'device\t%s\n' "$device_record"
+        return
+      else
+        device_status=$?
+      fi
+      if [[ "$effective_mode" == "auto" && "$device_status" -eq 3 ]]; then
+        simulator_destination="$(resolve_destination)"
+        simulator_id="$(simulator_id_from_destination "$simulator_destination")"
+        printf 'simulator\t%s\t%s\n' "$simulator_id" "$SIMULATOR_NAME"
+        return
+      fi
+      if [[ "$device_status" -eq 3 ]]; then
+        echo "没有检测到 available、paired、USB 连接的 iOS 真机。" >&2
+      fi
+      return "$device_status"
+      ;;
+    *)
+      echo "IOS_TARGET_MODE 只支持 auto、device 或 simulator：$effective_mode" >&2
+      return 2
+      ;;
+  esac
 }
 
 simulator_id_from_destination() {
@@ -152,6 +256,28 @@ run_xcodebuild() {
     "$action"
 }
 
+run_device_action() {
+  local action="$1"
+  local target_id="$2"
+  local target_name="$3"
+  shift 3
+
+  echo "==> 检测到 USB 真机，使用 $target_name ($target_id)"
+  if [[ "$action" == "build" ]]; then
+    DEVICE_ID="$target_id" \
+      DEVICE_NAME="$target_name" \
+      DERIVED_DATA_PATH="$DEVICE_DERIVED_DATA_PATH" \
+      SKIP_INSTALL=1 \
+      SKIP_LAUNCH=1 \
+      bash "$ROOT_DIR/scripts/deploy-ipad.sh" "$@"
+  else
+    DEVICE_ID="$target_id" \
+      DEVICE_NAME="$target_name" \
+      DERIVED_DATA_PATH="$DEVICE_DERIVED_DATA_PATH" \
+      bash "$ROOT_DIR/scripts/deploy-ipad.sh" "$@"
+  fi
+}
+
 command_name="${1:-build}"
 if [[ $# -gt 0 ]]; then
   shift
@@ -168,10 +294,30 @@ case "$command_name" in
     require_command ruby
     prepare_destination
     ;;
+  target)
+    require_command xcrun
+    require_command ruby
+    target_record="$(resolve_build_target)"
+    IFS=$'\t' read -r target_kind target_id target_name <<< "$target_record"
+    printf '%s: %s (%s)\n' "$target_kind" "$target_name" "$target_id"
+    ;;
   derived-data-path)
     printf '%s\n' "$DERIVED_DATA_PATH"
     ;;
-  build|build-for-testing|test)
+  build)
+    require_command xcodebuild
+    require_command xcrun
+    require_command ruby
+    target_record="$(resolve_build_target)"
+    IFS=$'\t' read -r target_kind target_id target_name <<< "$target_record"
+    if [[ "$target_kind" == "device" ]]; then
+      run_device_action build "$target_id" "$target_name" "$@"
+    else
+      resolved_destination="$(prepare_destination)"
+      run_xcodebuild build "$resolved_destination" "$@"
+    fi
+    ;;
+  build-for-testing|test)
     require_command xcodebuild
     require_command xcrun
     require_command ruby
@@ -183,9 +329,15 @@ case "$command_name" in
     require_command xcodebuild
     require_command xcrun
     require_command ruby
+    target_record="$(resolve_build_target)"
+    IFS=$'\t' read -r target_kind target_id target_name <<< "$target_record"
+    if [[ "$target_kind" == "device" ]]; then
+      run_device_action run "$target_id" "$target_name" "$@"
+      exit 0
+    fi
+
     resolved_destination="$(prepare_destination)"
     resolved_simulator_id="$(simulator_id_from_destination "$resolved_destination")"
-
     if ! simulator_is_booted "$resolved_simulator_id"; then
       xcrun simctl boot "$resolved_simulator_id"
     fi

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_PATH="${PROJECT_PATH:-$ROOT_DIR/ios/MimiRemote/MimiRemote.xcodeproj}"
+SCHEME="${SCHEME:-MimiRemote}"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+SIMULATOR_NAME="${IOS_SIMULATOR_NAME:-iPad Pro 13-inch (M5)}"
+SIMULATOR_ID="${IOS_SIMULATOR_ID:-}"
+DERIVED_DATA_PATH="${IOS_DERIVED_DATA_PATH:-$ROOT_DIR/ios/MimiRemote/build/dev-simulator-derived}"
+BUNDLE_ID="${BUNDLE_ID:-com.gaixianggeng.mimi}"
+
+usage() {
+  cat <<'EOF'
+用法：
+  bash ./scripts/ios-dev.sh [build|build-for-testing|test|run]
+  bash ./scripts/ios-dev.sh destination
+  bash ./scripts/ios-dev.sh prepare
+  bash ./scripts/ios-dev.sh derived-data-path
+
+默认目标：
+  Simulator: iPad Pro 13-inch (M5)
+  Scheme:    MimiRemote
+  Config:    Debug
+
+可选覆盖：
+  IOS_SIMULATOR_NAME      明确选择另一台 Simulator，用于兼容性测试
+  IOS_SIMULATOR_ID        用 UDID 明确选择 Simulator，优先于名称
+  IOS_TEST_DESTINATION    CI 使用的完整 destination，必须包含 Simulator UDID
+  IOS_DERIVED_DATA_PATH   覆盖固定的 DerivedData 目录
+
+脚本不会创建、擦除 Simulator，也不会回退到任意可用设备。
+EOF
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "缺少命令：$command_name" >&2
+    exit 1
+  fi
+}
+
+available_simulator_id() {
+  local requested_id="$1"
+  local requested_name="$2"
+
+  xcrun simctl list devices available -j | \
+    IOS_REQUESTED_ID="$requested_id" IOS_REQUESTED_NAME="$requested_name" ruby -rjson -e '
+      requested_id = ENV.fetch("IOS_REQUESTED_ID", "")
+      requested_name = ENV.fetch("IOS_REQUESTED_NAME")
+      entries = JSON.parse(STDIN.read).fetch("devices").flat_map do |runtime, devices|
+        version = runtime.scan(/\d+/).map(&:to_i)
+        devices.map { |device| [version, device] }
+      end
+
+      candidates = entries.select do |_version, device|
+        device["isAvailable"] &&
+          (requested_id.empty? ? device["name"] == requested_name : device["udid"] == requested_id)
+      end
+      chosen = candidates.max_by { |version, _device| version }
+      print chosen.last.fetch("udid") if chosen
+    '
+}
+
+resolve_destination() {
+  if [[ -n "${IOS_TEST_DESTINATION:-}" ]]; then
+    if [[ "$IOS_TEST_DESTINATION" != *"platform=iOS Simulator"* || "$IOS_TEST_DESTINATION" != *"id="* ]]; then
+      echo "IOS_TEST_DESTINATION 必须是包含 Simulator UDID 的完整 destination。" >&2
+      echo "示例：platform=iOS Simulator,id=00000000-0000-0000-0000-000000000000" >&2
+      exit 1
+    fi
+    printf '%s\n' "$IOS_TEST_DESTINATION"
+    return
+  fi
+
+  local resolved_id
+  resolved_id="$(available_simulator_id "$SIMULATOR_ID" "$SIMULATOR_NAME")"
+  if [[ -z "$resolved_id" ]]; then
+    if [[ -n "$SIMULATOR_ID" ]]; then
+      echo "找不到可用的 iOS Simulator：$SIMULATOR_ID" >&2
+    else
+      echo "找不到默认 iOS Simulator：$SIMULATOR_NAME" >&2
+    fi
+    echo "脚本不会自动选择其他设备。当前可用设备：" >&2
+    xcrun simctl list devices available >&2
+    exit 1
+  fi
+
+  printf 'platform=iOS Simulator,id=%s\n' "$resolved_id"
+}
+
+simulator_id_from_destination() {
+  local destination="$1"
+  local suffix
+  suffix="${destination#*id=}"
+  if [[ "$suffix" == "$destination" ]]; then
+    return 1
+  fi
+  printf '%s\n' "${suffix%%,*}"
+}
+
+prepare_destination() {
+  local destination target_id booted_id booted_ids
+  destination="$(resolve_destination)"
+  target_id="$(simulator_id_from_destination "$destination")"
+  booted_ids="$(
+    xcrun simctl list devices booted -j | ruby -rjson -e '
+      JSON.parse(STDIN.read).fetch("devices").values.flatten.each do |device|
+        puts device.fetch("udid") if device["state"] == "Booted"
+      end
+    '
+  )"
+
+  # 切换目标前关闭其他已启动设备，保证 Xcode、Codex 和测试脚本共用一台 Simulator。
+  while IFS= read -r booted_id; do
+    [[ -n "$booted_id" ]] || continue
+    if [[ "$booted_id" != "$target_id" ]]; then
+      echo "==> 关闭非默认 Simulator：$booted_id" >&2
+      xcrun simctl shutdown "$booted_id"
+    fi
+  done <<< "$booted_ids"
+
+  printf '%s\n' "$destination"
+}
+
+simulator_is_booted() {
+  local target_id="$1"
+  xcrun simctl list devices booted -j | IOS_TARGET_ID="$target_id" ruby -rjson -e '
+    devices = JSON.parse(STDIN.read).fetch("devices").values.flatten
+    exit(devices.any? { |device| device["udid"] == ENV.fetch("IOS_TARGET_ID") } ? 0 : 1)
+  '
+}
+
+run_xcodebuild() {
+  local action="$1"
+  local destination="$2"
+  shift 2
+
+  echo "==> $SCHEME $CONFIGURATION · $action"
+  echo "    destination: $destination"
+  echo "    DerivedData: $DERIVED_DATA_PATH"
+
+  xcodebuild \
+    -project "$PROJECT_PATH" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -destination "$destination" \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
+    CODE_SIGNING_ALLOWED=NO \
+    "$@" \
+    "$action"
+}
+
+command_name="${1:-build}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+case "$command_name" in
+  destination)
+    require_command xcrun
+    require_command ruby
+    resolve_destination
+    ;;
+  prepare)
+    require_command xcrun
+    require_command ruby
+    prepare_destination
+    ;;
+  derived-data-path)
+    printf '%s\n' "$DERIVED_DATA_PATH"
+    ;;
+  build|build-for-testing|test)
+    require_command xcodebuild
+    require_command xcrun
+    require_command ruby
+    resolved_destination="$(prepare_destination)"
+    run_xcodebuild "$command_name" "$resolved_destination" "$@"
+    ;;
+  run)
+    require_command open
+    require_command xcodebuild
+    require_command xcrun
+    require_command ruby
+    resolved_destination="$(prepare_destination)"
+    resolved_simulator_id="$(simulator_id_from_destination "$resolved_destination")"
+
+    if ! simulator_is_booted "$resolved_simulator_id"; then
+      xcrun simctl boot "$resolved_simulator_id"
+    fi
+    open -a Simulator
+    xcrun simctl bootstatus "$resolved_simulator_id" -b
+    run_xcodebuild build "$resolved_destination" "$@"
+
+    app_path="$DERIVED_DATA_PATH/Build/Products/$CONFIGURATION-iphonesimulator/MimiRemote.app"
+    if [[ ! -d "$app_path" ]]; then
+      echo "构建成功但找不到 App：$app_path" >&2
+      exit 1
+    fi
+    xcrun simctl install "$resolved_simulator_id" "$app_path"
+    xcrun simctl launch --terminate-running-process "$resolved_simulator_id" "$BUNDLE_ID"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "不支持的操作：$command_name" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/test-conversation-regressions.sh
+++ b/scripts/test-conversation-regressions.sh
@@ -4,23 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-if [[ -n "${IOS_TEST_DESTINATION:-}" ]]; then
-  resolved_destination="$IOS_TEST_DESTINATION"
-else
-  # GitHub runner 和开发机安装的 Simulator 名称/OS 会变化。优先复用已启动设备，
-  # 否则选择第一个可用 iPad/iPhone，避免把测试绑死到某个 beta runtime。
-  simulator_id="$(xcrun simctl list devices available -j | ruby -rjson -e '
-    devices = JSON.parse(STDIN.read).fetch("devices").values.flatten
-    candidates = devices.select { |item| item["isAvailable"] && item["name"].match?(/iPad|iPhone/) }
-    chosen = candidates.find { |item| item["state"] == "Booted" } || candidates.first
-    print chosen.fetch("udid", "") if chosen
-  ')"
-  if [[ -z "$simulator_id" ]]; then
-    echo "没有可用的 iOS Simulator，请安装 iOS runtime 或设置 IOS_TEST_DESTINATION" >&2
-    exit 1
-  fi
-  resolved_destination="platform=iOS Simulator,id=$simulator_id"
-fi
+# 本地固定到项目默认 iPad；CI 在任务开始时只解析一次 UDID，再由两个测试脚本复用。
+resolved_destination="$(bash "$ROOT_DIR/scripts/ios-dev.sh" prepare)"
+derived_data_path="$(bash "$ROOT_DIR/scripts/ios-dev.sh" derived-data-path)"
 
 echo "==> Go gateway conversation regressions"
 if command -v go >/dev/null 2>&1; then
@@ -49,7 +35,9 @@ echo "==> iOS conversation regressions"
 xcodebuild test -quiet \
   -project ios/MimiRemote/MimiRemote.xcodeproj \
   -scheme MimiRemote \
+  -configuration Debug \
   -destination "$resolved_destination" \
+  -derivedDataPath "$derived_data_path" \
   -testLanguage zh-Hans \
   -testRegion CN \
   -only-testing:MimiRemoteTests/AgentAPIClientRequestTests \

--- a/scripts/test-ios-localization-smoke.sh
+++ b/scripts/test-ios-localization-smoke.sh
@@ -4,29 +4,17 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-if [[ -n "${IOS_TEST_DESTINATION:-}" ]]; then
-  resolved_destination="$IOS_TEST_DESTINATION"
-else
-  # Reuse an already booted Simulator when one exists. CI can otherwise select
-  # any available iPhone/iPad runtime without coupling this smoke test to a beta name.
-  simulator_id="$(xcrun simctl list devices available -j | ruby -rjson -e '
-    devices = JSON.parse(STDIN.read).fetch("devices").values.flatten
-    candidates = devices.select { |item| item["isAvailable"] && item["name"].match?(/iPad|iPhone/) }
-    chosen = candidates.find { |item| item["state"] == "Booted" } || candidates.first
-    print chosen.fetch("udid", "") if chosen
-  ')"
-  if [[ -z "$simulator_id" ]]; then
-    echo "No available iOS Simulator. Install an iOS runtime or set IOS_TEST_DESTINATION." >&2
-    exit 1
-  fi
-  resolved_destination="platform=iOS Simulator,id=$simulator_id"
-fi
+# Keep the English smoke test on the same destination and DerivedData as the core suite.
+resolved_destination="$(bash "$ROOT_DIR/scripts/ios-dev.sh" prepare)"
+derived_data_path="$(bash "$ROOT_DIR/scripts/ios-dev.sh" derived-data-path)"
 
 echo "==> iOS English localization smoke"
 xcodebuild test -quiet \
   -project ios/MimiRemote/MimiRemote.xcodeproj \
   -scheme MimiRemote \
+  -configuration Debug \
   -destination "$resolved_destination" \
+  -derivedDataPath "$derived_data_path" \
   -testLanguage en \
   -testRegion US \
   -only-testing:MimiRemoteTests/LocalizationTests


### PR DESCRIPTION
## 变更说明

- 新增统一的 `scripts/ios-dev.sh` 入口，覆盖目标查看、构建、测试和运行。
- 日常 `build` / `run` 优先选择 available、paired、USB 连接的 iOS 真机；没有可用 USB 真机时回退固定 `iPad Pro 13-inch (M5)` Simulator。
- 多台 USB 真机同时存在时执行确定性选择，无法唯一确定则要求显式设置设备 ID。
- `build-for-testing`、`test` 和 CI 固定使用 Simulator，真机与 Simulator 分别复用独立 DerivedData。
- 统一测试脚本、XcodeBuildMCP 默认配置、设备用途和 Simulator 生命周期文档。

## 背景

原有 README、真机部署脚本、测试脚本和 XcodeBuildMCP 使用不同的目标选择方式，可能在实体机、任意已启动 Simulator 和列表第一台设备之间漂移，造成签名干扰、重复编译和排障成本。

本次改动把目标选择规则集中到一个入口，并保留明确的显式覆盖方式。多个开发会话仍按项目约定串行执行 Xcode 构建；暂不增加全局互斥锁。

## 验证

- USB iPad Pro 自动目标检测通过。
- 固定 iPad Simulator 显式目标检测通过。
- 不可用真机 ID 会明确失败，不会静默切换。
- USB iPad Pro Debug 签名构建通过，build-only 未安装或启动 App。
- Simulator 构建与运行通过，并完成首屏运行态检查。
- `bash -n scripts/ios-dev.sh scripts/deploy-ipad.sh`
- `bash ./scripts/check-ios-localization.sh`
- `bash ./scripts/check-source-size.sh`
- `git diff --check`

Linear: MIM-19
