### PR TITLE
MIM-7 允许取消语音输入准备

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -25399,6 +25399,23 @@
         }
       }
     },
+    "ui.tap_to_cancel_voice_input_preparation" : {
+      "comment" : "Accessibility hint for the enabled microphone button while its audio session is still preparing.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to cancel voice input preparation"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻点取消语音输入准备"
+          }
+        }
+      }
+    },
     "ui.tap_to_stop_apple_voice_input" : {
       "localizations" : {
         "en" : {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -779,13 +779,18 @@ extension ComposerView {
     }
 
     func toggleVoiceInput() {
-        guard !isVoiceTranscribing else {
-            return
-        }
-        if isVoicePressActive || voiceInput.isRecording {
-            endHoldToTalk()
-        } else {
+        switch VoiceInputToggleAction.resolve(
+            isPressActive: isVoicePressActive,
+            isPreparing: voiceInput.isPreparing,
+            isRecording: voiceInput.isRecording,
+            isTranscribing: isVoiceTranscribing
+        ) {
+        case .start:
             beginHoldToTalk()
+        case .end:
+            endHoldToTalk()
+        case .ignore:
+            break
         }
     }
 
@@ -1542,5 +1547,26 @@ extension ComposerView {
         case .text:
             return "text.alignleft"
         }
+    }
+}
+
+enum VoiceInputToggleAction: Equatable {
+    case start
+    case end
+    case ignore
+
+    static func resolve(
+        isPressActive: Bool,
+        isPreparing: Bool,
+        isRecording: Bool,
+        isTranscribing: Bool
+    ) -> Self {
+        if isTranscribing {
+            return .ignore
+        }
+        if isPressActive || isPreparing || isRecording {
+            return .end
+        }
+        return .start
     }
 }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -3,6 +3,82 @@ import AudioToolbox
 import SwiftUI
 import UIKit
 
+enum VoiceMicButtonState: Equatable {
+    case idle
+    case preparing
+    case recording
+    case transcribing
+
+    init(isPreparing: Bool, isRecording: Bool, isTranscribing: Bool) {
+        // 转写阶段必须优先：即使异步状态短暂重叠，也不能把不可重复触发的转写误报成可操作状态。
+        if isTranscribing {
+            self = .transcribing
+        } else if isRecording {
+            self = .recording
+        } else if isPreparing {
+            self = .preparing
+        } else {
+            self = .idle
+        }
+    }
+
+    var isEnabled: Bool {
+        self != .transcribing
+    }
+
+    var showsProgress: Bool {
+        self == .preparing || self == .transcribing
+    }
+
+    var isActive: Bool {
+        self != .idle
+    }
+
+    var accessibilityTitle: String {
+        switch self {
+        case .idle:
+            return L10n.text("ui.start_voice_input")
+        case .preparing:
+            return L10n.text("ui.end_voice_input")
+        case .recording:
+            return L10n.text("ui.stop_recording")
+        case .transcribing:
+            return L10n.text("ui.transcribing_speech")
+        }
+    }
+
+    var accessibilityValue: String {
+        switch self {
+        case .idle:
+            return L10n.text("ui.not_started")
+        case .preparing:
+            return L10n.text("ui.preparing")
+        case .recording:
+            return L10n.text("ui.recording")
+        case .transcribing:
+            return L10n.text("ui.transcribing")
+        }
+    }
+
+    func accessibilityHint(usesRealtimeTranscription: Bool) -> String {
+        switch self {
+        case .idle:
+            return usesRealtimeTranscription
+                ? L10n.text("ui.tap_to_start_apple_realtime_voice_input")
+                : L10n.text("ui.click_to_start_recording")
+        case .preparing:
+            return L10n.text("ui.tap_to_cancel_voice_input_preparation")
+        case .recording:
+            return usesRealtimeTranscription
+                ? L10n.text("ui.tap_to_stop_apple_voice_input")
+                : L10n.text("ui.tap_to_stop_recording_and_start_transcribing")
+        case .transcribing:
+            // 转写阶段按钮不可重复触发；标题和值已经完整表达状态，不再提供错误的操作提示。
+            return ""
+        }
+    }
+}
+
 struct VoiceMicButton: View {
     @EnvironmentObject private var themeStore: ThemeStore
     @Environment(\.colorScheme) private var colorScheme
@@ -16,19 +92,24 @@ struct VoiceMicButton: View {
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
+        let state = VoiceMicButtonState(
+            isPreparing: isPreparing,
+            isRecording: isRecording,
+            isTranscribing: isTranscribing
+        )
 
         Button(action: onTap) {
             Group {
-                if isPreparing || isTranscribing {
+                if state.showsProgress {
                     ProgressView()
                 } else {
-                    Image(systemName: isRecording ? "stop.fill" : "mic.fill")
+                    Image(systemName: state == .recording ? "stop.fill" : "mic.fill")
                 }
             }
             .font(themeStore.uiFont(size: 16, weight: .semibold))
             // 空闲态和其它工具按钮保持中性；录音、准备和转写才使用主题紫表达活动状态。
             .foregroundStyle(
-                isRecording || isPreparing || isTranscribing
+                state.isActive
                     ? tokens.primaryAction
                     : tokens.primaryText
             )
@@ -44,41 +125,11 @@ struct VoiceMicButton: View {
             .contentShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
         }
         .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
-        .disabled(isPreparing || isTranscribing)
-        .accessibilityLabel(accessibilityTitle)
-        .accessibilityValue(accessibilityValue)
-        .accessibilityHint(accessibilityHint)
-    }
-
-    private var accessibilityTitle: String {
-        if isRecording {
-            return L10n.text("ui.stop_recording")
-        }
-        if isPreparing {
-            return L10n.text("ui.preparing_microphone")
-        }
-        return isTranscribing ? L10n.text("ui.transcribing_speech") : L10n.text("ui.start_voice_input")
-    }
-
-    private var accessibilityValue: String {
-        if isRecording {
-            return L10n.text("ui.recording")
-        }
-        if isPreparing {
-            return L10n.text("ui.preparing")
-        }
-        return isTranscribing ? L10n.text("ui.transcribing") : L10n.text("ui.not_started")
-    }
-
-    private var accessibilityHint: String {
-        if isRecording {
-            return usesRealtimeTranscription
-                ? L10n.text("ui.tap_to_stop_apple_voice_input")
-                : L10n.text("ui.tap_to_stop_recording_and_start_transcribing")
-        }
-        return usesRealtimeTranscription
-            ? L10n.text("ui.tap_to_start_apple_realtime_voice_input")
-            : L10n.text("ui.click_to_start_recording")
+        // 准备音频会话可能耗时，必须允许用户再次点击取消；否则准备卡住时按钮会永久无响应。
+        .disabled(!state.isEnabled)
+        .accessibilityLabel(state.accessibilityTitle)
+        .accessibilityValue(state.accessibilityValue)
+        .accessibilityHint(state.accessibilityHint(usesRealtimeTranscription: usesRealtimeTranscription))
     }
 }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -370,6 +370,83 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(accumulator.text, "检查项目并补测试")
     }
 
+    func testVoiceInputToggleStateMachineCancelsPreparingAndIgnoresTranscribing() {
+        let scenarios: [
+            (
+                isPressActive: Bool,
+                isPreparing: Bool,
+                isRecording: Bool,
+                isTranscribing: Bool,
+                expected: VoiceInputToggleAction
+            )
+        ] = [
+            (false, false, false, false, .start),
+            (true, false, false, false, .end),
+            (false, true, false, false, .end),
+            (false, false, true, false, .end),
+            (true, true, false, false, .end),
+            (true, true, true, true, .ignore)
+        ]
+
+        for scenario in scenarios {
+            XCTAssertEqual(
+                VoiceInputToggleAction.resolve(
+                    isPressActive: scenario.isPressActive,
+                    isPreparing: scenario.isPreparing,
+                    isRecording: scenario.isRecording,
+                    isTranscribing: scenario.isTranscribing
+                ),
+                scenario.expected,
+                "state=\(scenario)"
+            )
+        }
+    }
+
+    func testPreparingVoiceMicButtonStateRemainsEnabledAndDescribesCancel() {
+        let state = VoiceMicButtonState(
+            isPreparing: true,
+            isRecording: false,
+            isTranscribing: false
+        )
+        let host = hostVoiceMicButton(
+            isPreparing: true,
+            isRecording: false,
+            isTranscribing: false
+        )
+        let fittedSize = host.sizeThatFits(in: CGSize(width: 200, height: 200))
+
+        XCTAssertTrue(state.isEnabled)
+        XCTAssertEqual(state.accessibilityTitle, L10n.text("ui.end_voice_input"))
+        XCTAssertEqual(state.accessibilityValue, L10n.text("ui.preparing"))
+        XCTAssertEqual(
+            state.accessibilityHint(usesRealtimeTranscription: false),
+            L10n.text("ui.tap_to_cancel_voice_input_preparation")
+        )
+        XCTAssertGreaterThanOrEqual(fittedSize.width, 44)
+        XCTAssertGreaterThanOrEqual(fittedSize.height, 44)
+    }
+
+    func testTranscribingVoiceMicButtonStateStaysDisabledAndHasNoActionHint() {
+        let state = VoiceMicButtonState(
+            isPreparing: false,
+            isRecording: false,
+            isTranscribing: true
+        )
+        let host = hostVoiceMicButton(
+            isPreparing: false,
+            isRecording: false,
+            isTranscribing: true
+        )
+        let fittedSize = host.sizeThatFits(in: CGSize(width: 200, height: 200))
+
+        XCTAssertFalse(state.isEnabled)
+        XCTAssertEqual(state.accessibilityTitle, L10n.text("ui.transcribing_speech"))
+        XCTAssertEqual(state.accessibilityValue, L10n.text("ui.transcribing"))
+        XCTAssertTrue(state.accessibilityHint(usesRealtimeTranscription: false).isEmpty)
+        XCTAssertGreaterThanOrEqual(fittedSize.width, 44)
+        XCTAssertGreaterThanOrEqual(fittedSize.height, 44)
+    }
+
     func testVoiceAudioSessionCoordinatorSerializesLifecycleAndIgnoresStaleCleanup() async throws {
         let backend = RecordingVoiceAudioSessionBackend()
         let coordinator = VoiceAudioSessionCoordinator(backend: backend)
@@ -2948,4 +3025,24 @@ private final class RecordingVoiceAudioSessionBackend: VoiceAudioSessionBackend,
             }
         }
     }
+}
+
+@MainActor
+private func hostVoiceMicButton(
+    isPreparing: Bool,
+    isRecording: Bool,
+    isTranscribing: Bool
+) -> UIHostingController<AnyView> {
+    let themeStore = ThemeStore()
+    let view = VoiceMicButton(
+        isPreparing: isPreparing,
+        isRecording: isRecording,
+        isTranscribing: isTranscribing,
+        usesRealtimeTranscription: false,
+        onTap: {}
+    )
+    .environmentObject(themeStore)
+    .frame(width: 44, height: 44)
+
+    return UIHostingController(rootView: AnyView(view))
 }


### PR DESCRIPTION
## 目标

修复语音输入准备音频会话耗时或卡住时，麦克风按钮被禁用、用户无法主动取消的问题。

## 改动

- 把麦克风按钮状态收敛为 idle / preparing / recording / transcribing；仅 transcribing 禁用。
- preparing 阶段保留 44×44 点击区，第二次点击立即走取消语义。
- 修正 VoiceOver 标题、状态值与操作提示；准备阶段明确提示可取消，转写阶段不提供错误操作提示。
- 补充状态机、SwiftUI 44×44 点击区和无障碍语义测试。

## 验证

- XcodeBuildMCP：MimiRemote Debug 构建并运行成功，无构建告警或错误。
- 5 个定向测试通过，0 失败：准备取消状态机、preparing/transcribing 按钮语义与尺寸、音频会话串行与失败传播。
- iOS 本地化静态检查与 String Catalog 编译通过。
- PR Gate、公开仓库安全检查、git diff --check 通过。

## 运行态

复用现有 iPhone 17 Pro（iOS 27.0）模拟器：在 Codex 语音提供方下对同一 composer.voice 目标连续点击两次，两次点击均成功接收，随后回到空闲麦克风形态且未进入转写。验证后已停止 App 并关闭模拟器。

说明：iOS 27 模拟器在音频会话切换后出现无障碍快照服务退化为单节点的基础设施现象；截图与进程日志未见 App 崩溃，不影响上述点击和状态结果。
