### PR TITLE
MIM-12 修复 Apple 语音输入半失效恢复

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -2329,6 +2329,40 @@
         }
       }
     },
+    "ui.apple_voice_input_stopped_please_try_again" : {
+      "comment" : "Shown when the on-device speech result stream becomes unhealthy while microphone audio is still arriving.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-device voice input stopped. Tap the microphone to try again."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备端语音输入已停止，请点击麦克风重试。"
+          }
+        }
+      }
+    },
+    "ui.apple_voice_input_was_interrupted_please_try_again" : {
+      "comment" : "Shown after iOS interrupts an active on-device voice input session.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice input was interrupted by the system. Tap the microphone to try again."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音输入被系统中断，请点击麦克风重试。"
+          }
+        }
+      }
+    },
     "ui.application" : {
       "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations" : {

--- a/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
@@ -39,14 +39,13 @@ struct AppleSpeechHealthMonitor: Equatable {
     private var nextGeneration = 0
 
     mutating func observeLevel(_ level: CGFloat, at uptime: TimeInterval) -> Int? {
-        guard awaitingResultGeneration == nil else {
-            return nil
-        }
         guard level >= Self.audibleThreshold else {
             if let lastAudibleAt,
                uptime - lastAudibleAt > Self.maximumAudibleGap {
+                // 已经停止连续发音时解除本代等待，避免短暂噪声或一句话后的静音误触发超时。
                 audibleSequenceStartedAt = nil
                 self.lastAudibleAt = nil
+                awaitingResultGeneration = nil
             }
             return nil
         }
@@ -55,10 +54,15 @@ struct AppleSpeechHealthMonitor: Equatable {
            uptime - lastAudibleAt <= Self.maximumAudibleGap {
             // 当前声音仍属于同一段连续发音。
         } else {
+            // 音频采样本身出现较长间隔时，也视为上一段发音已经结束。
             audibleSequenceStartedAt = uptime
+            awaitingResultGeneration = nil
         }
         lastAudibleAt = uptime
 
+        guard awaitingResultGeneration == nil else {
+            return nil
+        }
         guard let audibleSequenceStartedAt,
               uptime - audibleSequenceStartedAt >= Self.sustainedAudioDuration else {
             return nil

--- a/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import os
 import Speech
 
 /// SpeechTranscriber 会交替发布可变结果和最终结果；这里只保留一个可变尾段，
@@ -24,11 +25,99 @@ struct AppleSpeechTranscriptAccumulator: Equatable {
     }
 }
 
+/// 把“确实有人持续说话，但分析器迟迟没有新结果”的判定做成纯状态机，
+/// 既避免一次咳嗽或环境噪声误触发，也便于不依赖真机 Speech 模型做回归测试。
+struct AppleSpeechHealthMonitor: Equatable {
+    static let audibleThreshold: CGFloat = 0.18
+    static let sustainedAudioDuration: TimeInterval = 0.6
+    static let maximumAudibleGap: TimeInterval = 0.35
+    static let resultTimeout: TimeInterval = 5
+
+    private var audibleSequenceStartedAt: TimeInterval?
+    private var lastAudibleAt: TimeInterval?
+    private var awaitingResultGeneration: Int?
+    private var nextGeneration = 0
+
+    mutating func observeLevel(_ level: CGFloat, at uptime: TimeInterval) -> Int? {
+        guard awaitingResultGeneration == nil else {
+            return nil
+        }
+        guard level >= Self.audibleThreshold else {
+            if let lastAudibleAt,
+               uptime - lastAudibleAt > Self.maximumAudibleGap {
+                audibleSequenceStartedAt = nil
+                self.lastAudibleAt = nil
+            }
+            return nil
+        }
+
+        if let lastAudibleAt,
+           uptime - lastAudibleAt <= Self.maximumAudibleGap {
+            // 当前声音仍属于同一段连续发音。
+        } else {
+            audibleSequenceStartedAt = uptime
+        }
+        lastAudibleAt = uptime
+
+        guard let audibleSequenceStartedAt,
+              uptime - audibleSequenceStartedAt >= Self.sustainedAudioDuration else {
+            return nil
+        }
+        nextGeneration += 1
+        awaitingResultGeneration = nextGeneration
+        return nextGeneration
+    }
+
+    mutating func observeResult() {
+        audibleSequenceStartedAt = nil
+        lastAudibleAt = nil
+        awaitingResultGeneration = nil
+    }
+
+    func isAwaitingResult(generation: Int) -> Bool {
+        awaitingResultGeneration == generation
+    }
+
+    mutating func reset() {
+        audibleSequenceStartedAt = nil
+        lastAudibleAt = nil
+        awaitingResultGeneration = nil
+    }
+}
+
+enum AppleSpeechAudioSessionEvent: Equatable, Sendable {
+    case interruptionBegan(reasonRawValue: UInt?)
+    case interruptionEnded
+    case mediaServicesReset
+
+    static func interruption(from notification: Notification) -> Self? {
+        guard notification.name == AVAudioSession.interruptionNotification,
+              let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: rawType) else {
+            return nil
+        }
+        switch type {
+        case .began:
+            return .interruptionBegan(
+                reasonRawValue: notification.userInfo?[AVAudioSessionInterruptionReasonKey] as? UInt
+            )
+        case .ended:
+            return .interruptionEnded
+        @unknown default:
+            return nil
+        }
+    }
+}
+
 enum AppleSpeechTranscriptionError: LocalizedError {
     case unsupportedLocale
     case audioFormatUnavailable
     case audioConversionFailed
     case recordingFailed
+    case resultStreamEnded
+    case noTranscriptionResult
+    case audioSessionInterrupted
+    case mediaServicesReset
 
     var errorDescription: String? {
         switch self {
@@ -40,6 +129,31 @@ enum AppleSpeechTranscriptionError: LocalizedError {
             return L10n.text("ui.apple_voice_input_audio_conversion_failed")
         case .recordingFailed:
             return L10n.text("ui.apple_voice_input_could_not_start_recording")
+        case .resultStreamEnded, .noTranscriptionResult, .mediaServicesReset:
+            return L10n.text("ui.apple_voice_input_stopped_please_try_again")
+        case .audioSessionInterrupted:
+            return L10n.text("ui.apple_voice_input_was_interrupted_please_try_again")
+        }
+    }
+
+    var diagnosticCode: String {
+        switch self {
+        case .unsupportedLocale:
+            return "unsupported_locale"
+        case .audioFormatUnavailable:
+            return "audio_format_unavailable"
+        case .audioConversionFailed:
+            return "audio_conversion_failed"
+        case .recordingFailed:
+            return "recording_failed"
+        case .resultStreamEnded:
+            return "result_stream_ended"
+        case .noTranscriptionResult:
+            return "no_transcription_result"
+        case .audioSessionInterrupted:
+            return "audio_session_interrupted"
+        case .mediaServicesReset:
+            return "media_services_reset"
         }
     }
 }
@@ -48,12 +162,25 @@ enum AppleSpeechTranscriptionError: LocalizedError {
 /// 该对象限定在主线程持有生命周期；音频 tap 里只做同步格式转换和 AsyncStream yield。
 @MainActor
 final class AppleSpeechTranscriptionSession {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.gaixianggeng.mimi",
+        category: "AppleSpeech"
+    )
+
+    private let sessionID = UUID()
     private var analyzer: SpeechAnalyzer?
     private var audioEngine: AVAudioEngine?
     private let audioSessionCoordinator: VoiceAudioSessionCoordinator
     private var audioSessionActivation: VoiceAudioSessionCoordinator.Activation?
     private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
     private var resultsTask: Task<Void, Never>?
+    private var audioSessionObserverTokens: [NSObjectProtocol] = []
+    private var healthWatchdogTask: Task<Void, Never>?
+    private var healthMonitor = AppleSpeechHealthMonitor()
+    private var didReceiveFirstAudioBuffer = false
+    private var didReceiveFirstResult = false
+    private var didReportFailure = false
+    private var acceptsTranscriptionResults = false
     private var isFinishing = false
 
     init(audioSessionCoordinator: VoiceAudioSessionCoordinator = .shared) {
@@ -69,7 +196,19 @@ final class AppleSpeechTranscriptionSession {
         guard analyzer == nil, audioEngine == nil else {
             throw AppleSpeechTranscriptionError.recordingFailed
         }
+        isFinishing = false
+        didReportFailure = false
+        didReceiveFirstAudioBuffer = false
+        didReceiveFirstResult = false
+        acceptsTranscriptionResults = true
+        healthMonitor.reset()
+        Self.logger.info(
+            "session_start id=\(self.sessionID.uuidString, privacy: .public) locale=\(locale.identifier, privacy: .public)"
+        )
         guard let supportedLocale = await SpeechTranscriber.supportedLocale(equivalentTo: locale) else {
+            Self.logger.error(
+                "session_start_failed id=\(self.sessionID.uuidString, privacy: .public) reason=unsupported_locale"
+            )
             throw AppleSpeechTranscriptionError.unsupportedLocale
         }
 
@@ -86,34 +225,52 @@ final class AppleSpeechTranscriptionSession {
         let analyzer = SpeechAnalyzer(modules: modules)
         try await analyzer.prepareToAnalyze(in: analyzerFormat)
         try Task.checkCancellation()
+        Self.logger.info(
+            "analyzer_prepared id=\(self.sessionID.uuidString, privacy: .public)"
+        )
 
         let (inputSequence, continuation) = AsyncStream<AnalyzerInput>.makeStream()
         self.analyzer = analyzer
         inputContinuation = continuation
-        isFinishing = false
+        startObservingAudioSession(onFailure: onFailure)
 
         resultsTask = Task { [weak self] in
             var accumulator = AppleSpeechTranscriptAccumulator()
             do {
                 for try await result in transcriber.results {
-                    guard !Task.isCancelled else { return }
+                    guard !Task.isCancelled,
+                          let self,
+                          self.acceptsTranscriptionResults else {
+                        return
+                    }
+                    self.handleTranscriptionResult()
                     accumulator.apply(String(result.text.characters), isFinal: result.isFinal)
                     let transcript = accumulator.text
                     if !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         onTranscript(transcript)
                     }
                 }
+                guard let self, !self.isFinishing else { return }
+                self.reportFailure(
+                    AppleSpeechTranscriptionError.resultStreamEnded,
+                    stage: "result_stream",
+                    onFailure: onFailure
+                )
             } catch is CancellationError {
                 return
             } catch {
-                guard self?.isFinishing != true else {
-                    return
-                }
-                onFailure(error)
+                guard let self, !self.isFinishing else { return }
+                self.reportFailure(error, stage: "result_stream", onFailure: onFailure)
             }
         }
 
         try await analyzer.start(inputSequence: inputSequence)
+        guard !isFinishing else {
+            throw CancellationError()
+        }
+        Self.logger.info(
+            "analyzer_started id=\(self.sessionID.uuidString, privacy: .public)"
+        )
         do {
             try await startAudioCapture(
                 analyzerFormat: analyzerFormat,
@@ -122,6 +279,7 @@ final class AppleSpeechTranscriptionSession {
                 onFailure: onFailure
             )
         } catch {
+            stopObservingAudioSession()
             await cancel()
             throw error
         }
@@ -131,7 +289,13 @@ final class AppleSpeechTranscriptionSession {
         guard let analyzer else {
             return
         }
+        Self.logger.info(
+            "session_finish id=\(self.sessionID.uuidString, privacy: .public)"
+        )
         isFinishing = true
+        stopObservingAudioSession()
+        healthWatchdogTask?.cancel()
+        healthWatchdogTask = nil
         await stopAudioCapture()
         inputContinuation?.finish()
         inputContinuation = nil
@@ -141,7 +305,14 @@ final class AppleSpeechTranscriptionSession {
     }
 
     func cancel() async {
+        Self.logger.info(
+            "session_cancel id=\(self.sessionID.uuidString, privacy: .public)"
+        )
         isFinishing = true
+        acceptsTranscriptionResults = false
+        stopObservingAudioSession()
+        healthWatchdogTask?.cancel()
+        healthWatchdogTask = nil
         await stopAudioCapture()
         inputContinuation?.finish()
         inputContinuation = nil
@@ -174,21 +345,25 @@ final class AppleSpeechTranscriptionSession {
             }
 
             var didFailConversion = false
-            inputNode.installTap(onBus: 0, bufferSize: 1_024, format: inputFormat) { buffer, _ in
+            inputNode.installTap(onBus: 0, bufferSize: 1_024, format: inputFormat) { [weak self] buffer, _ in
                 guard !didFailConversion else { return }
                 do {
                     let converted = try converter.convert(buffer)
                     continuation.yield(AnalyzerInput(buffer: converted))
                     let level = AppleSpeechAudioLevel.normalizedPower(from: buffer)
-                    Task { @MainActor in
-                        onLevel(level)
+                    Task { @MainActor [weak self] in
+                        self?.handleAudioLevel(level, onLevel: onLevel, onFailure: onFailure)
                     }
                 } catch {
                     guard !didFailConversion else { return }
                     didFailConversion = true
                     continuation.finish()
-                    Task { @MainActor in
-                        onFailure(error)
+                    Task { @MainActor [weak self] in
+                        self?.reportFailure(
+                            AppleSpeechTranscriptionError.audioConversionFailed,
+                            stage: "audio_conversion",
+                            onFailure: onFailure
+                        )
                     }
                 }
             }
@@ -201,10 +376,152 @@ final class AppleSpeechTranscriptionSession {
             }
             audioEngine = engine
             audioSessionActivation = activation
+            Self.logger.info(
+                "audio_capture_started id=\(self.sessionID.uuidString, privacy: .public)"
+            )
         } catch {
             await audioSessionCoordinator.deactivate(activation)
             throw error
         }
+    }
+
+    private func handleAudioLevel(
+        _ level: CGFloat,
+        onLevel: @escaping @MainActor (CGFloat) -> Void,
+        onFailure: @escaping @MainActor (Error) -> Void
+    ) {
+        guard !isFinishing else { return }
+        if !didReceiveFirstAudioBuffer {
+            didReceiveFirstAudioBuffer = true
+            Self.logger.info(
+                "first_audio_buffer id=\(self.sessionID.uuidString, privacy: .public)"
+            )
+        }
+        onLevel(level)
+
+        let uptime = ProcessInfo.processInfo.systemUptime
+        guard let generation = healthMonitor.observeLevel(level, at: uptime) else {
+            return
+        }
+        Self.logger.info(
+            "result_watchdog_armed id=\(self.sessionID.uuidString, privacy: .public) generation=\(generation)"
+        )
+        healthWatchdogTask?.cancel()
+        healthWatchdogTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(AppleSpeechHealthMonitor.resultTimeout))
+            } catch {
+                return
+            }
+            guard let self,
+                  !self.isFinishing,
+                  self.healthMonitor.isAwaitingResult(generation: generation) else {
+                return
+            }
+            self.reportFailure(
+                AppleSpeechTranscriptionError.noTranscriptionResult,
+                stage: "result_watchdog",
+                onFailure: onFailure
+            )
+        }
+    }
+
+    private func handleTranscriptionResult() {
+        healthMonitor.observeResult()
+        healthWatchdogTask?.cancel()
+        healthWatchdogTask = nil
+        guard !didReceiveFirstResult else { return }
+        didReceiveFirstResult = true
+        Self.logger.info(
+            "first_result id=\(self.sessionID.uuidString, privacy: .public)"
+        )
+    }
+
+    private func startObservingAudioSession(
+        onFailure: @escaping @MainActor (Error) -> Void
+    ) {
+        stopObservingAudioSession()
+        let center = NotificationCenter.default
+        let interruptionToken = center.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let event = AppleSpeechAudioSessionEvent.interruption(from: notification) else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                self?.handleAudioSessionEvent(event, onFailure: onFailure)
+            }
+        }
+        let resetToken = center.addObserver(
+            forName: AVAudioSession.mediaServicesWereResetNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.handleAudioSessionEvent(.mediaServicesReset, onFailure: onFailure)
+            }
+        }
+        audioSessionObserverTokens = [interruptionToken, resetToken]
+    }
+
+    private func stopObservingAudioSession() {
+        let center = NotificationCenter.default
+        audioSessionObserverTokens.forEach(center.removeObserver)
+        audioSessionObserverTokens.removeAll()
+    }
+
+    private func handleAudioSessionEvent(
+        _ event: AppleSpeechAudioSessionEvent,
+        onFailure: @escaping @MainActor (Error) -> Void
+    ) {
+        guard !isFinishing else { return }
+        switch event {
+        case .interruptionBegan(let reasonRawValue):
+            Self.logger.error(
+                "audio_interruption_began id=\(self.sessionID.uuidString, privacy: .public) reason=\(String(describing: reasonRawValue), privacy: .public)"
+            )
+            reportFailure(
+                AppleSpeechTranscriptionError.audioSessionInterrupted,
+                stage: "audio_session",
+                onFailure: onFailure
+            )
+        case .mediaServicesReset:
+            Self.logger.error(
+                "media_services_reset id=\(self.sessionID.uuidString, privacy: .public)"
+            )
+            reportFailure(
+                AppleSpeechTranscriptionError.mediaServicesReset,
+                stage: "audio_session",
+                onFailure: onFailure
+            )
+        case .interruptionEnded:
+            Self.logger.info(
+                "audio_interruption_ended id=\(self.sessionID.uuidString, privacy: .public)"
+            )
+        }
+    }
+
+    private func reportFailure(
+        _ error: Error,
+        stage: String,
+        onFailure: @escaping @MainActor (Error) -> Void
+    ) {
+        guard !isFinishing, !didReportFailure else { return }
+        didReportFailure = true
+        isFinishing = true
+        acceptsTranscriptionResults = false
+        stopObservingAudioSession()
+        healthWatchdogTask?.cancel()
+        healthWatchdogTask = nil
+
+        let nsError = error as NSError
+        let reason = (error as? AppleSpeechTranscriptionError)?.diagnosticCode ?? "system_error"
+        Self.logger.error(
+            "session_failed id=\(self.sessionID.uuidString, privacy: .public) stage=\(stage, privacy: .public) reason=\(reason, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code)"
+        )
+        onFailure(error)
     }
 
     private func stopAudioCapture() async {
@@ -224,8 +541,12 @@ final class AppleSpeechTranscriptionSession {
     private func reset() {
         resultsTask?.cancel()
         resultsTask = nil
+        healthWatchdogTask?.cancel()
+        healthWatchdogTask = nil
+        stopObservingAudioSession()
+        healthMonitor.reset()
+        acceptsTranscriptionResults = false
         analyzer = nil
-        isFinishing = false
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -739,14 +739,29 @@ final class VoiceInputController: NSObject, ObservableObject {
                 try await session.start(
                     locale: locale,
                     onTranscript: { [weak self] transcript in
-                        guard self?.activeProvider == .apple else { return }
+                        guard self?.activeProvider == .apple,
+                              self?.startRequestID == requestID else {
+                            return
+                        }
                         onTranscript(transcript)
                     },
                     onLevel: { [weak self] level in
+                        guard self?.activeProvider == .apple,
+                              self?.startRequestID == requestID else {
+                            return
+                        }
                         self?.levelMeter.push(level)
                     },
                     onFailure: { [weak self, weak session] error in
-                        guard let self, let session, activeProvider == .apple else { return }
+                        guard let self,
+                              let session,
+                              activeProvider == .apple,
+                              startRequestID == requestID else {
+                            return
+                        }
+                        // 结果流可能在 session.start() 返回前就失败；先让本次请求失效，
+                        // 防止外层启动任务随后又把已经失败的会话标成录音中。
+                        startRequestID = nil
                         errorMessage = userFacingAppleSpeechError(error)
                         isPreparing = false
                         isRecording = false

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -39,6 +39,27 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(monitor.observeLevel(0.8, at: 3.7), 2)
     }
 
+    func testAppleSpeechHealthMonitorDisarmsAfterSilenceAndCanRearm() {
+        var monitor = AppleSpeechHealthMonitor()
+
+        XCTAssertNil(monitor.observeLevel(0.8, at: 1))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 1.25))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 1.5))
+        XCTAssertEqual(monitor.observeLevel(0.8, at: 1.7), 1)
+        XCTAssertTrue(monitor.isAwaitingResult(generation: 1))
+
+        XCTAssertNil(monitor.observeLevel(0.05, at: 1.8))
+        XCTAssertTrue(monitor.isAwaitingResult(generation: 1))
+        XCTAssertNil(monitor.observeLevel(0.05, at: 2.1))
+        XCTAssertFalse(monitor.isAwaitingResult(generation: 1))
+
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2.2))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2.45))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2.7))
+        XCTAssertEqual(monitor.observeLevel(0.8, at: 2.9), 2)
+        XCTAssertTrue(monitor.isAwaitingResult(generation: 2))
+    }
+
     func testAppleSpeechAudioSessionEventParsesInterruptionNotifications() {
         let began = Notification(
             name: AVAudioSession.interruptionNotification,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AVFoundation
 import Combine
 import Security
 import SwiftUI
@@ -7,6 +8,69 @@ import UIKit
 
 @MainActor
 extension ConversationDataFlowTests {
+    func testAppleSpeechHealthMonitorOnlyArmsAfterSustainedAudibleInput() {
+        var monitor = AppleSpeechHealthMonitor()
+
+        XCTAssertNil(monitor.observeLevel(0.05, at: 1))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2.25))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2.5))
+        XCTAssertEqual(monitor.observeLevel(0.8, at: 2.7), 1)
+        XCTAssertTrue(monitor.isAwaitingResult(generation: 1))
+    }
+
+    func testAppleSpeechHealthMonitorResetsAfterGapAndAfterResult() {
+        var monitor = AppleSpeechHealthMonitor()
+
+        XCTAssertNil(monitor.observeLevel(0.8, at: 1))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 1.2))
+        XCTAssertNil(monitor.observeLevel(0.05, at: 1.6))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2.25))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 2.5))
+        XCTAssertEqual(monitor.observeLevel(0.8, at: 2.7), 1)
+
+        monitor.observeResult()
+
+        XCTAssertFalse(monitor.isAwaitingResult(generation: 1))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 3))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 3.25))
+        XCTAssertNil(monitor.observeLevel(0.8, at: 3.5))
+        XCTAssertEqual(monitor.observeLevel(0.8, at: 3.7), 2)
+    }
+
+    func testAppleSpeechAudioSessionEventParsesInterruptionNotifications() {
+        let began = Notification(
+            name: AVAudioSession.interruptionNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.began.rawValue,
+                AVAudioSessionInterruptionReasonKey: UInt(1)
+            ]
+        )
+        let ended = Notification(
+            name: AVAudioSession.interruptionNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.ended.rawValue
+            ]
+        )
+
+        XCTAssertEqual(
+            AppleSpeechAudioSessionEvent.interruption(from: began),
+            .interruptionBegan(reasonRawValue: 1)
+        )
+        XCTAssertEqual(
+            AppleSpeechAudioSessionEvent.interruption(from: ended),
+            .interruptionEnded
+        )
+        XCTAssertNil(
+            AppleSpeechAudioSessionEvent.interruption(
+                from: Notification(name: AVAudioSession.routeChangeNotification)
+            )
+        )
+    }
+
     func testImageAttachmentEncoderDownsamplesLargeScreenshotAndProducesJPEGDataURL() throws {
         let sourceSize = CGSize(width: 2_732, height: 2_048)
         let rendererFormat = UIGraphicsImageRendererFormat.default()


### PR DESCRIPTION
## 变更内容

- 在 `SpeechTranscriber.results` 非主动结束时进入统一失败清理，不再让麦克风波形继续停留在半失效状态。
- 监听 `AVAudioSession` 中断和媒体服务重置，停止当前 Apple 语音会话并恢复为可重试状态。
- 检测持续有效声音；5 秒没有新转写结果时结束失效会话并提示用户再次点击麦克风。
- 用 request ID 隔离旧会话的 transcript、level 和 failure 回调，避免启动/失败竞态影响新会话。
- 正常 finalize 阶段继续接收最后一段转写；只有取消或失败才拒绝晚到结果。
- 增加不包含原始音频或转写正文的结构化生命周期日志，以及中英文恢复提示。

## 根因

音频波形直接来自 `AVAudioEngine` 输入缓冲区，文字只来自 `SpeechTranscriber.results`。结果流静默结束、系统音频中断或分析器长期无结果时，旧实现没有健康检查和统一清理，因此会出现“波形正常但不再生成文字”，只能通过重启 App 重建整个语音会话。

## 用户影响

Apple 设备端语音输入发生半失效后会明确停止并提示重试，下一次点击会创建全新会话；系统中断后不会自动重新开启麦克风，保持权限和隐私边界。

## 验证

- iPhone 17 Pro Simulator / iOS 27 / Debug 构建通过，无 warning。
- Apple 语音、音频会话租约、草稿、波形和本地化相关测试 14/14 通过。
- 完整 `MimiRemoteTests`：854 通过、39 跳过、5 个既有视觉快照失败。失败集中在审批卡、用户输入表单和技能卡快照，与本 PR 修改文件及 Apple 语音路径无关。
- 模拟器运行态启动成功；点击设备端语音后，当前 Simulator 因不支持 `zh_CN` SpeechTranscriber 正确进入错误和清理路径。日志记录 `session_start → unsupported_locale → session_cancel`，未记录录音或转写正文。

## 待真机验证

- [ ] 支持设备端语音的真机正常实时转写和主动停止时保留最终文字。
- [ ] 系统音频中断或媒体服务重置后停止当前会话，并可再次点击重试。
- [ ] 持续有效声音但无转写结果时触发 5 秒恢复提示。
- [ ] 快速取消及 Codex 语音输入不回归。

Linear: MIM-12
