### PR TITLE
MIM-37 锚定 iPad 移除目录确认弹窗

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -150,7 +150,6 @@ struct WorkspaceRootView: View {
     @State private var catalogState: CatalogState = .idle
     @State private var sessionLoadStates: [String: WorkspaceSessionLoadState] = [:]
     @State private var isPresentingOpenWorkspace = false
-    @State private var pendingWorkspaceRemoval: AgentProject?
     @State private var gitInspectionTarget: WorkspaceGitInspectionTarget?
 
     init(
@@ -244,29 +243,6 @@ struct WorkspaceRootView: View {
                     }
             }
             .presentationDetents([.large])
-        }
-        .confirmationDialog(
-            L10n.text("ui.remove_directory"),
-            isPresented: Binding(
-                get: { pendingWorkspaceRemoval != nil },
-                set: { isPresented in
-                    if !isPresented {
-                        pendingWorkspaceRemoval = nil
-                    }
-                }
-            ),
-            titleVisibility: .visible
-        ) {
-            if let project = pendingWorkspaceRemoval {
-                Button(L10n.format("ui.remove_directory_value", project.name), role: .destructive) {
-                    removeWorkspace(project)
-                }
-            }
-            Button(L10n.text("ui.cancel"), role: .cancel) {
-                pendingWorkspaceRemoval = nil
-            }
-        } message: {
-            Text(L10n.text("ui.removing_a_directory_only_removes_it_from_the_workspace"))
         }
         .background(tokens.background.ignoresSafeArea())
     }
@@ -464,7 +440,7 @@ struct WorkspaceRootView: View {
                                     tokens: tokens,
                                     action: {},
                                     onOpenGitChanges: {},
-                                    onRemove: {}
+                                    onConfirmRemove: {}
                                 )
                                 .frame(width: WorkspaceStripLayout.cardWidth)
                                 .redacted(reason: .placeholder)
@@ -520,10 +496,8 @@ struct WorkspaceRootView: View {
                                     selectedWorkspaceID = project.id
                                 } onOpenGitChanges: {
                                     gitInspectionTarget = WorkspaceGitInspectionTarget(project: project)
-                                } onRemove: {
-                                    // 当前浏览中的卡片不允许移除；用户需先切到正确工作区，再处理误开的目录。
-                                    guard selectedWorkspaceID != project.id else { return }
-                                    pendingWorkspaceRemoval = project
+                                } onConfirmRemove: {
+                                    removeWorkspace(project)
                                 }
                                 .frame(width: WorkspaceStripLayout.cardWidth)
                                 .id(project.id)
@@ -631,7 +605,6 @@ struct WorkspaceRootView: View {
     }
 
     private func removeWorkspace(_ project: AgentProject) {
-        pendingWorkspaceRemoval = nil
         guard selectedWorkspaceID != project.id else { return }
         sessionLoadStates.removeValue(forKey: project.id)
         sessionStore.forgetWorkspace(project)
@@ -751,8 +724,9 @@ private struct WorkspaceLibraryCard: View {
     let tokens: ThemeTokens
     let action: () -> Void
     let onOpenGitChanges: () -> Void
-    let onRemove: () -> Void
+    let onConfirmRemove: () -> Void
     @State private var isPresentingIconPicker = false
+    @State private var isPresentingRemoveConfirmation = false
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -777,9 +751,12 @@ private struct WorkspaceLibraryCard: View {
                 }
 
                 if !isSelected {
-                    Button(role: .destructive, action: onRemove) {
+                    Button(role: .destructive) {
+                        isPresentingRemoveConfirmation = true
+                    } label: {
                         Label(L10n.text("ui.remove_directory"), systemImage: "xmark.circle")
                     }
+                    .accessibilityIdentifier("workspace.remove.request.\(project.id)")
                 }
             } label: {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "ellipsis.circle")
@@ -790,6 +767,24 @@ private struct WorkspaceLibraryCard: View {
             }
             .menuStyle(.button)
             .accessibilityLabel(L10n.text("ui.workspace_actions"))
+            .accessibilityIdentifier("workspace.card.actions.\(project.id)")
+            // iPad 会把 confirmationDialog 适配成 popover；必须挂在真实的 44pt 操作源上，
+            // 让系统在旋转和分栏宽度变化时从当前卡片计算箭头与安全区域，而不是使用整页根视图。
+            .confirmationDialog(
+                L10n.text("ui.remove_directory"),
+                isPresented: $isPresentingRemoveConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(L10n.format("ui.remove_directory_value", project.name), role: .destructive) {
+                    onConfirmRemove()
+                }
+                .accessibilityIdentifier("workspace.remove.confirm.\(project.id)")
+                Button(L10n.text("ui.cancel"), role: .cancel) {
+                    isPresentingRemoveConfirmation = false
+                }
+            } message: {
+                Text(L10n.text("ui.removing_a_directory_only_removes_it_from_the_workspace"))
+            }
             .padding(.top, 4)
             .padding(.trailing, 2)
 

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -370,6 +370,61 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         add(pickerScreenshot)
     }
 
+    func testWorkspaceRemoveDirectoryConfirmationAnchorsToCardAcrossIPadLayouts() throws {
+        try XCTSkipUnless(
+            UIDevice.current.userInterfaceIdiom == .pad,
+            "目录移除确认的 popover 锚点只在 iPad regular width 下验收。"
+        )
+        try relaunchDirectlyIntoWorkspaces()
+
+        let projectID = "debug-sample-app"
+        for (orientation, attachmentName) in [
+            (UIDeviceOrientation.landscapeLeft, "landscape-sidebar"),
+            (.portrait, "portrait")
+        ] {
+            rotate(to: orientation)
+
+            let source = app.descendant(identifier: "workspace.card.actions.\(projectID)")
+            XCTAssertTrue(source.waitForExistence(timeout: 10), "旋转后工作区卡片操作入口应保持可见")
+            assertMinimumTouchTarget(source, named: "工作区卡片操作入口")
+            source.tap()
+
+            let request = app.descendant(identifier: "workspace.remove.request.\(projectID)")
+            XCTAssertTrue(request.waitForExistence(timeout: 6), "卡片菜单应提供移除目录入口")
+            request.tap()
+
+            let confirmation = app.descendant(identifier: "workspace.remove.confirm.\(projectID)")
+            XCTAssertTrue(confirmation.waitForExistence(timeout: 8), "移除目录后应展示系统确认弹窗")
+            assertPopover(confirmation, isAnchoredNear: source)
+
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = "workspace-remove-confirmation-\(attachmentName)"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+
+            dismissPresentedMenuOrPopover()
+            XCTAssertTrue(
+                confirmation.waitForNonExistence(timeout: 6),
+                "点击弹窗外部应取消移除并关闭确认弹窗"
+            )
+            XCTAssertTrue(source.exists, "取消后工作区仍应保留在列表中")
+        }
+
+        let source = app.descendant(identifier: "workspace.card.actions.\(projectID)")
+        source.tap()
+        let request = app.descendant(identifier: "workspace.remove.request.\(projectID)")
+        XCTAssertTrue(request.waitForExistence(timeout: 6))
+        request.tap()
+        let confirmation = app.descendant(identifier: "workspace.remove.confirm.\(projectID)")
+        XCTAssertTrue(confirmation.waitForExistence(timeout: 8))
+        confirmation.tap()
+
+        XCTAssertTrue(
+            source.waitForNonExistence(timeout: 8),
+            "确认后只应从当前工作区列表移除 Debug 样例目录"
+        )
+    }
+
     func testWorkspaceIconStyleSwitchesBetweenEmojiAndJourney() throws {
         try enterWorkbenchIfNeeded()
         try openWorkspaceAppearanceSettings()
@@ -529,6 +584,31 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         // 真机读取的是系统最终命中矩形，可同时覆盖 SwiftUI 内容形状和平台适配结果。
         XCTAssertGreaterThanOrEqual(element.frame.width, 44, "\(name)宽度应至少为 44pt", file: file, line: line)
         XCTAssertGreaterThanOrEqual(element.frame.height, 44, "\(name)高度应至少为 44pt", file: file, line: line)
+    }
+
+    private func assertPopover(
+        _ confirmation: XCUIElement,
+        isAnchoredNear source: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let windowFrame = app.windows.firstMatch.frame
+        let confirmationFrame = confirmation.frame
+        let sourceFrame = source.frame
+
+        XCTAssertGreaterThanOrEqual(confirmationFrame.minX, windowFrame.minX, file: file, line: line)
+        XCTAssertLessThanOrEqual(confirmationFrame.maxX, windowFrame.maxX, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(confirmationFrame.minY, windowFrame.minY, file: file, line: line)
+        XCTAssertLessThanOrEqual(confirmationFrame.maxY, windowFrame.maxY, file: file, line: line)
+        // 系统确认按钮与 source rect 的中心应保持在一个 popover 宽度内；
+        // 旧实现挂在整页根视图时，两者会横跨主内容与左侧会话栏。
+        XCTAssertLessThanOrEqual(
+            abs(confirmationFrame.midX - sourceFrame.midX),
+            max(confirmationFrame.width, 360),
+            "确认弹窗必须锚定在对应卡片操作入口附近",
+            file: file,
+            line: line
+        )
     }
 
     private func openComposerIfNeeded() throws {


### PR DESCRIPTION
## 目标

让 iPad 工作区卡片的移除目录确认弹窗稳定锚定到当前卡片操作控件，不再覆盖左侧会话列表。

## 实现

- 将 confirmationDialog 从工作区根视图移动到卡片自身的 44×44 pt Menu 操作源。
- 由卡片保存确认弹窗状态，继续复用既有 removeWorkspace / forgetWorkspace 数据链路。
- 增加稳定的 VoiceOver / UI 测试标识。
- 新增 iPad UI 回归，覆盖横屏带侧栏、竖屏、安全区、锚点距离、取消与确认。

## 验证

- iPad Pro 13-inch (M5) Simulator：定向 UI 测试 1/1 通过。
- WorkspaceVisualSnapshotTests：1/1 通过。
- ConversationDataFlowTests.testForgetWorkspaceClearsUnavailableMark：1/1 通过。
- accessibility-medium Dynamic Type 运行态检查通过；确认文案完整、箭头指向卡片操作控件、未超出安全区。
- 完整测试尝试共执行 912 项，发现 7 个与本改动无关的既有快照精度差异；相关定向测试均通过。

## 影响范围

仅调整确认弹窗呈现位置、锚点和可访问性测试标识；不修改目录移除数据语义，不删除 Mac 文件。