### PR TITLE
MIM-27 将核心 CI 收敛为快速 PR Gate

### DIFF
--- a/.github/workflows/claude-bridge-ci.yml
+++ b/.github/workflows/claude-bridge-ci.yml
@@ -1,12 +1,7 @@
 name: Claude Bridge CI
 
 on:
-  pull_request:
-    paths:
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "bridges/claude/**"
-      - ".github/workflows/claude-bridge-ci.yml"
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/codex-protocol.yml
+++ b/.github/workflows/codex-protocol.yml
@@ -1,7 +1,7 @@
 name: Codex Protocol Drift
 
 on:
-  pull_request:
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,31 +1,7 @@
 name: Go CI
 
 on:
-  pull_request:
-    paths:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-      - ".goreleaser.yml"
-      - "packaging/**"
-      - "scripts/check-packaging.sh"
-      - "scripts/check-macos-release-signing.sh"
-      - "scripts/check-release-artifacts.sh"
-      - "scripts/check-source-size.sh"
-      - "scripts/install-linux.sh"
-      - "scripts/test-install-linux.sh"
-      - "scripts/build-windows-installer.ps1"
-      - "scripts/check-windows-installer.ps1"
-      - "scripts/test-windows-install.ps1"
-      - "scripts/sign-agentd-dev-macos.sh"
-      - "scripts/restart-agentd-dev-macos.sh"
-      - "scripts/restart-agentd-dev-handoff-macos.sh"
-      - "scripts/verify-release.sh"
-      - "README.md"
-      - "docs/install-upgrade-rollback.md"
-      - "docs/codex-protocol-support.md"
-      - ".github/workflows/go-ci.yml"
-      - ".github/workflows/release.yml"
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,23 +1,7 @@
 name: iOS CI
 
 on:
-  pull_request:
-    paths:
-      - "ios/MimiRemote/**"
-      - "scripts/ios-dev.sh"
-      - "scripts/test-conversation-regressions.sh"
-      - "scripts/test-ios-localization-smoke.sh"
-      - "scripts/check-ios-localization.sh"
-      - "scripts/check-ios-network-security.sh"
-      - "scripts/check-ios-privacy-manifest.sh"
-      - "scripts/check-app-store-metadata.sh"
-      - "scripts/check-source-size.sh"
-      - "docs/app-store/**"
-      - "docs/privacy-policy.md"
-      - "docs/support.md"
-      - "docs/terms-of-use.md"
-      - ".github/workflows/ios-ci.yml"
-      - ".xcodebuildmcp/config.yaml"
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,153 @@
+name: PR Gate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scope:
+    name: Detect change scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      go: ${{ steps.scope.outputs.go }}
+      ios: ${{ steps.scope.outputs.ios }}
+      rust: ${{ steps.scope.outputs.rust }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            bash ./scripts/ci-pr-scope.sh \
+              --base "$BASE_SHA" \
+              --head "$HEAD_SHA" \
+              --github-output "$GITHUB_OUTPUT" \
+              --summary "$GITHUB_STEP_SUMMARY"
+          else
+            bash ./scripts/ci-pr-scope.sh \
+              --all \
+              --github-output "$GITHUB_OUTPUT" \
+              --summary "$GITHUB_STEP_SUMMARY"
+          fi
+
+  codex-protocol:
+    name: Codex protocol
+    uses: ./.github/workflows/codex-protocol.yml
+
+  repository-safety:
+    name: Repository safety
+    uses: ./.github/workflows/public-repo-safety.yml
+
+  go:
+    name: Go and release
+    needs: scope
+    if: needs.scope.outputs.go == 'true'
+    uses: ./.github/workflows/go-ci.yml
+
+  ios:
+    name: iOS
+    needs: scope
+    if: needs.scope.outputs.ios == 'true'
+    uses: ./.github/workflows/ios-ci.yml
+
+  rust:
+    name: Rust bridge
+    needs: scope
+    if: needs.scope.outputs.rust == 'true'
+    uses: ./.github/workflows/claude-bridge-ci.yml
+
+  gate:
+    name: PR Gate
+    if: always()
+    needs:
+      - scope
+      - codex-protocol
+      - repository-safety
+      - go
+      - ios
+      - rust
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every applicable check
+        shell: bash
+        env:
+          SCOPE_RESULT: ${{ needs.scope.result }}
+          PROTOCOL_RESULT: ${{ needs.codex-protocol.result }}
+          SAFETY_RESULT: ${{ needs.repository-safety.result }}
+          GO_REQUIRED: ${{ needs.scope.outputs.go }}
+          GO_RESULT: ${{ needs.go.result }}
+          IOS_REQUIRED: ${{ needs.scope.outputs.ios }}
+          IOS_RESULT: ${{ needs.ios.result }}
+          RUST_REQUIRED: ${{ needs.scope.outputs.rust }}
+          RUST_RESULT: ${{ needs.rust.result }}
+        run: |
+          set -euo pipefail
+
+          failures=0
+
+          require_success() {
+            local label="$1"
+            local result="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "::error title=${label}::expected success, got ${result}"
+              failures=1
+            fi
+          }
+
+          require_scoped_success() {
+            local label="$1"
+            local required="$2"
+            local result="$3"
+            if [[ "$required" == "true" && "$result" != "success" ]]; then
+              echo "::error title=${label}::required by changed paths, got ${result}"
+              failures=1
+            elif [[ "$required" != "true" && "$result" != "skipped" ]]; then
+              echo "::error title=${label}::not required, expected skipped, got ${result}"
+              failures=1
+            fi
+          }
+
+          require_success "Change scope" "$SCOPE_RESULT"
+          require_success "Codex protocol" "$PROTOCOL_RESULT"
+          require_success "Repository safety" "$SAFETY_RESULT"
+          require_scoped_success "Go and release" "$GO_REQUIRED" "$GO_RESULT"
+          require_scoped_success "iOS" "$IOS_REQUIRED" "$IOS_RESULT"
+          require_scoped_success "Rust bridge" "$RUST_REQUIRED" "$RUST_RESULT"
+
+          {
+            echo "## PR Gate"
+            echo
+            echo "| 检查 | 是否需要 | 结果 |"
+            echo "| --- | --- | --- |"
+            echo "| Change scope | always | \`$SCOPE_RESULT\` |"
+            echo "| Codex protocol | always | \`$PROTOCOL_RESULT\` |"
+            echo "| Repository safety | always | \`$SAFETY_RESULT\` |"
+            echo "| Go and release | \`$GO_REQUIRED\` | \`$GO_RESULT\` |"
+            echo "| iOS | \`$IOS_REQUIRED\` | \`$IOS_RESULT\` |"
+            echo "| Rust bridge | \`$RUST_REQUIRED\` | \`$RUST_RESULT\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$failures" -ne 0 ]]; then
+            echo "PR Gate 失败：至少一项必需检查未成功完成。" >&2
+            exit 1
+          fi
+
+          echo "PR Gate 通过：所有必需检查均已成功完成。"

--- a/.github/workflows/public-repo-safety.yml
+++ b/.github/workflows/public-repo-safety.yml
@@ -1,7 +1,7 @@
 name: Public Repository Safety
 
 on:
-  pull_request:
+  workflow_call:
   push:
     branches:
       - main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,47 @@ bash ./scripts/check-public-repo-safety.sh
 bash ./scripts/check-third-party-notices.sh
 bash ./scripts/check-ios-privacy-manifest.sh
 ```
+
+## 快速 PR Gate
+
+每个 Pull Request 都会产生名称固定的 `PR Gate` check。该 workflow 本身不使用
+`paths` 或 `paths-ignore`，因此纯文档、删除文件或跨目录移动也会得到明确结果，
+不会因为整条 workflow 未触发而留下可忽略的检查缺口。
+
+门禁并行执行以下检查：
+
+- 始终执行 Codex 协议快照、公开仓库安全和 PR Gate 配置自检；
+- Go、macOS/Windows/Linux 打包或 Release 相关路径调用现有 Go CI；
+- iOS、App Store/TestFlight 脚本或相关文档路径调用现有 iOS CI；
+- Cargo 或 `bridges/claude` 路径调用现有 Rust bridge CI；
+- `.github/workflows`、`.github/actions` 或 Gate 分类脚本变化时执行全部语言检查。
+
+提交前始终运行：
+
+```bash
+bash ./scripts/check-pr-gate.sh
+bash ./scripts/check-public-repo-safety.sh
+bash ./scripts/check-codex-protocol.sh
+```
+
+再按改动范围运行本文件前述 Go、iOS 或 Claude bridge 命令。Release/打包改动还需运行：
+
+```bash
+bash ./scripts/check-packaging.sh
+```
+
+`PR Gate` 红灯时先打开失败的子 job；最终聚合 job 只负责判断必需检查是否成功，
+真正的错误日志保留在 `Go and release`、`iOS`、`Rust bridge`、`Codex protocol`
+或 `Repository safety` 中。`Detect change scope` 失败时，先用下面的命令确认
+base/head 可读取且路径分类符合预期：
+
+```bash
+bash ./scripts/ci-pr-scope.sh --base origin/main --head HEAD
+```
+
+`main` 分支保护必须把名称精确为 `PR Gate` 的 check 设为 required，并让未完成或
+失败状态阻止常规合并。紧急 bypass 只允许用于回滚已经确认影响生产可用性的提交；
+不得用于功能交付、测试不稳定或赶发布时间。使用 bypass 时必须在回滚 PR 或关联
+Issue 中记录原因、被绕过的失败 check、操作者、时间、回滚 commit，以及后续补验
+负责人和结果；补验完成前不得关闭关联 Issue。不要通过临时删除 required check、
+关闭 `enforce admins` 或修改 workflow 让 Gate 变绿。

--- a/scripts/check-packaging.sh
+++ b/scripts/check-packaging.sh
@@ -17,6 +17,7 @@ for command_name in awk bash cmp grep mktemp shasum; do
 done
 
 for required_file in \
+  .github/workflows/pr-gate.yml \
   .github/workflows/go-ci.yml \
   .github/workflows/release.yml \
   .goreleaser.yml \
@@ -29,6 +30,8 @@ for required_file in \
   packaging/windows/mimi-remote.iss \
   packaging/windows/register-service.ps1 \
   scripts/build-macos-installer.sh \
+  scripts/ci-pr-scope.sh \
+  scripts/check-pr-gate.sh \
   scripts/check-macos-installer.sh \
   scripts/build-windows-installer.ps1 \
   scripts/check-windows-installer.ps1 \
@@ -49,6 +52,8 @@ done
 
 bash -n \
   scripts/build-macos-installer.sh \
+  scripts/ci-pr-scope.sh \
+  scripts/check-pr-gate.sh \
   scripts/check-macos-installer.sh \
   scripts/check-release-prerequisites.sh \
   scripts/check-macos-release-signing.sh \

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "PR Gate 自检失败：$1" >&2
+  exit 1
+}
+
+for command_name in bash grep mktemp ruby; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "缺少命令 ${command_name}。"
+done
+
+bash -n scripts/ci-pr-scope.sh scripts/check-pr-gate.sh
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-pr-gate-check.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+
+assert_scope() {
+  local case_name="$1"
+  local expected_go="$2"
+  local expected_ios="$3"
+  local expected_rust="$4"
+  shift 4
+
+  local paths_path="$test_root/${case_name}.paths"
+  local output_path="$test_root/${case_name}.output"
+  printf '%s\0' "$@" > "$paths_path"
+  bash ./scripts/ci-pr-scope.sh --paths-file "$paths_path" > "$output_path"
+
+  grep -Fqx "go=$expected_go" "$output_path" \
+    || fail "${case_name} 的 Go 分类错误。"
+  grep -Fqx "ios=$expected_ios" "$output_path" \
+    || fail "${case_name} 的 iOS 分类错误。"
+  grep -Fqx "rust=$expected_rust" "$output_path" \
+    || fail "${case_name} 的 Rust 分类错误。"
+}
+
+assert_scope go_only true false false internal/httpapi/router.go
+assert_scope ios_only false true false ios/MimiRemote/Sources/App/MimiRemoteApp.swift
+assert_scope rust_only false false true bridges/claude/crates/claude-bridge/src/main.rs
+assert_scope release true false false scripts/check-release-artifacts.sh
+assert_scope windows_release true false false scripts/build-windows-installer.ps1
+assert_scope ios_release false true false scripts/ios_testflight_ci.sh
+assert_scope docs_only false false false CONTRIBUTING.md
+assert_scope workflow true true true .github/workflows/pr-gate.yml
+assert_scope mixed true true true \
+  cmd/agentd/main.go \
+  ios/MimiRemote/project.yml \
+  Cargo.lock
+
+ruby <<'RUBY'
+require "yaml"
+
+def load_workflow(path)
+  YAML.safe_load(File.read(path), aliases: true)
+rescue Psych::SyntaxError => error
+  abort("PR Gate 自检失败：#{path} YAML 无法解析：#{error.message}")
+end
+
+def triggers(workflow, path)
+  value = workflow["on"] || workflow[true]
+  abort("PR Gate 自检失败：#{path} 缺少 on。") unless value.is_a?(Hash)
+  value
+end
+
+gate_path = ".github/workflows/pr-gate.yml"
+gate = load_workflow(gate_path)
+abort("PR Gate 自检失败：workflow 名称必须稳定为 PR Gate。") unless gate["name"] == "PR Gate"
+
+gate_triggers = triggers(gate, gate_path)
+abort("PR Gate 自检失败：PR Gate 必须监听所有 pull_request。") unless gate_triggers.key?("pull_request")
+pull_request_trigger = gate_triggers["pull_request"]
+if pull_request_trigger.is_a?(Hash) && (pull_request_trigger.key?("paths") || pull_request_trigger.key?("paths-ignore"))
+  abort("PR Gate 自检失败：PR Gate 顶层禁止 paths/paths-ignore。")
+end
+
+unless gate.dig("concurrency", "cancel-in-progress") == true
+  abort("PR Gate 自检失败：必须保留 cancel-in-progress。")
+end
+
+expected_calls = {
+  "codex-protocol" => "./.github/workflows/codex-protocol.yml",
+  "repository-safety" => "./.github/workflows/public-repo-safety.yml",
+  "go" => "./.github/workflows/go-ci.yml",
+  "ios" => "./.github/workflows/ios-ci.yml",
+  "rust" => "./.github/workflows/claude-bridge-ci.yml",
+}
+jobs = gate.fetch("jobs")
+expected_calls.each do |job_id, workflow_path|
+  unless jobs.dig(job_id, "uses") == workflow_path
+    abort("PR Gate 自检失败：#{job_id} 没有调用 #{workflow_path}。")
+  end
+end
+
+final_gate = jobs.fetch("gate")
+abort("PR Gate 自检失败：最终 check 名称必须为 PR Gate。") unless final_gate["name"] == "PR Gate"
+unless final_gate["if"].to_s.include?("always()")
+  abort("PR Gate 自检失败：最终聚合 job 必须在上游失败或跳过时仍执行。")
+end
+expected_needs = %w[scope codex-protocol repository-safety go ios rust]
+unless Array(final_gate["needs"]).sort == expected_needs.sort
+  abort("PR Gate 自检失败：最终聚合 job 的 needs 不完整。")
+end
+
+expected_calls.values.each do |workflow_path|
+  called_workflow = load_workflow(workflow_path)
+  called_triggers = triggers(called_workflow, workflow_path)
+  unless called_triggers.key?("workflow_call")
+    abort("PR Gate 自检失败：#{workflow_path} 缺少 workflow_call。")
+  end
+  if called_triggers.key?("pull_request")
+    abort("PR Gate 自检失败：#{workflow_path} 不应绕过 PR Gate 单独监听 pull_request。")
+  end
+end
+RUBY
+
+rm -rf "$test_root"
+trap - EXIT
+
+echo "PR Gate 自检通过：触发器、聚合依赖和路径分类均符合预期。"

--- a/scripts/check-public-repo-safety.sh
+++ b/scripts/check-public-repo-safety.sh
@@ -95,5 +95,6 @@ if [[ "$failures" -ne 0 ]]; then
 fi
 
 bash ./scripts/check-third-party-notices.sh
+bash ./scripts/check-pr-gate.sh
 
 echo "公开仓库安全门禁通过。"

--- a/scripts/ci-pr-scope.sh
+++ b/scripts/ci-pr-scope.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'EOF'
+用法：
+  bash ./scripts/ci-pr-scope.sh --base <sha> --head <sha> [--github-output <path>] [--summary <path>]
+  bash ./scripts/ci-pr-scope.sh --paths-file <NUL-separated-paths> [--github-output <path>] [--summary <path>]
+  bash ./scripts/ci-pr-scope.sh --all [--github-output <path>] [--summary <path>]
+EOF
+}
+
+fail() {
+  echo "PR Gate 路径分类失败：$1" >&2
+  exit 1
+}
+
+base_sha=""
+head_sha=""
+paths_file=""
+github_output=""
+summary_file=""
+run_all=0
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ "$#" -ge 2 ]] || fail "--base 缺少 SHA。"
+      base_sha="$2"
+      shift 2
+      ;;
+    --head)
+      [[ "$#" -ge 2 ]] || fail "--head 缺少 SHA。"
+      head_sha="$2"
+      shift 2
+      ;;
+    --paths-file)
+      [[ "$#" -ge 2 ]] || fail "--paths-file 缺少路径。"
+      paths_file="$2"
+      shift 2
+      ;;
+    --github-output)
+      [[ "$#" -ge 2 ]] || fail "--github-output 缺少路径。"
+      github_output="$2"
+      shift 2
+      ;;
+    --summary)
+      [[ "$#" -ge 2 ]] || fail "--summary 缺少路径。"
+      summary_file="$2"
+      shift 2
+      ;;
+    --all)
+      run_all=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "未知参数 $1。"
+      ;;
+  esac
+done
+
+mode_count=0
+[[ "$run_all" -eq 1 ]] && mode_count=$((mode_count + 1))
+[[ -n "$paths_file" ]] && mode_count=$((mode_count + 1))
+if [[ -n "$base_sha" || -n "$head_sha" ]]; then
+  [[ -n "$base_sha" && -n "$head_sha" ]] || fail "--base 与 --head 必须同时提供。"
+  mode_count=$((mode_count + 1))
+fi
+[[ "$mode_count" -eq 1 ]] || fail "必须且只能选择 --all、--paths-file 或 --base/--head。"
+
+temporary_paths=""
+if [[ "$run_all" -eq 1 ]]; then
+  go_scope=true
+  ios_scope=true
+  rust_scope=true
+  path_count="all"
+else
+  if [[ -n "$paths_file" ]]; then
+    [[ -f "$paths_file" ]] || fail "路径文件不存在：$paths_file"
+    resolved_paths_file="$paths_file"
+  else
+    git cat-file -e "${base_sha}^{commit}" 2>/dev/null \
+      || fail "base commit 不存在：$base_sha"
+    git cat-file -e "${head_sha}^{commit}" 2>/dev/null \
+      || fail "head commit 不存在：$head_sha"
+    temporary_paths="$(mktemp "${TMPDIR:-/tmp}/mimi-pr-gate-paths.XXXXXX")"
+    trap 'rm -f "$temporary_paths"' EXIT
+    # 禁用 rename detection，让跨目录移动同时按旧路径删除和新路径新增分类。
+    git diff --name-only -z --no-renames "${base_sha}...${head_sha}" > "$temporary_paths"
+    resolved_paths_file="$temporary_paths"
+  fi
+
+  go_scope=false
+  ios_scope=false
+  rust_scope=false
+  path_count=0
+
+  while IFS= read -r -d '' changed_path; do
+    [[ -n "$changed_path" ]] || continue
+    path_count=$((path_count + 1))
+
+    # CI 编排或分类规则本身变化时执行全部语言门禁，避免分类器修改静默缩小覆盖面。
+    case "$changed_path" in
+      .github/workflows/*|.github/actions/*|scripts/ci-pr-scope.sh|scripts/check-pr-gate.sh)
+        go_scope=true
+        ios_scope=true
+        rust_scope=true
+        continue
+        ;;
+    esac
+
+    case "$changed_path" in
+      *.go|go.mod|go.sum|.goreleaser.yml|SKILL.md|packaging/*|packaging/**/*|macos/MimiRemoteMac/*|macos/MimiRemoteMac/**/*)
+        go_scope=true
+        ;;
+      scripts/check-packaging.sh|scripts/check-source-size.sh|scripts/check-macos-*|scripts/check-release-*|scripts/build-macos-installer.sh|scripts/build-windows-installer.ps1|scripts/check-windows-installer.ps1|scripts/test-windows-install.ps1|scripts/install-linux.sh|scripts/test-install-linux.sh|scripts/package-skill.sh|scripts/export-public-backend.sh|scripts/sign-agentd-dev-macos.sh|scripts/restart-agentd-dev-macos.sh|scripts/restart-agentd-dev-handoff-macos.sh|scripts/verify-release.sh)
+        go_scope=true
+        ;;
+      README.md|docs/install-upgrade-rollback.md|docs/codex-protocol-support.md|docs/p0-p1-roadmap.md)
+        go_scope=true
+        ;;
+    esac
+
+    case "$changed_path" in
+      ios/MimiRemote/*|ios/MimiRemote/**/*|.xcodebuildmcp/*|.xcodebuildmcp/**/*)
+        ios_scope=true
+        ;;
+      scripts/ios-dev.sh|scripts/ios_testflight_ci.sh|scripts/ios_testflight_local.sh|scripts/ios_asc_*|scripts/distribute_internal_build.rb|scripts/git-testflight-push|scripts/test-conversation-regressions.sh|scripts/test-ios-localization-smoke.sh|scripts/check-ios-*|scripts/check-app-store-metadata.sh|scripts/check-source-size.sh|scripts/deploy-ipad.sh)
+        ios_scope=true
+        ;;
+      docs/app-store/*|docs/app-store/**/*|docs/privacy-policy.md|docs/support.md|docs/terms-of-use.md|docs/local-testflight.md)
+        ios_scope=true
+        ;;
+    esac
+
+    case "$changed_path" in
+      Cargo.toml|Cargo.lock|bridges/claude/*|bridges/claude/**/*)
+        rust_scope=true
+        ;;
+    esac
+  done < "$resolved_paths_file"
+fi
+
+output="$(
+  printf 'go=%s\nios=%s\nrust=%s\n' \
+    "$go_scope" \
+    "$ios_scope" \
+    "$rust_scope"
+)"
+printf '%s\n' "$output"
+
+if [[ -n "$github_output" ]]; then
+  printf '%s\n' "$output" >> "$github_output"
+fi
+
+if [[ -n "$summary_file" ]]; then
+  {
+    echo "## PR Gate change scope"
+    echo
+    echo "- Changed paths: \`$path_count\`"
+    echo "- Go and release: \`$go_scope\`"
+    echo "- iOS: \`$ios_scope\`"
+    echo "- Rust bridge: \`$rust_scope\`"
+    echo "- Codex protocol and repository safety: \`always\`"
+  } >> "$summary_file"
+fi


### PR DESCRIPTION
## 改动

- 新增全局 `PR Gate` workflow：每个 Pull Request 都稳定生成同名最终 check，不使用顶层 path filter，并保留 `cancel-in-progress`。
- 复用现有 Codex 协议、公开仓库安全、Go/发布、iOS、Rust bridge workflow；按路径范围并行选择语言检查，CI 编排变化时强制全量覆盖。
- 新增 NUL-safe 路径分类和 Gate 结构自检，删除、跨目录移动及分类器自身变化均 fail-closed。
- 将 Gate 自检接入公开仓库安全与打包检查，并补充中文本地验证、失败排查和紧急回滚 bypass 审计要求。

## 原因

现有 PR workflow 各自使用 path filter；一旦把其 check 配为 required，未匹配路径时整条 workflow 不产生结果，required check 会一直等待。若不设 required，又可能让红灯或未完成检查被常规合并绕过。本改动用一个始终触发、名称稳定的聚合 Gate 解决两者兼容问题。

## 影响

- 普通 PR 只执行适用范围的语言检查；Codex 协议与仓库安全始终执行。
- workflow/Gate 规则变化会执行 Go、iOS、Rust 全部核心检查。
- 不修改业务协议、运行时行为、feature flag、Nightly 或重测试范围。
- 合并策略将在本 PR 的 `PR Gate` 首次成功后，仅把精确名称 `PR Gate` 配为 `main` required check；不修改其他分支保护规则。

## 验证

已在 macOS 本地真实运行并通过：

- `bash ./scripts/check-pr-gate.sh`
- `bash ./scripts/check-packaging.sh`
- `bash ./scripts/check-public-repo-safety.sh`
- `CODEX_BIN=/tmp/mim27-codex-01442/node_modules/.bin/codex bash ./scripts/check-codex-protocol.sh`
- Go：格式、`go mod tidy` 无差异、`go vet ./...`、`go test ./... -count=1`、CGO=0 agentd 构建
- Rust：`cargo fmt --all -- --check`，三个 crate 的测试
- iOS：ATS、Privacy Manifest、本地化静态检查、App Store metadata、源码体积检查
- `bash ./scripts/test-conversation-regressions.sh`
- workflow YAML/actionlint 静态检查与 `git diff --check`

托管 GitHub Actions 将在本 Draft PR 上验证新的 Gate 编排及 Ubuntu、Windows、固定 Xcode 26.6 runner。

## 已知风险

本机使用 Xcode 27.0 beta。额外的英语本地化 smoke 在重启既有 iPad Simulator 后共运行 9 项，其中 8 项通过、1 项因界面显示中文 `设置` 而不是预期的 `settings` 失败；这是 beta 工具链/运行态本地化差异，本 Issue 不修改业务本地化。`main` 上固定 Xcode 26.6 的最新 iOS CI 已通过，本 PR 仍以托管 CI 的固定版本结果为准。

本机未安装独立 GoReleaser，因此没有单独执行 `goreleaser check`；打包静态门禁已通过，托管 Go CI 将执行仓库固定的 GoReleaser Action。Windows job 无法在本机实跑，将由本 PR 的托管 CI 验证。

Linear: MIM-27
