### PR TITLE
MIM-18 简化首次连接页并修正操作区对齐

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -10782,13 +10782,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Opens the public GitHub Release page in your browser."
+            "value" : "Opens the public GitHub release page in the GitHub app or your default browser."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在浏览器中打开公开的 GitHub Release 页面。"
+            "value" : "在 GitHub App 或默认浏览器中打开公开的 GitHub Release 页面。"
           }
         }
       }
@@ -31281,13 +31281,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "View releases on GitHub"
+            "value" : "View latest release on GitHub"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 GitHub 查看发布版本"
+            "value" : "在 GitHub 查看最新版本"
           }
         }
       }

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -13386,13 +13386,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Requires macOS 26 or later. Send the download link to your Mac, open the DMG, then drag the app to Applications."
+            "value" : "Requires macOS 26 or later. Open the DMG, then drag Mimi Remote to Applications."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要 macOS 26 或更高版本。将下载链接发送到你的 Mac，打开 DMG 后拖入“应用程序”。"
+            "value" : "需要 macOS 26 或更高版本。打开 DMG 后，将 Mimi Remote 拖入“应用程序”。"
           }
         }
       }
@@ -33222,6 +33222,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "读取剪贴板中的 Mimi Remote 连接链接，验证后连接这台 Mac。"
+          }
+        }
+      }
+    },
+    "ui.connect_on_this_device" : {
+      "comment" : "Section title for the step completed on the current iPhone or iPad during first-time Mac pairing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect on this device"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在这台设备上连接"
+          }
+        }
+      }
+    },
+    "ui.other_connection_methods" : {
+      "comment" : "Section title for lower-priority command-line and manual Mac connection methods.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Other connection methods"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他连接方式"
+          }
+        }
+      }
+    },
+    "ui.prepare_on_mac" : {
+      "comment" : "Section title for the Mac-side preparation step during first-time pairing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prepare on your Mac"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Mac 上准备"
+          }
+        }
+      }
+    },
+    "ui.scan_qr_code_after_mac_setup" : {
+      "comment" : "Short instruction shown above the primary scan button during first-time pairing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "After setup on your Mac, scan the QR code shown there."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成 Mac 设置后，扫描它显示的二维码。"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -159,32 +159,41 @@ struct InitialConnectionSettingsSections: View {
                 }
             }
 
-            Section {
-#if targetEnvironment(macCatalyst)
-                if appStore.localAgentDetected {
-                    VStack(alignment: .leading, spacing: 5) {
-                        Label(
-                            appStore.isUsingLocalConnection ? L10n.text("ui.directly_connected_through_local_assistant") : L10n.text("ui.assistant_has_been_detected_on_this_mac"),
-                            systemImage: "checkmark.circle.fill"
-                        )
-                        .font(themeStore.uiFont(.body, weight: .semibold))
-                        .foregroundStyle(tokens.success)
-                        if !appStore.isConfigured {
-                            Text(localAgentPairingHint)
-                                .font(themeStore.uiFont(.footnote))
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .padding(.vertical, 2)
+            if !appStore.isConfigured && !appStore.localAgentDetected {
+                MacInstallationSetupView(
+                    connectionFooter: connectionSectionFooter,
+                    isScanDisabled: isSavingConnection || qrScannerPresentation.isRequestingCameraAuthorization,
+                    onScan: beginScanningMac,
+                    onPasteConnectionInfo: pasteConnectionInfo
+                )
+
+                connectionPresentationSection {
+                    advancedConnectionOptions(tokens: tokens)
+                } header: {
+                    Text(L10n.text("ui.other_connection_methods"))
+                } footer: {
+                    EmptyView()
                 }
+            } else {
+                connectionPresentationSection {
+#if targetEnvironment(macCatalyst)
+                    if appStore.localAgentDetected {
+                        VStack(alignment: .leading, spacing: 5) {
+                            Label(
+                                appStore.isUsingLocalConnection ? L10n.text("ui.directly_connected_through_local_assistant") : L10n.text("ui.assistant_has_been_detected_on_this_mac"),
+                                systemImage: "checkmark.circle.fill"
+                            )
+                            .font(themeStore.uiFont(.body, weight: .semibold))
+                            .foregroundStyle(tokens.success)
+                            if !appStore.isConfigured {
+                                Text(localAgentPairingHint)
+                                    .font(themeStore.uiFont(.footnote))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
 #endif
-                if !appStore.isConfigured && !appStore.localAgentDetected {
-                    MacInstallationSetupView(
-                        isScanDisabled: isSavingConnection || qrScannerPresentation.isRequestingCameraAuthorization,
-                        onScan: beginScanningMac,
-                        onPasteConnectionInfo: pasteConnectionInfo
-                    )
-                } else {
                     VStack(spacing: 10) {
                         Button {
                             beginScanningMac()
@@ -212,105 +221,13 @@ struct InitialConnectionSettingsSections: View {
                         .accessibilityHint(L10n.text("ui.paste_connection_info_hint"))
                         .accessibilityIdentifier("settings.connection.pasteConnectionInfo")
                     }
-                }
 
-                DisclosureGroup {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(L10n.text("ui.first_time_installation"))
-                            .font(themeStore.uiFont(.caption, weight: .semibold))
-                            .foregroundStyle(.secondary)
-                        Text("brew install gaixianggeng/tap/mimi-remote")
-                            .font(.system(.callout, design: .monospaced))
-                            .textSelection(.enabled)
-                        Text(L10n.text("ui.start_the_assistant_and_display_the_qr_code"))
-                            .font(themeStore.uiFont(.caption, weight: .semibold))
-                            .foregroundStyle(.secondary)
-                        Text("agentd up")
-                            .font(.system(.callout, design: .monospaced))
-                            .textSelection(.enabled)
-                        Text(L10n.text("ui.run_agentd_pair_when_the_qr_code_expires"))
-                            .font(themeStore.uiFont(.footnote))
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.vertical, 6)
-                } label: {
-                    Label(
-                        L10n.text("ui.command_line_installation_advanced"),
-                        systemImage: "terminal"
-                    )
+                    advancedConnectionOptions(tokens: tokens)
+                } header: {
+                    Text(appStore.isConfigured ? L10n.text("ui.add_mac") : L10n.text("ui.start_setup"))
+                } footer: {
+                    Text(connectionSectionFooter)
                 }
-
-                DisclosureGroup(isExpanded: manualConnectionExpandedBinding) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        if isAddingConnectionProfile {
-                            connectionFieldLabel(L10n.text("ui.display_name")) {
-                                TextField(L10n.text("ui.example_studio_mac"), text: $profileDisplayName)
-                                    .textInputAutocapitalization(.words)
-                                    .accessibilityIdentifier("settings.profileDisplayName")
-                            }
-                        }
-                        connectionFieldLabel(L10n.text("ui.connection_address")) {
-                            StableEndpointTextField(placeholder: endpointPlaceholder, text: $endpoint)
-                                .frame(minHeight: 28)
-                        }
-                        connectionFieldLabel(L10n.text("ui.access_code")) {
-                            SecureField(L10n.text("ui.enter_access_code"), text: $token)
-                                .textInputAutocapitalization(.never)
-                                .autocorrectionDisabled()
-                        }
-                        EndpointTransportNotice(assessment: endpointTransportAssessment)
-                        Button {
-                            Task { await save() }
-                        } label: {
-                            HStack(spacing: 8) {
-                                if isSavingConnection {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                }
-                                Text(isSavingConnection ? L10n.text("ui.connecting") : manualSaveButtonTitle)
-                            }
-                            .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(tokens.primaryAction)
-                        .disabled(!canSubmit)
-                    }
-                    .padding(.vertical, 6)
-                } label: {
-                    Label(manualConnectionTitle, systemImage: "keyboard")
-                }
-            } header: {
-                Text(appStore.isConfigured ? L10n.text("ui.add_mac") : L10n.text("ui.start_setup"))
-            } footer: {
-                Text(connectionSectionFooter)
-            }
-            // 这里注册业务回调；真正的相机 Cover 由 SettingsView 根层呈现，避免
-            // 系统权限弹窗期间 Form.Section 重建后丢失 presenter。
-            .onAppear(perform: configureQRCodeScannerPresentation)
-            .sheet(item: $profileRenameTarget) { profile in
-                ConnectionProfileRenameSheet(profile: profile) { displayName in
-                    try appStore.renameConnectionProfile(id: profile.id, displayName: displayName)
-                    localError = nil
-                }
-            }
-            .confirmationDialog(
-                pendingRemovalConfirmation?.title ?? L10n.text("ui.confirm_to_delete_connection_credentials"),
-                isPresented: removalConfirmationBinding,
-                titleVisibility: .visible,
-                presenting: pendingRemovalConfirmation
-            ) { confirmation in
-                Button(confirmation.confirmButtonTitle, role: .destructive) {
-                    Task {
-                        await performCredentialRemoval(confirmation)
-                    }
-                }
-                .accessibilityIdentifier(removalConfirmationAccessibilityIdentifier(confirmation))
-
-                Button(L10n.text("ui.cancel"), role: .cancel) {
-                    pendingRemovalConfirmation = nil
-                }
-            } message: { confirmation in
-                Text(confirmation.message)
             }
 
             if shouldShowConnectionStatus {
@@ -390,6 +307,120 @@ struct InitialConnectionSettingsSections: View {
             // 根启动任务负责自动配对和提交；这里与它复用同一个探测 Task，只更新设置页提示，
             // 避免两个连接事务争抢后导致 bootstrap 提前返回。
             _ = await appStore.detectLocalAgent()
+        }
+    }
+
+    /// 首次连接时只把高级恢复入口放进这一节；已有连接仍复用同一组控件。
+    /// 默认折叠能保留完整能力，同时不让低频技术信息和扫码主路径竞争注意力。
+    @ViewBuilder
+    private func advancedConnectionOptions(tokens: ThemeTokens) -> some View {
+        DisclosureGroup {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(L10n.text("ui.first_time_installation"))
+                    .font(themeStore.uiFont(.caption, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("brew install gaixianggeng/tap/mimi-remote")
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+                Text(L10n.text("ui.start_the_assistant_and_display_the_qr_code"))
+                    .font(themeStore.uiFont(.caption, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("agentd up")
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+                Text(L10n.text("ui.run_agentd_pair_when_the_qr_code_expires"))
+                    .font(themeStore.uiFont(.footnote))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 6)
+        } label: {
+            Label(
+                L10n.text("ui.command_line_installation_advanced"),
+                systemImage: "terminal"
+            )
+        }
+
+        DisclosureGroup(isExpanded: manualConnectionExpandedBinding) {
+            VStack(alignment: .leading, spacing: 12) {
+                if isAddingConnectionProfile {
+                    connectionFieldLabel(L10n.text("ui.display_name")) {
+                        TextField(L10n.text("ui.example_studio_mac"), text: $profileDisplayName)
+                            .textInputAutocapitalization(.words)
+                            .accessibilityIdentifier("settings.profileDisplayName")
+                    }
+                }
+                connectionFieldLabel(L10n.text("ui.connection_address")) {
+                    StableEndpointTextField(placeholder: endpointPlaceholder, text: $endpoint)
+                        .frame(minHeight: 28)
+                }
+                connectionFieldLabel(L10n.text("ui.access_code")) {
+                    SecureField(L10n.text("ui.enter_access_code"), text: $token)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+                EndpointTransportNotice(assessment: endpointTransportAssessment)
+                Button {
+                    Task { await save() }
+                } label: {
+                    HStack(spacing: 8) {
+                        if isSavingConnection {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(isSavingConnection ? L10n.text("ui.connecting") : manualSaveButtonTitle)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(tokens.primaryAction)
+                .disabled(!canSubmit)
+            }
+            .padding(.vertical, 6)
+        } label: {
+            Label(manualConnectionTitle, systemImage: "keyboard")
+        }
+    }
+
+    /// 业务回调和弹窗只挂到每条连接流程中的一个原生 Section，
+    /// 避免系统权限弹窗期间因多个 presenter 同时存在而重复呈现。
+    private func connectionPresentationSection<Content: View, Header: View, Footer: View>(
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder header: () -> Header,
+        @ViewBuilder footer: () -> Footer
+    ) -> some View {
+        Section {
+            content()
+        } header: {
+            header()
+        } footer: {
+            footer()
+        }
+        // 真正的相机 Cover 由 SettingsView 根层呈现，避免 Form.Section 重建后丢失 presenter。
+        .onAppear(perform: configureQRCodeScannerPresentation)
+        .sheet(item: $profileRenameTarget) { profile in
+            ConnectionProfileRenameSheet(profile: profile) { displayName in
+                try appStore.renameConnectionProfile(id: profile.id, displayName: displayName)
+                localError = nil
+            }
+        }
+        .confirmationDialog(
+            pendingRemovalConfirmation?.title ?? L10n.text("ui.confirm_to_delete_connection_credentials"),
+            isPresented: removalConfirmationBinding,
+            titleVisibility: .visible,
+            presenting: pendingRemovalConfirmation
+        ) { confirmation in
+            Button(confirmation.confirmButtonTitle, role: .destructive) {
+                Task {
+                    await performCredentialRemoval(confirmation)
+                }
+            }
+            .accessibilityIdentifier(removalConfirmationAccessibilityIdentifier(confirmation))
+
+            Button(L10n.text("ui.cancel"), role: .cancel) {
+                pendingRemovalConfirmation = nil
+            }
+        } message: { confirmation in
+            Text(confirmation.message)
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
-/// 首次连接的普通用户路径。安装、首次设置和扫码按真实任务顺序排列，
-/// Homebrew 与手动输入仍由外层设置页保留为高级恢复入口。
+/// 首次连接只保留两个用户阶段：先在 Mac 上准备，再在当前设备扫码。
+/// 命令行和手动输入由外层单独收进“其他连接方式”，避免恢复路径干扰主任务。
 struct MacInstallationSetupView: View {
     @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var themeStore: ThemeStore
 
+    let connectionFooter: String
     let isScanDisabled: Bool
     let onScan: () -> Void
     let onPasteConnectionInfo: () -> Void
@@ -13,74 +14,74 @@ struct MacInstallationSetupView: View {
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
 
-        VStack(alignment: .leading, spacing: 18) {
-            setupStep(
-                number: 1,
-                title: L10n.text("ui.install_mimi_remote_mac"),
-                detail: L10n.text("ui.mac_installer_requirements_and_instructions")
-            ) {
-                VStack(alignment: .leading, spacing: 10) {
-                    ShareLink(item: AppExternalLinks.macInstaller) {
-                        GloballyCenteredActionLabel(
-                            title: L10n.text("ui.send_download_link_to_mac"),
-                            systemImage: "square.and.arrow.up"
-                        )
-                    }
-                    .buttonStyle(.bordered)
-                    .tint(tokens.primaryAction)
-                    .controlSize(.large)
-                    .accessibilityIdentifier("settings.macInstaller.share")
+        Group {
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(L10n.text("ui.install_mimi_remote_mac"))
+                        .font(themeStore.uiFont(.body, weight: .semibold))
+                        .foregroundStyle(tokens.primaryText)
 
-                    Link(destination: AppExternalLinks.macRelease) {
-                        HStack(spacing: 10) {
-                            // 品牌资源保持官方黑白原色，不跟随 App 的主题色染色。
-                            Image("GitHubInvertocat")
-                                .renderingMode(.original)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 24, height: 24)
-                                .accessibilityHidden(true)
-
-                            Text(L10n.text("ui.view_releases_on_github"))
-                                .font(themeStore.uiFont(.callout, weight: .semibold))
-                                .foregroundStyle(tokens.primaryText)
-                                .fixedSize(horizontal: false, vertical: true)
-
-                            Spacer(minLength: 8)
-
-                            Image(systemName: "arrow.up.right")
-                                .font(themeStore.uiFont(.caption, weight: .semibold))
-                                .foregroundStyle(tokens.secondaryText)
-                                .accessibilityHidden(true)
-                        }
-                        .frame(minHeight: 44)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(L10n.text("ui.view_releases_on_github"))
-                    .accessibilityHint(L10n.text("ui.github_release_accessibility_hint"))
-                    .accessibilityIdentifier("settings.macInstaller.githubRelease")
+                    Text(L10n.text("ui.mac_installer_requirements_and_instructions"))
+                        .font(themeStore.uiFont(.footnote))
+                        .foregroundStyle(tokens.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
+                .padding(.vertical, 4)
+                .accessibilityElement(children: .combine)
+
+                ShareLink(item: AppExternalLinks.macInstaller) {
+                    GloballyCenteredActionLabel(
+                        title: L10n.text("ui.send_download_link_to_mac"),
+                        systemImage: "square.and.arrow.up"
+                    )
+                }
+                .buttonStyle(.bordered)
+                .tint(tokens.primaryAction)
+                .controlSize(.large)
+                .accessibilityIdentifier("settings.macInstaller.share")
+
+                Link(destination: AppExternalLinks.macRelease) {
+                    HStack(spacing: 12) {
+                        // 品牌资源保持官方黑白原色，不跟随 App 的主题色染色。
+                        Image("GitHubInvertocat")
+                            .renderingMode(.original)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 24, height: 24)
+                            .accessibilityHidden(true)
+
+                        Text(L10n.text("ui.view_releases_on_github"))
+                            .font(themeStore.uiFont(.body))
+                            .foregroundStyle(tokens.primaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Spacer(minLength: 8)
+
+                        Image(systemName: "arrow.up.right")
+                            .font(themeStore.uiFont(.caption, weight: .semibold))
+                            .foregroundStyle(tokens.secondaryText)
+                            .accessibilityHidden(true)
+                    }
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(L10n.text("ui.view_releases_on_github"))
+                .accessibilityHint(L10n.text("ui.github_release_accessibility_hint"))
+                .accessibilityIdentifier("settings.macInstaller.githubRelease")
+            } header: {
+                Text(L10n.text("ui.prepare_on_mac"))
+            } footer: {
+                Text(L10n.text("ui.select_code_directory_then_mac_shows_qr"))
             }
 
-            Divider()
+            Section {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text(L10n.text("ui.scan_qr_code_after_mac_setup"))
+                        .font(themeStore.uiFont(.footnote))
+                        .foregroundStyle(tokens.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
 
-            setupStep(
-                number: 2,
-                title: L10n.text("ui.open_and_finish_initial_setup"),
-                detail: L10n.text("ui.select_code_directory_then_mac_shows_qr")
-            ) {
-                EmptyView()
-            }
-
-            Divider()
-
-            setupStep(
-                number: 3,
-                title: L10n.text("ui.scan_qr_code_to_connect"),
-                detail: nil
-            ) {
-                VStack(spacing: 10) {
                     Button(action: onScan) {
                         GloballyCenteredActionLabel(
                             title: L10n.text("ui.scan_qr_code_on_mac"),
@@ -106,49 +107,14 @@ struct MacInstallationSetupView: View {
                     .accessibilityHint(L10n.text("ui.paste_connection_info_hint"))
                     .accessibilityIdentifier("settings.macInstaller.pasteConnectionInfo")
                 }
+                .padding(.vertical, 4)
+            } header: {
+                Text(L10n.text("ui.connect_on_this_device"))
+            } footer: {
+                Text(connectionFooter)
             }
         }
-        .padding(.vertical, 6)
-    }
-
-    private func setupStep<Actions: View>(
-        number: Int,
-        title: String,
-        detail: String?,
-        @ViewBuilder actions: () -> Actions
-    ) -> some View {
-        let tokens = themeStore.tokens(for: colorScheme)
-
-        return VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 12) {
-                Text(number.formatted())
-                    .font(themeStore.uiFont(.caption, weight: .bold))
-                    .foregroundStyle(tokens.primaryActionForeground)
-                    .frame(width: 26, height: 26)
-                    .background(tokens.primaryAction, in: Circle())
-                    .accessibilityHidden(true)
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(title)
-                        .font(themeStore.uiFont(.body, weight: .semibold))
-                        .foregroundStyle(tokens.primaryText)
-
-                    if let detail {
-                        Text(detail)
-                            .font(themeStore.uiFont(.footnote))
-                            .foregroundStyle(tokens.secondaryText)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-
-            // 步骤编号只负责标题层级，操作区独占完整内容宽度，
-            // 避免按钮和链接被编号列挤向屏幕右侧。
-            actions()
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .accessibilityElement(children: .contain)
+        .listRowBackground(tokens.elevatedSurface)
     }
 }
 
@@ -168,6 +134,8 @@ private struct GloballyCenteredActionLabel: View {
 
             Text(title)
                 .multilineTextAlignment(.center)
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity)
 
             Color.clear

--- a/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
@@ -38,18 +38,13 @@ struct MacInstallationSetupView: View {
                                 .renderingMode(.original)
                                 .resizable()
                                 .scaledToFit()
-                                .frame(width: 28, height: 28)
+                                .frame(width: 24, height: 24)
                                 .accessibilityHidden(true)
 
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(L10n.text("ui.view_releases_on_github"))
-                                    .font(themeStore.uiFont(.callout, weight: .semibold))
-                                    .foregroundStyle(tokens.primaryText)
-                                Text(AppExternalLinks.macRelease.absoluteString)
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(tokens.secondaryText)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
+                            Text(L10n.text("ui.view_releases_on_github"))
+                                .font(themeStore.uiFont(.callout, weight: .semibold))
+                                .foregroundStyle(tokens.primaryText)
+                                .fixedSize(horizontal: false, vertical: true)
 
                             Spacer(minLength: 8)
 
@@ -58,7 +53,7 @@ struct MacInstallationSetupView: View {
                                 .foregroundStyle(tokens.secondaryText)
                                 .accessibilityHidden(true)
                         }
-                        .padding(.vertical, 4)
+                        .frame(minHeight: 44)
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)

--- a/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
@@ -124,29 +124,34 @@ struct MacInstallationSetupView: View {
     ) -> some View {
         let tokens = themeStore.tokens(for: colorScheme)
 
-        return HStack(alignment: .top, spacing: 12) {
-            Text(number.formatted())
-                .font(themeStore.uiFont(.caption, weight: .bold))
-                .foregroundStyle(tokens.primaryActionForeground)
-                .frame(width: 26, height: 26)
-                .background(tokens.primaryAction, in: Circle())
-                .accessibilityHidden(true)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 12) {
+                Text(number.formatted())
+                    .font(themeStore.uiFont(.caption, weight: .bold))
+                    .foregroundStyle(tokens.primaryActionForeground)
+                    .frame(width: 26, height: 26)
+                    .background(tokens.primaryAction, in: Circle())
+                    .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text(title)
-                    .font(themeStore.uiFont(.body, weight: .semibold))
-                    .foregroundStyle(tokens.primaryText)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(title)
+                        .font(themeStore.uiFont(.body, weight: .semibold))
+                        .foregroundStyle(tokens.primaryText)
 
-                if let detail {
-                    Text(detail)
-                        .font(themeStore.uiFont(.footnote))
-                        .foregroundStyle(tokens.secondaryText)
-                        .fixedSize(horizontal: false, vertical: true)
+                    if let detail {
+                        Text(detail)
+                            .font(themeStore.uiFont(.footnote))
+                            .foregroundStyle(tokens.secondaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
-
-                actions()
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // 步骤编号只负责标题层级，操作区独占完整内容宽度，
+            // 避免按钮和链接被编号列挤向屏幕右侧。
+            actions()
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .accessibilityElement(children: .contain)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/MacInstallationSetupView.swift
@@ -29,17 +29,6 @@ struct MacInstallationSetupView: View {
                 .padding(.vertical, 4)
                 .accessibilityElement(children: .combine)
 
-                ShareLink(item: AppExternalLinks.macInstaller) {
-                    GloballyCenteredActionLabel(
-                        title: L10n.text("ui.send_download_link_to_mac"),
-                        systemImage: "square.and.arrow.up"
-                    )
-                }
-                .buttonStyle(.bordered)
-                .tint(tokens.primaryAction)
-                .controlSize(.large)
-                .accessibilityIdentifier("settings.macInstaller.share")
-
                 Link(destination: AppExternalLinks.macRelease) {
                     HStack(spacing: 12) {
                         // 品牌资源保持官方黑白原色，不跟随 App 的主题色染色。
@@ -69,6 +58,17 @@ struct MacInstallationSetupView: View {
                 .accessibilityLabel(L10n.text("ui.view_releases_on_github"))
                 .accessibilityHint(L10n.text("ui.github_release_accessibility_hint"))
                 .accessibilityIdentifier("settings.macInstaller.githubRelease")
+
+                ShareLink(item: AppExternalLinks.macInstaller) {
+                    GloballyCenteredActionLabel(
+                        title: L10n.text("ui.send_download_link_to_mac"),
+                        systemImage: "square.and.arrow.up"
+                    )
+                }
+                .buttonStyle(.bordered)
+                .tint(tokens.primaryAction)
+                .controlSize(.large)
+                .accessibilityIdentifier("settings.macInstaller.share")
             } header: {
                 Text(L10n.text("ui.prepare_on_mac"))
             } footer: {


### PR DESCRIPTION
## 变更内容

- 将首次连接页重构为“在 Mac 上准备”“在这台设备连接”“其他连接方式”三个原生分区。
- 修正安装与连接操作区整体右偏的问题，让按钮和入口相对屏幕中线保持对称。
- 将“在 GitHub 上查看新版本”改为单行外链入口，移除裸 URL，并调整到“发送下载链接到 Mac”之前。
- 保留扫码为唯一高强调主操作，粘贴作为次要操作；命令行安装和手动连接默认收起。
- 补充并更新相关本地化文案。

## 修改原因

原页面把安装说明、下载入口、连接动作和高级方式堆叠在同一张大卡片里，编号步骤与内部边距又让操作区产生视觉右偏。用户难以快速判断主路径，GitHub 裸地址也增加了无效信息密度。

## 用户影响

首次连接流程现在按实际操作顺序呈现，主次更清楚；iPhone 与 iPad 上的内容宽度、触控区域和动态字体表现保持可读。连接协议、相机权限、剪贴板解析、凭据保存和网络逻辑没有变化。

## 验证

- `git diff --check main...HEAD`
- Debug / iphoneos 实体机签名编译成功
- 已安装并启动到 iPhone 17 Pro（iOS 27.0）
- 已确认设备端 `MimiRemote` 进程正常运行
- 用户已在实体机完成人工验收
- 已检查 iPhone、iPad 和辅助功能大字号布局

关联：MIM-18
