### PR TITLE
MIM-36 发布可下载的 unsigned Windows EXE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,27 +111,46 @@ jobs:
         shell: pwsh
         run: choco install innosetup --yes --no-progress
 
-      - name: Build and verify signed Windows installer
+      - name: Build and verify Windows installer
         shell: pwsh
         env:
           WINDOWS_SIGN_PFX: ${{ secrets.WINDOWS_SIGN_PFX }}
           WINDOWS_SIGN_PFX_PASSWORD: ${{ secrets.WINDOWS_SIGN_PFX_PASSWORD }}
         run: |
-          if (-not $env:WINDOWS_SIGN_PFX -or -not $env:WINDOWS_SIGN_PFX_PASSWORD) {
-            throw 'WINDOWS_SIGN_PFX and WINDOWS_SIGN_PFX_PASSWORD are required for a release.'
+          $hasPfx = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_SIGN_PFX)
+          $hasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_SIGN_PFX_PASSWORD)
+          if ($hasPfx -ne $hasPassword) {
+            throw 'WINDOWS_SIGN_PFX and WINDOWS_SIGN_PFX_PASSWORD must either both be configured or both be absent.'
           }
-          $pfx = Join-Path $env:RUNNER_TEMP 'mimi-remote-signing.pfx'
+          $pfx = $null
           try {
-            [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_SIGN_PFX))
-            ./scripts/build-windows-installer.ps1 `
-              -Version ($env:GITHUB_REF_NAME).TrimStart('v') `
-              -OutputDirectory dist-windows `
-              -PfxPath $pfx `
-              -PfxPassword $env:WINDOWS_SIGN_PFX_PASSWORD
+            if ($hasPfx) {
+              $pfx = Join-Path $env:RUNNER_TEMP 'mimi-remote-signing.pfx'
+              [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_SIGN_PFX))
+              ./scripts/build-windows-installer.ps1 `
+                -Version ($env:GITHUB_REF_NAME).TrimStart('v') `
+                -OutputDirectory dist-windows `
+                -PfxPath $pfx `
+                -PfxPassword $env:WINDOWS_SIGN_PFX_PASSWORD
+            } else {
+              Write-Warning 'Windows signing secrets are absent. Publishing an unsigned installer that may trigger Microsoft Defender SmartScreen.'
+              ./scripts/build-windows-installer.ps1 `
+                -Version ($env:GITHUB_REF_NAME).TrimStart('v') `
+                -OutputDirectory dist-windows `
+                -AllowUnsignedRelease
+            }
             $installer = Get-Item "dist-windows\Mimi-Remote-Setup-*.exe"
-            ./scripts/check-windows-installer.ps1 -InstallerPath $installer.FullName -RequireSignature
+            if ($hasPfx) {
+              ./scripts/check-windows-installer.ps1 -InstallerPath $installer.FullName -RequireSignature
+              'Windows installer signing: Authenticode PFX (Valid).' | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+            } else {
+              ./scripts/check-windows-installer.ps1 -InstallerPath $installer.FullName
+              'Windows installer signing: unsigned-release. Verify SHA-256 before running; SmartScreen may warn.' | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+            }
           } finally {
-            Remove-Item -LiteralPath $pfx -Force -ErrorAction SilentlyContinue
+            if ($pfx) {
+              Remove-Item -LiteralPath $pfx -Force -ErrorAction SilentlyContinue
+            }
           }
 
       - name: Upload verified Windows installer

--- a/README.md
+++ b/README.md
@@ -188,13 +188,15 @@ Requirements:
 - Windows 10/11 x64, with Codex CLI installed and signed in as the same Windows user.
 - The PC and iPhone/iPad on the same private network. Tailscale is recommended across networks.
 
-Download the versioned `Mimi-Remote-Setup-*.exe`, `.sha256`, and `.metadata.json` files from [GitHub Releases](https://github.com/gaixianggeng/codex-ipad-agent/releases/latest). Verify the SHA-256 and confirm that the Authenticode status is `Valid`, then run the installer:
+Download the versioned `Mimi-Remote-Setup-*.exe`, `.sha256`, and `.metadata.json` files from [GitHub Releases](https://github.com/gaixianggeng/codex-ipad-agent/releases/latest). Always verify the SHA-256. When `metadata.json` reports `authenticode-pfx`, require an Authenticode status of `Valid`; when it reports `unsigned-release`, expect `NotSigned` and a possible Microsoft Defender SmartScreen warning:
 
 ```powershell
 $setup = Get-Item .\Mimi-Remote-Setup-*.exe
 (Get-FileHash $setup -Algorithm SHA256).Hash
 (Get-AuthenticodeSignature $setup).Status
 ```
+
+Unsigned assets include `-unsigned` in the EXE filename. Only run one when it came from this repository's official Release and its SHA-256 matches the published sidecar.
 
 The per-user installer embeds `agentd.exe`, `alleycat-claude-bridge.exe`, and a native `mimi-remote-tray.exe`; Go, Rust, and administrator-level services are not required. It registers a limited current-user Task Scheduler task, starts it, waits for `/api/readyz`, and launches the notification-area controller. The tray shows the endpoint and Codex/Claude state and provides start, stop, restart, pairing, Doctor, and log actions. Configuration and credentials stay under `%APPDATA%\mimi-remote`; logs stay under `%LOCALAPPDATA%\Mimi Remote\logs`. Normal upgrade and uninstall preserve them.
 
@@ -308,7 +310,7 @@ macOS does not provide one background-requestable permission for the entire user
 
 The Claude runtime is disabled by default. When enabled, `agentd` supervises one resident `alleycat-claude-bridge` and attaches mobile WebSocket sessions to it by a stable session key. Each Claude thread owns a headless stdio JSONL process; reconnects replay missed events or reload authoritative history instead of resubmitting `turn/start`.
 
-The Windows installer and Mac DMG already include a signed, compatible bridge next to `agentd`; do not install a second copy with Cargo for those setups. Install the bridge from source only for Homebrew, Linux, or standalone development:
+The Windows installer and Mac DMG already include a compatible bridge next to `agentd`; signed Windows releases and the notarized Mac DMG preserve platform code identity, while an `unsigned-release` Windows package does not. Do not install a second copy with Cargo for those setups. Install the bridge from source only for Homebrew, Linux, or standalone development:
 
 ```bash
 cargo install --git https://github.com/gaixianggeng/codex-ipad-agent.git \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -192,7 +192,7 @@ Claude bridge 位于本仓库 [`bridges/claude`](bridges/claude)，与 iOS 和 `
 
 ## 快速开始
 
-推荐使用平台正式安装包：Windows 使用 Authenticode 签名的一键安装器，macOS 使用 Developer ID 签名并经过 Apple 公证的菜单栏宿主 App。两者都内置 Go 后端和兼容 Claude bridge；Homebrew 保留给 macOS 命令行、服务器、自动化和故障恢复。
+推荐使用平台正式安装包：Windows 使用一键 EXE 安装器（有证书时使用 Authenticode 签名；无证书时明确标记为 `unsigned-release`），macOS 使用 Developer ID 签名并经过 Apple 公证的菜单栏宿主 App。两者都内置 Go 后端和兼容 Claude bridge；Homebrew 保留给 macOS 命令行、服务器、自动化和故障恢复。
 
 ### Windows 安装
 
@@ -204,7 +204,7 @@ $setup = Get-Item .\Mimi-Remote-Setup-*.exe
 (Get-AuthenticodeSignature $setup).Status
 ```
 
-签名状态必须为 `Valid`。安装器按当前用户安装，已经内置 `agentd.exe`、`alleycat-claude-bridge.exe` 与原生 `mimi-remote-tray.exe`，不要求 Go 或 Rust；它会注册 limited 权限的登录任务、启动服务、等待真实就绪并启动通知区域托盘。托盘可查看 Endpoint 与 Codex/Claude 状态，并提供启动、停止、重启、配对、Doctor 和日志入口。配置与 Token 位于 `%APPDATA%\mimi-remote`，日志位于 `%LOCALAPPDATA%\Mimi Remote\logs`，覆盖升级或普通卸载不会删除它们。
+先检查 `.metadata.json` 的 `signing`：`authenticode-pfx` 必须对应 `Valid`；`unsigned-release` 应对应 `NotSigned`，其 EXE 文件名包含 `-unsigned`，并可能触发 Microsoft Defender SmartScreen。未签名版本只应从本仓库正式 Release 下载，并在 SHA-256 与同 Release 的 sidecar 完全一致后运行。安装器按当前用户安装，已经内置 `agentd.exe`、`alleycat-claude-bridge.exe` 与原生 `mimi-remote-tray.exe`，不要求 Go 或 Rust；它会注册 limited 权限的登录任务、启动服务、等待真实就绪并启动通知区域托盘。托盘可查看 Endpoint 与 Codex/Claude 状态，并提供启动、停止、重启、配对、Doctor 和日志入口。配置与 Token 位于 `%APPDATA%\mimi-remote`，日志位于 `%LOCALAPPDATA%\Mimi Remote\logs`，覆盖升级或普通卸载不会删除它们。
 
 局域网访问默认关闭；没有 Tailscale 且没有明确勾选 LAN 时，新安装只监听 loopback。勾选后，安装器先要求默认 Windows 网络配置文件为“专用网络”，清理 Windows 弹窗可能为 `agentd.exe` 自动创建的额外入站规则，再创建唯一的 Private profile、LocalSubnet 受限规则，最后扩大到 LAN 监听。运行时会拒绝 Public/Any 或其它非托管入站 Allow 规则。Public 网络不会触发放宽防火墙边界；只应把可信的 Wi-Fi 或以太网改为“专用网络”。配对地址优先使用系统默认路由对应的物理网卡，并排除 Hyper-V、WSL、容器和仅 VPN 可见的虚拟网卡。也可以使用以下命令：
 
@@ -286,7 +286,7 @@ Mac App 用户从菜单栏选择“配对设备…”，CLI 用户扫描 `agentd
 
 ## Claude Code 实验通道
 
-Claude Runtime 默认关闭，当前要求 `alleycat-claude-bridge >= 0.2.1`。正式 Windows 安装器和 Mac DMG 都已经内置经过签名的兼容 bridge，不要为这些安装方式重复执行 `cargo install`。
+Claude Runtime 默认关闭，当前要求 `alleycat-claude-bridge >= 0.2.1`。正式 Windows 安装器和 Mac DMG 都已经内置兼容 bridge；Windows `authenticode-pfx` 安装包与 Mac DMG 保留平台代码身份，`unsigned-release` Windows 包则没有。不要为这些安装方式重复执行 `cargo install`。
 
 只有 Homebrew、Linux 或独立开发环境需要从源码安装外置 bridge：
 

--- a/docs/install-upgrade-rollback.md
+++ b/docs/install-upgrade-rollback.md
@@ -7,7 +7,7 @@
 ## 方案
 
 - macOS 普通用户使用已签名并公证的 DMG；Mac App 内嵌 `agentd`，不要求安装 Homebrew。
-- Windows 普通用户使用 Authenticode 签名的按用户安装器；安装包内嵌 `agentd.exe`、Claude bridge 和原生托盘控制端，后台由当前用户计划任务托管。
+- Windows 普通用户使用按用户 EXE 安装器；有证书时优先 Authenticode 签名，无证书时发布元数据明确标记为 `unsigned-release` 的安装包，后台由当前用户计划任务托管。
 - Homebrew 保留给命令行、服务器、自动化和故障恢复场景。
 - Linux 使用发布包中的 user-systemd 模板；当前不伪装成与 Homebrew 同等的一键体验。
 - 配置和两个 Token 都留在系统用户配置目录，升级二进制不会删除它们。
@@ -27,7 +27,7 @@ $setup = Get-Item .\Mimi-Remote-Setup-*.exe
 (Get-AuthenticodeSignature $setup).Status
 ```
 
-摘要必须与 `.sha256` 一致，签名状态必须为 `Valid`。安装器按用户安装到 `%LOCALAPPDATA%\Programs\Mimi Remote`，注册名为 `Mimi Remote agentd` 的当前用户登录任务，以 limited 权限执行：
+摘要必须与 `.sha256` 一致。`.metadata.json` 为 `authenticode-pfx` 时签名状态必须为 `Valid`；为 `unsigned-release` 时状态应为 `NotSigned`，EXE 文件名包含 `-unsigned`，Windows 可能显示 Microsoft Defender SmartScreen 警告。未签名版本只应从本仓库正式 Release 下载并核对摘要。安装器按用户安装到 `%LOCALAPPDATA%\Programs\Mimi Remote`，注册名为 `Mimi Remote agentd` 的当前用户登录任务，以 limited 权限执行：
 
 ```text
 agentd.exe serve --log-file "%LOCALAPPDATA%\Mimi Remote\logs\agentd.log"
@@ -373,14 +373,14 @@ macOS 产物还必须配置以下 GitHub Actions Secrets：
 | `MACOS_NOTARY_KEY_ID` | 10 位 API Key ID | 与 `.p8` 配套 |
 | `MACOS_NOTARY_ISSUER_ID` | App Store Connect Issuer UUID | 与 `.p8` 配套 |
 
-Windows 正式安装器还必须配置：
+Windows 安装器可选配置以下 Authenticode Secrets：
 
 | Secret | 内容 | 权限边界 |
 | --- | --- | --- |
 | `WINDOWS_SIGN_PFX` | Windows 代码签名证书与私钥导出的 PFX，再整体 base64 | 只用于签名两份 `.exe` 和最终安装器 |
 | `WINDOWS_SIGN_PFX_PASSWORD` | PFX 导出密码 | 只在 Windows release job 的临时文件生命周期内使用 |
 
-Windows verify job 会在发布前构建两种语言的 release 二进制、编译 Inno Setup、验证 SHA-256 和 Authenticode，再把已验证安装器作为 Actions artifact 交给发布 job；PFX 临时文件不会进入 artifact。缺少凭据、任一签名无效或安装器静态策略不满足时，正式 tag 发布必须失败。
+Windows verify job 会在发布前构建 release 二进制、编译 Inno Setup、验证 SHA-256 与签名模式，再把已验证安装器作为 Actions artifact 交给发布 job；PFX 临时文件不会进入 artifact。两个 Secret 都存在时强制要求有效 Authenticode，两个都缺失时显式构建 `unsigned-release`；只配置其中一个、签名无效或安装器静态策略不满足时，正式 tag 发布必须失败。
 
 Release 的 verify job 会在构建前解码到临时 `0700` 目录，确认 PKCS#12 确实包含 `Developer ID Application` 证书、密码可解密、`.p8` 是有效 PKCS#8 私钥，并校验 Key ID/Issuer 格式；不会打印证书正文或私钥。正式 job 会先生成并公证 universal Mac DMG，再由 GoReleaser 按“构建 Darwin 二进制 → Developer ID 签名 → Apple notarization → 归档 → checksum/Formula”顺序发布后端，最后把已经通过 Gatekeeper 校验的 DMG 和 SHA-256 上传到同一 GitHub Release。普通 snapshot 不读取 Apple 私钥。
 

--- a/packaging/windows/mimi-remote.iss
+++ b/packaging/windows/mimi-remote.iss
@@ -8,6 +8,9 @@
 #ifndef OutputDir
   #error OutputDir must be supplied by the build script
 #endif
+#ifndef MyOutputBaseFilename
+  #error MyOutputBaseFilename must be supplied by the build script
+#endif
 
 #define MyAppName "Mimi Remote"
 #define MyAppId "{{7D413E71-19C5-4F02-8AFC-437E1B8019FD}"
@@ -22,7 +25,7 @@ DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
 OutputDir={#OutputDir}
-OutputBaseFilename=Mimi-Remote-Setup-{#MyAppVersion}
+OutputBaseFilename={#MyOutputBaseFilename}
 Compression=lzma2/ultra64
 SolidCompression=yes
 ArchitecturesAllowed=x64compatible

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -7,6 +7,7 @@ param(
     [switch]$Snapshot,
     [string]$PfxPath,
     [string]$PfxPassword,
+    [switch]$AllowUnsignedRelease,
     [ValidateSet('x86_64-pc-windows-msvc', 'x86_64-pc-windows-gnullvm', 'x86_64-pc-windows-gnu')]
     [string]$RustTarget = 'x86_64-pc-windows-msvc',
     [string]$BridgeBinary
@@ -16,8 +17,13 @@ $ErrorActionPreference = 'Stop'
 $root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $OutputDirectory = if ($OutputDirectory) { $OutputDirectory } else { Join-Path $root 'dist-windows' }
 $Version = $Version.TrimStart('v')
+# 无证书发布必须显式传入开关，避免凭据遗漏时静默降级为未签名安装包。
 if ($Snapshot -and $PfxPath) { throw '-Snapshot and -PfxPath cannot be used together.' }
-if (-not $Snapshot -and -not $PfxPath) { throw 'Release builds require -PfxPath. Use -Snapshot only for unsigned local builds.' }
+if ($Snapshot -and $AllowUnsignedRelease) { throw '-Snapshot and -AllowUnsignedRelease cannot be used together.' }
+if ($PfxPath -and $AllowUnsignedRelease) { throw '-PfxPath and -AllowUnsignedRelease cannot be used together.' }
+if (-not $Snapshot -and -not $PfxPath -and -not $AllowUnsignedRelease) {
+    throw 'Release builds require -PfxPath or the explicit -AllowUnsignedRelease switch.'
+}
 if ($BridgeBinary -and -not $Snapshot) { throw '-BridgeBinary is accepted only for local snapshot builds; release builds must compile the bridge from source.' }
 if ($BridgeBinary) { $BridgeBinary = (Resolve-Path -LiteralPath $BridgeBinary).Path }
 if ($PfxPath -and -not (Test-Path -LiteralPath $PfxPath -PathType Leaf)) { throw "PFX file not found: $PfxPath" }
@@ -85,10 +91,12 @@ try {
             if ($LASTEXITCODE -ne 0) { throw "Signing failed: $($file.Name)" }
         }
     }
+    $outputBaseName = if ($AllowUnsignedRelease) { "Mimi-Remote-Setup-$Version-unsigned" } else { "Mimi-Remote-Setup-$Version" }
     $isccArgs = @(
         "/DMyAppVersion=$Version",
         "/DSourceDir=$stage",
-        "/DOutputDir=$output"
+        "/DOutputDir=$output",
+        "/DMyOutputBaseFilename=$outputBaseName"
     )
     if ($PfxPath) {
         $powershell = (Get-Command 'powershell.exe' -ErrorAction Stop).Source
@@ -102,14 +110,15 @@ try {
     $isccArgs += (Join-Path $root 'packaging\windows\mimi-remote.iss')
     & $iscc @isccArgs
     if ($LASTEXITCODE -ne 0) { throw 'Inno Setup compilation failed.' }
-    $setup = Join-Path $output "Mimi-Remote-Setup-$Version.exe"
+    $setup = Join-Path $output "$outputBaseName.exe"
     if (-not (Test-Path -LiteralPath $setup)) { throw "Expected installer was not produced: $setup" }
     $hash = (Get-FileHash -LiteralPath $setup -Algorithm SHA256).Hash.ToLowerInvariant()
     $payloadHashes = [ordered]@{}
     foreach ($payloadName in @('agentd.exe', 'alleycat-claude-bridge.exe', 'mimi-remote-tray.exe', 'mimi-remote.ico')) {
         $payloadHashes[$payloadName] = (Get-FileHash -LiteralPath (Join-Path $stage $payloadName) -Algorithm SHA256).Hash.ToLowerInvariant()
     }
-    [ordered]@{ product = 'Mimi Remote'; version = $Version; installer = [IO.Path]::GetFileName($setup); sha256 = $hash; signing = $(if ($Snapshot) { 'unsigned-snapshot' } else { 'authenticode-pfx' }); rust_target = $RustTarget; rust_crt = 'static'; binaries = @('agentd.exe', 'alleycat-claude-bridge.exe', 'mimi-remote-tray.exe'); assets = @('mimi-remote.ico'); payload_sha256 = $payloadHashes } | ConvertTo-Json | Set-Content -LiteralPath "$setup.metadata.json" -Encoding utf8
+    $signingMode = if ($Snapshot) { 'unsigned-snapshot' } elseif ($PfxPath) { 'authenticode-pfx' } else { 'unsigned-release' }
+    [ordered]@{ product = 'Mimi Remote'; version = $Version; installer = [IO.Path]::GetFileName($setup); sha256 = $hash; signing = $signingMode; rust_target = $RustTarget; rust_crt = 'static'; binaries = @('agentd.exe', 'alleycat-claude-bridge.exe', 'mimi-remote-tray.exe'); assets = @('mimi-remote.ico'); payload_sha256 = $payloadHashes } | ConvertTo-Json | Set-Content -LiteralPath "$setup.metadata.json" -Encoding utf8
     "$hash  $([IO.Path]::GetFileName($setup))" | Set-Content -LiteralPath "$setup.sha256" -Encoding ascii
     Write-Host "Created $setup"
 } finally {

--- a/scripts/check-windows-installer.ps1
+++ b/scripts/check-windows-installer.ps1
@@ -23,8 +23,8 @@ if (-not (Test-Path -LiteralPath $checksumPath)) { throw "Missing SHA-256 file: 
 $checksumLine = (Get-Content -LiteralPath $checksumPath -Raw).Trim()
 if ($checksumLine -ne "$actualHash  $([IO.Path]::GetFileName($installer))") { throw 'SHA-256 sidecar does not match installer.' }
 $signature = Get-AuthenticodeSignature -LiteralPath $installer
-if ($metadata.signing -eq 'unsigned-snapshot') {
-    if ($signature.Status -ne 'NotSigned') { throw "Snapshot installer must be unsigned, got $($signature.Status)." }
+if ($metadata.signing -in @('unsigned-snapshot', 'unsigned-release')) {
+    if ($signature.Status -ne 'NotSigned') { throw "Unsigned installer must report NotSigned, got $($signature.Status)." }
 } elseif ($metadata.signing -eq 'authenticode-pfx') {
     if ($signature.Status -ne 'Valid') { throw "Signed installer signature is not valid: $($signature.Status)." }
 } else { throw "Unknown signing mode: $($metadata.signing)" }

--- a/scripts/test-windows-install.ps1
+++ b/scripts/test-windows-install.ps1
@@ -18,7 +18,7 @@ $windowsDocs = @(
 )
 foreach ($path in @($iss, $register, $firewall, $signing, $icon, $build, $check, $releaseWorkflow) + $windowsDocs) { if (-not (Test-Path -LiteralPath $path)) { throw "Missing required packaging file: $path" } }
 $source = Get-Content -LiteralPath $iss -Raw
-foreach ($expected in @('{localappdata}\Programs\Mimi Remote', 'agentd.exe', 'alleycat-claude-bridge.exe', 'mimi-remote-tray.exe', 'mimi-remote.ico', 'SetupIconFile=mimi-remote.ico', 'UninstallDisplayIcon={app}\mimi-remote.ico', 'IconFilename: "{app}\mimi-remote.ico"', '{userstartup}\Mimi Remote', 'register-service.ps1', 'configure-firewall.ps1', 'PrivilegesRequired=lowest', 'Flags: unchecked', 'GetCustomSetupExitCode', 'PrivateLanFirewallRule', 'PrivateLanNetworkProfileIsReady', 'StopTrayApp', 'ConfigureLANAccess(False)', 'ConfigureLANAccess(True)', 'SignTool={#MySignTool}', 'SignedUninstaller=yes', 'SignedUninstaller=no')) {
+foreach ($expected in @('{localappdata}\Programs\Mimi Remote', 'agentd.exe', 'alleycat-claude-bridge.exe', 'mimi-remote-tray.exe', 'mimi-remote.ico', 'SetupIconFile=mimi-remote.ico', 'UninstallDisplayIcon={app}\mimi-remote.ico', 'IconFilename: "{app}\mimi-remote.ico"', '{userstartup}\Mimi Remote', 'register-service.ps1', 'configure-firewall.ps1', 'PrivilegesRequired=lowest', 'Flags: unchecked', 'GetCustomSetupExitCode', 'PrivateLanFirewallRule', 'PrivateLanNetworkProfileIsReady', 'StopTrayApp', 'ConfigureLANAccess(False)', 'ConfigureLANAccess(True)', 'OutputBaseFilename={#MyOutputBaseFilename}', 'SignTool={#MySignTool}', 'SignedUninstaller=yes', 'SignedUninstaller=no')) {
     if (-not $source.Contains($expected)) { throw "Installer source is missing required policy: $expected" }
 }
 $postInstallSource = $source.Substring($source.IndexOf('procedure CurStepChanged'))
@@ -41,17 +41,26 @@ foreach ($script in @($register, $firewall, $signing, $build, $check)) { [void][
 $buildSource = Get-Content -LiteralPath $build -Raw
 if (-not $buildSource.Contains('target-feature=+crt-static')) { throw 'Windows release bridge must use a static Rust CRT.' }
 if (-not $buildSource.Contains('/DMySignTool=mimi-authenticode')) { throw 'Release builds must register the Inno Setup Authenticode signing tool.' }
+if (-not $buildSource.Contains('[switch]$AllowUnsignedRelease')) { throw 'Unsigned release builds must require an explicit switch.' }
+if (-not $buildSource.Contains("'unsigned-release'")) { throw 'Unsigned release builds must record their signing mode in metadata.' }
+if (-not $buildSource.Contains('Mimi-Remote-Setup-$Version-unsigned')) { throw 'Unsigned release filenames must identify that they are unsigned.' }
+$checkSource = Get-Content -LiteralPath $check -Raw
+if (-not $checkSource.Contains("'unsigned-release'")) { throw 'Installer validation must recognize unsigned release metadata.' }
 $releaseSource = Get-Content -LiteralPath $releaseWorkflow -Raw
 $currentRepositoryGate = "github.repository == 'gaixianggeng/codex-ipad-agent'"
 $historicalRepositoryGate = "github.repository == 'gaixianggeng/mimi-remote'"
 if (($releaseSource.Split($currentRepositoryGate).Count - 1) -lt 4) { throw 'All release jobs, including Windows verify/publish, must target the source repository.' }
 if ($releaseSource.Contains($historicalRepositoryGate)) { throw 'Release jobs must not target the historical mimi-remote archive repository.' }
+if (-not $releaseSource.Contains('-AllowUnsignedRelease')) { throw 'Release workflow must explicitly opt into unsigned Windows packaging when credentials are absent.' }
+if (-not $releaseSource.Contains('must either both be configured or both be absent')) { throw 'Partial Windows signing credentials must fail the release.' }
+if (-not $releaseSource.Contains('-RequireSignature')) { throw 'Release workflow must still enforce Authenticode when signing credentials exist.' }
 $currentReleaseURL = 'https://github.com/gaixianggeng/codex-ipad-agent/releases/latest'
 $historicalReleaseURL = 'https://github.com/gaixianggeng/mimi-remote/releases/latest'
 foreach ($path in $windowsDocs) {
     $docSource = Get-Content -LiteralPath $path -Raw
     if (-not $docSource.Contains($currentReleaseURL)) { throw "Windows download documentation must target the source repository: $path" }
     if ($docSource.Contains($historicalReleaseURL)) { throw "Windows download documentation must not target the historical archive: $path" }
+    if (-not $docSource.Contains('unsigned-release')) { throw "Windows download documentation must explain unsigned release artifacts: $path" }
 }
 # Static-only acceptance: do not invoke Setup.exe or schtasks.exe, so no real user task or firewall rule is created.
 Write-Host 'Windows installer static/dry-run acceptance passed; no scheduled task or firewall rule was created.'


### PR DESCRIPTION
## 变更

- Windows 代码签名凭据完整时，继续生成并强制验证 Authenticode 安装包。
- 两个签名 Secret 都缺失时，显式生成 `unsigned-release` 安装包，文件名包含 `-unsigned`。
- 只配置一半凭据时直接失败，避免误降级。
- 未签名包仍验证 EXE、内嵌后端/bridge/托盘、静态 Rust CRT、metadata 和 SHA-256。
- 中英文安装与回滚文档补充 SmartScreen 风险和摘要核对说明。

## 原因

当前仓库没有 Windows 代码签名证书，但需要交付可直接下载的一键 EXE 安装包。该实现保留未来接入正式证书的路径，同时让当前无证书发布行为明确、可审计。

## 用户影响

Windows 用户可以下载并安装 EXE；首次运行未签名版本时，Microsoft Defender SmartScreen 可能显示未知发布者警告。未签名文件名和 metadata 会明确标识该状态。

## 验证

- `bash scripts/check-packaging.sh`
- `bash scripts/check-public-repo-safety.sh`
- `bash scripts/check-pr-gate.sh`
- Release workflow YAML 解析
- `git diff --check`

关联：MIM-36
