### PR TITLE
[MIM-9] 完善 Catalyst Keychain 与首次连接超时诊断

### DIFF
--- a/ios/MimiRemote/Resources/MimiRemote-Catalyst.entitlements
+++ b/ios/MimiRemote/Resources/MimiRemote-Catalyst.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.application-identifier</key>
+	<string>$(DEVELOPMENT_TEAM).$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 </dict>
 </plist>

--- a/ios/MimiRemote/Sources/Core/Security/TokenStore.swift
+++ b/ios/MimiRemote/Sources/Core/Security/TokenStore.swift
@@ -31,11 +31,15 @@ enum TokenStoreError: LocalizedError {
     case saveFailed(OSStatus)
     case deleteFailed(OSStatus)
 
-    var isMissingEntitlement: Bool {
+    private var status: OSStatus {
         switch self {
         case .loadFailed(let status), .saveFailed(let status), .deleteFailed(let status):
-            return status == errSecMissingEntitlement
+            return status
         }
+    }
+
+    var isMissingEntitlement: Bool {
+        status == errSecMissingEntitlement
     }
 
     var errorDescription: String? {
@@ -47,6 +51,34 @@ enum TokenStoreError: LocalizedError {
         case .deleteFailed(let status):
             return L10n.format("ui.failed_to_delete_token_value", status)
         }
+    }
+
+    /// 只允许展示由本地受信任模板生成的 Keychain 诊断。
+    ///
+    /// 不能仅凭字符串包含 “token”/“keychain” 就透传原文；服务端错误或历史缓存文本
+    /// 可能把真实访问码拼进消息。这里要求整段文本与某个 OSStatus 的本地化模板完全一致，
+    /// 既保留 -34018 等原始诊断码，也不会带出 Keychain 内容。
+    static func validatedUserFacingDescription(_ raw: String) -> String? {
+        let statusValues = raw
+            .split(whereSeparator: { !$0.isNumber && $0 != "-" })
+            .compactMap { value -> Int32? in
+                guard let parsed = Int(value) else {
+                    return nil
+                }
+                return Int32(exactly: parsed)
+            }
+
+        for status in Set(statusValues) {
+            let trustedDescriptions = [
+                TokenStoreError.loadFailed(status).localizedDescription,
+                TokenStoreError.saveFailed(status).localizedDescription,
+                TokenStoreError.deleteFailed(status).localizedDescription
+            ]
+            if trustedDescriptions.contains(raw) {
+                return raw
+            }
+        }
+        return nil
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -968,6 +968,10 @@ struct InitialConnectionSettingsSections: View {
         if lowercased.contains("timed out") || lowercased.contains("cannot connect") || raw.contains("无法连接") {
             return L10n.text("ui.the_current_device_cannot_find_this_mac_at")
         }
+        if let credentialDiagnostic = TokenStoreError.validatedUserFacingDescription(raw) {
+            // 凭据存储失败属于本机签名/系统权限问题，保留受信任模板中的原始 OSStatus。
+            return credentialDiagnostic
+        }
         if raw == L10n.text("ui.the_connection_credentials_have_been_saved_safely_but") ||
             raw.contains("连接凭据已安全保存") {
             // Old builds persisted this message in Chinese. Always return the current locale's

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -257,6 +257,7 @@ final class AppStore: ObservableObject {
     private static let profilesKey = "agentd.connectionProfiles.v2"
     private static let legacyProfilesKey = "agentd.connectionProfiles.v1"
     private static let activeProfileIDKey = "agentd.activeConnectionProfileID.v1"
+    private static let hostConnectionTimingPolicy = HostConnectionTimingPolicy()
     private let retiredFallbackEndpointKey = "agentd.fallbackEndpoint"
     private let retiredConnectionModeKey = "agentd.connectionMode"
     private let defaultEndpoint = "http://127.0.0.1:8787"
@@ -1275,7 +1276,10 @@ final class AppStore: ObservableObject {
                     connectionStatus = .idle
                     return false
                 }
-                let message = L10n.text("ui.the_native_assistant_was_detected_but_the_automatic")
+                // Keychain 与冷启动超时必须保留原始错误；旧 agentd 等兼容错误继续提示扫码升级。
+                let message = error is TokenStoreError || error is URLError
+                    ? error.localizedDescription
+                    : L10n.text("ui.the_native_assistant_was_detected_but_the_automatic")
                 connectionStatus = .failed(message)
                 lastError = message
                 return false
@@ -1590,7 +1594,11 @@ final class AppStore: ObservableObject {
         token: String,
         profileTarget: PreparedConnectionProfileTarget
     ) async throws -> PreparedConnectionSettings {
-        let deadline = Date().addingTimeInterval(8)
+        let preparationTimeout = Self.hostConnectionTimingPolicy.preparationTimeout(
+            hasActiveProfile: activeConnectionProfile != nil,
+            profileTarget: profileTarget
+        )
+        let deadline = Date().addingTimeInterval(preparationTimeout)
         let client = AgentAPIClient(endpoint: endpoint, token: token)
         HostSwitchSignpost.begin("switch_prepare")
         defer { HostSwitchSignpost.end("switch_prepare") }
@@ -1622,7 +1630,7 @@ final class AppStore: ObservableObject {
             let bundle = AppServerRuntimeBundle(
                 endpoint: endpoint,
                 token: token,
-                // 不给 initialize 人为增加最小超时，保证整个快速链路不会突破 8 秒总 deadline。
+                // 不给 initialize 人为增加最小超时，保证整个候选初始化不会突破当前 deadline。
                 requestTimeout: remaining,
                 preparedConfig: config
             )
@@ -1648,7 +1656,10 @@ final class AppStore: ObservableObject {
                             tokenFingerprint: Self.tokenFingerprint(token)
                         ),
                         runtimeBundle: bundle,
-                        expiresAt: deadline
+                        // 初始化成功后重新给提交阶段完整窗口，避免冷启动刚结束就让候选 Runtime 过期。
+                        expiresAt: Self.hostConnectionTimingPolicy.preparedRuntimeExpirationDate(
+                            runtimeReadyAt: Date()
+                        )
                     )
                 )
             } catch {

--- a/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
+++ b/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
@@ -1,6 +1,41 @@
 import Foundation
 import os
 
+struct HostConnectionTimingPolicy: Equatable {
+    let initialConnectionPreparationTimeout: TimeInterval
+    let hostSwitchPreparationTimeout: TimeInterval
+    let preparedRuntimeCommitLifetime: TimeInterval
+
+    init(
+        initialConnectionPreparationTimeout: TimeInterval = 20,
+        hostSwitchPreparationTimeout: TimeInterval = 8,
+        preparedRuntimeCommitLifetime: TimeInterval = 8
+    ) {
+        self.initialConnectionPreparationTimeout = initialConnectionPreparationTimeout
+        self.hostSwitchPreparationTimeout = hostSwitchPreparationTimeout
+        self.preparedRuntimeCommitLifetime = preparedRuntimeCommitLifetime
+    }
+
+    /// 真正没有活动档案的首次连接允许 Codex app-server 冷启动；任何已有主机切换
+    /// 都维持较短边界，包括 App 冷启动后尚未恢复 active profile 的情况。
+    func preparationTimeout(
+        hasActiveProfile: Bool,
+        profileTarget: PreparedConnectionProfileTarget
+    ) -> TimeInterval {
+        if case .existingProfile = profileTarget {
+            return hostSwitchPreparationTimeout
+        }
+        return hasActiveProfile
+            ? hostSwitchPreparationTimeout
+            : initialConnectionPreparationTimeout
+    }
+
+    /// 候选 Runtime 初始化成功才开始计算提交租约，避免准备阶段消耗提交窗口。
+    func preparedRuntimeExpirationDate(runtimeReadyAt: Date) -> Date {
+        runtimeReadyAt.addingTimeInterval(preparedRuntimeCommitLifetime)
+    }
+}
+
 struct PreparedHostLease: Equatable {
     let endpoint: String
     let installationID: String
@@ -129,7 +164,7 @@ final class PreparedHostContext {
         self.runtimeBundle = runtimeBundle
         self.expiresAt = expiresAt
         // Task 强持有 context 到 deadline；即使调用方直接丢弃 PreparedConnectionSettings，
-        // 候选 Runtime 也会在 8 秒内显式 shutdown，而不是只依赖 deinit。
+        // 候选 Runtime 也会在提交租约内显式 shutdown，而不是只依赖 deinit。
         expirationTask = Task { [self] in
             let delay = max(0, expiresAt.timeIntervalSinceNow)
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))

--- a/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
@@ -111,6 +111,27 @@ final class PairingLinkTests: XCTestCase {
         XCTAssertEqual(keychain.deleteCallCount, 0)
     }
 
+    func testTokenStoreOnlyTrustsTemplateGeneratedUserFacingDiagnostics() throws {
+        let safeDescription = TokenStoreError
+            .saveFailed(errSecMissingEntitlement)
+            .localizedDescription
+
+        XCTAssertEqual(
+            TokenStoreError.validatedUserFacingDescription(safeDescription),
+            safeDescription
+        )
+        XCTAssertNil(
+            TokenStoreError.validatedUserFacingDescription(
+                "\(safeDescription) token=test-only-placeholder"
+            )
+        )
+        XCTAssertNil(
+            TokenStoreError.validatedUserFacingDescription(
+                "Keychain token=test-only-placeholder (-34018)"
+            )
+        )
+    }
+
     func testTokenStoreKeepsProfileTokensInIndependentAccounts() throws {
         let keychain = TestKeychainOperations()
         let store = TokenStore(keychain: keychain)
@@ -584,6 +605,72 @@ final class PairingLinkTests: XCTestCase {
         XCTAssertThrowsError(try context.validatedRuntimeBundle(matching: mismatchedLease)) { error in
             XCTAssertEqual(error as? ConnectionProfileError, .preparedContextMismatch)
         }
+        await context.discard()
+    }
+
+    func testHostConnectionTimingSeparatesFirstConnectionAndExistingProfileSwitch() async throws {
+        let policy = HostConnectionTimingPolicy()
+
+        XCTAssertEqual(
+            policy.preparationTimeout(
+                hasActiveProfile: false,
+                profileTarget: .currentOrNew(displayName: nil)
+            ),
+            20
+        )
+        XCTAssertEqual(
+            policy.preparationTimeout(
+                hasActiveProfile: false,
+                profileTarget: .existingProfile(id: "saved-mac")
+            ),
+            8,
+            "已有档案切换不能因 active profile 尚未恢复而退化成首次连接超时"
+        )
+        XCTAssertEqual(
+            policy.preparationTimeout(
+                hasActiveProfile: true,
+                profileTarget: .newProfile(id: "new-mac", displayName: "New Mac")
+            ),
+            8
+        )
+    }
+
+    func testPreparedRuntimeSuccessRefreshesCommitExpiration() async throws {
+        let policy = HostConnectionTimingPolicy()
+        let preparationStartedAt = Date()
+        let preparationDeadline = preparationStartedAt.addingTimeInterval(
+            policy.initialConnectionPreparationTimeout
+        )
+        let runtimeReadyAt = preparationDeadline.addingTimeInterval(-0.1)
+        let target = PreparedConnectionProfileTarget.currentOrNew(displayName: nil)
+        let lease = PreparedHostLease(
+            endpoint: "http://127.0.0.1:8787",
+            installationID: "installation-local",
+            profileTarget: target,
+            profileRevision: nil,
+            tokenFingerprint: "test-fingerprint"
+        )
+        let context = PreparedHostContext(
+            lease: lease,
+            runtimeBundle: AppServerRuntimeBundle(
+                endpoint: lease.endpoint,
+                token: "test-only-placeholder"
+            ),
+            expiresAt: policy.preparedRuntimeExpirationDate(runtimeReadyAt: runtimeReadyAt)
+        )
+
+        XCTAssertEqual(
+            context.expiresAt.timeIntervalSince(runtimeReadyAt),
+            policy.preparedRuntimeCommitLifetime,
+            accuracy: 0.001
+        )
+        XCTAssertNoThrow(
+            try context.validatedRuntimeBundle(
+                matching: lease,
+                now: preparationDeadline.addingTimeInterval(7)
+            ),
+            "Runtime 在准备 deadline 前刚成功时，提交窗口应从成功时重新计算"
+        )
         await context.discard()
     }
 
@@ -1573,6 +1660,37 @@ final class PairingLinkTests: XCTestCase {
             probedEndpoints,
             ["http://127.0.0.1:8787", "http://127.0.0.1:8787"]
         )
+    }
+
+    func testMacCatalystPreflightPreservesSafeKeychainDiagnosticWithoutToken() async throws {
+        let suiteName = "PairingLinkTests.LocalAgentKeychainDiagnostic.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let keychain = TestKeychainOperations(forcedCopyStatus: errSecMissingEntitlement)
+        let claimedToken = "test-only-placeholder-token"
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: keychain),
+            routeProbeTimeout: 0.1,
+            prefersLocalConnection: true,
+            localAgentProbe: { _, _ in },
+            localAgentPairingClaim: { _, _ in claimedToken },
+            routeProbe: { _, _, _ in },
+            allowsEphemeralLocalCredentialFallback: false
+        )
+        let expected = TokenStoreError
+            .loadFailed(errSecMissingEntitlement)
+            .localizedDescription
+
+        let connected = await store.preflightConnection()
+
+        XCTAssertFalse(connected)
+        XCTAssertEqual(store.lastError, expected)
+        XCTAssertFalse(store.lastError?.contains(claimedToken) ?? true)
+        guard case .failed(let message) = store.connectionStatus else {
+            return XCTFail("Keychain 失败应发布可诊断的失败状态")
+        }
+        XCTAssertEqual(message, expected)
     }
 
     func testMacCatalystPreflightKeepsManualPairingFallbackForOldLocalAgent() async throws {


### PR DESCRIPTION
## 目标

收口 MIM-5 cleanup 留下的 Catalyst Keychain 与首次连接诊断改动，避免凭据权限和冷启动问题被误报成 Mac 助手不可用。

## 根因

- Catalyst 构建缺少明确的 application identifier entitlement，未正确签名时 Keychain 可能返回 `errSecMissingEntitlement (-34018)`。
- 旧界面只凭错误文本含 `token`/`keychain` 就原样展示，可能把非受信来源中的敏感内容带到用户界面。
- 候选连接统一使用 8 秒准备窗口，首次连接冷启动 app-server 容易超时；同时候选 Runtime 成功后仍沿用旧 deadline，提交阶段可能立即过期。

## 实现

- 为 Mac Catalyst 增加 `com.apple.application-identifier`，由 Team ID 与 Bundle ID 在签名阶段展开。
- 仅允许由本地 `TokenStoreError` 模板生成的 Keychain 诊断原样展示，保留 OSStatus，但拒绝夹带访问码的任意原始文本。
- 首次连接使用 20 秒准备窗口；活动主机之间或已有档案切换使用 8 秒窗口。
- 候选 Runtime 初始化成功后重新给予 8 秒提交租约。
- 补齐 Keychain、Token 脱敏、首次连接/已有档案超时与 Runtime 有效期回归测试。

## 验证

- `PairingLinkTests`：84/84 通过（iPad Pro 13-inch (M5) Simulator）。
- `go test ./... -count=1`：通过。
- Mac Catalyst Debug 签名构建：`BUILD SUCCEEDED`。
- `codesign --verify --deep --strict`：通过；签名 entitlement 为 `9HZ89R58PZ.com.gaixianggeng.mimi`。
- Mac Catalyst Debug App 使用种子参数实际启动并正常终止：通过。
- iOS localization：1704 keys / 50 technical exceptions，通过。
- ATS、隐私清单、公开仓库安全、源码体积、Swift 语法解析、`git diff --check`：通过。

## 风险与边界

- 未向日志、测试或用户错误中写入真实 Token、Keychain 内容或用户凭据。
- 没有在用户真实 Keychain 上执行写入/删除验证；权限声明由真实签名产物与 `codesign` 检查验证，读写错误路径由注入式 Keychain 回归测试覆盖。
- 不涉及 TestFlight 或 App Store 发布。
