### PR TITLE
MIM-23 在 iOS 历史会话中标记已读与未读

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -11548,6 +11548,24 @@
         }
       }
     },
+    "ui.unread_result" : {
+      "comment" : "Accessibility value for a history session that has a new completed result the user has not opened.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unread result"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未读结果"
+          }
+        }
+      }
+    },
     "ui.host_in_parentheses" : {
       "comment" : "Endpoint host enclosed in language-appropriate parentheses.",
       "localizations" : {

--- a/ios/MimiRemote/Sources/Features/Projects/ProjectSidebarView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/ProjectSidebarView.swift
@@ -971,6 +971,7 @@ private struct ProjectSessionRows: View {
                 isArchived: isArchived,
                 reminder: reminder,
                 isObserving: sessionStore.isSessionObserving(session),
+                isUnread: sessionStore.isHistorySessionUnread(session),
                 searchSnippet: sessionStore.sessionSearchSnippet(for: session.id),
                 themeRenderKey: themeRenderKey
             )
@@ -1140,6 +1141,7 @@ private struct SessionRow: View, Equatable {
     let isArchived: Bool
     let reminder: SessionReminder?
     let isObserving: Bool
+    let isUnread: Bool
     let searchSnippet: String?
     let themeRenderKey: SidebarThemeRenderKey
 
@@ -1151,6 +1153,7 @@ private struct SessionRow: View, Equatable {
             && lhs.isArchived == rhs.isArchived
             && lhs.reminder == rhs.reminder
             && lhs.isObserving == rhs.isObserving
+            && lhs.isUnread == rhs.isUnread
             && lhs.searchSnippet == rhs.searchSnippet
             // 主题 key 让色彩/字体 token 变化能刷新，但仍避免流式状态更新重绘所有侧栏行。
             && lhs.themeRenderKey == rhs.themeRenderKey
@@ -1187,6 +1190,9 @@ private struct SessionRow: View, Equatable {
                     .foregroundStyle(isSelected ? tokens.primaryText : tokens.secondaryText)
                     .lineLimit(1)
                     .layoutPriority(1)
+                if isUnread {
+                    SessionUnreadIndicator()
+                }
                 Spacer(minLength: 8)
                 trailingMetadata
             }
@@ -1229,6 +1235,8 @@ private struct SessionRow: View, Equatable {
         }
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         .onHover { isHovered = $0 }
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(isUnread ? L10n.text("ui.unread_result") : "")
     }
 
     @ViewBuilder

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -563,6 +563,7 @@ struct WorkspaceRootView: View {
         return WorkspaceDetailView(
             // 工作区详情承担完整历史浏览，展示所有已加载页；项目侧栏才保留 5 条预览窗口。
             recentSessions: sessionStore.sessions(forProjectID: project.id),
+            unreadHistorySessionIDs: sessionStore.unreadHistorySessionIDs,
             sessionLoadState: loadState,
             canLoadMoreSessions: sessionStore.canLoadMoreSessions(projectID: project.id),
             claudeChannelAvailable: sessionStore.hasClaudeRuntimeChannel,
@@ -1341,6 +1342,7 @@ private struct WorkspaceDetailView: View {
     @State private var isLoadingMoreSessions = false
 
     let recentSessions: [AgentSession]
+    let unreadHistorySessionIDs: Set<SessionID>
     let sessionLoadState: WorkspaceSessionLoadState
     let canLoadMoreSessions: Bool
     let claudeChannelAvailable: Bool
@@ -1635,10 +1637,17 @@ private struct WorkspaceDetailView: View {
                 )
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(session.title)
-                    .font(themeStore.uiFont(.callout, weight: .medium))
-                    .foregroundStyle(tokens.primaryText)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(session.title)
+                        .font(themeStore.uiFont(.callout, weight: .medium))
+                        .foregroundStyle(tokens.primaryText)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+
+                    if unreadHistorySessionIDs.contains(session.id) {
+                        SessionUnreadIndicator()
+                    }
+                }
 
                 HStack(spacing: 6) {
                     if let branch = session.gitBranchName {
@@ -1693,6 +1702,12 @@ private struct WorkspaceDetailView: View {
         .padding(.horizontal, 14)
         .frame(minHeight: 62)
         .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(
+            unreadHistorySessionIDs.contains(session.id)
+                ? L10n.text("ui.unread_result")
+                : ""
+        )
     }
 
     private func shouldShowRecentSessionStatus(

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -44,6 +44,27 @@ struct SessionRuntimePresentation: Equatable {
     }
 }
 
+/// 未读只是一条历史结果的轻量提示，不承担进行状态，也不参与点击命中区域。
+/// 视觉点隐藏给 VoiceOver，完整语义由会话行的 accessibilityValue 提供。
+struct SessionUnreadIndicator: View {
+    @EnvironmentObject private var themeStore: ThemeStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+
+        Circle()
+            .fill(tokens.primaryAction)
+            .frame(width: 7, height: 7)
+            .overlay {
+                Circle()
+                    .stroke(tokens.background.opacity(0.72), lineWidth: 0.75)
+            }
+            .fixedSize()
+            .accessibilityHidden(true)
+    }
+}
+
 /// 会话列表里的运行时标识使用中性胶囊承载品牌图标和名称。
 /// 它需要比普通元数据更容易扫读，但不能抢过会话标题和需要处理的状态。
 struct SessionRuntimeBadge: View {
@@ -412,11 +433,20 @@ struct SessionListView: View {
                 reminder: sessionStore.sessionReminder(for: session.id),
                 isObserving: sessionStore.isSessionObserving(session),
                 isExternalReadOnly: sessionStore.isExternalReadOnlySession(session),
+                isUnread: sessionStore.isHistorySessionUnread(session),
                 style: .library,
                 searchSnippet: sessionStore.sessionSearchSnippet(for: session.id)
             )
             .contentShape(Rectangle())
             .onTapGesture { select(session) }
+            .accessibilityElement(children: .combine)
+            .accessibilityValue(
+                sessionStore.isHistorySessionUnread(session)
+                    ? L10n.text("ui.unread_result")
+                    : ""
+            )
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction { select(session) }
             .accessibilityIdentifier("sessions.row.\(session.id)")
             .sessionRowActions(session)
             .listRowInsets(.init(top: 4, leading: 20, bottom: 4, trailing: 20))
@@ -513,6 +543,7 @@ struct SessionIndexRow: View {
     let reminder: SessionReminder?
     let isObserving: Bool
     let isExternalReadOnly: Bool
+    var isUnread = false
     let style: SessionIndexRowStyle
     var searchSnippet: String? = nil
 
@@ -527,6 +558,10 @@ struct SessionIndexRow: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .layoutPriority(1)
+
+                if isUnread {
+                    SessionUnreadIndicator()
+                }
 
                 Spacer(minLength: 8)
 

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -790,9 +790,15 @@ struct UnifiedWorkbenchShell: View {
                 reminder: sessionStore.sessionReminder(for: session.id),
                 isObserving: sessionStore.isSessionObserving(session),
                 isExternalReadOnly: sessionStore.isExternalReadOnlySession(session),
+                isUnread: sessionStore.isHistorySessionUnread(session),
                 style: .sidebar
             )
         }
+        .accessibilityValue(
+            sessionStore.isHistorySessionUnread(session)
+                ? L10n.text("ui.unread_result")
+                : ""
+        )
         .sessionRowActions(session)
         .listRowInsets(.init(top: 2, leading: 8, bottom: 2, trailing: 8))
         .listRowSeparator(.hidden)

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -633,6 +633,10 @@ final class AppStore: ObservableObject {
     var shouldSeedDebugMCPApprovalUI: Bool {
         debugLaunchConfiguration.seedsMCPApprovalUI
     }
+
+    var shouldSeedDebugHistoryUnreadUI: Bool {
+        debugLaunchConfiguration.seedsHistoryUnreadUI
+    }
 #endif
 
     func client() throws -> AgentAPIClient {
@@ -1922,6 +1926,7 @@ private struct DebugLaunchConfiguration {
     let seedsWorkbenchUI: Bool
     let seedsQueuedTurnsUI: Bool
     let seedsMCPApprovalUI: Bool
+    let seedsHistoryUnreadUI: Bool
     let endpoint: String?
     let token: String?
 
@@ -1932,15 +1937,19 @@ private struct DebugLaunchConfiguration {
             || boolValue(environment["MIMI_DEBUG_SEED_QUEUE_UI"])
         let seedsMCPApprovalUI = arguments.contains("--debug-seed-mcp-approval-ui")
             || boolValue(environment["MIMI_DEBUG_SEED_MCP_APPROVAL_UI"])
+        let seedsHistoryUnreadUI = arguments.contains("--debug-seed-history-unread-ui")
+            || boolValue(environment["MIMI_DEBUG_SEED_HISTORY_UNREAD_UI"])
         return DebugLaunchConfiguration(
             opensWorkbenchWithoutPairing: arguments.contains("--debug-skip-pairing")
                 || boolValue(environment["MIMI_DEBUG_SKIP_PAIRING"]),
             seedsWorkbenchUI: arguments.contains("--debug-seed-ui")
                 || boolValue(environment["MIMI_DEBUG_SEED_UI"])
                 || seedsQueuedTurnsUI
-                || seedsMCPApprovalUI,
+                || seedsMCPApprovalUI
+                || seedsHistoryUnreadUI,
             seedsQueuedTurnsUI: seedsQueuedTurnsUI,
             seedsMCPApprovalUI: seedsMCPApprovalUI,
+            seedsHistoryUnreadUI: seedsHistoryUnreadUI,
             endpoint: argumentValue(named: "--debug-endpoint", in: arguments)
                 ?? environment["MIMI_DEBUG_ENDPOINT"],
             token: argumentValue(named: "--debug-token", in: arguments)

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -51,6 +51,7 @@ final class SessionStore: ObservableObject {
     @Published var isLoadingMoreSessionSearchResults = false
     @Published var pinnedSessionIDs: Set<SessionID> = []
     @Published var archivedSessionIDs: Set<SessionID> = []
+    @Published private(set) var unreadHistorySessionIDs: Set<SessionID> = []
     @Published var sessionWorkspaceIDs: Set<String>? = nil
     @Published var sessionRemindersByID: [SessionID: SessionReminder] = [:]
     @Published var selectedProjectID: String?
@@ -150,6 +151,13 @@ final class SessionStore: ObservableObject {
         connectionSwitchTargetProfileID = profileID
     }
 
+    func setUnreadHistorySessionIDs(_ value: Set<SessionID>) {
+        guard unreadHistorySessionIDs != value else {
+            return
+        }
+        unreadHistorySessionIDs = value
+    }
+
     let appStore: AppStore
     let conversationStore: ConversationStore
     let logStore: LogStore
@@ -157,6 +165,7 @@ final class SessionStore: ObservableObject {
     let eventReducer: EventReducer
     let recentWorkspaceStore: RecentWorkspaceStore
     let sessionListPreferenceStore: SessionListPreferenceStore
+    let sessionHistoryReadStateStore: SessionHistoryReadStateStore
     let sessionControlStateStore: SessionControlStateStore
     let sessionReminderStore: SessionReminderStore
     let sessionReminderScheduler: any SessionReminderScheduling
@@ -255,6 +264,7 @@ final class SessionStore: ObservableObject {
     var deliveredRuntimeNotificationIDs: Set<String> = []
     var locallyCompletedSessionIDs: Set<SessionID> = []
     var locallyCompletedGoalThreadIDs: Set<SessionID> = []
+    var historyReadStateBySessionID: [SessionID: SessionHistoryReadState] = [:]
     var listProjectionBySessionID: [SessionID: SessionListProjection] = [:]
     var recentActivityProjectionBySessionID: [SessionID: SessionRecentActivityProjection] = [:]
     // 队列订阅不依赖当前页面；用户切到其他会话后，原 thread 仍能在完成时继续 FIFO 派发。
@@ -357,6 +367,7 @@ final class SessionStore: ObservableObject {
         contextStore: SessionContextStore? = nil,
         recentWorkspaceStore: RecentWorkspaceStore? = nil,
         sessionListPreferenceStore: SessionListPreferenceStore? = nil,
+        sessionHistoryReadStateStore: SessionHistoryReadStateStore? = nil,
         sessionControlStateStore: SessionControlStateStore? = nil,
         sessionReminderStore: SessionReminderStore? = nil,
         historySavingsNoticeStore: HistorySavingsNoticeStore? = nil,
@@ -413,6 +424,14 @@ final class SessionStore: ObservableObject {
             self.sessionListPreferenceStore = SessionListPreferenceStore(defaults: defaults)
         } else {
             self.sessionListPreferenceStore = SessionListPreferenceStore()
+        }
+        if let sessionHistoryReadStateStore {
+            self.sessionHistoryReadStateStore = sessionHistoryReadStateStore
+        } else if clientFactory != nil {
+            let defaults = UserDefaults(suiteName: "SessionStore.HistoryReadStates.\(UUID().uuidString)") ?? .standard
+            self.sessionHistoryReadStateStore = SessionHistoryReadStateStore(defaults: defaults)
+        } else {
+            self.sessionHistoryReadStateStore = SessionHistoryReadStateStore()
         }
         if let sessionControlStateStore {
             self.sessionControlStateStore = sessionControlStateStore
@@ -492,6 +511,7 @@ final class SessionStore: ObservableObject {
         self.externalActivitySleep = externalActivitySleep
         self.dismissedHistorySavingsNoticeEndpoints = self.historySavingsNoticeStore.loadDismissedEndpoints()
         reloadSessionListPreferences()
+        reloadHistoryReadStates()
         reloadSessionControlStates()
         reloadSessionReminders()
         reloadQueuedTurns()

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -1242,6 +1242,7 @@ extension SessionStore {
             )
         )
         reloadSessionListPreferences()
+        reloadHistoryReadStates()
         reloadSessionControlStates()
         reloadSessionReminders()
     }
@@ -1277,6 +1278,129 @@ extension SessionStore {
             ),
             profileID: appStore.notificationRoutingProfileID
         )
+    }
+
+    func reloadHistoryReadStates() {
+        let loaded = sessionHistoryReadStateStore.load(
+            profileID: appStore.notificationRoutingProfileID,
+            legacyEndpoint: appStore.endpoint,
+            profiles: appStore.connectionProfiles
+        )
+        if historyReadStateBySessionID != loaded {
+            historyReadStateBySessionID = loaded
+        }
+        synchronizeHistoryReadStates()
+    }
+
+    /// 把会话快照归并到本机已读水位。初次见到的旧历史直接建立已读基线，避免升级后
+    /// 所有旧会话一起亮点；只有观察到运行结束或稳定完成版本变化时才产生未读。
+    func synchronizeHistoryReadStates() {
+        var next = historyReadStateBySessionID
+        var didChange = false
+
+        for session in sessions where !session.isLocalDraft {
+            var state = next[session.id] ?? SessionHistoryReadState()
+            let previousState = state
+
+            if session.isRunning {
+                state.observedRunning = true
+                if let activeTurnID = normalizedCompletionTurnID(session.activeTurnID) {
+                    state.pendingTurnID = activeTurnID
+                }
+            } else {
+                let version = SessionCompletionVersion(
+                    session: session,
+                    completedTurnID: state.observedRunning ? state.pendingTurnID : nil
+                )
+                guard version.hasStableSignal else {
+                    continue
+                }
+
+                if let latest = state.latestCompletion {
+                    if latest.representsSameCompletion(as: version) {
+                        let wasRead = state.readCompletion?.representsSameCompletion(as: latest) == true
+                        let merged = latest.merging(version)
+                        state.latestCompletion = merged
+                        if selectedSessionID == session.id || wasRead {
+                            state.readCompletion = merged
+                        }
+                    } else {
+                        state.latestCompletion = version
+                        if selectedSessionID == session.id {
+                            state.readCompletion = version
+                        }
+                    }
+                } else {
+                    state.latestCompletion = version
+                    // 旧历史首次进入索引时视为已读；从已观察运行态进入终态才是新结果。
+                    if !state.observedRunning || selectedSessionID == session.id {
+                        state.readCompletion = version
+                    }
+                }
+                state.observedRunning = false
+                state.pendingTurnID = nil
+            }
+
+            if state != previousState {
+                next[session.id] = state
+                didChange = true
+            }
+        }
+
+        if didChange {
+            historyReadStateBySessionID = next
+            sessionHistoryReadStateStore.save(
+                next,
+                profileID: appStore.notificationRoutingProfileID
+            )
+        }
+        publishUnreadHistorySessionIDs(from: next)
+    }
+
+    func isHistorySessionUnread(_ session: AgentSession) -> Bool {
+        !session.isRunning
+            && !session.isLocalDraft
+            && unreadHistorySessionIDs.contains(session.id)
+    }
+
+    func markHistorySessionRead(_ sessionID: SessionID) {
+        guard let session = sessionsByID[sessionID],
+              !session.isRunning,
+              !session.isLocalDraft else {
+            return
+        }
+        synchronizeHistoryReadStates()
+        guard var state = historyReadStateBySessionID[sessionID],
+              let latest = state.latestCompletion,
+              state.readCompletion?.representsSameCompletion(as: latest) != true else {
+            return
+        }
+        state.readCompletion = latest
+        historyReadStateBySessionID[sessionID] = state
+        sessionHistoryReadStateStore.save(
+            historyReadStateBySessionID,
+            profileID: appStore.notificationRoutingProfileID
+        )
+        publishUnreadHistorySessionIDs(from: historyReadStateBySessionID)
+    }
+
+    private func publishUnreadHistorySessionIDs(
+        from states: [SessionID: SessionHistoryReadState]
+    ) {
+        let visibleUnreadIDs = Set(sessions.lazy.compactMap { session -> SessionID? in
+            guard !session.isRunning,
+                  !session.isLocalDraft,
+                  states[session.id]?.isUnread == true else {
+                return nil
+            }
+            return session.id
+        })
+        setUnreadHistorySessionIDs(visibleUnreadIDs)
+    }
+
+    private func normalizedCompletionTurnID(_ value: TurnID?) -> TurnID? {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized?.isEmpty == false ? normalized : nil
     }
 
     func setSessionWorkspaceIDs(_ value: Set<String>?) {
@@ -1910,6 +2034,7 @@ extension SessionStore {
         capabilityErrorMessage = nil
         isRefreshingCapabilities = false
         reloadSessionListPreferences()
+        reloadHistoryReadStates()
         reloadSessionControlStates()
         reloadSessionReminders()
         foregroundActivityBySessionID = [:]

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -1941,6 +1941,7 @@ extension SessionStore {
         }
         sessionsByID = byID
         sessionIndexByID = indexByID
+        synchronizeHistoryReadStates()
         pruneSessionScopedState(validSessionIDs: Set(byID.keys))
 
         // 和 Codex/Litter 的 snapshot 思路一致：Store 在数据变更时生成排序/分组投影，

--- a/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
@@ -86,6 +86,7 @@ extension SessionStore {
         terminalStreamStore.removeAll(profileID: profileID)
         recentWorkspaceStore.remove(profileID: profileID)
         sessionListPreferenceStore.remove(profileID: profileID)
+        sessionHistoryReadStateStore.remove(profileID: profileID)
         sessionControlStateStore.remove(profileID: profileID)
         sessionReminderStore.remove(profileID: profileID)
         sessionReminderScheduler.cancel(profileID: profileID)

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -98,6 +98,7 @@ extension SessionStore {
         )
         let selectedSessionID = "debug-session-layout"
         let runningSessionID = "debug-session-running"
+        let historySessionID = "debug-session-workspace"
         // MCP 审批样例只在显式 Debug 参数下出现，用于真机检查 Codex 声明的
         // 一次、会话和永久信任入口；不连接真实 MCP，也不会写入用户授权配置。
         let mcpApproval = appStore.shouldSeedDebugMCPApprovalUI
@@ -145,7 +146,7 @@ extension SessionStore {
                 activeTurnID: "debug-turn-running"
             ),
             AgentSession(
-                id: "debug-session-workspace",
+                id: historySessionID,
                 projectID: sampleApp.id,
                 project: sampleApp.name,
                 dir: sampleApp.path,
@@ -207,11 +208,28 @@ extension SessionStore {
         sessionWorkspaceIDs = nil
         setExpandedProjectIDs([mimiDemo.id])
         replaceSessionsIfChanged(with: sessions, projectID: nil)
+        if appStore.shouldSeedDebugHistoryUnreadUI,
+           var unreadCandidate = sessions.first(where: { $0.id == historySessionID }) {
+            // 先让未选中的历史会话经历一次“运行中 → 新完成”，以复用生产判定链路。
+            // 该参数只服务 iPhone/iPad 运行态验收，不污染普通 Debug 种子与快照。
+            unreadCandidate.status = SessionStatus.running.rawValue
+            unreadCandidate.activeTurnID = "debug-turn-history-unread"
+            unreadCandidate.updatedAt = now.addingTimeInterval(-60)
+            unreadCandidate.recencyAt = now.addingTimeInterval(-60)
+            upsert(unreadCandidate)
+
+            unreadCandidate.status = SessionStatus.completed.rawValue
+            unreadCandidate.activeTurnID = nil
+            unreadCandidate.updatedAt = now.addingTimeInterval(-30)
+            unreadCandidate.recencyAt = now.addingTimeInterval(-30)
+            upsert(unreadCandidate)
+        }
         _ = commitSelection(
             projectID: mimiDemo.id,
             sessionID: appStore.shouldSeedDebugQueuedTurnsUI ? runningSessionID : selectedSessionID,
             reason: .userOpen
         )
+        markHistorySessionRead(selectedSessionID)
         if appStore.shouldSeedDebugQueuedTurnsUI {
             // 队列样例需要处于可控的运行中会话，才能同时验收“排队（默认）/引导”切换；
             // 普通 Debug 工作台仍保留原来的观察态样例，不改变其接管流程覆盖。

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -230,6 +230,175 @@ enum ProfileScopedPersistence {
     }
 }
 
+/// 历史会话的“完成版本”只使用服务端会话快照里稳定、可跨刷新恢复的水位。
+///
+/// 比较时优先使用双方都具备的最高等级信号，而不是把所有字段拼成哈希：
+/// app-server 的轻量列表和实时事件携带字段不同，同一次完成在后续补齐 recencyAt / revision
+/// 时仍应视为同一版本；排序、分页和重连本身不会改变这些值。
+struct SessionCompletionVersion: Codable, Equatable {
+    var turnID: TurnID?
+    var recencyAt: Date?
+    var revision: ModelRevision?
+    var lastSeq: EventSequence?
+    var updatedAt: Date?
+
+    init(session: AgentSession, completedTurnID: TurnID? = nil) {
+        turnID = Self.normalizedID(completedTurnID)
+        recencyAt = session.recencyAt
+        revision = session.revision.flatMap { $0 > 0 ? $0 : nil }
+        lastSeq = session.lastSeq.flatMap { $0 > 0 ? $0 : nil }
+        updatedAt = session.updatedAt
+    }
+
+    var hasStableSignal: Bool {
+        turnID != nil || recencyAt != nil || revision != nil || lastSeq != nil || updatedAt != nil
+    }
+
+    func representsSameCompletion(as other: SessionCompletionVersion) -> Bool {
+        if let turnID, let otherTurnID = other.turnID {
+            return turnID == otherTurnID
+        }
+        if let recencyAt, let otherRecencyAt = other.recencyAt {
+            return recencyAt == otherRecencyAt
+        }
+        if let revision, let otherRevision = other.revision {
+            return revision == otherRevision
+        }
+        if let lastSeq, let otherLastSeq = other.lastSeq {
+            return lastSeq == otherLastSeq
+        }
+        if let updatedAt, let otherUpdatedAt = other.updatedAt {
+            return updatedAt == otherUpdatedAt
+        }
+        return false
+    }
+
+    /// 同一次完成从实时态过渡到完整列表快照时，把新出现的稳定字段并入同一水位。
+    func merging(_ other: SessionCompletionVersion) -> SessionCompletionVersion {
+        SessionCompletionVersion(
+            turnID: other.turnID ?? turnID,
+            recencyAt: other.recencyAt ?? recencyAt,
+            revision: other.revision ?? revision,
+            lastSeq: other.lastSeq ?? lastSeq,
+            updatedAt: other.updatedAt ?? updatedAt
+        )
+    }
+
+    private init(
+        turnID: TurnID?,
+        recencyAt: Date?,
+        revision: ModelRevision?,
+        lastSeq: EventSequence?,
+        updatedAt: Date?
+    ) {
+        self.turnID = turnID
+        self.recencyAt = recencyAt
+        self.revision = revision
+        self.lastSeq = lastSeq
+        self.updatedAt = updatedAt
+    }
+
+    private static func normalizedID(_ value: String?) -> String? {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized?.isEmpty == false ? normalized : nil
+    }
+}
+
+struct SessionHistoryReadState: Codable, Equatable {
+    var latestCompletion: SessionCompletionVersion?
+    var readCompletion: SessionCompletionVersion?
+    var observedRunning = false
+    var pendingTurnID: TurnID?
+
+    var isUnread: Bool {
+        guard let latestCompletion else {
+            return false
+        }
+        guard let readCompletion else {
+            return true
+        }
+        return !readCompletion.representsSameCompletion(as: latestCompletion)
+    }
+}
+
+/// 已读水位按连接 Profile 隔离，避免不同 Mac 上碰巧相同的 thread ID 串读。
+/// UserDefaults 只保存每个会话的几个标量水位，不引入数据库或服务端协议。
+struct SessionHistoryReadStateStore {
+    typealias Storage = ProfileScopedStorage<[SessionID: SessionHistoryReadState]>
+
+    let defaults: UserDefaults
+    let key: String
+
+    init(defaults: UserDefaults = .standard, key: String = "agentd.sessionHistoryReadStates") {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func load(
+        profileID: String,
+        legacyEndpoint: String,
+        profiles: [ConnectionProfile]
+    ) -> [SessionID: SessionHistoryReadState] {
+        var storage = storage()
+        let didMigrate = storage.migrateLegacyValueIfUnique(
+            profileID: profileID,
+            endpoint: legacyEndpoint,
+            profiles: profiles
+        )
+        if didMigrate {
+            persist(storage)
+        }
+        guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID) else {
+            return profiles.isEmpty
+                ? storage.byEndpoint[AgentAPIClient.normalizedEndpoint(legacyEndpoint)] ?? [:]
+                : [:]
+        }
+        if let value = storage.byProfileID[profileKey] {
+            return value
+        }
+        if profiles.isEmpty {
+            return storage.byEndpoint[AgentAPIClient.normalizedEndpoint(legacyEndpoint)] ?? [:]
+        }
+        return [:]
+    }
+
+    func save(_ states: [SessionID: SessionHistoryReadState], profileID: String) {
+        guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID) else {
+            return
+        }
+        var storage = storage()
+        storage.byProfileID[profileKey] = states
+        persist(storage)
+    }
+
+    func remove(profileID: String) {
+        guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID) else {
+            return
+        }
+        var storage = storage()
+        guard storage.byProfileID.removeValue(forKey: profileKey) != nil else {
+            return
+        }
+        persist(storage)
+    }
+
+    private func storage() -> Storage {
+        guard let data = defaults.data(forKey: key),
+              let decoded = try? JSONDecoder().decode(Storage.self, from: data)
+        else {
+            return Storage()
+        }
+        return decoded
+    }
+
+    private func persist(_ storage: Storage) {
+        guard let data = try? JSONEncoder().encode(storage) else {
+            return
+        }
+        defaults.set(data, forKey: key)
+    }
+}
+
 struct SessionListPreferenceStore {
     typealias Storage = ProfileScopedStorage<SessionListPreferences>
 

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -484,6 +484,9 @@ extension SessionStore {
         ) else {
             return false
         }
+        // 选择提交意味着详情已经成为当前可见目标；历史加载即使随后失败，也不能让列表
+        // 继续把用户刚打开过的完成结果标成未读。
+        markHistorySessionRead(session.id)
         if wasNoOpSelection {
             return true
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -1573,6 +1573,210 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(sockets.count, 1)
     }
 
+    func testCompletionVersionIgnoresHydrationAndOrderingOnlyChanges() {
+        let original = AgentSession(
+            id: "session-version",
+            projectID: "project-version",
+            project: "project-version",
+            dir: "/tmp/project-version",
+            title: "完成版本",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            resumeID: "session-version",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 20),
+            recencyAt: Date(timeIntervalSince1970: 18)
+        )
+        let refreshedMetadata = AgentSession(
+            id: original.id,
+            projectID: original.projectID,
+            project: original.project,
+            dir: original.dir,
+            title: "刷新后标题",
+            status: original.status,
+            source: original.source,
+            resumeID: original.resumeID,
+            createdAt: original.createdAt,
+            updatedAt: Date(timeIntervalSince1970: 99),
+            recencyAt: original.recencyAt
+        )
+        let newCompletion = AgentSession(
+            id: original.id,
+            projectID: original.projectID,
+            project: original.project,
+            dir: original.dir,
+            title: original.title,
+            status: original.status,
+            source: original.source,
+            resumeID: original.resumeID,
+            createdAt: original.createdAt,
+            updatedAt: Date(timeIntervalSince1970: 30),
+            recencyAt: Date(timeIntervalSince1970: 30)
+        )
+
+        let originalVersion = SessionCompletionVersion(session: original)
+        XCTAssertTrue(
+            originalVersion.representsSameCompletion(
+                as: SessionCompletionVersion(session: refreshedMetadata)
+            ),
+            "recencyAt 未变化时，标题刷新和 updatedAt 元数据变化不能制造未读"
+        )
+        XCTAssertFalse(
+            originalVersion.representsSameCompletion(
+                as: SessionCompletionVersion(session: newCompletion)
+            )
+        )
+
+        let sparse = AgentSession(
+            id: original.id,
+            projectID: original.projectID,
+            project: original.project,
+            dir: original.dir,
+            title: original.title,
+            status: original.status,
+            source: original.source,
+            resumeID: original.resumeID,
+            createdAt: original.createdAt,
+            updatedAt: original.updatedAt
+        )
+        XCTAssertTrue(
+            SessionCompletionVersion(session: sparse).representsSameCompletion(
+                as: originalVersion
+            ),
+            "轻量列表后续补齐 recencyAt 时，应通过双方共有的 updatedAt 识别为同一次完成"
+        )
+    }
+
+    func testHistoryUnreadPersistsReadAndReopensForNextCompletion() async {
+        let suiteName = "ConversationSessionStoreTests.HistoryUnread.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let readStateStore = SessionHistoryReadStateStore(defaults: defaults)
+        let appStore = AppStore(defaults: defaults)
+        let project = makeProject(id: "project-unread")
+        let initialHistory = makeSession(
+            id: "session-unread",
+            projectID: project.id,
+            title: "初始旧历史",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            resumeID: "session-unread",
+            updatedAt: Date(timeIntervalSince1970: 10),
+            recencyAt: Date(timeIntervalSince1970: 10)
+        )
+        let conversationStore = ConversationStore()
+        conversationStore.setHistory([
+            CodexHistoryMessage(
+                id: "history-unread-message",
+                role: "assistant",
+                content: "已加载",
+                createdAt: Date(timeIntervalSince1970: 10)
+            )
+        ], sessionID: initialHistory.id)
+        let client = MockSessionStoreClient(projects: [project], sessions: [initialHistory])
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            sessionHistoryReadStateStore: readStateStore,
+            clientFactory: { client },
+            webSocketFactory: { MockWebSocketClient() }
+        )
+
+        store.sessions = [initialHistory]
+        XCTAssertFalse(store.isHistorySessionUnread(initialHistory), "升级后首次见到的旧历史应建立已读基线")
+
+        let running = makeSession(
+            id: initialHistory.id,
+            projectID: project.id,
+            title: "新一轮运行中",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            resumeID: initialHistory.resumeID,
+            activeTurnID: "turn-1",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            recencyAt: Date(timeIntervalSince1970: 20)
+        )
+        store.sessions = [running]
+        XCTAssertFalse(store.isHistorySessionUnread(running), "进行中会话不能显示历史未读")
+
+        let firstCompletion = makeSession(
+            id: initialHistory.id,
+            projectID: project.id,
+            title: "第一轮完成",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            resumeID: initialHistory.resumeID,
+            updatedAt: Date(timeIntervalSince1970: 21),
+            recencyAt: Date(timeIntervalSince1970: 21)
+        )
+        store.sessions = [firstCompletion]
+        XCTAssertTrue(store.isHistorySessionUnread(firstCompletion))
+
+        await store.selectSession(firstCompletion)
+        XCTAssertFalse(store.isHistorySessionUnread(firstCompletion), "打开历史会话后应立即标记已读")
+
+        let persisted = readStateStore.load(
+            profileID: appStore.notificationRoutingProfileID,
+            legacyEndpoint: appStore.endpoint,
+            profiles: appStore.connectionProfiles
+        )
+        XCTAssertFalse(try XCTUnwrap(persisted[firstCompletion.id]).isUnread)
+
+        let restartedStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            sessionHistoryReadStateStore: readStateStore,
+            clientFactory: { client },
+            webSocketFactory: { MockWebSocketClient() }
+        )
+        restartedStore.sessions = [firstCompletion]
+        XCTAssertFalse(
+            restartedStore.isHistorySessionUnread(firstCompletion),
+            "App 重启和列表重新加载后不能把已读状态回退"
+        )
+
+        restartedStore.returnToSessionList()
+        let secondRunning = makeSession(
+            id: firstCompletion.id,
+            projectID: project.id,
+            title: "第二轮运行中",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            resumeID: firstCompletion.resumeID,
+            activeTurnID: "turn-2",
+            updatedAt: Date(timeIntervalSince1970: 30),
+            recencyAt: Date(timeIntervalSince1970: 30)
+        )
+        restartedStore.sessions = [secondRunning]
+        XCTAssertFalse(restartedStore.isHistorySessionUnread(secondRunning))
+
+        let secondCompletion = makeSession(
+            id: firstCompletion.id,
+            projectID: project.id,
+            title: "第二轮完成",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            resumeID: firstCompletion.resumeID,
+            updatedAt: Date(timeIntervalSince1970: 31),
+            recencyAt: Date(timeIntervalSince1970: 31)
+        )
+        restartedStore.sessions = [secondCompletion]
+        XCTAssertTrue(
+            restartedStore.isHistorySessionUnread(secondCompletion),
+            "同一会话产生新的完成结果后应重新进入未读"
+        )
+
+        restartedStore.sessions = [secondCompletion]
+        XCTAssertTrue(
+            restartedStore.isHistorySessionUnread(secondCompletion),
+            "相同完成版本的重复刷新不能改变未读判定"
+        )
+    }
+
     func testSelectingHistorySessionKeepsSelectionWhenMessages404() async {
         let project = makeProject(id: "proj_1")
         let history = makeSession(id: "codex_missing", projectID: project.id, title: "缺失 rollout", status: "history", source: "codex", resumeID: "missing")


### PR DESCRIPTION
## 目标

让 iPhone / iPad 用户识别已经完成但尚未打开查看的历史会话，并在打开后持久化已读状态。

## 方案

- 以 Profile 隔离的本地 UserDefaults 保存每个会话的完成水位与已读水位，不增加服务端协议或新依赖。
- 完成版本优先比较 turn ID、recencyAt、revision、lastSeq 与 updatedAt 的双方共有稳定信号，避免排序、分页、重连和快照补字段制造误报。
- 初次见到的旧历史建立已读基线；观察到运行结束或完成版本变化时进入未读；打开会话后立即标记已读。
- 在 iPhone 会话库、iPad 侧栏和工作区最近会话中显示轻量圆点；进行中会话不显示；VoiceOver 将整行表达为“未读结果”。
- 增加隔离的 Debug 启动种子，仅用于 iPhone / iPad 运行态验收。

## 验证

- 相关测试：4/4 通过，覆盖完成版本稳定性、已读持久化、App 重启、列表重载、同会话新结果重新未读及相关列表快照。
- 完整测试：执行 919 项，功能测试与 MIM-23 新增测试通过；7 个既有 Composer / Skill 图片快照在当前 Xcode 27 beta 环境失败。已在同一 Simulator 上用原始 origin/main 临时 Worktree 复跑，失败项与像素精度完全一致，确认不是本分支回归。
- 运行态：iPad Pro 13-inch (M5) 与 iPhone 17 Pro 均完成构建、启动、未读显示、打开清除、返回列表及手动刷新验证；未发现标题截断、图标重叠或点击区域异常。辅助功能树仅播报一次“未读结果”。
- 公开仓库安全门禁、第三方许可门禁与 PR Gate 自检通过。

## 边界

仅包含 iOS 本地会话列表与已读状态持久化；不包含系统推送、App 角标、跨设备同步或 Mac UI。

Linear: MIM-23