### PR TITLE
MIM-22 修复 iOS MCP 工具可信审批

### DIFF
--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -1417,6 +1417,24 @@ func TestAppServerGatewayServerRequestAllowlistMatchesMobileCapabilities(t *test
 	}
 }
 
+func TestAppServerGatewayPassesCodexMCPToolApprovalMetadataAndDecisionUnchanged(t *testing.T) {
+	policy := &appServerGatewayPolicy{
+		runtimeID:             "codex",
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	request := []byte(`{"id":"mcp-approval-1","method":"mcpServer/elicitation/request","params":{"threadId":"thread-1","serverName":"linear","mode":"form","message":"Allow save_issue?","requestedSchema":{"type":"object","properties":{}},"_meta":{"codex_approval_kind":"mcp_tool_call","persist":["session","always"]}}}`)
+	forwarded, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request)
+	if policyErr != nil || !forward || !bytes.Equal(forwarded, request) {
+		t.Fatalf("MCP 工具审批元数据应透明转发给移动端：forward=%t err=%+v payload=%s", forward, policyErr, forwarded)
+	}
+
+	decision := []byte(`{"id":"mcp-approval-1","result":{"action":"accept","content":null,"_meta":{"persist":"always"}}}`)
+	forwardedDecision, err := policy.validateClientFrame(websocket.TextMessage, decision)
+	if err != nil || !bytes.Equal(forwardedDecision, decision) {
+		t.Fatalf("Mac 端 Codex 需要原始 persist 决策完成精确工具授权：err=%v payload=%s", err, forwardedDecision)
+	}
+}
+
 func TestAppServerGatewayRejectsUnsupportedServerRequestBackToUpstream(t *testing.T) {
 	var sentRequest atomic.Bool
 	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -1559,13 +1559,47 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Allow access to entire file system"
+            "value" : "Access all files; MCP tools may still ask for approval"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许访问整个文件系统"
+            "value" : "可访问所有文件；MCP 工具仍可能请求审批"
+          }
+        }
+      }
+    },
+    "ui.allow_for_this_session" : {
+      "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow for This Session"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本会话允许"
+          }
+        }
+      }
+    },
+    "ui.allow_once" : {
+      "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow Once"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅允许一次"
           }
         }
       }
@@ -1635,6 +1669,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已开启"
+          }
+        }
+      }
+    },
+    "ui.always_allow_this_tool" : {
+      "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Always Allow This Tool"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始终允许此工具"
           }
         }
       }
@@ -4632,6 +4683,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Codex 剩余用量"
+          }
+        }
+      }
+    },
+    "ui.codex_saves_this_choice_on_the_mac" : {
+      "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codex saves this choice on the Mac; no MCP credentials are stored on this device."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codex 会在 Mac 端保存此选择；本设备不保存 MCP 凭据。"
           }
         }
       }
@@ -10430,13 +10498,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Full Access"
+            "value" : "Full File Access"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "完全访问"
+            "value" : "完全文件访问"
           }
         }
       }
@@ -17085,13 +17153,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Permissions · Full Access"
+            "value" : "Permissions · Full File Access"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "权限 · 完全访问"
+            "value" : "权限 · 完全文件访问"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -1587,19 +1587,23 @@ extension CodexAppServerSessionRuntime {
         if lower.contains("approval") {
             return true
         }
-        // URL 型 MCP elicitation 没有表单内容，复用明确的批准/拒绝交互更安全。
+        let params = request.params?.objectValue ?? [:]
+        // URL 型 elicitation 和 Codex 明确标记的工具调用都走审批；普通 form 仍是补充信息。
         return request.method == "mcpServer/elicitation/request"
-            && request.params?.objectValue?["mode"]?.stringValue == "url"
+            && (params["mode"]?.stringValue == "url"
+                || CodexMCPToolApprovalProtocol.isToolCall(params))
     }
 
     func isUserInputServerRequest(_ request: CodexAppServerServerRequest) -> Bool {
         if request.method == "item/tool/requestUserInput" {
             return true
         }
-        // form/openai-form 都投影到现有补充信息卡；未知 mode 也走此路径，
-        // 用户没有填入时回 decline，不会误接受无法理解的 MCP 请求。
+        let params = request.params?.objectValue ?? [:]
+        // form/openai-form 都投影到现有补充信息卡；Codex 工具审批例外，避免空 schema
+        // 被渲染成虚假的“补充信息”输入框。
         return request.method == "mcpServer/elicitation/request"
-            && request.params?.objectValue?["mode"]?.stringValue != "url"
+            && params["mode"]?.stringValue != "url"
+            && !CodexMCPToolApprovalProtocol.isToolCall(params)
     }
 
     func uniqueStrings(_ values: [String]) -> [String] {
@@ -1624,6 +1628,9 @@ extension CodexAppServerSessionRuntime {
             ])
         }
         if method == "mcpServer/elicitation/request" {
+            if CodexMCPToolApprovalProtocol.isToolCall(params) {
+                return mcpToolApprovalResponse(params: params, decision: decision)
+            }
             return .object([
                 "action": .string(decision == "accept" ? "accept" : decision == "cancel" ? "cancel" : "decline"),
                 "content": .null,
@@ -1631,6 +1638,33 @@ extension CodexAppServerSessionRuntime {
             ])
         }
         return .object(["decision": .string(decision)])
+    }
+
+    func mcpToolApprovalResponse(
+        params: [String: CodexAppServerJSONValue],
+        decision: String
+    ) -> CodexAppServerJSONValue {
+        let persistenceModes = CodexMCPToolApprovalProtocol.persistenceModes(params)
+        let normalized = normalizeApprovalDecision(decision)
+        let persist: String?
+        switch normalized {
+        case "accept":
+            persist = nil
+        case "acceptForSession" where persistenceModes.contains("session"):
+            persist = "session"
+        case "acceptAlways" where persistenceModes.contains("always"):
+            persist = "always"
+        case "cancel":
+            return .object(["action": .string("cancel"), "content": .null, "_meta": .null])
+        default:
+            // 客户端不能扩大上游声明的权限范围；未知或未提供的持久化选项一律拒绝。
+            return .object(["action": .string("decline"), "content": .null, "_meta": .null])
+        }
+        return .object([
+            "action": .string("accept"),
+            "content": .null,
+            "_meta": persist.map { .object(["persist": .string($0)]) } ?? .null
+        ])
     }
 
     func userInputResponse(
@@ -1709,6 +1743,8 @@ extension CodexAppServerSessionRuntime {
             return "accept"
         case "acceptforsession", "accept_for_session":
             return "acceptForSession"
+        case "acceptalways", "accept_always", "acceptandremember", "accept_and_remember":
+            return "acceptAlways"
         case "acceptwithpermissionupdate", "accept_with_permission_update":
             return "acceptWithPermissionUpdate"
         case "cancel":

--- a/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
@@ -1,5 +1,38 @@
 import Foundation
 
+// Codex 0.146+ 会把 MCP 工具审批编码成一个空 schema 的 form elicitation。
+// 必须依赖私有元数据精确识别，不能把所有空表单都当成审批，否则第三方 MCP 的普通表单会被误授权。
+enum CodexMCPToolApprovalProtocol {
+    static let kind = "mcp_tool"
+
+    static func isToolCall(_ params: [String: CodexAppServerJSONValue]) -> Bool {
+        params["_meta"]?.objectValue?["codex_approval_kind"]?.stringValue == "mcp_tool_call"
+    }
+
+    static func persistenceModes(_ params: [String: CodexAppServerJSONValue]) -> Set<String> {
+        guard let value = params["_meta"]?.objectValue?["persist"] else {
+            return []
+        }
+        if let mode = value.stringValue {
+            return [mode]
+        }
+        return Set(value.arrayValue?.compactMap(\.stringValue) ?? [])
+    }
+
+    static func availableDecisions(_ params: [String: CodexAppServerJSONValue]) -> [String] {
+        let modes = persistenceModes(params)
+        var decisions = ["accept"]
+        if modes.contains("session") {
+            decisions.append("acceptForSession")
+        }
+        if modes.contains("always") {
+            decisions.append("acceptAlways")
+        }
+        decisions.append("decline")
+        return decisions
+    }
+}
+
 enum AgentEvent {
     case session(AgentSession)
     case sessionRow(DataFlowSessionRow, AgentEventMetadata)
@@ -732,7 +765,8 @@ struct CodexAppServerEventProjector {
             return .userInputRequest(request, metadata)
         }
         if request.method == "mcpServer/elicitation/request",
-           params["mode"]?.stringValue != "url" {
+           params["mode"]?.stringValue != "url",
+           !CodexMCPToolApprovalProtocol.isToolCall(params) {
             let metadata = makeMetadata(from: params)
             guard let userInput = mcpElicitationUserInputRequest(
                 from: params,
@@ -747,7 +781,7 @@ struct CodexAppServerEventProjector {
             return nil
         }
         let metadata = makeMetadata(from: params)
-        let kind = approvalKind(method: request.method)
+        let kind = approvalKind(method: request.method, params: params)
         let itemID = metadata.itemID ?? request.id.description
         return .approvalRequest(
             AgentApprovalRequest(
@@ -756,7 +790,9 @@ struct CodexAppServerEventProjector {
                 body: approvalBody(kind: kind, params: params),
                 kind: kind,
                 risk: firstString(in: params, keys: ["risk"]) ?? "high",
-                availableDecisions: params["availableDecisions"]?.arrayValue?.compactMap(\.stringValue),
+                availableDecisions: kind == CodexMCPToolApprovalProtocol.kind
+                    ? CodexMCPToolApprovalProtocol.availableDecisions(params)
+                    : params["availableDecisions"]?.arrayValue?.compactMap(\.stringValue),
                 persistentPermissionRules: eligiblePersistentPermissionRules(from: params)
             ),
             metadata
@@ -1501,16 +1537,25 @@ struct CodexAppServerEventProjector {
     ) -> Bool {
         let lower = method.lowercased()
         return lower.contains("approval")
-            || (method == "mcpServer/elicitation/request" && params["mode"]?.stringValue == "url")
+            || (method == "mcpServer/elicitation/request"
+                && (params["mode"]?.stringValue == "url"
+                    || CodexMCPToolApprovalProtocol.isToolCall(params)))
     }
 
-    private func approvalKind(method: String) -> String {
+    private func approvalKind(
+        method: String,
+        params: [String: CodexAppServerJSONValue]
+    ) -> String {
         let lower = method.lowercased()
         if lower.contains("filechange") || lower.contains("applypatch") {
             return "file_change"
         }
         if lower.contains("permission") {
             return "permission"
+        }
+        if lower.contains("mcpserver/elicitation"),
+           CodexMCPToolApprovalProtocol.isToolCall(params) {
+            return CodexMCPToolApprovalProtocol.kind
         }
         if lower.contains("mcpserver/elicitation") {
             return "mcp_elicitation"
@@ -1526,7 +1571,7 @@ struct CodexAppServerEventProjector {
             return L10n.text("ui.agent_requests_elevated_privileges")
         case "user_input":
             return L10n.text("ui.agent_requests_additional_input")
-        case "mcp_elicitation":
+        case "mcp_elicitation", CodexMCPToolApprovalProtocol.kind:
             let server = firstString(in: params, keys: ["serverName"]) ?? L10n.text("ui.mcp_service")
             return L10n.format("ui.value_requests_user_confirmation", server)
         default:
@@ -1548,7 +1593,7 @@ struct CodexAppServerEventProjector {
             let reason = firstString(in: params, keys: ["reason", "message"])
             return [command, toolName, inputSummary, reason].compactMap { $0 }.joined(separator: "\n\n").nilIfEmpty
         }
-        if kind == "mcp_elicitation" {
+        if kind == "mcp_elicitation" || kind == CodexMCPToolApprovalProtocol.kind {
             return [
                 firstString(in: params, keys: ["message"]),
                 firstString(in: params, keys: ["url"])

--- a/ios/MimiRemote/Sources/Core/Models/AgentRuntimeModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentRuntimeModels.swift
@@ -722,6 +722,20 @@ struct ApprovalSummary: Codable, Hashable {
         } == true
         return supportsDecision && persistentPermissionRules?.isEmpty == false
     }
+
+    var canAcceptMCPToolForSession: Bool {
+        kind == CodexMCPToolApprovalProtocol.kind && supportsDecision("acceptForSession")
+    }
+
+    var canAlwaysAllowMCPTool: Bool {
+        kind == CodexMCPToolApprovalProtocol.kind && supportsDecision("acceptAlways")
+    }
+
+    private func supportsDecision(_ expected: String) -> Bool {
+        availableDecisions?.contains {
+            $0.caseInsensitiveCompare(expected) == .orderedSame
+        } == true
+    }
 }
 
 struct AgentUserInputRequest: Identifiable, Codable, Hashable {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerRequestCards.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerRequestCards.swift
@@ -124,7 +124,7 @@ struct PendingApprovalActionCard: View {
             return L10n.text("ui.file_changes")
         case "permission":
             return L10n.text("ui.permissions_request_approval")
-        case "mcp_elicitation":
+        case "mcp_elicitation", CodexMCPToolApprovalProtocol.kind:
             return L10n.text("ui.mcp_service")
         default:
             return approval.kind.replacingOccurrences(of: "_", with: " ")
@@ -333,6 +333,59 @@ struct PendingApprovalActionCard: View {
             .accessibilityIdentifier("approval.alwaysAllow")
             .accessibilityHint(L10n.text("ui.after_confirmation_write_the_precise_rules_suggested_by"))
         }
+
+        if approval.canAcceptMCPToolForSession {
+            mcpTrustButton(
+                title: L10n.text("ui.allow_for_this_session"),
+                systemImage: "clock.badge.checkmark",
+                decision: "acceptForSession",
+                identifier: "approval.allowMCPForSession",
+                tokens: tokens
+            )
+        }
+
+        if approval.canAlwaysAllowMCPTool {
+            mcpTrustButton(
+                title: L10n.text("ui.always_allow_this_tool"),
+                systemImage: "checkmark.shield",
+                decision: "acceptAlways",
+                identifier: "approval.alwaysAllowMCPTool",
+                tokens: tokens
+            )
+        }
+
+        if approval.canAcceptMCPToolForSession || approval.canAlwaysAllowMCPTool {
+            Label(
+                L10n.text("ui.codex_saves_this_choice_on_the_mac"),
+                systemImage: "macbook.and.iphone"
+            )
+            .font(themeStore.uiFont(.footnote))
+            .foregroundStyle(tokens.secondaryText)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func mcpTrustButton(
+        title: String,
+        systemImage: String,
+        decision: String,
+        identifier: String,
+        tokens: ThemeTokens
+    ) -> some View {
+        Button {
+            onDecision(decision)
+        } label: {
+            Label(title, systemImage: systemImage)
+                .font(themeStore.uiFont(.subheadline, weight: .semibold))
+                .foregroundStyle(tokens.accent)
+                .frame(maxWidth: .infinity, minHeight: 50)
+                .background(tokens.accentSoft, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .disabled(isSendingDecision || !approval.hasDecisionContext)
+        .accessibilityIdentifier(identifier)
+        .accessibilityHint(L10n.text("ui.codex_saves_this_choice_on_the_mac"))
     }
 
     private func rejectButton(tokens: ThemeTokens) -> some View {
@@ -359,10 +412,13 @@ struct PendingApprovalActionCard: View {
 
     private func approveButton(tokens: ThemeTokens) -> some View {
         let isEnabled = !isSendingDecision && approval.hasDecisionContext
+        let title = approval.kind == CodexMCPToolApprovalProtocol.kind
+            ? L10n.text("ui.allow_once")
+            : L10n.text("ui.approve_once")
         return Button {
             onDecision("accept")
         } label: {
-            Label(L10n.text("ui.approve_once"), systemImage: "checkmark.circle.fill")
+            Label(title, systemImage: "checkmark.circle.fill")
                 .font(themeStore.uiFont(.callout, weight: .semibold))
                 .foregroundStyle(isEnabled ? tokens.primaryActionForeground : tokens.tertiaryText)
                 .frame(maxWidth: .infinity, minHeight: 52)

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -629,6 +629,10 @@ final class AppStore: ObservableObject {
     var shouldSeedDebugQueuedTurnsUI: Bool {
         debugLaunchConfiguration.seedsQueuedTurnsUI
     }
+
+    var shouldSeedDebugMCPApprovalUI: Bool {
+        debugLaunchConfiguration.seedsMCPApprovalUI
+    }
 #endif
 
     func client() throws -> AgentAPIClient {
@@ -1917,6 +1921,7 @@ private struct DebugLaunchConfiguration {
     let opensWorkbenchWithoutPairing: Bool
     let seedsWorkbenchUI: Bool
     let seedsQueuedTurnsUI: Bool
+    let seedsMCPApprovalUI: Bool
     let endpoint: String?
     let token: String?
 
@@ -1925,13 +1930,17 @@ private struct DebugLaunchConfiguration {
         let environment = processInfo.environment
         let seedsQueuedTurnsUI = arguments.contains("--debug-seed-queue-ui")
             || boolValue(environment["MIMI_DEBUG_SEED_QUEUE_UI"])
+        let seedsMCPApprovalUI = arguments.contains("--debug-seed-mcp-approval-ui")
+            || boolValue(environment["MIMI_DEBUG_SEED_MCP_APPROVAL_UI"])
         return DebugLaunchConfiguration(
             opensWorkbenchWithoutPairing: arguments.contains("--debug-skip-pairing")
                 || boolValue(environment["MIMI_DEBUG_SKIP_PAIRING"]),
             seedsWorkbenchUI: arguments.contains("--debug-seed-ui")
                 || boolValue(environment["MIMI_DEBUG_SEED_UI"])
-                || seedsQueuedTurnsUI,
+                || seedsQueuedTurnsUI
+                || seedsMCPApprovalUI,
             seedsQueuedTurnsUI: seedsQueuedTurnsUI,
+            seedsMCPApprovalUI: seedsMCPApprovalUI,
             endpoint: argumentValue(named: "--debug-endpoint", in: arguments)
                 ?? environment["MIMI_DEBUG_ENDPOINT"],
             token: argumentValue(named: "--debug-token", in: arguments)

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -98,6 +98,18 @@ extension SessionStore {
         )
         let selectedSessionID = "debug-session-layout"
         let runningSessionID = "debug-session-running"
+        // MCP 审批样例只在显式 Debug 参数下出现，用于真机检查 Codex 声明的
+        // 一次、会话和永久信任入口；不连接真实 MCP，也不会写入用户授权配置。
+        let mcpApproval = appStore.shouldSeedDebugMCPApprovalUI
+            ? ApprovalSummary(
+                id: "debug-mcp-tool-approval",
+                title: L10n.text("ui.mcp_tool_call"),
+                body: #"Allow the linear MCP server to run tool "save_issue"?"#,
+                kind: CodexMCPToolApprovalProtocol.kind,
+                count: 1,
+                availableDecisions: ["accept", "acceptForSession", "acceptAlways", "decline"]
+            )
+            : nil
         let sessions = [
             AgentSession(
                 id: selectedSessionID,
@@ -105,14 +117,17 @@ extension SessionStore {
                 project: mimiDemo.name,
                 dir: mimiDemo.path,
                 title: L10n.text("ui.organize_open_source_release_notes"),
-                status: SessionStatus.completed.rawValue,
+                status: mcpApproval == nil
+                    ? SessionStatus.completed.rawValue
+                    : SessionStatus.waitingForApproval.rawValue,
                 source: "debug",
                 runtimeProvider: "codex",
                 resumeID: selectedSessionID,
                 createdAt: now.addingTimeInterval(-60 * 40),
                 updatedAt: now.addingTimeInterval(-60 * 3),
                 preview: L10n.text("ui.review_installation_steps_architecture_diagrams_privacy_boundaries_and"),
-                rateLimit: debugRateLimit
+                rateLimit: debugRateLimit,
+                pendingApproval: mcpApproval
             ),
             AgentSession(
                 id: runningSessionID,
@@ -201,6 +216,9 @@ extension SessionStore {
             // 队列样例需要处于可控的运行中会话，才能同时验收“排队（默认）/引导”切换；
             // 普通 Debug 工作台仍保留原来的观察态样例，不改变其接管流程覆盖。
             setSessionControlState(.takenOver, sessionID: runningSessionID)
+        } else if appStore.shouldSeedDebugMCPApprovalUI {
+            // 审批按钮只属于已接管会话；真机 UI 样例必须进入可操作态，才能覆盖完整决策入口。
+            setSessionControlState(.takenOver, sessionID: selectedSessionID)
         }
         webSocketStatus = .disconnected
         disconnectWebSocket()

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -1664,6 +1664,86 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(userInput.questions.first(where: { $0.id == "environment" })?.options.map(\.label), ["staging", "production"])
     }
 
+    func testCodexMcpToolElicitationProjectsToApprovalWithDeclaredTrustChoices() throws {
+        let request = CodexAppServerServerRequest(
+            id: .string("mcp-tool-approval-1"),
+            method: "mcpServer/elicitation/request",
+            params: .object([
+                "threadId": .string("thread-1"),
+                "turnId": .string("turn-1"),
+                "serverName": .string("linear"),
+                "mode": .string("form"),
+                "message": .string(#"Allow the linear MCP server to run tool "save_issue"?"#),
+                "requestedSchema": .object([
+                    "type": .string("object"),
+                    "properties": .object([:])
+                ]),
+                "_meta": .object([
+                    "codex_approval_kind": .string("mcp_tool_call"),
+                    "persist": .array([.string("session"), .string("always")])
+                ])
+            ])
+        )
+
+        var projector = CodexAppServerEventProjector()
+        guard case .approvalRequest(let approval, let metadata) = projector.project(request) else {
+            return XCTFail("Codex MCP 工具调用应投影为审批，而不是空表单")
+        }
+        XCTAssertEqual(metadata.sessionID, "thread-1")
+        XCTAssertEqual(approval.kind, CodexMCPToolApprovalProtocol.kind)
+        XCTAssertTrue(approval.body?.contains("save_issue") == true)
+        XCTAssertEqual(
+            approval.availableDecisions,
+            ["accept", "acceptForSession", "acceptAlways", "decline"]
+        )
+        let summary = ApprovalSummary(
+            id: approval.id,
+            title: approval.title,
+            body: approval.body,
+            kind: approval.kind,
+            count: 1,
+            availableDecisions: approval.availableDecisions
+        )
+        XCTAssertTrue(summary.canAcceptMCPToolForSession)
+        XCTAssertTrue(summary.canAlwaysAllowMCPTool)
+    }
+
+    func testCodexMcpToolElicitationDoesNotInventPersistentTrustChoices() throws {
+        let request = CodexAppServerServerRequest(
+            id: .string("mcp-tool-destructive"),
+            method: "mcpServer/elicitation/request",
+            params: .object([
+                "threadId": .string("thread-1"),
+                "serverName": .string("linear"),
+                "mode": .string("form"),
+                "message": .string("Allow destructive tool call?"),
+                "requestedSchema": .object([
+                    "type": .string("object"),
+                    "properties": .object([:])
+                ]),
+                "_meta": .object([
+                    "codex_approval_kind": .string("mcp_tool_call")
+                ])
+            ])
+        )
+
+        var projector = CodexAppServerEventProjector()
+        guard case .approvalRequest(let approval, _) = projector.project(request) else {
+            return XCTFail("expected MCP tool approval")
+        }
+        XCTAssertEqual(approval.availableDecisions, ["accept", "decline"])
+        let summary = ApprovalSummary(
+            id: approval.id,
+            title: approval.title,
+            body: approval.body,
+            kind: approval.kind,
+            count: 1,
+            availableDecisions: approval.availableDecisions
+        )
+        XCTAssertFalse(summary.canAcceptMCPToolForSession)
+        XCTAssertFalse(summary.canAlwaysAllowMCPTool)
+    }
+
     func testMcpURLelicitationProjectsToExplicitApproval() {
         let request = CodexAppServerServerRequest(
             id: .int(17),
@@ -1758,6 +1838,53 @@ final class CodexAppServerProtocolTests: XCTestCase {
         let urlAccepted = await runtime.approvalResponse(method: url.method, params: url.params?.objectValue ?? [:], decision: "accept")
         XCTAssertEqual(urlAccepted["action"]?.stringValue, "accept")
         XCTAssertEqual(urlAccepted["content"], .null)
+    }
+
+    func testRuntimeBuildsScopedCodexMcpToolApprovalResponsesAndFailsClosed() async {
+        let runtime = CodexAppServerSessionRuntime(endpoint: "http://127.0.0.1:8787", token: "test")
+        let params: [String: CodexAppServerJSONValue] = [
+            "mode": .string("form"),
+            "_meta": .object([
+                "codex_approval_kind": .string("mcp_tool_call"),
+                "persist": .array([.string("session"), .string("always")])
+            ])
+        ]
+
+        let once = await runtime.approvalResponse(
+            method: "mcpServer/elicitation/request",
+            params: params,
+            decision: "accept"
+        )
+        XCTAssertEqual(once["action"]?.stringValue, "accept")
+        XCTAssertEqual(once["_meta"], .null)
+
+        let session = await runtime.approvalResponse(
+            method: "mcpServer/elicitation/request",
+            params: params,
+            decision: "acceptForSession"
+        )
+        XCTAssertEqual(session["action"]?.stringValue, "accept")
+        XCTAssertEqual(session["_meta"]?.objectValue?["persist"]?.stringValue, "session")
+
+        let always = await runtime.approvalResponse(
+            method: "mcpServer/elicitation/request",
+            params: params,
+            decision: "acceptAlways"
+        )
+        XCTAssertEqual(always["action"]?.stringValue, "accept")
+        XCTAssertEqual(always["_meta"]?.objectValue?["persist"]?.stringValue, "always")
+
+        let oneTimeOnlyParams: [String: CodexAppServerJSONValue] = [
+            "mode": .string("form"),
+            "_meta": .object(["codex_approval_kind": .string("mcp_tool_call")])
+        ]
+        let forgedAlways = await runtime.approvalResponse(
+            method: "mcpServer/elicitation/request",
+            params: oneTimeOnlyParams,
+            decision: "acceptAlways"
+        )
+        XCTAssertEqual(forgedAlways["action"]?.stringValue, "decline")
+        XCTAssertEqual(forgedAlways["_meta"], .null)
     }
 
     func testProjectorMapsPlanReasoningUsageCompactionNameMCPAndDeprecationNotifications() throws {

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -13,6 +13,9 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
             "--debug-skip-pairing",
             "--debug-seed-ui"
         ]
+        if name.contains("testMCPToolApprovalShowsScopedTrustActions") {
+            app.launchArguments.append("--debug-seed-mcp-approval-ui")
+        }
         app.launch()
         XCTAssertTrue(
             app.wait(for: .runningForeground, timeout: 25),
@@ -122,6 +125,26 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         )
         dismissPresentedMenuOrPopover()
         XCTAssertEqual(app.state, .runningForeground, "完成紧凑工具栏操作后 App 应保持前台运行")
+    }
+
+    func testMCPToolApprovalShowsScopedTrustActions() throws {
+        try openComposerIfNeeded()
+
+        let approveOnce = app.descendant(identifier: "approval.approveOnce")
+        let allowForSession = app.descendant(identifier: "approval.allowMCPForSession")
+        let alwaysAllow = app.descendant(identifier: "approval.alwaysAllowMCPTool")
+        let reject = app.descendant(identifier: "approval.reject")
+
+        XCTAssertTrue(approveOnce.waitForExistence(timeout: 12), "MCP 工具审批应保留单次允许入口")
+        XCTAssertTrue(allowForSession.waitForExistence(timeout: 5), "Codex 声明 session 持久化后应展示本次会话允许")
+        XCTAssertTrue(alwaysAllow.waitForExistence(timeout: 5), "Codex 声明 always 持久化后应展示始终允许")
+        XCTAssertTrue(reject.waitForExistence(timeout: 5), "MCP 工具审批应始终允许拒绝")
+
+        assertMinimumTouchTarget(approveOnce, named: "单次允许")
+        assertMinimumTouchTarget(allowForSession, named: "本次会话允许")
+        assertMinimumTouchTarget(alwaysAllow, named: "始终允许")
+        assertMinimumTouchTarget(reject, named: "拒绝")
+        XCTAssertEqual(app.state, .runningForeground, "展示完整 MCP 信任选项后 App 应保持前台运行")
     }
 
     func testComposerCameraAttachmentCanPresentAndCancel() throws {


### PR DESCRIPTION
## 目标

修复 iOS 端在“完全文件访问”模式下仍把 Codex MCP 工具审批显示为空表单、无法按 Codex 声明的范围授权的问题。

关联 Linear：MIM-22

## 根因

Codex 0.146+ 使用 `mcpServer/elicitation/request` 携带 `_meta.codex_approval_kind=mcp_tool_call` 表达 MCP 工具审批。原 iOS 投影层把它按普通 form elicitation 处理，因此空 schema 无法形成可操作的审批决策。

## 改动

- 精确识别 Codex MCP 工具审批元数据，避免误判第三方普通 MCP 表单。
- 根据服务端声明展示“仅允许一次”“本会话允许”“始终允许此工具”“拒绝”。
- 回传 `accept`、`acceptForSession`、`acceptAlways` 对应的 action 和 `_meta.persist`。
- 未声明的持久化范围、未知决策和伪造永久授权全部 fail closed。
- 明确“完全文件访问”只代表文件沙盒范围，不代表自动放行 MCP 工具。
- 增加协议、网关及实体 iPad UI 回归覆盖。

## 安全边界

- 未放宽 `approvalPolicy=never`。
- iOS 不保存 MCP 凭据；持久选择仍由 Mac 端 Codex 保存。
- 真机 UI 回归使用仅 Debug 生效的离线内存样例，没有调用真实 Linear 工具，也没有写入永久信任。

## 验证

- Swift `CodexAppServerProtocolTests`：58/58 通过。
- MIM-22 实体 iPad 协议测试：3/3 通过。
- 实体 iPad Pro 12.9 英寸（第 5 代，iPadOS 27.0）UI 回归：1/1 通过。
  - 四个审批入口均已实际渲染并可由 UI Automation 识别。
  - 四个入口命中区域均不小于 44pt。
- Go 网关定向测试通过：
  - `TestAppServerGatewayPassesCodexMCPToolApprovalMetadataAndDecisionUnchanged`
  - `TestAppServerGatewayServerRequestAllowlistMatchesMobileCapabilities`
- iPhoneOS 与 iPhoneSimulator `build-for-testing` 均构建成功。

完整 Go 包测试仍有一个与本 PR 无关的既有 Claude bridge 最低版本断言失败，本 PR 未修改该逻辑。
