### PR TITLE
MIM-21 修复新增第二台电脑扫码身份校验

### DIFF
--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -713,33 +713,36 @@ final class AppStore: ObservableObject {
         )
     }
 
-    func preparePairingURL(_ url: URL) async throws -> PreparedConnectionSettings {
+    func preparePairingURL(
+        _ url: URL,
+        profileTarget: PreparedConnectionProfileTarget = .currentOrNew(displayName: nil)
+    ) async throws -> PreparedConnectionSettings {
         if let ticket = try Self.pairingTicket(from: url) {
             let credentials = try await claimPairing(ticket)
             return try await prepareConnectionSettings(
                 endpoint: credentials.endpoint,
-                token: credentials.token
+                token: credentials.token,
+                profileTarget: profileTarget
             )
         }
         let credentials = try Self.pairingCredentials(from: url)
         return try await prepareConnectionSettings(
             endpoint: credentials.endpoint,
-            token: credentials.token
+            token: credentials.token,
+            profileTarget: profileTarget
         )
     }
 
     func prepareNewPairingURL(_ url: URL, displayName: String) async throws -> PreparedConnectionSettings {
-        let prepared = try await preparePairingURL(url)
-        return PreparedConnectionSettings(
-            endpoint: prepared.endpoint,
-            token: prepared.token,
+        // 新档案目标必须在兑换二维码前就确定，并贯穿身份校验、Runtime 预热和提交。
+        // 如果先按 currentOrNew 准备、最后再改成 newProfile，第二台电脑会被误判为
+        // 当前档案更换了安装身份，且 PreparedHostLease 仍会保留错误目标。
+        return try await preparePairingURL(
+            url,
             profileTarget: .newProfile(
                 id: UUID().uuidString,
-                displayName: Self.normalizedProfileDisplayName(displayName, endpoint: prepared.endpoint)
-            ),
-            validatedAt: prepared.validatedAt,
-            installationID: prepared.installationID,
-            hostContext: prepared.hostContext
+                displayName: displayName
+            )
         )
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
@@ -460,6 +460,60 @@ final class PairingLinkTests: XCTestCase {
         XCTAssertNil(keychain.data(account: "agentd-profile.mac-b"))
     }
 
+    func testNewPairingURLCarriesNewProfileTargetThroughPreparationAndCommit() async throws {
+        let suiteName = "PairingLinkTests.NewPairingTarget.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let currentProfile = ConnectionProfile(
+            id: "windows-a",
+            displayName: "Windows",
+            endpoint: "http://100.64.0.10:8787",
+            lastSuccessfulAt: nil,
+            installationID: "installation-windows"
+        )
+        defaults.set(try JSONEncoder().encode([currentProfile]), forKey: "agentd.connectionProfiles.v2")
+        defaults.set(currentProfile.id, forKey: "agentd.activeConnectionProfileID.v1")
+        defaults.set(currentProfile.endpoint, forKey: "agentd.endpoint")
+        let keychain = TestKeychainOperations()
+        keychain.setData(Data("windows-token".utf8), account: "agentd-profile.windows-a")
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: keychain),
+            routeProbe: { _, _, _ in }
+        )
+        let url = try XCTUnwrap(URL(
+            string: "mimiremote://connect?endpoint=http%3A%2F%2F100.94.18.120%3A8787&token=mac-token"
+        ))
+
+        let prepared = try await store.prepareNewPairingURL(url, displayName: "本机 Mac")
+        guard case .newProfile(let newProfileID, let displayName) = prepared.profileTarget else {
+            return XCTFail("新增二维码必须在连接准备前携带 newProfile 目标")
+        }
+        XCTAssertFalse(newProfileID.isEmpty)
+        XCTAssertEqual(displayName, "本机 Mac")
+
+        // 注入候选 Mac 在 /api/version 返回的稳定安装身份，验证它不会与当前 Windows
+        // 档案做“必须相等”校验，而是按独立档案提交。
+        let preparedWithInstallationIdentity = PreparedConnectionSettings(
+            endpoint: prepared.endpoint,
+            token: prepared.token,
+            profileTarget: prepared.profileTarget,
+            validatedAt: prepared.validatedAt,
+            installationID: "installation-mac"
+        )
+        _ = try await store.commitConnectionSettings(preparedWithInstallationIdentity)
+
+        XCTAssertEqual(store.connectionProfiles.count, 2)
+        XCTAssertEqual(store.activeConnectionProfileID, newProfileID)
+        XCTAssertEqual(store.activeConnectionProfile?.displayName, "本机 Mac")
+        XCTAssertEqual(store.activeConnectionProfile?.installationID, "installation-mac")
+        XCTAssertEqual(
+            keychain.data(account: "agentd-profile.\(newProfileID)"),
+            Data("mac-token".utf8)
+        )
+    }
+
     func testUnboundV1ProfileCannotBindToAnotherSavedMacInstallation() async throws {
         let suiteName = "PairingLinkTests.DuplicateV1Binding.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))


### PR DESCRIPTION
## 目标

修复 iOS 已保存一台 Windows / Mac 后，扫描第二台不同电脑的二维码时被错误提示“返回了不同的安装身份”，导致无法新增连接档案的问题。

Linear：[MIM-21](https://linear.app/code89757/issue/MIM-21/新增第二台电脑时扫码被错误按当前设备身份校验)

## 根因

`prepareNewPairingURL` 先通过默认 `.currentOrNew` 目标兑换并验证二维码，完成后才把结果包装成 `.newProfile`。因此候选电脑的安装身份会先与当前活动档案强制比较；Windows 与 Mac 的安装身份正常不同，却被误判成当前档案发生身份替换。预热 Runtime 的 `PreparedHostLease` 也会保留错误目标。

## 实现

- 让 `preparePairingURL` 显式接收并传递 `PreparedConnectionProfileTarget`。
- 新增设备扫码在兑换二维码前生成 `.newProfile`，让同一目标贯穿身份校验、Runtime 预热和提交。
- 保留首次连接、当前档案修复、重复安装身份保护和单活多档案架构。
- 增加 Windows 当前档案 → 新增 Mac 档案的回归测试，验证不同安装身份能作为独立档案提交。

## 验证

- `MimiRemoteTests/PairingLinkTests/testNewPairingURLCarriesNewProfileTargetThroughPreparationAndCommit`：1/1 通过。
- `MimiRemoteTests/PairingLinkTests`：80/80 通过。
- iPhone 17 Pro Simulator Debug 构建、安装、启动通过。
- 运行态 UI 快照确认 App 正常进入会话页。
- `git diff --check` 通过。
- `scripts/check-source-size.sh` 通过。
