### PR TITLE
MIM-17 修复 iPad 发起轮次被误判为 Mac 活动

### DIFF
--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -21,6 +21,16 @@ const (
 	defaultExternalActivityStaleAfter = 30 * time.Minute
 	externalActivityCandidateLimit    = 500
 	maxExternalActivityLineBytes      = 1 << 20
+	// Gateway 登记只需要覆盖 turn/start 到 rollout 写入 user_message 的短窗口。
+	// 有界 TTL 可以避免断线或 upstream 写失败后留下永久“本机发起”证据。
+	gatewayTurnRegistrationTTL   = 2 * time.Minute
+	gatewayTurnRegistrationLimit = 512
+	gatewayTurnRegistrationIDMax = 256
+	gatewayTurnEventClockSkew    = 2 * time.Second
+	// task_started 与 user_message 是同一次 turn/start 的相邻生命周期事件。
+	// 除了都要落在 registration TTL 内，两者还必须足够接近，避免失败请求的
+	// user_message 证据错误归属给稍后真正由 Mac 发起的 turn。
+	gatewayTurnLifecycleWindow = 10 * time.Second
 )
 
 // ExternalActivity 是允许返回给移动端的最小只读快照。
@@ -61,6 +71,23 @@ type externalRolloutCacheEntry struct {
 	threadSource string
 	active       bool
 	turnID       string
+	// gatewayTurnPending 表示在 task_started 之前到达的 user_message 已与 gateway 登记匹配；
+	// gatewayOwned 绑定当前 active turn。真实 rollout 可能先写 task_started，也可能先写
+	// user_message，因此两个方向都要支持；新的 task_started 仍必须重新取证。
+	gatewayTurnPending             bool
+	gatewayTurnPendingAt           time.Time
+	gatewayTurnPendingRegisteredAt time.Time
+	gatewayOwned                   bool
+	turnStartedAt                  time.Time
+}
+
+type gatewayTurnRegistration struct {
+	registeredAt time.Time
+}
+
+type gatewayTurnEvidence struct {
+	registeredAt time.Time
+	eventAt      time.Time
 }
 
 type externalRolloutRecord struct {
@@ -73,6 +100,7 @@ type externalRolloutRecord struct {
 		ThreadSource string `json:"thread_source"`
 		Type         string `json:"type"`
 		TurnID       string `json:"turn_id"`
+		ClientID     string `json:"client_id"`
 	} `json:"payload"`
 }
 
@@ -88,23 +116,25 @@ type ExternalActivityTracker struct {
 	open       func(string) (*os.File, error)
 	query      func(string, string) ([]byte, error)
 
-	dbSignature dbSignature
-	dbCached    bool
-	candidates  []externalActivityCandidate
-	files       map[string]externalRolloutCacheEntry
-	diagnostics ExternalActivityDiagnostics
+	dbSignature  dbSignature
+	dbCached     bool
+	candidates   []externalActivityCandidate
+	files        map[string]externalRolloutCacheEntry
+	gatewayTurns map[string]gatewayTurnRegistration
+	diagnostics  ExternalActivityDiagnostics
 }
 
 func NewExternalActivityTracker(db string, registry *projects.Registry) *ExternalActivityTracker {
 	return &ExternalActivityTracker{
-		store:      NewThreadStore(db),
-		registry:   registry,
-		staleAfter: defaultExternalActivityStaleAfter,
-		now:        time.Now,
-		stat:       os.Stat,
-		open:       os.Open,
-		query:      sqliteQueryFunc,
-		files:      map[string]externalRolloutCacheEntry{},
+		store:        NewThreadStore(db),
+		registry:     registry,
+		staleAfter:   defaultExternalActivityStaleAfter,
+		now:          time.Now,
+		stat:         os.Stat,
+		open:         os.Open,
+		query:        sqliteQueryFunc,
+		files:        map[string]externalRolloutCacheEntry{},
+		gatewayTurns: map[string]gatewayTurnRegistration{},
 	}
 }
 
@@ -116,6 +146,32 @@ func (t *ExternalActivityTracker) Diagnostics() ExternalActivityDiagnostics {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.diagnostics
+}
+
+// RegisterGatewayTurnStart 登记一个已经通过 agentd gateway 校验的 Codex turn/start。
+// 登记本身不会改变外部活动判断；只有同线程 rollout 随后写出时间相符且 client_id
+// 完全一致的 user_message，才能把紧随其后的 task_started 认定为 iPad 发起。
+func (t *ExternalActivityTracker) RegisterGatewayTurnStart(threadID string, clientUserMessageID string) {
+	threadID = strings.TrimSpace(threadID)
+	clientUserMessageID = strings.TrimSpace(clientUserMessageID)
+	if threadID == "" ||
+		clientUserMessageID == "" ||
+		len(threadID) > gatewayTurnRegistrationIDMax ||
+		len(clientUserMessageID) > gatewayTurnRegistrationIDMax {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now().UTC()
+	t.pruneGatewayTurnRegistrations(now)
+	if t.gatewayTurns == nil {
+		t.gatewayTurns = map[string]gatewayTurnRegistration{}
+	}
+	key := gatewayTurnRegistrationKey(threadID, clientUserMessageID)
+	t.gatewayTurns[key] = gatewayTurnRegistration{registeredAt: now}
+	t.trimGatewayTurnRegistrations()
 }
 
 // Snapshot 只返回仍有外部 turn 运行证据的白名单项目线程。
@@ -133,6 +189,7 @@ func (t *ExternalActivityTracker) Snapshot() ([]ExternalActivity, error) {
 	}
 
 	now := t.now()
+	t.pruneGatewayTurnRegistrations(now.UTC())
 	activities := make([]ExternalActivity, 0, len(candidates))
 	knownPaths := make(map[string]struct{}, len(candidates))
 	for _, candidate := range candidates {
@@ -153,10 +210,14 @@ func (t *ExternalActivityTracker) Snapshot() ([]ExternalActivity, error) {
 		if err != nil {
 			continue
 		}
+		if expireGatewayTurnPending(&entry, now.UTC()) {
+			t.files[path] = entry
+		}
 		if !isCodexDesktopOriginator(entry.originator) ||
 			entry.metaThreadID != candidate.ThreadID ||
 			!isTopLevelExternalThreadSource(entry.threadSource) ||
 			!entry.active ||
+			entry.gatewayOwned ||
 			now.Sub(info.ModTime()) > t.staleAfter {
 			continue
 		}
@@ -398,17 +459,157 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 	case "event_msg":
 		turnID := strings.TrimSpace(record.Payload.TurnID)
 		switch strings.TrimSpace(record.Payload.Type) {
+		case "user_message":
+			// rollout 的落盘顺序并不固定：当前版本通常先写 task_started，再写
+			// user_message；旧版本或边界窗口也可能相反。精确证据到达时，已有 active
+			// turn 就直接归属本机，否则留给紧随其后的 task_started 消费。
+			evidence, matched := t.consumeGatewayTurnRegistration(
+				entry.metaThreadID,
+				record.Payload.ClientID,
+				record.Timestamp,
+			)
+			clearGatewayTurnPending(entry)
+			if matched &&
+				entry.active &&
+				gatewayTurnEvidenceMatchesTaskStart(evidence, entry.turnStartedAt) {
+				entry.gatewayOwned = true
+			} else if matched && !entry.active {
+				entry.gatewayTurnPending = true
+				entry.gatewayTurnPendingAt = evidence.eventAt
+				entry.gatewayTurnPendingRegisteredAt = evidence.registeredAt
+			}
 		case "task_started":
+			turnStartedAt, _ := parseExternalRolloutTimestamp(record.Timestamp)
 			entry.active = true
 			entry.turnID = turnID
+			entry.turnStartedAt = turnStartedAt
+			entry.gatewayOwned = entry.gatewayTurnPending &&
+				gatewayTurnEvidenceMatchesTaskStart(
+					gatewayTurnEvidence{
+						registeredAt: entry.gatewayTurnPendingRegisteredAt,
+						eventAt:      entry.gatewayTurnPendingAt,
+					},
+					turnStartedAt,
+				)
+			clearGatewayTurnPending(entry)
 		case "task_complete", "turn_aborted":
 			// 旧 turn 的迟到 terminal 不能终止已经开始的新 turn。
 			if turnID == "" || entry.turnID == "" || turnID == entry.turnID {
 				entry.active = false
 				entry.turnID = ""
+				entry.turnStartedAt = time.Time{}
+				entry.gatewayOwned = false
+				clearGatewayTurnPending(entry)
 			}
 		}
 	}
+}
+
+func clearGatewayTurnPending(entry *externalRolloutCacheEntry) {
+	entry.gatewayTurnPending = false
+	entry.gatewayTurnPendingAt = time.Time{}
+	entry.gatewayTurnPendingRegisteredAt = time.Time{}
+}
+
+func expireGatewayTurnPending(entry *externalRolloutCacheEntry, now time.Time) bool {
+	if !entry.gatewayTurnPending {
+		return false
+	}
+	if !entry.gatewayTurnPendingAt.IsZero() &&
+		!now.After(entry.gatewayTurnPendingAt.Add(gatewayTurnLifecycleWindow)) {
+		return false
+	}
+	clearGatewayTurnPending(entry)
+	return true
+}
+
+func (t *ExternalActivityTracker) consumeGatewayTurnRegistration(
+	threadID string,
+	clientUserMessageID string,
+	rawTimestamp string,
+) (gatewayTurnEvidence, bool) {
+	threadID = strings.TrimSpace(threadID)
+	clientUserMessageID = strings.TrimSpace(clientUserMessageID)
+	rawTimestamp = strings.TrimSpace(rawTimestamp)
+	if threadID == "" || clientUserMessageID == "" || rawTimestamp == "" {
+		return gatewayTurnEvidence{}, false
+	}
+	eventAt, ok := parseExternalRolloutTimestamp(rawTimestamp)
+	if !ok {
+		return gatewayTurnEvidence{}, false
+	}
+	key := gatewayTurnRegistrationKey(threadID, clientUserMessageID)
+	registration, ok := t.gatewayTurns[key]
+	if !ok {
+		return gatewayTurnEvidence{}, false
+	}
+	// 同一个 client id 只能消费一次。即使时间校验失败也删除，避免恶意或损坏
+	// rollout 在稍后的重复行中重新尝试命中。
+	delete(t.gatewayTurns, key)
+	if eventAt.Before(registration.registeredAt.Add(-gatewayTurnEventClockSkew)) {
+		return gatewayTurnEvidence{}, false
+	}
+	if eventAt.After(registration.registeredAt.Add(gatewayTurnRegistrationTTL)) {
+		return gatewayTurnEvidence{}, false
+	}
+	return gatewayTurnEvidence{
+		registeredAt: registration.registeredAt,
+		eventAt:      eventAt,
+	}, true
+}
+
+func parseExternalRolloutTimestamp(rawTimestamp string) (time.Time, bool) {
+	eventAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(rawTimestamp))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return eventAt.UTC(), true
+}
+
+func gatewayTurnEvidenceMatchesTaskStart(evidence gatewayTurnEvidence, turnStartedAt time.Time) bool {
+	if evidence.registeredAt.IsZero() || evidence.eventAt.IsZero() || turnStartedAt.IsZero() {
+		return false
+	}
+	if turnStartedAt.Before(evidence.registeredAt.Add(-gatewayTurnEventClockSkew)) ||
+		turnStartedAt.After(evidence.registeredAt.Add(gatewayTurnRegistrationTTL)) {
+		return false
+	}
+	delta := turnStartedAt.Sub(evidence.eventAt)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= gatewayTurnLifecycleWindow
+}
+
+func (t *ExternalActivityTracker) pruneGatewayTurnRegistrations(now time.Time) {
+	for key, registration := range t.gatewayTurns {
+		if now.After(registration.registeredAt.Add(gatewayTurnRegistrationTTL)) {
+			delete(t.gatewayTurns, key)
+		}
+	}
+}
+
+func (t *ExternalActivityTracker) trimGatewayTurnRegistrations() {
+	for len(t.gatewayTurns) > gatewayTurnRegistrationLimit {
+		var oldestKey string
+		var oldestAt time.Time
+		for key, registration := range t.gatewayTurns {
+			if oldestKey == "" ||
+				registration.registeredAt.Before(oldestAt) ||
+				(registration.registeredAt.Equal(oldestAt) && key < oldestKey) {
+				oldestKey = key
+				oldestAt = registration.registeredAt
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(t.gatewayTurns, oldestKey)
+	}
+}
+
+func gatewayTurnRegistrationKey(threadID string, clientUserMessageID string) string {
+	return strings.TrimSpace(threadID) + "\x00" + strings.TrimSpace(clientUserMessageID)
 }
 
 func externalActivityRevision(info os.FileInfo) string {

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -2,6 +2,7 @@ package codexhistory
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,6 +154,255 @@ func TestExternalActivityWithoutStateDatabaseReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestExternalActivityExcludesExactGatewayOwnedTurn(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
+	path := fixture.writeRollout("thread-ipad", "Codex Desktop", fixture.projectDir,
+		externalEventLineAt(now.Add(100*time.Millisecond), "task_started", "turn-ipad"),
+		externalUserMessageLine(now.Add(500*time.Millisecond), "client-ipad"))
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-ipad", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("同线程、同 client_id 且时间相符的 gateway turn 不应被识别为 Desktop 外部活动：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if !entry.active || !entry.gatewayOwned || entry.turnID != "turn-ipad" {
+		t.Fatalf("rollout 应保留运行态并标记 gateway 归属：%+v", entry)
+	}
+}
+
+func TestExternalActivityAlsoSupportsUserMessageBeforeTaskStarted(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
+	path := fixture.writeRollout("thread-ipad", "Codex Desktop", fixture.projectDir,
+		externalUserMessageLine(now.Add(100*time.Millisecond), "client-ipad"),
+		externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-ipad"))
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-ipad", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("user_message 先落盘时也应把紧随其后的 task_started 识别为 gateway turn：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if !entry.active || !entry.gatewayOwned || entry.turnID != "turn-ipad" {
+		t.Fatalf("反向落盘顺序也应保留 gateway 归属：%+v", entry)
+	}
+}
+
+func TestExternalActivityExpiredPendingEvidenceCannotHideLaterDesktopTurn(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+	path := fixture.writeRollout(
+		"thread-1",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalUserMessageLine(now.Add(100*time.Millisecond), "client-ipad"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("只有 user_message、尚未开始 turn 时不应产生外部活动：%+v", got)
+	}
+	if !fixture.tracker.files[path].gatewayTurnPending {
+		t.Fatal("反向落盘顺序应暂存带时间界限的 gateway 证据")
+	}
+
+	now = now.Add(gatewayTurnLifecycleWindow + time.Second)
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("pending 过期时仍没有 active turn，不应产生外部活动：%+v", got)
+	}
+	if fixture.tracker.files[path].gatewayTurnPending {
+		t.Fatal("超过生命周期关联窗口后，pending gateway 证据必须主动失效")
+	}
+
+	now = now.Add(gatewayTurnRegistrationTTL + time.Second)
+	fixture.appendLine(path, externalEventLineAt(now, "task_started", "turn-desktop"))
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+		t.Fatalf("过期 pending 证据不能隐藏稍后的 Desktop turn：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if entry.gatewayOwned || entry.gatewayTurnPending {
+		t.Fatalf("Desktop turn 不应继承过期 gateway 证据：%+v", entry)
+	}
+}
+
+func TestExternalActivityMatchingUserMessageCannotClaimOlderActiveDesktopTurn(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+	path := fixture.writeRollout(
+		"thread-1",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(now.Add(-time.Minute), "task_started", "turn-desktop"),
+		externalUserMessageLine(now.Add(100*time.Millisecond), "client-ipad"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+		t.Fatalf("匹配消息不能把 registration 之前已运行的 Desktop turn 改写为 gateway 所有：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if entry.gatewayOwned || entry.gatewayTurnPending {
+		t.Fatalf("旧 Desktop turn 不应吸收新 gateway 消息证据：%+v", entry)
+	}
+}
+
+func TestExternalActivityGatewayOwnershipRequiresExactEvidence(t *testing.T) {
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		registeredThread string
+		registeredClient string
+		eventClient      string
+		eventAt          time.Time
+	}{
+		{
+			name:             "wrong client id",
+			registeredThread: "thread-1",
+			registeredClient: "client-ipad",
+			eventClient:      "client-desktop",
+			eventAt:          now.Add(time.Second),
+		},
+		{
+			name:             "wrong thread",
+			registeredThread: "thread-other",
+			registeredClient: "client-ipad",
+			eventClient:      "client-ipad",
+			eventAt:          now.Add(time.Second),
+		},
+		{
+			name:             "old rollout timestamp",
+			registeredThread: "thread-1",
+			registeredClient: "client-ipad",
+			eventClient:      "client-ipad",
+			eventAt:          now.Add(-gatewayTurnRegistrationTTL),
+		},
+		{
+			name:             "missing client id",
+			registeredThread: "thread-1",
+			registeredClient: "client-ipad",
+			eventClient:      "",
+			eventAt:          now.Add(time.Second),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newExternalActivityTrackerFixture(t)
+			fixture.tracker.now = func() time.Time { return now }
+			fixture.tracker.RegisterGatewayTurnStart(tc.registeredThread, tc.registeredClient)
+			path := fixture.writeRollout("thread-1", "Codex Desktop", fixture.projectDir,
+				externalUserMessageLine(tc.eventAt, tc.eventClient),
+				externalEventLine("task_started", "turn-desktop"))
+			if err := os.Chtimes(path, now, now); err != nil {
+				t.Fatal(err)
+			}
+			fixture.rows = []externalActivityTestRow{{
+				ID: "thread-1", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+			}}
+
+			got := fixture.snapshot(t)
+			if len(got) != 1 || got[0].ThreadID != "thread-1" || got[0].TurnID != "turn-desktop" {
+				t.Fatalf("证据不完整时必须 fail-safe 保留 Desktop 外部活动：%+v", got)
+			}
+		})
+	}
+}
+
+func TestExternalActivityNewDesktopTurnResetsGatewayOwnership(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+	path := fixture.writeRollout("thread-1", "Codex Desktop", fixture.projectDir,
+		externalUserMessageLine(now.Add(100*time.Millisecond), "client-ipad"),
+		externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-ipad"))
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode", ThreadSource: "user", RolloutPath: path,
+	}}
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("第一轮 iPad turn 不应显示为外部活动：%+v", got)
+	}
+
+	// 后续没有匹配 user_message 的新 task_started 是真正的 Desktop turn，
+	// 必须覆盖上一轮 gateway 归属，重新进入“仅观察”保护。
+	fixture.appendLine(path, externalEventLineAt(now.Add(time.Second), "task_started", "turn-desktop"))
+	if err := os.Chtimes(path, now.Add(time.Second), now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+		t.Fatalf("新的 Desktop task_started 应恢复外部活动：%+v", got)
+	}
+
+	fixture.appendLine(path, externalEventLineAt(now.Add(2*time.Second), "task_complete", "turn-desktop"))
+	if err := os.Chtimes(path, now.Add(2*time.Second), now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("terminal 应清除活动与归属状态：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if entry.active || entry.gatewayOwned || entry.gatewayTurnPending {
+		t.Fatalf("terminal 后不应残留 gateway 状态：%+v", entry)
+	}
+}
+
+func TestGatewayTurnRegistrationsAreBoundedAndExpire(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	for index := 0; index < gatewayTurnRegistrationLimit+7; index++ {
+		fixture.tracker.RegisterGatewayTurnStart("thread-1", fmt.Sprintf("client-%d", index))
+		now = now.Add(time.Microsecond)
+	}
+	if got := len(fixture.tracker.gatewayTurns); got != gatewayTurnRegistrationLimit {
+		t.Fatalf("gateway 登记表必须有容量上限：got=%d want=%d", got, gatewayTurnRegistrationLimit)
+	}
+
+	now = now.Add(gatewayTurnRegistrationTTL + time.Second)
+	fixture.tracker.RegisterGatewayTurnStart("thread-fresh", "client-fresh")
+	if got := len(fixture.tracker.gatewayTurns); got != 1 {
+		t.Fatalf("过期 gateway 登记应在新写入时被裁剪：got=%d entries=%+v", got, fixture.tracker.gatewayTurns)
+	}
+	if _, ok := fixture.tracker.gatewayTurns[gatewayTurnRegistrationKey("thread-fresh", "client-fresh")]; !ok {
+		t.Fatal("最新 gateway 登记不应被裁剪")
+	}
+}
+
 type externalActivityTestRow struct {
 	ID           string `json:"id"`
 	CWD          string `json:"cwd"`
@@ -247,8 +497,31 @@ func (f *externalActivityTrackerFixture) snapshot(t *testing.T) []ExternalActivi
 }
 
 func externalEventLine(eventType, turnID string) string {
-	return `{"timestamp":"2026-07-28T14:00:01Z","type":"event_msg","payload":{"type":` +
+	return externalEventLineAt(
+		time.Date(2026, 7, 28, 14, 0, 1, 0, time.UTC),
+		eventType,
+		turnID,
+	)
+}
+
+func externalEventLineAt(timestamp time.Time, eventType, turnID string) string {
+	return `{"timestamp":` + strconvQuote(timestamp.UTC().Format(time.RFC3339Nano)) +
+		`,"type":"event_msg","payload":{"type":` +
 		strconvQuote(eventType) + `,"turn_id":` + strconvQuote(turnID) + `}}`
+}
+
+func externalUserMessageLine(timestamp time.Time, clientID string) string {
+	payload := map[string]any{"type": "user_message"}
+	if strings.TrimSpace(clientID) != "" {
+		payload["client_id"] = clientID
+	}
+	record := map[string]any{
+		"timestamp": timestamp.UTC().Format(time.RFC3339Nano),
+		"type":      "event_msg",
+		"payload":   payload,
+	}
+	data, _ := json.Marshal(record)
+	return string(data)
 }
 
 func mustJSONQuote(t *testing.T, value string) string {

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -79,6 +79,7 @@ func (p *appServerGatewayPolicy) validateClientFrame(messageType int, payload []
 		p.forgetPending(frame.ID)
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "app-server gateway 连接已关闭"}
 	}
+	p.router.registerGatewayTurnStart(p.runtimeID, method, rewritten)
 	logGatewayForwardedClientTurnSummary(method, rewritten)
 	return rewritten, nil
 }

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -1892,6 +1892,92 @@ func TestAppServerGatewayForwardsAuthorizedFrameUnchanged(t *testing.T) {
 	}
 }
 
+func TestAppServerGatewayRegistersOnlyValidatedCodexTurnStarts(t *testing.T) {
+	_, router, projectDir := buildAppServerGatewayFixture(t, "", nil)
+	recorder := &recordingExternalActivitySource{}
+	router.externalActivity = recorder
+	scope, ok := router.gatewayScopeForPath(projectDir)
+	if !ok {
+		t.Fatal("测试项目目录应命中 gateway scope")
+	}
+	newPolicy := func(runtimeID string) *appServerGatewayPolicy {
+		return &appServerGatewayPolicy{
+			router:    router,
+			runtimeID: runtimeID,
+			allowedThreads: map[string]appServerGatewayAllowedThread{
+				"thread-1": {
+					id: "thread-1", runtimeID: runtimeID, cwd: projectDir, scopeID: scope.id,
+				},
+			},
+		}
+	}
+	turnStart := func(id int, clientID string, networkAccess bool) []byte {
+		clientField := ""
+		if clientID != "" {
+			clientField = fmt.Sprintf(`,"clientUserMessageId":%q`, clientID)
+		}
+		return []byte(fmt.Sprintf(
+			`{"id":%d,"method":"turn/start","params":{"threadId":"thread-1","cwd":%q,"input":[{"type":"text","text":"hi"}]%s,"approvalPolicy":"on-request","approvalsReviewer":"user","sandboxPolicy":{"type":"workspaceWrite","writableRoots":[%q],"networkAccess":%t}}}`,
+			id,
+			projectDir,
+			clientField,
+			projectDir,
+			networkAccess,
+		))
+	}
+
+	forwarded, policyErr := newPolicy("codex").validateClientFrame(
+		websocket.TextMessage,
+		turnStart(1, "client-ipad", false),
+	)
+	if policyErr != nil || !bytes.Contains(forwarded, []byte(`"clientUserMessageId":"client-ipad"`)) {
+		t.Fatalf("合法 Codex turn/start 应完成安全改写并转发：err=%+v payload=%s", policyErr, forwarded)
+	}
+	if len(recorder.registrations) != 1 ||
+		recorder.registrations[0].threadID != "thread-1" ||
+		recorder.registrations[0].clientUserMessageID != "client-ipad" {
+		t.Fatalf("合法 Codex turn/start 应登记精确关联 ID：%+v", recorder.registrations)
+	}
+
+	if _, policyErr := newPolicy("codex").validateClientFrame(
+		websocket.TextMessage,
+		turnStart(2, "client-invalid", true),
+	); policyErr == nil {
+		t.Fatal("networkAccess=true 的非法 turn/start 应被拒绝")
+	}
+	if len(recorder.registrations) != 1 {
+		t.Fatalf("未通过策略校验的 turn/start 不应登记：%+v", recorder.registrations)
+	}
+
+	if _, policyErr := newPolicy("codex").validateClientFrame(
+		websocket.TextMessage,
+		turnStart(3, "", false),
+	); policyErr != nil {
+		t.Fatalf("缺 clientUserMessageId 仍可由上游处理，但不能作为 ownership 证据：%+v", policyErr)
+	}
+	if len(recorder.registrations) != 1 {
+		t.Fatalf("缺 clientUserMessageId 的 turn/start 不应登记：%+v", recorder.registrations)
+	}
+
+	steer := []byte(`{"id":4,"method":"turn/steer","params":{"threadId":"thread-1","expectedTurnId":"turn-1","clientUserMessageId":"client-steer","input":[{"type":"text","text":"继续"}]}}`)
+	if _, policyErr := newPolicy("codex").validateClientFrame(websocket.TextMessage, steer); policyErr != nil {
+		t.Fatalf("合法 turn/steer 应继续转发：%+v", policyErr)
+	}
+	if len(recorder.registrations) != 1 {
+		t.Fatalf("turn/steer 不是新 turn ownership 证据，不应登记：%+v", recorder.registrations)
+	}
+
+	if _, policyErr := newPolicy("claude").validateClientFrame(
+		websocket.TextMessage,
+		turnStart(5, "client-claude", false),
+	); policyErr != nil {
+		t.Fatalf("合法 Claude turn/start 应继续转发：%+v", policyErr)
+	}
+	if len(recorder.registrations) != 1 {
+		t.Fatalf("Claude turn/start 不属于 Codex rollout 跟踪，不应登记：%+v", recorder.registrations)
+	}
+}
+
 func TestAppServerHistoryImageRedactionRewritesImageGenerationResult(t *testing.T) {
 	router := &Router{historyMedia: newAppServerHistoryMediaStore()}
 	pngBytes := append([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}, bytes.Repeat([]byte{0xAB}, 20<<10)...)

--- a/internal/httpapi/external_activity.go
+++ b/internal/httpapi/external_activity.go
@@ -1,8 +1,10 @@
 package httpapi
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gaixianggeng/mimi-remote/internal/codexhistory"
@@ -12,9 +14,42 @@ type externalActivitySource interface {
 	Snapshot() ([]codexhistory.ExternalActivity, error)
 }
 
+type gatewayTurnStartRegistrar interface {
+	RegisterGatewayTurnStart(threadID string, clientUserMessageID string)
+}
+
 type externalActivityResponse struct {
 	Activities []codexhistory.ExternalActivity `json:"activities"`
 	ScannedAt  time.Time                       `json:"scanned_at"`
+}
+
+// registerGatewayTurnStart 只接收已经完成 gateway 校验和安全改写的最终帧。
+// 这里再次限定 Codex + turn/start，并要求两个关联 ID 都存在；任何证据缺失都不登记，
+// 让外部活动检测继续按 Desktop turn 处理，避免错误放宽控制权限。
+func (r *Router) registerGatewayTurnStart(runtimeID string, method string, payload []byte) {
+	if r == nil ||
+		normalizeAppServerRuntimeID(runtimeID) != "codex" ||
+		strings.TrimSpace(method) != "turn/start" {
+		return
+	}
+	registrar, ok := r.externalActivity.(gatewayTurnStartRegistrar)
+	if !ok {
+		return
+	}
+	var frame appServerGatewayFrame
+	if err := json.Unmarshal(payload, &frame); err != nil || strings.TrimSpace(frame.Method) != "turn/start" {
+		return
+	}
+	params, err := decodeGatewayParams(frame.Params)
+	if err != nil {
+		return
+	}
+	threadID, threadOK := gatewayStringParam(params, "threadId")
+	clientUserMessageID, clientOK := gatewayStringParam(params, "clientUserMessageId")
+	if !threadOK || !clientOK {
+		return
+	}
+	registrar.RegisterGatewayTurnStart(threadID, clientUserMessageID)
 }
 
 func (r *Router) externalActivityHandler(w http.ResponseWriter, req *http.Request) {

--- a/internal/httpapi/external_activity_test.go
+++ b/internal/httpapi/external_activity_test.go
@@ -20,6 +20,26 @@ func (s stubExternalActivitySource) Snapshot() ([]codexhistory.ExternalActivity,
 	return s.activities, s.err
 }
 
+type recordingExternalActivitySource struct {
+	registrations []gatewayTurnStartRegistration
+}
+
+type gatewayTurnStartRegistration struct {
+	threadID            string
+	clientUserMessageID string
+}
+
+func (s *recordingExternalActivitySource) Snapshot() ([]codexhistory.ExternalActivity, error) {
+	return []codexhistory.ExternalActivity{}, nil
+}
+
+func (s *recordingExternalActivitySource) RegisterGatewayTurnStart(threadID string, clientUserMessageID string) {
+	s.registrations = append(s.registrations, gatewayTurnStartRegistration{
+		threadID:            threadID,
+		clientUserMessageID: clientUserMessageID,
+	})
+}
+
 func TestExternalActivityRequiresAuthAndReturnsSanitizedSnapshot(t *testing.T) {
 	handler, router := appServerGatewayRouterFixtureWithRouter(t, "", nil)
 	router.externalActivity = stubExternalActivitySource{activities: []codexhistory.ExternalActivity{{

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -233,6 +233,11 @@ final class SessionStore: ObservableObject {
     // 终态刷新期间 activity 已从服务端快照消失，但历史还没补齐；这段窗口仍必须保持只读，
     // 防止旧的持久化 `.takenOver` 状态抢先触发 thread/resume。
     var externalReadOnlySessionIDs: Set<SessionID> = []
+    // 只记录当前 Host 生命周期内由 iPad 的 turn/start 明确返回的 turnID。不能用持久化的
+    // `.takenOver` / `.ipadOwned` 代替：同一 thread 后续可能真的在 Mac 启动新 turn。
+    // 精确到 session + turn 后，既能过滤 Desktop-origin 历史线程的 rollout 镜像，
+    // 又不会放行 turnID 不同的真实 Mac 活动。
+    var locallyStartedTurnIDBySessionID: [SessionID: TurnID] = [:]
     var isRefreshingExternalActivity = false
     var externalActivityCapabilityUnavailable = false
     var connectionChangeGeneration = 0

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -145,12 +145,23 @@ extension SessionStore {
         }
         socket.onTurnSendOutcome = { [weak self] clientMessageID, outcome in
             Task { @MainActor in
-                guard let self,
-                      self.isCurrentWebSocketConnection(
-                          sessionID: session.id,
-                          generation: connectionGeneration,
-                          hostScope: hostScope
-                      ) else {
+                guard let self else {
+                    return
+                }
+                let isCurrentConnection = self.isCurrentWebSocketConnection(
+                    sessionID: session.id,
+                    generation: connectionGeneration,
+                    hostScope: hostScope
+                )
+                // external-activity 可能在 turn/start ACK 前先误断开 socket。仅当迟到 ACK 的
+                // turnID 与被标成 Mac 活动的 turn 精确一致时，允许旧连接完成这次对账；
+                // Host 已切换、turnID 不同或普通旧回调仍全部丢弃。
+                guard isCurrentConnection ||
+                        self.canReconcileAcceptedTurnFromRetiredSocket(
+                            sessionID: session.id,
+                            outcome: outcome,
+                            hostScope: hostScope
+                        ) else {
                     return
                 }
                 self.handleTurnSendOutcome(
@@ -1896,6 +1907,7 @@ extension SessionStore {
         foregroundActivityBySessionID = [:]
         externalActivityBySessionID = [:]
         externalReadOnlySessionIDs = []
+        locallyStartedTurnIDBySessionID = [:]
         isRefreshingExternalActivity = false
         externalActivityCapabilityUnavailable = false
         runtimeActivityBySessionID = [:]

--- a/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
@@ -3,6 +3,80 @@ import Foundation
 // Codex Desktop 与 Mimi 的 app-server 是两个独立进程，runtime status 不能跨进程复用。
 // 这里消费 agentd 从 rollout 提炼出的只读活动层；所有消息仍走现有历史读取，不建立控制连接。
 extension SessionStore {
+    func isLocallyStartedExternalActivity(_ activity: ExternalSessionActivity) -> Bool {
+        guard let turnID = activity.turnID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !turnID.isEmpty else {
+            return false
+        }
+        return locallyStartedTurnIDBySessionID[activity.threadID] == turnID
+    }
+
+    /// 记录由当前 iPad 明确启动成功的 turn，并撤销轮询先于 ACK 时造成的误判。
+    ///
+    /// 这里只接受精确的 session + turnID 证据。持久化控制状态、运行状态或 thread originator
+    /// 都不足以证明当前 turn 的所有权，不能用于清除真实的 Mac 只读边界。
+    @discardableResult
+    func recordLocallyStartedTurn(
+        sessionID: SessionID,
+        turnID rawTurnID: TurnID,
+        restoreSelectedConnection: Bool = true
+    ) -> Bool {
+        let turnID = rawTurnID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !turnID.isEmpty else {
+            return false
+        }
+        locallyStartedTurnIDBySessionID[sessionID] = turnID
+
+        let externalTurnID = externalActivityBySessionID[sessionID]?.turnID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let sessionTurnID = sessionsByID[sessionID]?.activeTurnID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let matchesMisclassifiedTurn = externalTurnID == turnID ||
+            (externalReadOnlySessionIDs.contains(sessionID) && sessionTurnID == turnID)
+        guard matchesMisclassifiedTurn else {
+            return false
+        }
+
+        externalActivityBySessionID.removeValue(forKey: sessionID)
+        externalReadOnlySessionIDs.remove(sessionID)
+        updateSession(sessionID) { session in
+            session.status = SessionStatus.running.rawValue
+            session.activeTurnID = turnID
+        }
+
+        if restoreSelectedConnection,
+           selectedSessionID == sessionID,
+           let session = sessionsByID[sessionID] {
+            // external snapshot 已退役旧 socket；精确 ACK 到达后恢复本轮事件流。
+            // 历史内容已在断线前或 create/resume 流程中对账，这里只回放状态边界。
+            connectWebSocket(session, replayBufferedEvents: false)
+        }
+        return true
+    }
+
+    func canReconcileAcceptedTurnFromRetiredSocket(
+        sessionID: SessionID,
+        outcome: TurnSendOutcome,
+        hostScope: HostScope
+    ) -> Bool {
+        guard appStore.activeHostScope == hostScope,
+              sessionsByID[sessionID] != nil,
+              case .accepted(let acceptedTurnID) = outcome,
+              let acceptedTurnID else {
+            return false
+        }
+        let normalizedTurnID = acceptedTurnID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedTurnID.isEmpty else {
+            return false
+        }
+        let externalTurnID = externalActivityBySessionID[sessionID]?.turnID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let sessionTurnID = sessionsByID[sessionID]?.activeTurnID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return externalTurnID == normalizedTurnID ||
+            (externalReadOnlySessionIDs.contains(sessionID) && sessionTurnID == normalizedTurnID)
+    }
+
     func externalActivityPollingDelayNanoseconds() -> UInt64 {
         if let selectedSessionID,
            externalActivityBySessionID[selectedSessionID] != nil {
@@ -100,6 +174,11 @@ extension SessionStore {
         var nextByID: [SessionID: ExternalSessionActivity] = [:]
         for activity in activities where activity.state.lowercased() == "running" {
             guard workspacesByID[activity.projectID] != nil || projectsByID[activity.projectID] != nil else {
+                continue
+            }
+            // Desktop 创建的历史 thread 会永久保留 originator。若当前 rollout turn 与
+            // iPad 的 turn/start ACK 精确一致，它只是本轮的磁盘镜像，不是 Mac 接管。
+            guard !isLocallyStartedExternalActivity(activity) else {
                 continue
             }
             nextByID[activity.threadID] = activity

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -146,6 +146,15 @@ extension SessionStore {
             }
             upsert(responseSession)
             setSessionControlState(resume == nil ? .ipadOwned : .takenOver, sessionID: responseSession.id)
+            if !payload.isEmpty, let activeTurnID = responseSession.activeTurnID {
+                // create/resume 内部的 turn/start 已由 app-server 接受；在历史补拉前登记，
+                // 防止同一 Desktop-origin rollout 的轮询快照把本轮误判成 Mac 接管。
+                recordLocallyStartedTurn(
+                    sessionID: responseSession.id,
+                    turnID: activeTurnID,
+                    restoreSelectedConnection: false
+                )
+            }
             insertExpandedProjectID(responseSession.projectID)
 
             let responseSelectionLease: SessionSelectionLease?
@@ -2279,6 +2288,9 @@ extension SessionStore {
         let runtimeActivities = runtimeActivityBySessionID.filter { validSessionIDs.contains($0.key) }
         if runtimeActivities != runtimeActivityBySessionID {
             runtimeActivityBySessionID = runtimeActivities
+        }
+        locallyStartedTurnIDBySessionID = locallyStartedTurnIDBySessionID.filter {
+            validSessionIDs.contains($0.key)
         }
     }
 

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -1023,10 +1023,22 @@ extension SessionStore {
         }
         socket.onTurnSendOutcome = { [weak self] clientMessageID, outcome in
             Task { @MainActor in
-                guard self?.isCurrentQueuedSessionSocket(sessionID: sessionID, generation: generation) == true else {
+                guard let self else {
                     return
                 }
-                self?.handleTurnSendOutcome(
+                let isCurrentConnection = self.isCurrentQueuedSessionSocket(
+                    sessionID: sessionID,
+                    generation: generation
+                )
+                guard isCurrentConnection ||
+                        self.canReconcileAcceptedTurnFromRetiredSocket(
+                            sessionID: sessionID,
+                            outcome: outcome,
+                            hostScope: eventLease.hostScope
+                        ) else {
+                    return
+                }
+                self.handleTurnSendOutcome(
                     clientMessageID: clientMessageID,
                     sessionID: sessionID,
                     outcome: outcome
@@ -1136,7 +1148,7 @@ extension SessionStore {
         guard let location = queuedTurnLocation(clientMessageID: clientMessageID),
               location.sessionID == sessionID,
               let item = queuedRunningTurnsBySessionID[sessionID]?[location.index],
-              item.dispatchState == .dispatching
+              item.dispatchState == .dispatching || item.dispatchState == .needsConfirmation
         else {
             return false
         }
@@ -1208,6 +1220,15 @@ extension SessionStore {
         sessionID: SessionID,
         outcome: TurnSendOutcome
     ) {
+        let recoveredExternalMisclassification: Bool
+        if case .accepted(let turnID) = outcome, let turnID {
+            recoveredExternalMisclassification = recordLocallyStartedTurn(
+                sessionID: sessionID,
+                turnID: turnID
+            )
+        } else {
+            recoveredExternalMisclassification = false
+        }
         guard let clientMessageID else { return }
         switch outcome {
         case .accepted:
@@ -1221,6 +1242,13 @@ extension SessionStore {
                     clientMessageID: clientMessageID,
                     sessionID: sessionID
                 )
+            }
+            if recoveredExternalMisclassification,
+               selectedSessionID != sessionID,
+               queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false {
+                // external snapshot 会停止后台队列 socket。ACK 对账成功且仍有后续项时，
+                // 重新建立监听，让 FIFO 能在当前 turn 完成后继续派发。
+                ensureQueuedSessionMonitoring(sessionID: sessionID)
             }
         case .activeTurnConflict(let activeTurnID, let message):
             // 这是“新消息未被接受”，不是原会话失败。恢复权威 active turn，

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
@@ -190,6 +190,306 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(client.createPayloads.isEmpty)
     }
 
+    func testLocallyStartedTurnIgnoresMatchingDesktopOriginActivityButNotNewMacTurn() async throws {
+        let project = makeProject(id: "proj_local_turn_ownership")
+        let threadID = "thread-desktop-origin"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "由 Mac 创建、在 iPad 续写",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID,
+            activeTurnID: "turn-ipad"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            workspacePages: [project.id: SessionsPage(sessions: [history])]
+        )
+        let socket = MockWebSocketClient()
+        let store = makeExternalActivityStore(
+            project: project,
+            session: history,
+            client: client,
+            socket: socket
+        )
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+        store.sessionControlStateByID[threadID] = .takenOver
+        store.recordLocallyStartedTurn(
+            sessionID: threadID,
+            turnID: "turn-ipad",
+            restoreSelectedConnection: false
+        )
+
+        await store.applyExternalActivitySnapshot(
+            [makeExternalActivity(
+                threadID: threadID,
+                projectID: project.id,
+                turnID: "turn-ipad",
+                revision: "rev-ipad"
+            )],
+            client: client,
+            hostScope: store.appStore.activeHostScope
+        )
+
+        let ipadOwned = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.isExternalReadOnlySession(ipadOwned))
+        XCTAssertEqual(store.controlState(for: ipadOwned), .takenOver)
+        XCTAssertEqual(ipadOwned.activeTurnID, "turn-ipad")
+        XCTAssertEqual(socket.disconnectCallCount, 0)
+
+        await store.applyExternalActivitySnapshot(
+            [makeExternalActivity(
+                threadID: threadID,
+                projectID: project.id,
+                turnID: "turn-mac-next",
+                revision: "rev-mac-next"
+            )],
+            client: client,
+            hostScope: store.appStore.activeHostScope
+        )
+
+        let macOwned = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertEqual(store.externalActivityBySessionID[threadID]?.turnID, "turn-mac-next")
+        XCTAssertTrue(store.isExternalReadOnlySession(macOwned))
+        XCTAssertEqual(store.controlState(for: macOwned), .observing)
+        XCTAssertFalse(store.canControlSession(macOwned))
+    }
+
+    func testHistoricalResumeRecordsReturnedTurnBeforeExternalPolling() async throws {
+        let project = makeProject(id: "proj_desktop_history_resume")
+        let threadID = "thread-desktop-history-resume"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "Mac 历史会话",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let resumed = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "Mac 历史会话",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID,
+            activeTurnID: "turn-ipad-resume"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            workspacePages: [project.id: SessionsPage(sessions: [resumed])],
+            createSessionResponse: CreateSessionResponse(
+                session: resumed,
+                row: nil,
+                wsURL: "/api/app-server/ws?thread_id=\(threadID)",
+                firstMessage: nil
+            )
+        )
+        let socket = MockWebSocketClient()
+        let store = makeExternalActivityStore(
+            project: project,
+            session: history,
+            client: client,
+            socket: socket
+        )
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+
+        let didSend = await store.sendTurn(CodexAppServerTurnPayload(prompt: "从 iPad 继续"))
+
+        XCTAssertTrue(didSend)
+        XCTAssertEqual(client.createPayloads.first?.resumeID, threadID)
+        XCTAssertEqual(store.locallyStartedTurnIDBySessionID[threadID], "turn-ipad-resume")
+        XCTAssertEqual(store.controlState(for: try XCTUnwrap(store.sessionsByID[threadID])), .takenOver)
+
+        await store.applyExternalActivitySnapshot(
+            [makeExternalActivity(
+                threadID: threadID,
+                projectID: project.id,
+                turnID: "turn-ipad-resume",
+                revision: "rev-ipad-resume"
+            )],
+            client: client,
+            hostScope: store.appStore.activeHostScope
+        )
+
+        let controlled = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.isExternalReadOnlySession(controlled))
+        XCTAssertEqual(store.controlState(for: controlled), .takenOver)
+        XCTAssertEqual(socket.disconnectCallCount, 0)
+    }
+
+    func testLocalTurnAckReconcilesExternalSnapshotThatArrivedFirstAndReconnects() async throws {
+        let project = makeProject(id: "proj_external_ack_race")
+        let threadID = "thread-ack-race"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "轮询早于 ACK",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            workspacePages: [project.id: SessionsPage(sessions: [history])]
+        )
+        let socket = MockWebSocketClient()
+        let store = makeExternalActivityStore(
+            project: project,
+            session: history,
+            client: client,
+            socket: socket
+        )
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+        store.sessionControlStateByID[threadID] = .takenOver
+        store.connectWebSocket(history, allowNonRunning: true)
+        XCTAssertEqual(socket.connectedSessionIDs, [threadID])
+
+        let activity = makeExternalActivity(
+            threadID: threadID,
+            projectID: project.id,
+            turnID: "turn-local-race",
+            revision: "rev-race"
+        )
+        await store.applyExternalActivitySnapshot(
+            [activity],
+            client: client,
+            hostScope: store.appStore.activeHostScope
+        )
+        XCTAssertTrue(store.externalReadOnlySessionIDs.contains(threadID))
+        XCTAssertNil(store.connectedSessionID)
+        XCTAssertGreaterThanOrEqual(socket.disconnectCallCount, 1)
+        XCTAssertTrue(store.canReconcileAcceptedTurnFromRetiredSocket(
+            sessionID: threadID,
+            outcome: .accepted(turnID: "turn-local-race"),
+            hostScope: store.appStore.activeHostScope
+        ))
+
+        socket.onTurnSendOutcome?(nil, .accepted(turnID: "turn-local-race"))
+        for _ in 0..<10 where store.externalActivityBySessionID[threadID] != nil {
+            await Task.yield()
+        }
+
+        let recovered = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.isExternalReadOnlySession(recovered))
+        XCTAssertEqual(recovered.activeTurnID, "turn-local-race")
+        XCTAssertEqual(store.controlState(for: recovered), .takenOver)
+        XCTAssertEqual(store.connectedSessionID, threadID)
+        XCTAssertEqual(socket.connectedSessionIDs, [threadID, threadID])
+    }
+
+    func testLateAcceptedAckCompletesQueuedItemAfterExternalDisconnect() throws {
+        let project = makeProject(id: "proj_external_queue_ack")
+        let threadID = "thread-queue-ack"
+        let clientMessageID = "client-queue-ack"
+        let session = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "排队 ACK 竞态",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID,
+            activeTurnID: "turn-queue-local"
+        )
+        let client = MockSessionStoreClient(projects: [project], sessions: [session])
+        let store = makeExternalActivityStore(project: project, session: session, client: client)
+        let payload = CodexAppServerTurnPayload(prompt: "排队消息")
+        store.queuedRunningTurnsBySessionID[threadID] = [QueuedTurnEntry(
+            sessionID: threadID,
+            projectID: project.id,
+            payload: payload,
+            clientMessageID: clientMessageID,
+            intent: .standard,
+            dispatchState: .needsConfirmation
+        )]
+        store.conversationStore.appendLocalUser(
+            "排队消息",
+            sessionID: threadID,
+            clientMessageID: clientMessageID,
+            sendStatus: .sending,
+            turnPayload: payload,
+            userDelivery: .queued
+        )
+        let activity = makeExternalActivity(
+            threadID: threadID,
+            projectID: project.id,
+            turnID: "turn-queue-local",
+            revision: "rev-queue-local"
+        )
+        store.externalActivityBySessionID[threadID] = activity
+        store.externalReadOnlySessionIDs.insert(threadID)
+
+        store.handleTurnSendOutcome(
+            clientMessageID: clientMessageID,
+            sessionID: threadID,
+            outcome: .accepted(turnID: "turn-queue-local")
+        )
+
+        XCTAssertTrue(store.queuedRunningTurnsBySessionID[threadID]?.isEmpty != false)
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.externalReadOnlySessionIDs.contains(threadID))
+        XCTAssertEqual(store.locallyStartedTurnIDBySessionID[threadID], "turn-queue-local")
+        XCTAssertEqual(
+            store.conversationStore.messages(for: threadID)
+                .first(where: { $0.clientMessageID == clientMessageID })?
+                .sendStatus,
+            .sent
+        )
+    }
+
+    func testCompletedLocalTurnIgnoresLaggingSameTurnSnapshot() async throws {
+        let project = makeProject(id: "proj_external_terminal_lag")
+        let threadID = "thread-terminal-lag"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "本轮已完成",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let client = MockSessionStoreClient(projects: [project], sessions: [history])
+        let store = makeExternalActivityStore(project: project, session: history, client: client)
+        store.recordLocallyStartedTurn(
+            sessionID: threadID,
+            turnID: "turn-local-completed",
+            restoreSelectedConnection: false
+        )
+
+        await store.applyExternalActivitySnapshot(
+            [makeExternalActivity(
+                threadID: threadID,
+                projectID: project.id,
+                turnID: "turn-local-completed",
+                revision: "rev-terminal-lag"
+            )],
+            client: client,
+            hostScope: store.appStore.activeHostScope
+        )
+
+        let completed = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertEqual(completed.status, SessionStatus.history.rawValue)
+        XCTAssertNil(completed.activeTurnID)
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.isExternalReadOnlySession(completed))
+    }
+
     func testExternalActivityPollingStopsWhenOldAgentDDoesNotAdvertiseCapability() async {
         let project = makeProject(id: "proj_external_legacy")
         let history = makeSession(


### PR DESCRIPTION
## 变更内容

- agentd 只登记通过 Gateway 校验的 Codex `turn/start`，通过 `threadId + clientUserMessageId + rollout client_id` 精确识别 iPad 发起的 turn。
- 将 registration、`user_message`、`task_started` 约束在有限因果时间窗内；缺失、过期或不匹配的证据继续按 Mac 外部活动处理。
- iOS 记录当前 Host 生命周期内本地启动成功的精确 `sessionID + turnID`，避免 Desktop-origin 历史线程的同一 turn 被降级为“仅观察”。
- 处理 external activity 轮询早于 `turn/start` ACK 的竞态；精确匹配的迟到 ACK 可以撤销误判并恢复当前连接或后台排队监听。

## 根因

由 Mac Codex 创建的历史线程会长期保留 `Codex Desktop` originator。旧逻辑只依据线程级 originator 和 rollout 的 `task_started` 判断外部 Mac 活动，因此即使当前 turn 是 iPad 通过 `thread/resume` 发起，也会被 agentd 识别成 Mac 活动。iOS 收到快照后会进入只读状态并断开 WebSocket，导致发送、停止和排队交互不可用。

## 用户影响

- iPad 在 Mac 创建的历史线程中续写时，不再误进入“仅观察”。
- 真正由 Mac 发起、turnID 不同的运行中任务仍保持只读，双端控制边界不放宽。
- 轮询与 ACK 竞态不会再让已接受的排队消息卡在待确认状态。

## 验证

- `go test ./internal/codexhistory ./internal/httpapi -count=1`
- `go test -race ./internal/codexhistory -count=1`
- `go vet ./internal/codexhistory ./internal/httpapi`
- iOS external activity 定向回归：10/10 通过
- iOS 排队/断线既有回归：5/5 通过
- rebase 到最新 `main` 后，统一 iOS 脚本在实体 iPad Pro 目标完成 Debug 签名构建
- Build 100064 已安装并运行在实体 iPad Pro，用户真机验收通过

Linear: [MIM-17](https://linear.app/code89757/issue/MIM-17/ipad-发起的运行中会话被误判为-mac-活动并降级为仅观察)
