### PR TITLE
MIM-31: establish Nightly, release validation, and rollback checks

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -17,6 +17,9 @@ on:
       - "scripts/test-conversation-regressions.sh"
       - "scripts/check-macos-release-signing.sh"
       - "scripts/check-release-artifacts.sh"
+      - "scripts/check-rollback-readiness.sh"
+      - "scripts/check-validation-workflows.sh"
+      - "scripts/history-sync-regression.sh"
       - "scripts/check-source-size.sh"
       - "scripts/check-mimi-protocol-contract.sh"
       - "scripts/install-linux.sh"
@@ -32,7 +35,10 @@ on:
       - "docs/install-upgrade-rollback.md"
       - "docs/codex-protocol-support.md"
       - "docs/mimi-protocol-contracts.md"
+      - "docs/nightly-release-rollback.md"
       - ".github/workflows/go-ci.yml"
+      - ".github/workflows/nightly.yml"
+      - ".github/workflows/release-validation.yml"
       - ".github/workflows/release.yml"
   workflow_dispatch:
 
@@ -59,6 +65,9 @@ jobs:
 
       - name: Check packaging sources
         run: bash ./scripts/check-packaging.sh
+
+      - name: Check Nightly and Release validation policy
+        run: bash ./scripts/check-validation-workflows.sh
 
       - name: Check Mimi protocol contract
         run: bash ./scripts/check-mimi-protocol-contract.sh

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -2,6 +2,22 @@ name: iOS CI
 
 on:
   workflow_call:
+    inputs:
+      source_ref:
+        description: "要验证的 immutable commit；为空时使用触发事件 SHA"
+        required: false
+        default: ""
+        type: string
+      validate_app_store:
+        description: "仅归档并调用 App Store 服务端验证，不上传 TestFlight"
+        required: false
+        default: false
+        type: boolean
+      what_to_test:
+        description: "验证报告说明；validate 模式不写入 TestFlight"
+        required: false
+        default: "Release validation only."
+        type: string
   push:
     branches:
       - main
@@ -54,6 +70,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.source_ref || github.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -118,15 +136,17 @@ jobs:
         run: bash ./scripts/test-ios-localization-smoke.sh
 
   app-store-release:
-    if: github.event_name == 'workflow_dispatch' && inputs.publish_app_store
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.publish_app_store) ||
+      (github.event_name == 'workflow_call' && inputs.validate_app_store)
     runs-on: macos-26
     timeout-minutes: 45
     env:
       IOS_BUNDLE_ID: com.gaixianggeng.mimi
       DEVELOPMENT_TEAM: 9HZ89R58PZ
       TESTFLIGHT_BETA_GROUP_ID: 26b7c973-b94f-46d5-b300-1c252fd6fdb1
-      IOS_TESTFLIGHT_UPLOAD: "1"
-      IOS_TESTFLIGHT_VALIDATE: "0"
+      IOS_TESTFLIGHT_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_app_store && '1' || '0' }}
+      IOS_TESTFLIGHT_VALIDATE: ${{ github.event_name == 'workflow_call' && inputs.validate_app_store && '1' || '0' }}
       IOS_RELEASE_EXPECTED_MACOS_MAJOR: "26"
       IOS_RELEASE_EXPECTED_XCODE_VERSION: "26.6"
       IOS_RELEASE_EXPECTED_XCODE_BUILD: 17F113
@@ -137,6 +157,7 @@ jobs:
       - name: Checkout clean release source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           fetch-depth: 0
           clean: true
 
@@ -273,3 +294,12 @@ jobs:
       - name: Archive, audit, upload, and distribute build
         shell: bash
         run: bash ./scripts/ios_testflight_ci.sh
+
+      - name: Upload validated IPA without publishing
+        if: github.event_name == 'workflow_call' && inputs.validate_app_store
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-ios-validated-${{ inputs.source_ref || github.sha }}
+          path: ${{ runner.temp }}/mimi-testflight/**/*.ipa
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,289 @@
+name: Nightly Validation
+
+on:
+  schedule:
+    # 每天北京时间 02:30 运行一次；重任务不进入普通 PR Gate。
+    - cron: "30 18 * * *"
+  workflow_dispatch:
+    inputs:
+      run_controlled_runtime_smoke:
+        description: "在受控自托管 runner 上运行只读 Codex/Claude smoke"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-race-and-release-snapshot:
+    name: Go race, fixtures, and release snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Install pinned Codex CLI
+        run: npm install --global "@openai/codex@$(cat internal/httpapi/testdata/codex-protocol/codex-version.txt)"
+
+      - name: Check protocol and workflow contracts
+        run: |
+          bash ./scripts/check-codex-protocol.sh
+          bash ./scripts/check-mimi-protocol-contract.sh
+          bash ./scripts/check-validation-workflows.sh
+
+      - name: Run full Go suite with race detector
+        run: go test -race ./... -count=1
+
+      - name: Replay Linux install, upgrade, and rollback fixtures
+        run: bash ./scripts/test-install-linux.sh
+
+      - name: Build and inspect four-platform GoReleaser snapshot
+        run: bash ./scripts/verify-release.sh verify
+
+      - name: Upload GoReleaser snapshot
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nightly-goreleaser-${{ github.run_id }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  rust-cross-platform:
+    name: Rust bridge (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Show pinned runner toolchain
+        run: |
+          rustc --version
+          cargo --version
+
+      - name: Run complete bridge workspace
+        shell: bash
+        run: |
+          cargo fmt --all -- --check
+          cargo test --locked \
+            -p alleycat-codex-proto \
+            -p alleycat-bridge-core \
+            -p alleycat-claude-bridge
+
+  mac-and-ios-full:
+    name: Mac App and full iOS suite
+    runs-on: macos-26
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install universal macOS Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Test Mimi Remote Mac
+        run: |
+          xcodebuild \
+            -project macos/MimiRemoteMac/MimiRemoteMac.xcodeproj \
+            -scheme MimiRemoteMac \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -derivedDataPath "$RUNNER_TEMP/MimiRemoteMacTests" \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
+      - name: Run complete iOS unit and snapshot suite
+        run: bash ./scripts/ios-dev.sh test
+
+      - name: Build and inspect universal Mac DMG snapshot
+        run: |
+          bash ./scripts/build-macos-installer.sh \
+            --snapshot \
+            --version 0.0.0 \
+            --build-number "$GITHUB_RUN_NUMBER" \
+            --output-dir dist-macos
+          bash ./scripts/check-macos-installer.sh dist-macos/Mimi-Remote-Mac.dmg
+
+      - name: Upload Mac DMG snapshot
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nightly-macos-snapshot-${{ github.run_id }}
+          path: dist-macos/
+          if-no-files-found: error
+          retention-days: 7
+
+  windows-installer-snapshot:
+    name: Windows installer snapshot
+    runs-on: windows-latest
+    timeout-minutes: 55
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --yes --no-progress
+
+      - name: Build and inspect unsigned installer
+        shell: pwsh
+        run: |
+          ./scripts/build-windows-installer.ps1 `
+            -Version 0.0.0 `
+            -OutputDirectory dist-windows `
+            -Snapshot
+          $installer = Get-Item "dist-windows\Mimi-Remote-Setup-*.exe"
+          ./scripts/check-windows-installer.ps1 -InstallerPath $installer.FullName
+          ./scripts/test-windows-install.ps1
+
+      - name: Upload Windows installer snapshot
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nightly-windows-snapshot-${{ github.run_id }}
+          path: dist-windows/
+          if-no-files-found: error
+          retention-days: 7
+
+  controlled-runtime-smoke:
+    name: Controlled Codex and Claude smoke
+    if: >-
+      (github.event_name == 'schedule' && vars.MIMI_NIGHTLY_RUNTIME_SMOKE_ENABLED == 'true') ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_controlled_runtime_smoke)
+    runs-on:
+      - self-hosted
+      - mimi-runtime-smoke
+    environment: nightly-runtime-smoke
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Require isolated runtime credentials
+        shell: bash
+        env:
+          MIMI_RUNTIME_ENDPOINT: ${{ secrets.MIMI_NIGHTLY_RUNTIME_ENDPOINT }}
+          AGENTD_TOKEN: ${{ secrets.MIMI_NIGHTLY_RUNTIME_TOKEN }}
+          CONTROLLED_RUNTIME_CANDIDATE_SHA: ${{ vars.MIMI_NIGHTLY_RUNTIME_CANDIDATE_SHA }}
+          EXPECTED_CANDIDATE_SHA: ${{ github.sha }}
+        run: |
+          [[ "$MIMI_RUNTIME_ENDPOINT" == https://* || "$MIMI_RUNTIME_ENDPOINT" == http://127.0.0.1:* ]] \
+            || { echo "受控 Endpoint 必须是 HTTPS 或 runner loopback。" >&2; exit 1; }
+          [[ -n "$AGENTD_TOKEN" ]] \
+            || { echo "缺少受控、可撤销的 Nightly Token。" >&2; exit 1; }
+          [[ "$CONTROLLED_RUNTIME_CANDIDATE_SHA" == "$EXPECTED_CANDIDATE_SHA" ]] \
+            || { echo "受控 Runtime 未声明运行当前 Nightly commit。" >&2; exit 1; }
+
+      - name: Run read-only Codex history smoke
+        shell: bash
+        env:
+          MIMI_RUNTIME_ENDPOINT: ${{ secrets.MIMI_NIGHTLY_RUNTIME_ENDPOINT }}
+          AGENTD_TOKEN: ${{ secrets.MIMI_NIGHTLY_RUNTIME_TOKEN }}
+        run: |
+          bash ./scripts/history-sync-regression.sh \
+            --endpoint "controlled=$MIMI_RUNTIME_ENDPOINT" \
+            --rounds 10 \
+            --limit 20 \
+            --require-all-successful
+
+      - name: Run explicitly enabled Claude model smoke
+        shell: bash
+        env:
+          MIMI_RUNTIME_ENDPOINT: ${{ secrets.MIMI_NIGHTLY_RUNTIME_ENDPOINT }}
+          AGENTD_TOKEN: ${{ secrets.MIMI_NIGHTLY_RUNTIME_TOKEN }}
+          MIMI_CLAUDE_SMOKE_ENABLED: ${{ vars.MIMI_NIGHTLY_CLAUDE_SMOKE_ENABLED }}
+        run: |
+          if [[ "$MIMI_CLAUDE_SMOKE_ENABLED" != "true" ]]; then
+            echo "Claude smoke: SKIPPED（受控环境未显式启用）。" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          go run ./scripts/ipad-ws-probe.go \
+            -endpoint "$MIMI_RUNTIME_ENDPOINT" \
+            -runtime claude \
+            -models-only
+          echo "Claude smoke: PASS（只读 models/list，不启动 turn）。" >>"$GITHUB_STEP_SUMMARY"
+
+  nightly-result:
+    name: Nightly Validation
+    if: always()
+    needs:
+      - go-race-and-release-snapshot
+      - rust-cross-platform
+      - mac-and-ios-full
+      - windows-installer-snapshot
+      - controlled-runtime-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Summarize required results
+        shell: bash
+        env:
+          GO_RESULT: ${{ needs.go-race-and-release-snapshot.result }}
+          RUST_RESULT: ${{ needs.rust-cross-platform.result }}
+          MAC_IOS_RESULT: ${{ needs.mac-and-ios-full.result }}
+          WINDOWS_RESULT: ${{ needs.windows-installer-snapshot.result }}
+          RUNTIME_RESULT: ${{ needs.controlled-runtime-smoke.result }}
+          RUNTIME_REQUESTED: ${{ (github.event_name == 'schedule' && vars.MIMI_NIGHTLY_RUNTIME_SMOKE_ENABLED == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_controlled_runtime_smoke) }}
+        run: |
+          {
+            echo "## Nightly Validation"
+            echo
+            echo "| 层 | 结果 |"
+            echo "| --- | --- |"
+            echo "| Go race / fixtures / release snapshot | \`$GO_RESULT\` |"
+            echo "| Rust bridge cross-platform | \`$RUST_RESULT\` |"
+            echo "| Mac App / full iOS | \`$MAC_IOS_RESULT\` |"
+            echo "| Windows installer snapshot | \`$WINDOWS_RESULT\` |"
+            echo "| Controlled Runtime | \`$RUNTIME_RESULT\` |"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          [[ "$GO_RESULT" == "success" ]]
+          [[ "$RUST_RESULT" == "success" ]]
+          [[ "$MAC_IOS_RESULT" == "success" ]]
+          [[ "$WINDOWS_RESULT" == "success" ]]
+          if [[ "$RUNTIME_REQUESTED" == "true" ]]; then
+            [[ "$RUNTIME_RESULT" == "success" ]]
+          else
+            [[ "$RUNTIME_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,0 +1,507 @@
+name: Release Validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_ref:
+        description: "待发布 commit、分支或 tag；只读取，不创建 tag"
+        required: true
+        default: "main"
+        type: string
+      previous_release_ref:
+        description: "上一已知可用的正式 commit 或 tag；必须是 candidate 祖先"
+        required: true
+        type: string
+      candidate_version:
+        description: "候选语义版本（不含 v）；dry-run 可用 0.0.0，publish-readiness 必须使用真实版本"
+        required: true
+        default: "0.0.0"
+        type: string
+      validation_mode:
+        description: "dry-run 不读取发布凭据；publish-readiness 验证签名/公证/ASC，但仍不发布"
+        required: true
+        default: "dry-run"
+        type: choice
+        options:
+          - dry-run
+          - publish-readiness
+      run_controlled_runtime_smoke:
+        description: "在隔离 runner 上运行只读 Codex/Claude smoke；publish-readiness 必须启用"
+        required: true
+        default: false
+        type: boolean
+      internal_testflight_evidence:
+        description: "publish-readiness 必填：同一 candidate 的 Internal TestFlight 证据 URL"
+        required: false
+        type: string
+      rollback_drill_evidence:
+        description: "publish-readiness 必填：上一签名产物恢复演练证据 URL"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-validation-${{ inputs.candidate_ref }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve candidate and rollback window
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    outputs:
+      candidate_sha: ${{ steps.refs.outputs.candidate_sha }}
+      previous_sha: ${{ steps.refs.outputs.previous_sha }}
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.candidate_ref }}
+          fetch-depth: 0
+
+      - name: Resolve immutable commits
+        id: refs
+        shell: bash
+        env:
+          PREVIOUS_RELEASE_REF: ${{ inputs.previous_release_ref }}
+        run: |
+          candidate_sha="$(git rev-parse --verify 'HEAD^{commit}')"
+          previous_sha="$(git rev-parse --verify "${PREVIOUS_RELEASE_REF}^{commit}")"
+          echo "candidate_sha=$candidate_sha" >>"$GITHUB_OUTPUT"
+          echo "previous_sha=$previous_sha" >>"$GITHUB_OUTPUT"
+          echo "Candidate: \`$candidate_sha\`" >>"$GITHUB_STEP_SUMMARY"
+          echo "Previous known-good: \`$previous_sha\`" >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Validate candidate version metadata
+        shell: bash
+        env:
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          VALIDATION_MODE: ${{ inputs.validation_mode }}
+        run: |
+          [[ "$CANDIDATE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+            || { echo "candidate_version 必须是不含 v 的语义版本。" >&2; exit 1; }
+          if [[ "$VALIDATION_MODE" == "publish-readiness" && "$CANDIDATE_VERSION" == "0.0.0" ]]; then
+            echo "publish-readiness 必须提供真实 candidate_version，不能使用 0.0.0。" >&2
+            exit 1
+          fi
+          echo "Candidate version: \`$CANDIDATE_VERSION\`" >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Check N/N-1 and rollback readiness
+        shell: bash
+        env:
+          CANDIDATE_SHA: ${{ steps.refs.outputs.candidate_sha }}
+          PREVIOUS_SHA: ${{ steps.refs.outputs.previous_sha }}
+        run: |
+          mkdir -p release-validation-report
+          bash ./scripts/check-rollback-readiness.sh \
+            --candidate-ref "$CANDIDATE_SHA" \
+            --previous-ref "$PREVIOUS_SHA" \
+            --output release-validation-report/rollback-readiness.md
+
+      - name: Upload rollback report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-rollback-report-${{ github.run_id }}
+          path: release-validation-report/
+          if-no-files-found: error
+          retention-days: 30
+
+  go-rust-and-packaging:
+    name: Protocol, Go, Rust, and cross-platform archives
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout immutable candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve.outputs.candidate_sha }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check contracts and critical regression map
+        run: |
+          bash ./scripts/check-mimi-protocol-contract.sh
+          bash ./scripts/check-critical-regressions.sh
+          bash ./scripts/check-validation-workflows.sh
+
+      - name: Vet and test Go
+        run: |
+          go vet ./...
+          go test ./... -count=1
+
+      - name: Test complete Rust bridge workspace
+        run: |
+          cargo fmt --all -- --check
+          cargo test --locked \
+            -p alleycat-codex-proto \
+            -p alleycat-bridge-core \
+            -p alleycat-claude-bridge
+
+      - name: Replay Linux install and rollback fixtures
+        run: bash ./scripts/test-install-linux.sh
+
+      - name: Build and inspect GoReleaser snapshot
+        run: bash ./scripts/verify-release.sh verify
+
+      - name: Upload four-platform archives
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-goreleaser-${{ needs.resolve.outputs.candidate_sha }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+
+  macos-candidate:
+    name: Mac tests and ${{ inputs.validation_mode }} DMG
+    needs: resolve
+    runs-on: macos-26
+    timeout-minutes: 90
+    steps:
+      - name: Checkout immutable candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve.outputs.candidate_sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install universal macOS Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Test Mimi Remote Mac
+        run: |
+          xcodebuild \
+            -project macos/MimiRemoteMac/MimiRemoteMac.xcodeproj \
+            -scheme MimiRemoteMac \
+            -configuration Release \
+            -destination 'platform=macOS' \
+            -derivedDataPath "$RUNNER_TEMP/MimiRemoteMacTests" \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
+      - name: Build ad-hoc DMG for dry-run
+        if: inputs.validation_mode == 'dry-run'
+        env:
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+        run: |
+          bash ./scripts/build-macos-installer.sh \
+            --snapshot \
+            --version "$CANDIDATE_VERSION" \
+            --build-number "$GITHUB_RUN_NUMBER" \
+            --output-dir dist-macos
+          bash ./scripts/check-macos-installer.sh dist-macos/Mimi-Remote-Mac.dmg
+
+      - name: Build, sign, notarize, and inspect DMG without publishing
+        if: inputs.validation_mode == 'publish-readiness'
+        env:
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          bash ./scripts/build-macos-installer.sh \
+            --version "$CANDIDATE_VERSION" \
+            --build-number "$GITHUB_RUN_NUMBER" \
+            --output-dir dist-macos
+          bash ./scripts/check-macos-installer.sh \
+            --require-notarization \
+            dist-macos/Mimi-Remote-Mac.dmg
+
+      - name: Upload audited Mac candidate
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-macos-${{ needs.resolve.outputs.candidate_sha }}
+          path: dist-macos/
+          if-no-files-found: error
+          retention-days: 30
+
+  windows-candidate:
+    name: Windows ${{ inputs.validation_mode }} installer
+    needs: resolve
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout immutable candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve.outputs.candidate_sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --yes --no-progress
+
+      - name: Build and inspect Windows candidate
+        shell: pwsh
+        env:
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          VALIDATION_MODE: ${{ inputs.validation_mode }}
+          WINDOWS_SIGN_PFX: ${{ secrets.WINDOWS_SIGN_PFX }}
+          WINDOWS_SIGN_PFX_PASSWORD: ${{ secrets.WINDOWS_SIGN_PFX_PASSWORD }}
+        run: |
+          if ($env:VALIDATION_MODE -eq 'publish-readiness') {
+            if (-not $env:WINDOWS_SIGN_PFX -or -not $env:WINDOWS_SIGN_PFX_PASSWORD) {
+              throw 'publish-readiness requires Windows signing secrets.'
+            }
+            $pfx = Join-Path $env:RUNNER_TEMP 'mimi-release-validation.pfx'
+            try {
+              [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_SIGN_PFX))
+              ./scripts/build-windows-installer.ps1 `
+                -Version $env:CANDIDATE_VERSION `
+                -OutputDirectory dist-windows `
+                -PfxPath $pfx `
+                -PfxPassword $env:WINDOWS_SIGN_PFX_PASSWORD
+              $installer = Get-Item "dist-windows\Mimi-Remote-Setup-*.exe"
+              ./scripts/check-windows-installer.ps1 `
+                -InstallerPath $installer.FullName `
+                -RequireSignature
+            } finally {
+              Remove-Item -LiteralPath $pfx -Force -ErrorAction SilentlyContinue
+            }
+          } else {
+            ./scripts/build-windows-installer.ps1 `
+              -Version $env:CANDIDATE_VERSION `
+              -OutputDirectory dist-windows `
+              -Snapshot
+            $installer = Get-Item "dist-windows\Mimi-Remote-Setup-*.exe"
+            ./scripts/check-windows-installer.ps1 -InstallerPath $installer.FullName
+          }
+          ./scripts/test-windows-install.ps1
+
+      - name: Upload audited Windows candidate
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-windows-${{ needs.resolve.outputs.candidate_sha }}
+          path: dist-windows/
+          if-no-files-found: error
+          retention-days: 30
+
+  ios-full:
+    name: Full iOS regression and unsigned archive
+    needs: resolve
+    runs-on: macos-26
+    timeout-minutes: 80
+    steps:
+      - name: Checkout immutable candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve.outputs.candidate_sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run complete iOS test suite
+        run: bash ./scripts/ios-dev.sh test
+
+      - name: Create and inspect unsigned iOS archive
+        run: |
+          xcodebuild archive \
+            -project ios/MimiRemote/MimiRemote.xcodeproj \
+            -scheme MimiRemote \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/MimiRemote.xcarchive" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            -quiet
+          info="$RUNNER_TEMP/MimiRemote.xcarchive/Products/Applications/MimiRemote.app/Info.plist"
+          [[ -f "$info" ]]
+          plutil -extract CFBundleIdentifier raw -o - "$info"
+          plutil -extract CFBundleShortVersionString raw -o - "$info"
+          plutil -extract CFBundleVersion raw -o - "$info"
+
+      - name: Upload unsigned iOS archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-ios-unsigned-${{ needs.resolve.outputs.candidate_sha }}
+          path: ${{ runner.temp }}/MimiRemote.xcarchive/
+          if-no-files-found: error
+          retention-days: 14
+
+  ios-app-store-validation:
+    name: Signed iOS archive and App Store validation
+    if: inputs.validation_mode == 'publish-readiness'
+    needs: resolve
+    uses: ./.github/workflows/ios-ci.yml
+    with:
+      source_ref: ${{ needs.resolve.outputs.candidate_sha }}
+      validate_app_store: true
+      what_to_test: "Release validation only；不上传、不分发 Internal TestFlight。"
+    secrets: inherit
+
+  controlled-runtime-smoke:
+    name: Controlled Runtime release smoke
+    if: inputs.run_controlled_runtime_smoke
+    needs: resolve
+    runs-on:
+      - self-hosted
+      - mimi-runtime-smoke
+    environment: nightly-runtime-smoke
+    timeout-minutes: 20
+    steps:
+      - name: Checkout immutable candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve.outputs.candidate_sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run read-only Codex and explicitly enabled Claude smoke
+        shell: bash
+        env:
+          MIMI_RUNTIME_ENDPOINT: ${{ secrets.MIMI_NIGHTLY_RUNTIME_ENDPOINT }}
+          AGENTD_TOKEN: ${{ secrets.MIMI_NIGHTLY_RUNTIME_TOKEN }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          CANDIDATE_SHA: ${{ needs.resolve.outputs.candidate_sha }}
+          CONTROLLED_RUNTIME_CANDIDATE_SHA: ${{ vars.MIMI_NIGHTLY_RUNTIME_CANDIDATE_SHA }}
+          MIMI_CLAUDE_SMOKE_ENABLED: ${{ vars.MIMI_NIGHTLY_CLAUDE_SMOKE_ENABLED }}
+        run: |
+          [[ "$MIMI_RUNTIME_ENDPOINT" == https://* || "$MIMI_RUNTIME_ENDPOINT" == http://127.0.0.1:* ]]
+          [[ -n "$AGENTD_TOKEN" ]]
+          [[ "$CONTROLLED_RUNTIME_CANDIDATE_SHA" == "$CANDIDATE_SHA" ]] || {
+            echo "受控 Runtime commit 不匹配：expected=$CANDIDATE_SHA actual=${CONTROLLED_RUNTIME_CANDIDATE_SHA:-missing}" >&2
+            exit 1
+          }
+          version_response="$(mktemp)"
+          trap 'rm -f "$version_response"' EXIT
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --max-time 15 \
+            --header "Authorization: Bearer $AGENTD_TOKEN" \
+            --output "$version_response" \
+            "${MIMI_RUNTIME_ENDPOINT%/}/api/version"
+          runtime_version="$(
+            ruby -rjson -e '
+              body = JSON.parse(File.read(ARGV.fetch(0)))
+              version = body["version"]
+              abort "Runtime /api/version 缺少 version" unless version.is_a?(String) && !version.empty?
+              print version
+            ' "$version_response"
+          )"
+          [[ "$runtime_version" == "$CANDIDATE_VERSION" ]] || {
+            echo "受控 Runtime 版本不匹配：expected=$CANDIDATE_VERSION actual=$runtime_version" >&2
+            exit 1
+          }
+          echo "Controlled Runtime version: \`$runtime_version\`" >>"$GITHUB_STEP_SUMMARY"
+          bash ./scripts/history-sync-regression.sh \
+            --endpoint "controlled=$MIMI_RUNTIME_ENDPOINT" \
+            --rounds 10 \
+            --limit 20 \
+            --require-all-successful
+          if [[ "$MIMI_CLAUDE_SMOKE_ENABLED" == "true" ]]; then
+            go run ./scripts/ipad-ws-probe.go \
+              -endpoint "$MIMI_RUNTIME_ENDPOINT" \
+              -runtime claude \
+              -models-only
+          else
+            echo "Claude smoke: SKIPPED（没有受控凭据或未显式启用）。" >>"$GITHUB_STEP_SUMMARY"
+          fi
+
+  release-validation-result:
+    name: Release Validation
+    if: always()
+    needs:
+      - resolve
+      - go-rust-and-packaging
+      - macos-candidate
+      - windows-candidate
+      - ios-full
+      - ios-app-store-validation
+      - controlled-runtime-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail closed and summarize evidence
+        shell: bash
+        env:
+          VALIDATION_MODE: ${{ inputs.validation_mode }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          RUNTIME_REQUESTED: ${{ inputs.run_controlled_runtime_smoke }}
+          INTERNAL_TESTFLIGHT_EVIDENCE: ${{ inputs.internal_testflight_evidence }}
+          ROLLBACK_DRILL_EVIDENCE: ${{ inputs.rollback_drill_evidence }}
+          RESOLVE_RESULT: ${{ needs.resolve.result }}
+          GO_RUST_RESULT: ${{ needs.go-rust-and-packaging.result }}
+          MACOS_RESULT: ${{ needs.macos-candidate.result }}
+          WINDOWS_RESULT: ${{ needs.windows-candidate.result }}
+          IOS_FULL_RESULT: ${{ needs.ios-full.result }}
+          IOS_SIGNED_RESULT: ${{ needs.ios-app-store-validation.result }}
+          RUNTIME_RESULT: ${{ needs.controlled-runtime-smoke.result }}
+        run: |
+          {
+            echo "## Release Validation"
+            echo
+            echo "- Mode: \`$VALIDATION_MODE\`"
+            echo "- Candidate version: \`$CANDIDATE_VERSION\`"
+            echo "- 该 workflow 不创建 tag/Release、不上传 TestFlight、不部署、不执行生产回滚。"
+            echo
+            echo "| 检查 | 结果 |"
+            echo "| --- | --- |"
+            echo "| Candidate / rollback window | \`$RESOLVE_RESULT\` |"
+            echo "| Protocol / Go / Rust / archives | \`$GO_RUST_RESULT\` |"
+            echo "| macOS candidate | \`$MACOS_RESULT\` |"
+            echo "| Windows candidate | \`$WINDOWS_RESULT\` |"
+            echo "| Full iOS / unsigned archive | \`$IOS_FULL_RESULT\` |"
+            echo "| Signed iOS / ASC validation | \`$IOS_SIGNED_RESULT\` |"
+            echo "| Controlled Runtime | \`$RUNTIME_RESULT\` |"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          [[ "$RESOLVE_RESULT" == "success" ]]
+          [[ "$GO_RUST_RESULT" == "success" ]]
+          [[ "$MACOS_RESULT" == "success" ]]
+          [[ "$WINDOWS_RESULT" == "success" ]]
+          [[ "$IOS_FULL_RESULT" == "success" ]]
+
+          if [[ "$VALIDATION_MODE" == "dry-run" ]]; then
+            [[ "$IOS_SIGNED_RESULT" == "skipped" ]]
+            if [[ "$RUNTIME_REQUESTED" == "true" ]]; then
+              [[ "$RUNTIME_RESULT" == "success" ]]
+            else
+              [[ "$RUNTIME_RESULT" == "skipped" ]]
+            fi
+            echo "DRY-RUN 完成：只证明候选可构建和静态可回滚，不授权发布。" >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          [[ "$VALIDATION_MODE" == "publish-readiness" ]]
+          [[ "$RUNTIME_REQUESTED" == "true" ]] \
+            || { echo "publish-readiness 必须运行受控 Runtime smoke。" >&2; exit 1; }
+          [[ "$RUNTIME_RESULT" == "success" ]]
+          [[ "$IOS_SIGNED_RESULT" == "success" ]]
+          [[ "$INTERNAL_TESTFLIGHT_EVIDENCE" == https://* ]] \
+            || { echo "缺少同一 candidate 的 Internal TestFlight 证据 URL。" >&2; exit 1; }
+          [[ "$ROLLBACK_DRILL_EVIDENCE" == https://* ]] \
+            || { echo "缺少上一签名产物恢复演练证据 URL。" >&2; exit 1; }
+          {
+            echo
+            echo "- Internal TestFlight evidence: $INTERNAL_TESTFLIGHT_EVIDENCE"
+            echo "- Signed rollback drill evidence: $ROLLBACK_DRILL_EVIDENCE"
+            echo
+            echo "PUBLISH-READINESS 通过：仍需由维护者按运行手册做最终人工确认；本 workflow 没有执行发布。"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,3 +131,26 @@ bash ./scripts/ci-pr-scope.sh --base origin/main --head HEAD
 Issue 中记录原因、被绕过的失败 check、操作者、时间、回滚 commit，以及后续补验
 负责人和结果；补验完成前不得关闭关联 Issue。不要通过临时删除 required check、
 关闭 `enforce admins` 或修改 workflow 让 Gate 变绿。
+
+## Nightly 与发布候选验证
+
+普通 PR 继续以约 10–12 分钟为反馈目标。Go race、完整 iOS/Mac App、跨平台安装包、
+真实 Runtime 和签名发布证据归入 Nightly / Release validation，不应复制进 PR Gate。
+修改 `.github/workflows`、发布验证脚本或回滚规则时，本地先运行：
+
+```bash
+bash ./scripts/check-validation-workflows.sh
+bash ./scripts/check-pr-gate.sh
+```
+
+发布候选必须显式提供上一已知可用 commit/tag，并先做只读 dry-run：
+
+```bash
+bash ./scripts/check-rollback-readiness.sh \
+  --candidate-ref HEAD \
+  --previous-ref "<上一正式 tag 或 commit>" \
+  --output /tmp/mimi-rollback-readiness.md
+```
+
+完整触发方式、artifact、失败处理、Internal TestFlight 证据和 capability kill switch
+见 [Nightly、Release validation 与回滚检查](docs/nightly-release-rollback.md)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -460,6 +460,7 @@ bridges/claude/          Rust Claude Code 协议 bridge
 - [Tailscale 与 Peer Relay 运维](docs/tailscale-peer-relay-ops.md)
 - [Codex 协议支持边界](docs/codex-protocol-support.md)
 - [Capability 声明与本地降级](docs/capability-rollout.md)
+- [Nightly、Release validation 与回滚检查](docs/nightly-release-rollback.md)
 - [Claude bridge 架构](docs/claude-bridge-architecture.md)
 - [与 Litter 的能力对照](docs/litter-comparison.md)
 - [隐私政策](docs/privacy-policy.md)

--- a/docs/nightly-release-rollback.md
+++ b/docs/nightly-release-rollback.md
@@ -1,0 +1,223 @@
+# Nightly、Release validation 与回滚检查
+
+## 目标
+
+把 Mimi 的验证分成三个互不冒充的层级：
+
+| 层级 | 反馈目标 | 负责内容 | 不负责 |
+| --- | --- | --- | --- |
+| PR Gate | 约 10–12 分钟 | 变更路径分类、协议/安全静态检查、Go/iOS/Rust 关键回归 | 全量 iOS、Mac App、跨平台安装包、真实 Runtime |
+| Nightly | 每天一次，允许约 90 分钟 | Go race、完整 Rust、Mac App、全量 iOS、Linux rollback fixture、Mac/Windows/GoReleaser snapshot | 签名、公证、TestFlight、生产数据 |
+| Release validation | 明确 candidate + previous 后手工触发 | N/N-1、全量回归、跨平台归档、安装包元数据；发布准备模式再验证签名、公证、ASC 与真实 Runtime 证据 | 创建 tag/Release、上传 TestFlight、部署、自动生产回滚 |
+
+`.github/workflows/pr-gate.yml` 继续只承担快速 Gate。`.github/workflows/nightly.yml`
+与 `.github/workflows/release-validation.yml` 承担重任务。workflow、action、路径分类或
+验证脚本自身变化时，`scripts/check-validation-workflows.sh` 会进入 PR Gate 静态验证，
+不会等到夜间才发现 YAML、权限或 fail-closed 语义已经漂移。
+
+## 方案
+
+### Nightly
+
+定时任务每天北京时间 02:30 运行，也可以在 GitHub Actions 的 **Nightly Validation**
+页面手工选择 **Run workflow**。默认任务只使用仓库源码、公开工具链和脱敏 fixture：
+
+- Ubuntu：Codex/Mimi 契约、Go race、Linux 安装/升级/回滚 fixture、四平台
+  GoReleaser snapshot；
+- Ubuntu + Windows：完整 Rust bridge workspace；
+- macOS：Mac App 测试、完整 iOS 单测/快照、universal DMG snapshot；
+- Windows：unsigned installer、SHA-256、metadata、静态安装策略；
+- artifact 保留 7 天；旧运行由 concurrency 取消，避免重复消耗 runner。
+
+Nightly 不读取 Apple/Windows 发布私钥，也不使用真实用户仓库、Token 或会话。
+
+真实 Runtime smoke 是独立可选 job。定时启用前必须同时满足：
+
+1. 仓库变量 `MIMI_NIGHTLY_RUNTIME_SMOKE_ENABLED=true`；
+2. 存在标签为 `self-hosted`、`mimi-runtime-smoke` 的隔离 runner；
+3. `nightly-runtime-smoke` environment 中配置可撤销的
+   `MIMI_NIGHTLY_RUNTIME_ENDPOINT`、`MIMI_NIGHTLY_RUNTIME_TOKEN`；
+4. environment 变量 `MIMI_NIGHTLY_RUNTIME_CANDIDATE_SHA` 必须是该受控环境实际运行的
+   完整 commit SHA，并与当前 Nightly commit 一致；
+5. Endpoint 只允许 HTTPS 或 runner 自己的 loopback，后端只暴露一次性样例仓库；
+6. Claude 还需仓库变量 `MIMI_NIGHTLY_CLAUDE_SMOKE_ENABLED=true`。
+
+Codex smoke 只执行 `initialize + thread/list` 多轮读取。Claude smoke 只执行
+`models/list`，不启动 turn。缺少 Claude 明确开关时结果写为 `SKIPPED`，不能伪造成功；
+请求了整个 Runtime job 但 runner、Endpoint、Token、候选 SHA 缺失，或任一次只读请求
+失败时，Nightly 直接失败。
+
+### Release validation
+
+Release validation 只能 `workflow_dispatch`，输入必须绑定到不可变证据：
+
+- `candidate_ref`：待发布 commit、分支或 tag；
+- `previous_release_ref`：上一已知可用正式版本，必须解析为 candidate 的祖先；
+- `candidate_version`：不含 `v` 的候选语义版本；`dry-run` 可用 `0.0.0`，
+  `publish-readiness` 必须填写真实版本；
+- `validation_mode`：`dry-run` 或 `publish-readiness`；
+- `run_controlled_runtime_smoke`：是否运行隔离 Runtime；
+- `internal_testflight_evidence`：同一 candidate 的 Internal TestFlight 证据 URL；
+- `rollback_drill_evidence`：同一 candidate 发布前，上一签名产物恢复演练证据 URL。
+
+`dry-run` 不读取发布凭据，生成：
+
+- N/N-1 与 capability/rollback Markdown 报告，保留 30 天；
+- 四平台 Go 归档、checksums 与 Homebrew Formula；
+- ad-hoc universal Mac DMG；
+- unsigned Windows installer、metadata 与 SHA-256；
+- unsigned iOS xcarchive；
+- Go、Rust、Mac 和完整 iOS 测试结果。
+
+`dry-run` 变绿只表示“候选可构建、静态兼容和回滚入口存在”，明确不授权发布。
+
+`publish-readiness` 仍不发布，但会 fail-closed 地增加：
+
+- 使用 Developer ID 构建并 notarize Mac DMG，再验证 Gatekeeper/ticket；
+- 使用 Authenticode PFX 签名三份 Windows payload 和 installer，再验证签名；
+- 使用 Distribution certificate/profile 生成 IPA，并通过 App Store 服务端
+  `validate-app`；`IOS_TESTFLIGHT_UPLOAD=0`，不上传、不关联 beta group；
+- 强制运行受控 Codex Runtime smoke；Claude 未显式配置时保留 `SKIPPED` 证据；
+- environment 的候选 SHA 和 `/api/version` 必须分别与已解析 candidate commit、
+  `candidate_version` 完全一致，防止误验旧环境；
+- 强制要求 Internal TestFlight 与上一签名产物恢复演练的 `https://` 证据。
+
+任何 secret、runner、previous ref、N/N-1、签名、ASC、Runtime 或人工证据缺失都会失败；
+不能把 `dry-run` artifact 或 `SKIPPED` 当作正式发布凭据。artifact 保留 30 天（unsigned
+iOS archive 保留 14 天），同一 candidate 的新验证不会取消已经开始的旧验证。
+
+## 实现
+
+### 本地无副作用检查
+
+先检查 workflow 与文档约束：
+
+```bash
+bash ./scripts/check-validation-workflows.sh
+bash ./scripts/check-pr-gate.sh
+```
+
+再对明确的 candidate / previous 生成回滚报告。命令只读 Git，不安装或停止服务：
+
+```bash
+candidate_ref="HEAD"
+previous_ref="<上一正式 tag 或 commit>"
+report_dir="$(mktemp -d)"
+
+bash ./scripts/check-rollback-readiness.sh \
+  --candidate-ref "$candidate_ref" \
+  --previous-ref "$previous_ref" \
+  --output "$report_dir/rollback-readiness.md"
+```
+
+需要本地复现发布 artifact 时：
+
+```bash
+bash ./scripts/verify-release.sh verify
+
+bash ./scripts/build-macos-installer.sh \
+  --snapshot \
+  --version 0.0.0 \
+  --output-dir dist-macos
+bash ./scripts/check-macos-installer.sh dist-macos/Mimi-Remote-Mac.dmg
+```
+
+Windows snapshot 必须在 Windows PowerShell 运行：
+
+```powershell
+./scripts/build-windows-installer.ps1 `
+  -Version 0.0.0 `
+  -OutputDirectory dist-windows `
+  -Snapshot
+$Installer = Get-Item "dist-windows\Mimi-Remote-Setup-*.exe"
+./scripts/check-windows-installer.ps1 -InstallerPath $Installer.FullName
+./scripts/test-windows-install.ps1
+```
+
+### 读取结果
+
+先打开最终 `Nightly Validation` 或 `Release Validation` job summary，再进入失败的具体 job。
+最终 job 只聚合判定，根因日志位于对应平台：
+
+- 协议/Go/Rust：测试名、package 与 GoReleaser artifact；
+- Mac/iOS：XCTest method、archive metadata、codesign/notary/Gatekeeper；
+- Windows：payload SHA-256、Authenticode、Inno policy；
+- Rollback：`release-rollback-report-*` artifact；
+- Runtime：只读成功率/P50/P95；日志不得出现 Endpoint 或 Token。
+
+Nightly 第一次失败先在同一 GitHub run 上重跑失败 job，确认是否为 runner/网络瞬态。连续
+两次定时运行失败，必须查重并创建或更新一张 Mimi Linear Issue，附两个 run URL、失败
+job、首个确定错误和负责人；Nightly 红灯本身不冻结所有 PR，但关联问题解决前不能忽略。
+
+### 允许继续发布的条件
+
+只有以下条件同时满足才允许进入“人工发布”阶段：
+
+1. candidate SHA 与准备发布的 commit 完全一致；
+2. `candidate_version` 与安装包元数据、受控 Runtime `/api/version` 完全一致；
+3. `Release Validation` 的 `publish-readiness` 最终 job 成功；
+4. Mac/Windows 签名、Mac notarization、iOS ASC validate 均为成功，不是 snapshot；
+5. Internal TestFlight 使用同一 candidate，关键移动端链路已记录；
+6. previous 是仍可下载的上一签名正式版本，恢复演练已记录实际版本、`readyz` 和结果；
+7. 未执行项、手工项、构建号、artifact/run URL 已回写发布 Issue；
+8. 没有未解释的 `SKIPPED`。Claude 可以因实验通道未启用而跳过，但必须明确记录。
+
+本仓库 workflow 到此停止。创建 tag、GitHub Release、TestFlight 分发或正式部署是后续
+独立人工动作，不由本验证流程自动执行。
+
+### capability kill switch 降级
+
+当 `file_upload_v1` 出现问题，但基础会话、审批与 Git 仍健康时，优先只关闭该能力。
+操作前备份私有配置，按
+[Capability 声明与本地降级](capability-rollout.md) 中对应平台的完整命令修改
+`capabilities.disabled`，然后：
+
+```bash
+agentd restart --no-pair
+agentd status --json | jq '
+  .doctor.checks[]
+  | select(.name == "capability-file-upload-v1")
+'
+```
+
+必须同时确认：
+
+- `/api/version` 不再声明 `file_upload_v1`；
+- 状态为 `locally_disabled / disabled_by_local_config`；
+- 文件上传端点返回结构化 `503 capability_locally_disabled`；
+- iOS 当前 Host 隐藏或禁用入口，不发送请求；
+- 基础会话、审批、Git/Worktree 仍可用。
+
+恢复时只移除 `file_upload_v1`，保留其他禁用项；依赖仍异常时必须保持
+`dependency_unavailable`，不能强制宣告 capability。禁止通过清 Token、删连接档案、
+擦除 Simulator 或关闭服务端权限检查来“恢复”。
+
+### 上一签名产物恢复演练
+
+演练只能在隔离测试用户/主机执行，不能对生产主机自动回滚。记录中至少包含 candidate、
+previous、平台、安装方式、配置备份位置（只记录类型，不记录真实路径/Token）、开始和
+结束时间、恢复后的版本、`service_ok`/`readyz`、Doctor、移动端连接和执行人。
+
+- Mac：用上一仍可下载、Developer ID 签名并 notarize 的 DMG 覆盖测试 App，或按
+  `docs/install-upgrade-rollback.md` 使用上一签名 Homebrew keg；
+- Windows：重新运行上一仍为 `Valid` Authenticode 的正式 installer；
+- Linux：使用正式归档保存的 helper 执行：
+
+```bash
+bash "$HOME/.local/share/mimi-remote/install-linux.sh" rollback
+"$HOME/.local/bin/agentd" status --json
+```
+
+如果 previous artifact 不可下载、签名无效、配置不再向后兼容、恢复后 `service_ok`
+不是 `true`，或证据无法关联到同一 candidate，结论必须是 fail-closed。
+
+## 风险与优化
+
+- 托管 runner 能证明跨平台构建和静态安装策略，不能替代相机、通知、Keychain、
+  Tailscale/弱网、性能和真实设备专项；这些结果必须单独记录。
+- macOS notarization 与 ASC validate 会访问 Apple，但不向用户分发；只有显式选择
+  `publish-readiness` 才读取凭据。
+- 自托管 Runtime runner 是权限最高的环节，只允许样例仓库、只读 smoke、短期 Token 和
+  environment approval；不要挂载个人工作目录或复用日常 agentd Token。
+- 当前不建设自动生产回滚、设备农场或商业灰度系统。真实故障数据证明需要更多组合前，
+  保持这套薄编排。

--- a/scripts/check-packaging.sh
+++ b/scripts/check-packaging.sh
@@ -19,6 +19,8 @@ done
 for required_file in \
   .github/workflows/pr-gate.yml \
   .github/workflows/go-ci.yml \
+  .github/workflows/nightly.yml \
+  .github/workflows/release-validation.yml \
   .github/workflows/release.yml \
   .goreleaser.yml \
   README.md \
@@ -42,12 +44,15 @@ for required_file in \
   scripts/check-release-prerequisites.sh \
   scripts/check-macos-release-signing.sh \
   scripts/check-release-artifacts.sh \
+  scripts/check-rollback-readiness.sh \
+  scripts/check-validation-workflows.sh \
   scripts/package-skill.sh \
   scripts/sign-agentd-dev-macos.sh \
   scripts/restart-agentd-dev-macos.sh \
   scripts/restart-agentd-dev-handoff-macos.sh \
   scripts/verify-release.sh \
-  docs/install-upgrade-rollback.md; do
+  docs/install-upgrade-rollback.md \
+  docs/nightly-release-rollback.md; do
   [[ -f "$required_file" ]] || fail "缺少 ${required_file}。"
 done
 
@@ -60,6 +65,8 @@ bash -n \
   scripts/check-release-prerequisites.sh \
   scripts/check-macos-release-signing.sh \
   scripts/check-release-artifacts.sh \
+  scripts/check-rollback-readiness.sh \
+  scripts/check-validation-workflows.sh \
   scripts/package-skill.sh \
   scripts/sign-agentd-dev-macos.sh \
   scripts/restart-agentd-dev-macos.sh \
@@ -68,6 +75,7 @@ bash -n \
   scripts/test-install-linux.sh \
   scripts/verify-release.sh
 bash ./scripts/check-release-prerequisites.sh --self-test >/dev/null
+bash ./scripts/check-validation-workflows.sh >/dev/null
 bash ./scripts/check-macos-release-signing.sh --self-test >/dev/null
 bash ./scripts/restart-agentd-dev-macos.sh --self-test >/dev/null
 bash ./scripts/verify-release.sh --self-test >/dev/null

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -17,9 +17,12 @@ done
 bash -n \
   scripts/ci-pr-scope.sh \
   scripts/check-critical-regressions.sh \
+  scripts/check-rollback-readiness.sh \
+  scripts/check-validation-workflows.sh \
   scripts/check-pr-gate.sh
 
 bash ./scripts/check-critical-regressions.sh
+bash ./scripts/check-validation-workflows.sh
 
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-pr-gate-check.XXXXXX")"
 trap 'rm -rf "$test_root"' EXIT
@@ -56,6 +59,11 @@ assert_scope critical_runner true true false scripts/test-conversation-regressio
 assert_scope critical_checker true true false scripts/check-critical-regressions.sh
 assert_scope docs_only false false false CONTRIBUTING.md
 assert_scope workflow true true true .github/workflows/pr-gate.yml
+assert_scope nightly_workflow true true true .github/workflows/nightly.yml
+assert_scope release_validation_workflow true true true .github/workflows/release-validation.yml
+assert_scope validation_checker true true true scripts/check-validation-workflows.sh
+assert_scope rollback_checker true true true scripts/check-rollback-readiness.sh
+assert_scope runtime_smoke true false false scripts/history-sync-regression.sh
 assert_scope mixed true true true \
   cmd/agentd/main.go \
   ios/MimiRemote/project.yml \

--- a/scripts/check-rollback-readiness.sh
+++ b/scripts/check-rollback-readiness.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CANDIDATE_REF="HEAD"
+PREVIOUS_REF=""
+OUTPUT_PATH=""
+
+usage() {
+  cat <<'EOF'
+用法：
+  bash ./scripts/check-rollback-readiness.sh \
+    --candidate-ref <commit-or-tag> \
+    --previous-ref <known-good-commit-or-tag> \
+    [--output <report.md>]
+
+只读取 Git 历史并生成发布前回滚报告，不安装、停止、回滚或发布任何真实服务。
+previous 必须是 candidate 的祖先；缺少上一已知版本或兼容证据时脚本会失败关闭。
+EOF
+}
+
+fail() {
+  echo "回滚就绪检查失败：$1" >&2
+  exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --candidate-ref)
+      [[ "$#" -ge 2 ]] || fail "--candidate-ref 缺少值。"
+      CANDIDATE_REF="$2"
+      shift 2
+      ;;
+    --previous-ref)
+      [[ "$#" -ge 2 ]] || fail "--previous-ref 缺少值。"
+      PREVIOUS_REF="$2"
+      shift 2
+      ;;
+    --output)
+      [[ "$#" -ge 2 ]] || fail "--output 缺少值。"
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "未知参数 $1。"
+      ;;
+  esac
+done
+
+[[ -n "$PREVIOUS_REF" ]] || fail "必须显式提供 --previous-ref，不能猜测上一已知版本。"
+
+for command_name in cat git grep mkdir mktemp ruby sed tr; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "缺少命令 ${command_name}。"
+done
+
+candidate_sha="$(git rev-parse --verify "${CANDIDATE_REF}^{commit}" 2>/dev/null)" \
+  || fail "candidate 不是可读取的 commit：${CANDIDATE_REF}"
+previous_sha="$(git rev-parse --verify "${PREVIOUS_REF}^{commit}" 2>/dev/null)" \
+  || fail "previous 不是可读取的 commit：${PREVIOUS_REF}"
+[[ "$candidate_sha" != "$previous_sha" ]] \
+  || fail "candidate 与 previous 指向同一 commit，无法证明降级路径。"
+git merge-base --is-ancestor "$previous_sha" "$candidate_sha" \
+  || fail "previous 不是 candidate 的祖先；拒绝对不明确的历史关系给出发布结论。"
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/mimi-rollback-readiness.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+candidate_contract="$work_dir/candidate-contract.json"
+previous_contract="$work_dir/previous-contract.json"
+contract_report="$work_dir/contract-report.md"
+contract_errors="$work_dir/contract-errors.txt"
+
+git show "${candidate_sha}:contracts/mimi-protocol/contract.json" >"$candidate_contract" \
+  || fail "candidate 缺少 Mimi 协议契约。"
+previous_contract_source="previous commit contract.json"
+if ! git show "${previous_sha}:contracts/mimi-protocol/contract.json" >"$previous_contract" 2>/dev/null; then
+  # 第一次引入正式协议 manifest 时，上一正式版本没有 contract.json。
+  # 只能使用 MIM-28 中由两端共同消费的 revision-1 fixture 作为 legacy 基线；
+  # fixture 缺失或已经带入新字段时失败关闭，不能凭版本字符串猜测。
+  previous_fixture="$work_dir/version-previous.json"
+  git show "${candidate_sha}:contracts/mimi-protocol/fixtures/version-previous.json" >"$previous_fixture" \
+    || fail "previous 没有协议 manifest，candidate 也缺少 revision-1 fixture。"
+  ruby -rjson - "$candidate_contract" "$previous_fixture" >"$previous_contract" <<'RUBY'
+candidate_path, fixture_path = ARGV
+candidate = JSON.parse(File.read(candidate_path))
+fixture = JSON.parse(File.read(fixture_path))
+abort("legacy fixture 必须是 JSON object") unless fixture.is_a?(Hash)
+forbidden = %w[protocol_revision minimum_client_protocol_revision minimum_server_protocol_revision]
+abort("legacy fixture 意外包含新协议字段") unless forbidden.none? { |key| fixture.key?(key) }
+legacy_client = candidate["legacy_client_revision"]
+legacy_server = candidate["legacy_server_revision"]
+abort("candidate 缺少 legacy revision") unless
+  legacy_client.is_a?(Integer) && legacy_client.positive? &&
+  legacy_server.is_a?(Integer) && legacy_server.positive?
+puts JSON.pretty_generate(
+  "schema_version" => candidate["schema_version"],
+  "protocol_name" => candidate["protocol_name"],
+  "current_revision" => legacy_server,
+  "minimum_supported_client_revision" => legacy_client,
+  "minimum_supported_server_revision" => legacy_server,
+  "capabilities" => []
+)
+RUBY
+  previous_contract_source="candidate revision-1 golden fixture（previous 无 manifest）"
+fi
+
+set +e
+ruby -rjson - "$candidate_contract" "$previous_contract" >"$contract_report" 2>"$contract_errors" <<'RUBY'
+candidate_path, previous_path = ARGV
+candidate = JSON.parse(File.read(candidate_path))
+previous = JSON.parse(File.read(previous_path))
+errors = []
+
+required_integer_keys = %w[
+  current_revision
+  minimum_supported_client_revision
+  minimum_supported_server_revision
+]
+[["candidate", candidate], ["previous", previous]].each do |label, contract|
+  required_integer_keys.each do |key|
+    errors << "#{label}.#{key} 必须是正整数" unless contract[key].is_a?(Integer) && contract[key].positive?
+  end
+  errors << "#{label}.capabilities 必须是字符串数组" unless
+    contract["capabilities"].is_a?(Array) && contract["capabilities"].all? { |item| item.is_a?(String) }
+end
+
+if errors.empty?
+  errors << "schema_version 改变，缺少显式迁移证据" unless candidate["schema_version"] == previous["schema_version"]
+  errors << "protocol_name 改变，不能视为同一兼容窗口" unless candidate["protocol_name"] == previous["protocol_name"]
+  errors << "candidate revision 不能低于 previous revision" if
+    candidate["current_revision"] < previous["current_revision"]
+  errors << "previous 客户端不能连接 candidate agentd" if
+    candidate["minimum_supported_client_revision"] > previous["current_revision"]
+  errors << "candidate 客户端不能连接 previous agentd" if
+    candidate["minimum_supported_server_revision"] > previous["current_revision"]
+  errors << "candidate revision 不满足 previous 声明的最低客户端要求" if
+    previous["minimum_supported_client_revision"] > candidate["current_revision"]
+  errors << "candidate revision 不满足 previous 声明的最低服务端要求" if
+    previous["minimum_supported_server_revision"] > candidate["current_revision"]
+
+  removed = previous.fetch("capabilities", []) - candidate.fetch("capabilities", [])
+  errors << "candidate 删除了上一窗口 capability：#{removed.join(', ')}" unless removed.empty?
+end
+
+puts "| 项目 | 上一已知版本 | 当前候选 |"
+puts "| --- | --- | --- |"
+puts "| protocol revision | `#{previous["current_revision"]}` | `#{candidate["current_revision"]}` |"
+puts "| minimum client revision | `#{previous["minimum_supported_client_revision"]}` | `#{candidate["minimum_supported_client_revision"]}` |"
+puts "| minimum server revision | `#{previous["minimum_supported_server_revision"]}` | `#{candidate["minimum_supported_server_revision"]}` |"
+puts "| capabilities | `#{previous.fetch("capabilities", []).join(", ")}` | `#{candidate.fetch("capabilities", []).join(", ")}` |"
+
+unless errors.empty?
+  warn errors.map { |item| "- #{item}" }.join("\n")
+  exit 1
+end
+RUBY
+contract_status=$?
+set -e
+
+checks=()
+failures=()
+
+record_check() {
+  local label="$1"
+  local status="$2"
+  local detail="$3"
+  checks+=("| ${label} | ${status} | ${detail} |")
+  [[ "$status" == "PASS" ]] || failures+=("$label")
+}
+
+if [[ "$contract_status" == "0" ]]; then
+  record_check "MIM-28 N/N-1 协议窗口" "PASS" "双方最低修订可互连，capability 未从上一窗口删除"
+else
+  detail="$(tr '\n' ' ' <"$contract_errors" | sed -E 's/[[:space:]]+/ /g')"
+  record_check "MIM-28 N/N-1 协议窗口" "FAIL" "${detail:-协议 JSON 不满足兼容约束}"
+fi
+
+required_release_paths=(
+  .goreleaser.yml
+  scripts/install-linux.sh
+  scripts/build-macos-installer.sh
+  scripts/build-windows-installer.ps1
+  docs/install-upgrade-rollback.md
+)
+for ref_label in candidate previous; do
+  ref_sha="$candidate_sha"
+  [[ "$ref_label" == "candidate" ]] || ref_sha="$previous_sha"
+  missing_paths=()
+  for path in "${required_release_paths[@]}"; do
+    git cat-file -e "${ref_sha}:${path}" 2>/dev/null || missing_paths+=("$path")
+  done
+  if [[ "${#missing_paths[@]}" == "0" ]]; then
+    record_check "${ref_label} 可恢复发布源" "PASS" "GoReleaser、Mac/Windows 构建与 Linux rollback 入口完整"
+  else
+    record_check "${ref_label} 可恢复发布源" "FAIL" "缺少：${missing_paths[*]}"
+  fi
+done
+
+if git grep -Fq "file_upload_v1" "$candidate_sha" -- contracts/mimi-protocol/contract.json \
+  && git grep -Fq "capabilities.disabled" "$candidate_sha" -- docs/capability-rollout.md \
+  && git grep -Fq "TestFileUploadCapabilityRolloutMatrix" "$candidate_sha" -- internal/httpapi \
+  && git grep -Fq "testFileUploadCapabilityDecisionMatrixFailsClosed" "$candidate_sha" -- ios/MimiRemote/Tests; then
+  record_check "MIM-30 capability kill switch" "PASS" "配置禁用、服务端拒绝、iOS fail-closed 与回归证据齐全"
+else
+  record_check "MIM-30 capability kill switch" "FAIL" "缺少 file_upload_v1 禁用、服务端或 iOS fail-closed 证据"
+fi
+
+if git grep -Fq "rollback" "$candidate_sha" -- scripts/install-linux.sh \
+  && git grep -Fq "上一版" "$candidate_sha" -- docs/install-upgrade-rollback.md; then
+  record_check "降级操作入口" "PASS" "Linux 可执行 rollback；Mac/Windows 明确使用上一签名正式产物"
+else
+  record_check "降级操作入口" "FAIL" "缺少可执行 rollback 或上一签名产物说明"
+fi
+
+if [[ -z "$OUTPUT_PATH" ]]; then
+  OUTPUT_PATH="$work_dir/rollback-readiness.md"
+else
+  mkdir -p "$(dirname "$OUTPUT_PATH")"
+fi
+
+{
+  echo "# Mimi Release 回滚就绪报告"
+  echo
+  echo "- Candidate：\`${candidate_sha}\`（输入：\`${CANDIDATE_REF}\`）"
+  echo "- Previous known-good：\`${previous_sha}\`（输入：\`${PREVIOUS_REF}\`）"
+  echo "- 历史关系：previous 是 candidate 的祖先"
+  echo "- Previous 协议证据：${previous_contract_source}"
+  echo "- 执行边界：只读检查；未安装、未停止、未回滚、未发布任何真实服务"
+  echo
+  echo "## 协议窗口"
+  echo
+  cat "$contract_report"
+  echo
+  echo "## 结果"
+  echo
+  echo "| 检查 | 状态 | 证据 |"
+  echo "| --- | --- | --- |"
+  printf '%s\n' "${checks[@]}"
+  echo
+  echo "## 发布结论"
+  echo
+  if [[ "${#failures[@]}" == "0" ]]; then
+    echo "静态回滚检查通过。此结果不等于已执行真实安装回滚；正式发布仍必须附上一签名产物恢复演练和 Internal TestFlight 证据。"
+  else
+    echo "FAIL-CLOSED：证据不足，禁止继续发布。失败项：${failures[*]}。"
+  fi
+} >"$OUTPUT_PATH"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  cat "$OUTPUT_PATH" >>"$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ "${#failures[@]}" != "0" ]]; then
+  echo "回滚就绪检查失败，报告：$OUTPUT_PATH" >&2
+  exit 1
+fi
+
+echo "回滚就绪检查通过，报告：$OUTPUT_PATH"

--- a/scripts/check-validation-workflows.sh
+++ b/scripts/check-validation-workflows.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "Nightly/Release workflow 自检失败：$1" >&2
+  exit 1
+}
+
+for command_name in bash grep ruby; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "缺少命令 ${command_name}。"
+done
+
+nightly=".github/workflows/nightly.yml"
+release_validation=".github/workflows/release-validation.yml"
+runbook="docs/nightly-release-rollback.md"
+rollback_script="scripts/check-rollback-readiness.sh"
+
+for path in "$nightly" "$release_validation" "$runbook" "$rollback_script"; do
+  [[ -f "$path" ]] || fail "缺少 ${path}。"
+done
+
+bash -n "$rollback_script" scripts/check-validation-workflows.sh scripts/history-sync-regression.sh
+
+ruby - "$nightly" "$release_validation" <<'RUBY'
+require "yaml"
+
+def abort_check(message)
+  abort("Nightly/Release workflow 自检失败：#{message}")
+end
+
+def load_workflow(path)
+  YAML.safe_load(File.read(path), aliases: true)
+rescue Psych::SyntaxError => error
+  abort_check("#{path} YAML 无法解析：#{error.message}")
+end
+
+def triggers(workflow)
+  value = workflow["on"] || workflow[true]
+  abort_check("workflow 缺少 on") unless value.is_a?(Hash)
+  value
+end
+
+def validate_common(path, workflow)
+  permissions = workflow["permissions"]
+  abort_check("#{path} 必须固定 permissions.contents=read") unless
+    permissions.is_a?(Hash) && permissions["contents"] == "read" && permissions.keys == ["contents"]
+
+  concurrency = workflow["concurrency"]
+  abort_check("#{path} 缺少 concurrency.group") unless concurrency.is_a?(Hash) && concurrency["group"]
+  abort_check("#{path} 缺少 cancel-in-progress") unless [true, false].include?(concurrency["cancel-in-progress"])
+
+  workflow.fetch("jobs").each do |job_id, job|
+    next if job.key?("uses")
+    timeout = job["timeout-minutes"]
+    abort_check("#{path} 的 #{job_id} 缺少正数 timeout-minutes") unless timeout.is_a?(Integer) && timeout.positive?
+  end
+
+  File.readlines(path, chomp: true).each do |line|
+    next unless line =~ /^\s*uses:\s*(\S+)/
+    action = Regexp.last_match(1)
+    next if action.start_with?("./")
+    abort_check("#{path} action 未固定完整 commit SHA：#{action}") unless action.match?(/@[0-9a-f]{40}$/)
+  end
+end
+
+nightly_path, release_path = ARGV
+nightly = load_workflow(nightly_path)
+release = load_workflow(release_path)
+validate_common(nightly_path, nightly)
+validate_common(release_path, release)
+
+nightly_triggers = triggers(nightly)
+abort_check("Nightly 必须同时支持 schedule 和 workflow_dispatch") unless
+  nightly_triggers.key?("schedule") && nightly_triggers.key?("workflow_dispatch")
+abort_check("Nightly 每个 cron 条目必须有 cron") unless
+  Array(nightly_triggers["schedule"]).all? { |entry| entry.is_a?(Hash) && entry["cron"].to_s != "" }
+
+release_triggers = triggers(release)
+abort_check("Release validation 只能手工触发") unless release_triggers.keys == ["workflow_dispatch"]
+inputs = release_triggers.dig("workflow_dispatch", "inputs")
+%w[candidate_ref previous_release_ref candidate_version validation_mode run_controlled_runtime_smoke internal_testflight_evidence rollback_drill_evidence].each do |name|
+  abort_check("Release validation 缺少 input #{name}") unless inputs.is_a?(Hash) && inputs.key?(name)
+end
+RUBY
+
+grep -Fq 'retention-days:' "$nightly" \
+  || fail "Nightly artifact 没有明确保留期。"
+grep -Fq 'retention-days:' "$release_validation" \
+  || fail "Release artifact 没有明确保留期。"
+grep -Fq 'scripts/check-rollback-readiness.sh' "$release_validation" \
+  || fail "Release validation 没有执行回滚检查。"
+grep -Fq 'validation_mode == '\''publish-readiness'\''' "$release_validation" \
+  || fail "Release validation 没有区分 dry-run 与 publish-readiness。"
+grep -Fq 'run_controlled_runtime_smoke' "$nightly" \
+  || fail "Nightly 没有受控 Runtime smoke 开关。"
+grep -Fq 'MIMI_NIGHTLY_RUNTIME_SMOKE_ENABLED' "$nightly" \
+  || fail "Nightly 定时 Runtime smoke 没有显式仓库变量开关。"
+grep -Fq 'scripts/history-sync-regression.sh' "$nightly" \
+  || fail "Nightly 没有复用只读真实 Codex history smoke。"
+grep -Fq -- '--require-all-successful' "$nightly" \
+  && grep -Fq -- '--require-all-successful' "$release_validation" \
+  || fail "Nightly/Release 的 Runtime smoke 没有在请求失败时 fail-closed。"
+grep -Fq 'runtime claude' "$nightly" \
+  || fail "Nightly 没有记录受控 Claude smoke。"
+grep -Fq 'runtime_version' "$release_validation" \
+  && grep -Fq 'CANDIDATE_VERSION' "$release_validation" \
+  && grep -Fq 'MIMI_NIGHTLY_RUNTIME_CANDIDATE_SHA' "$nightly" \
+  && grep -Fq 'MIMI_NIGHTLY_RUNTIME_CANDIDATE_SHA' "$release_validation" \
+  || fail "Nightly/Release 没有把受控 Runtime 绑定到候选 commit 与版本。"
+
+for forbidden in \
+  'gh release create' \
+  'gh release upload' \
+  'goreleaser.*release --clean' \
+  'ios_testflight_local.sh.*--upload' \
+  'git push'; do
+  if grep -Eq "$forbidden" "$nightly" "$release_validation"; then
+    fail "验证 workflow 包含禁止的发布动作：${forbidden}"
+  fi
+done
+
+for phrase in \
+  'PR Gate' \
+  'Nightly' \
+  'Release validation' \
+  'fail-closed' \
+  'file_upload_v1' \
+  'Internal TestFlight'; do
+  grep -Fq "$phrase" "$runbook" || fail "运行手册缺少：${phrase}"
+done
+
+grep -Fq 'git merge-base --is-ancestor' "$rollback_script" \
+  || fail "回滚检查没有验证 previous/candidate 历史关系。"
+grep -Fq 'minimum_supported_client_revision' "$rollback_script" \
+  || fail "回滚检查没有验证 MIM-28 最低客户端窗口。"
+grep -Fq 'minimum_supported_server_revision' "$rollback_script" \
+  || fail "回滚检查没有验证 MIM-28 最低服务端窗口。"
+grep -Fq 'file_upload_v1' "$rollback_script" \
+  || fail "回滚检查没有验证 MIM-30 kill switch 证据。"
+
+echo "Nightly/Release workflow 自检通过：触发、权限、超时、action 固定、artifact、回滚和禁止发布边界均明确。"

--- a/scripts/ci-pr-scope.sh
+++ b/scripts/ci-pr-scope.sh
@@ -109,7 +109,7 @@ else
 
     # CI 编排或分类规则本身变化时执行全部语言门禁，避免分类器修改静默缩小覆盖面。
     case "$changed_path" in
-      .github/workflows/*|.github/actions/*|scripts/ci-pr-scope.sh|scripts/check-pr-gate.sh)
+      .github/workflows/*|.github/actions/*|scripts/ci-pr-scope.sh|scripts/check-pr-gate.sh|scripts/check-validation-workflows.sh|scripts/check-rollback-readiness.sh)
         go_scope=true
         ios_scope=true
         rust_scope=true
@@ -121,10 +121,10 @@ else
       *.go|go.mod|go.sum|.goreleaser.yml|SKILL.md|packaging/*|packaging/**/*|macos/MimiRemoteMac/*|macos/MimiRemoteMac/**/*|contracts/mimi-protocol/*|contracts/mimi-protocol/**/*)
         go_scope=true
         ;;
-      scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-packaging.sh|scripts/check-source-size.sh|scripts/check-mimi-protocol-contract.sh|scripts/check-macos-*|scripts/check-release-*|scripts/build-macos-installer.sh|scripts/build-windows-installer.ps1|scripts/check-windows-installer.ps1|scripts/test-windows-install.ps1|scripts/install-linux.sh|scripts/test-install-linux.sh|scripts/package-skill.sh|scripts/export-public-backend.sh|scripts/sign-agentd-dev-macos.sh|scripts/restart-agentd-dev-macos.sh|scripts/restart-agentd-dev-handoff-macos.sh|scripts/verify-release.sh)
+      scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-packaging.sh|scripts/check-source-size.sh|scripts/check-mimi-protocol-contract.sh|scripts/check-macos-*|scripts/check-release-*|scripts/check-validation-workflows.sh|scripts/check-rollback-readiness.sh|scripts/history-sync-regression.sh|scripts/build-macos-installer.sh|scripts/build-windows-installer.ps1|scripts/check-windows-installer.ps1|scripts/test-windows-install.ps1|scripts/install-linux.sh|scripts/test-install-linux.sh|scripts/package-skill.sh|scripts/export-public-backend.sh|scripts/sign-agentd-dev-macos.sh|scripts/restart-agentd-dev-macos.sh|scripts/restart-agentd-dev-handoff-macos.sh|scripts/verify-release.sh)
         go_scope=true
         ;;
-      README.md|docs/install-upgrade-rollback.md|docs/codex-protocol-support.md|docs/mimi-protocol-contracts.md|docs/p0-p1-roadmap.md)
+      README.md|docs/install-upgrade-rollback.md|docs/codex-protocol-support.md|docs/mimi-protocol-contracts.md|docs/nightly-release-rollback.md|docs/p0-p1-roadmap.md)
         go_scope=true
         ;;
     esac

--- a/scripts/history-sync-regression.sh
+++ b/scripts/history-sync-regression.sh
@@ -7,6 +7,7 @@ ROUNDS=10
 LIST_LIMIT=20
 TIMEOUT="15s"
 ENDPOINTS=()
+REQUIRE_ALL_SUCCESSFUL=0
 
 usage() {
   cat <<'USAGE'
@@ -22,6 +23,8 @@ Options:
   --limit N             thread/list 页大小，默认 20
   --timeout DURATION    单次 RPC 超时，默认 15s
   --config PATH         agentd config.json 路径
+  --require-all-successful
+                        任一只读请求失败即返回非零；用于 Nightly/Release Gate
   -h, --help            显示帮助
 
 示例：
@@ -62,6 +65,10 @@ while [[ $# -gt 0 ]]; do
     --config)
       CONFIG_PATH="${2:?--config 需要路径}"
       shift 2
+      ;;
+    --require-all-successful)
+      REQUIRE_ALL_SUCCESSFUL=1
+      shift
       ;;
     -h|--help)
       usage
@@ -155,6 +162,7 @@ trap 'rm -f "$probe_bin" "$timings_file"' EXIT
 go build -tags ipadwsprobe -o "$probe_bin" "$ROOT_DIR/scripts/ipad-ws-probe.go"
 
 printf '%-12s %8s %8s %8s %8s %8s\n' "链路" "成功" "失败" "P50(ms)" "P95(ms)" "最大(ms)"
+gate_failed=0
 for entry in "${ENDPOINTS[@]}"; do
   if [[ "$entry" != *=* ]]; then
     echo "--endpoint 格式必须是 NAME=URL：$entry" >&2
@@ -183,6 +191,9 @@ for entry in "${ENDPOINTS[@]}"; do
 
   if [[ "$successes" == "0" ]]; then
     printf '%-12s %8d %8d %8s %8s %8s\n' "$name" "$successes" "$failures" "-" "-" "-"
+    if [[ "$REQUIRE_ALL_SUCCESSFUL" == "1" && "$failures" != "0" ]]; then
+      gate_failed=1
+    fi
     continue
   fi
 
@@ -197,4 +208,12 @@ for entry in "${ENDPOINTS[@]}"; do
     '
   )
   printf '%-12s %8d %8d %8d %8d %8d\n' "$name" "$successes" "$failures" "$p50" "$p95" "$maximum"
+  if [[ "$REQUIRE_ALL_SUCCESSFUL" == "1" && "$failures" != "0" ]]; then
+    gate_failed=1
+  fi
 done
+
+if [[ "$gate_failed" == "1" ]]; then
+  echo "只读 history smoke 存在失败请求；按 Gate 要求失败关闭。" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 堆叠依赖

- Linear: MIM-31（MIM-26 子 Issue 链第五步）
- Base: `codex/mim-30-capability-fallbacks` / Draft PR #67
- 本 PR 只包含 MIM-31 diff；不改写或 force-push 前序分支。

## 变更

- 新增每日定时 + 手工触发的 Nightly：Go race、协议契约、完整 Rust、Mac App、全量 iOS、Linux rollback fixture、GoReleaser/Mac/Windows snapshot；产物保留 7 天。
- 新增手工 Release Validation：解析 immutable candidate/previous SHA，验证 MIM-28 N/N-1、Go/Rust/iOS 关键回归、跨平台归档和安装包元数据。`dry-run` 不读取发布凭据；`publish-readiness` 只做签名、公证和 ASC validate，不上传 TestFlight、不创建 Release、不部署。
- 新增 fail-closed 回滚检查：验证历史祖先关系、协议版本窗口、候选/上一版发布源、MIM-30 `file_upload_v1` kill switch 和平台降级入口；只生成审计报告，不自动生产回滚。
- 受控 Runtime smoke 绑定 candidate commit + version；任一只读请求失败即失败关闭。Nightly 默认不读取真实凭据，受控 job 需要显式变量、隔离 runner 和 environment。
- PR Gate 保持约 10–12 分钟，只增加 workflow/policy 静态检查和路径分类；重测试留在 Nightly/Release。
- 新增中文运行手册，覆盖触发、结果读取、失败处理、继续发布条件、Internal TestFlight/回滚演练证据和 capability kill switch。

## 权限与成本边界

- workflow 固定 `permissions: contents: read`，第三方 action 固定完整 commit SHA。
- Nightly 每日一次、同分支取消旧运行、各 job 明确 timeout、artifact 保留 7 天；Release 同 candidate 不取消运行、证据保留 14/30 天。
- 不新增付费 SaaS 或重型服务；受控 Runtime 仅使用短期 Token 和样例数据。
- 本 PR 未创建 tag/Release，未上传 TestFlight，未部署、未发布、未修改生产数据，也未执行真实回滚。

## 本地 dry-run 与验证

- `bash scripts/check-validation-workflows.sh`
- `bash scripts/check-pr-gate.sh`
- `bash scripts/check-packaging.sh`
- `bash scripts/check-public-repo-safety.sh`
- `actionlint` v1.7.7（自定义 runner label warning 已显式忽略）
- `go test ./... -count=1 && go vet ./...`
- `cargo fmt --all -- --check` 与完整 bridge workspace tests
- Codex/Mimi 协议契约、Linux install/rollback fixture、GoReleaser snapshot 均通过
- 回滚脚本对当前 N/N-1 与 previous 无 manifest 的 legacy fixture 两条路径均通过
- Runtime fail-closed 自检：不可达 endpoint 在严格模式返回 1，默认观测模式保持返回 0
- 本地 iPad Simulator 全量 XCTest：907 passed / 7 failed / 4 skipped。7 项均为既有 UI snapshot 在本机 Xcode 27 的像素阈值差异；本 PR 不改 UI，未重录 snapshot。托管 PR Gate 使用固定 macOS 26/Xcode 26.6 关键回归作为合并前证据。

## 托管验证

Draft PR 创建后等待 PR Gate 的 Go/iOS/Rust/协议与仓库安全 checks。Nightly/Release workflow 本身必须先通过该静态 Gate；真实签名、ASC、受控 Runtime 和跨平台托管 runner 项仅在合并后的手工/定时验证阶段执行。