### PR TITLE
MIM-47 修复 Claude 会话流式事件与启动回执竞态

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -406,12 +406,10 @@ pub async fn handle_turn_start(
         return Err(TurnError::ClaudeRpc(e.to_string()));
     }
 
-    // Backfill the thread preview from the first user message. AppServer
-    // threads are created with an empty preview (thread/start) and, unlike
-    // codex, nothing else fills it in — so clients would fall back to the
-    // "Thread <id>" placeholder title. Mirror the on-disk hydrator, which
-    // uses the first user message's first line as the preview.
-    maybe_backfill_preview(state, &params.thread_id, &params.input).await;
+    // 标题回填只是列表体验，不能阻塞 turn/start ACK。Claude 已经收到输入后可能
+    // 立即产出甚至完成；若这里等待索引落盘，通知就会先于 ACK 很久到达，客户端
+    // 在 actor 重入窗口里容易被迟到 ACK 重新写回旧 active turn。
+    spawn_preview_backfill(state, &params.thread_id, &params.input);
 
     Ok(p::TurnStartResponse { turn })
 }
@@ -449,23 +447,28 @@ fn is_explicit_invalid_model_message(message: &str) -> bool {
     .any(|marker| normalized.contains(marker))
 }
 
+/// Schedule preview persistence outside the `turn/start` response path.
+fn spawn_preview_backfill(state: &Arc<ConnectionState>, thread_id: &str, input: &[p::UserInput]) {
+    let Some(preview) = preview_from_input(input) else {
+        return;
+    };
+    let state = Arc::clone(state);
+    let thread_id = thread_id.to_string();
+    tokio::spawn(async move {
+        maybe_backfill_preview(&state, &thread_id, preview).await;
+    });
+}
+
 /// If the thread's preview is still empty, backfill it from the first line of
-/// the user's message. Fire-and-forget: any lookup/persist failure is ignored
-/// since a missing preview only degrades the title, never the turn.
-async fn maybe_backfill_preview(
-    state: &Arc<ConnectionState>,
-    thread_id: &str,
-    input: &[p::UserInput],
-) {
+/// the user's message. Any lookup/persist failure is ignored since a missing
+/// preview only degrades the title, never the turn.
+async fn maybe_backfill_preview(state: &Arc<ConnectionState>, thread_id: &str, preview: String) {
     let Some(entry) = state.thread_index().lookup(thread_id).await else {
         return;
     };
     if !entry.preview.trim().is_empty() {
         return;
     }
-    let Some(preview) = preview_from_input(input) else {
-        return;
-    };
     let _ = state
         .thread_index()
         .update_preview_and_updated_at(thread_id, preview, chrono::Utc::now())
@@ -1386,8 +1389,9 @@ mod tests {
             .unwrap();
 
         let input = vec![text_input("你好世界\n更多内容")];
-        maybe_backfill_preview(&state, "empty", &input).await;
-        maybe_backfill_preview(&state, "named", &input).await;
+        let preview = preview_from_input(&input).unwrap();
+        maybe_backfill_preview(&state, "empty", preview.clone()).await;
+        maybe_backfill_preview(&state, "named", preview).await;
 
         assert_eq!(
             state.thread_index().lookup("empty").await.unwrap().preview,

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		41B2009F6B92E4B407CFDB72 /* ModelReasoningGridPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A4A2B3A4B718F54CB4F8AE /* ModelReasoningGridPicker.swift */; };
 		420F5F2A694B0E491DBD45B0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7348A6FCD28C7489CC7097AD /* ThemeStoreTests.swift */; };
 		439355570F5ED69354673D07 /* testAppearancePreview.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 190DA6E3F95C3577B94AB67C /* testAppearancePreview.1.png */; };
+		45C1DA2766CF0D3F7DB0843C /* CodexAppServerTurnStartObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */; };
 		467ED9D49A463D5F5AF02A3C /* ConversationDataFlowTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078AEE7E4BDAC1751244A05A /* ConversationDataFlowTestSupport.swift */; };
 		49C17A8B6741B1D16B626FF6 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-claude-popover-420-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = AFDEF6C57E7FE342A5411C7B /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-claude-popover-420-dark.png */; };
 		4B4DDB0179C0326DBC0BBA00 /* GitQuickPublishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2FCF65A5A23A9D87948F4F /* GitQuickPublishTests.swift */; };
@@ -307,6 +308,7 @@
 		528144CF5078B2715AF9D696 /* ShareJourneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareJourneyView.swift; sourceTree = "<group>"; };
 		52BCEEFCD8324800FC52F2DC /* AgentRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRuntimeModels.swift; sourceTree = "<group>"; };
 		5330D382730C4473E4D9EC92 /* AgentEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEvent.swift; sourceTree = "<group>"; };
+		5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerTurnStartObservation.swift; sourceTree = "<group>"; };
 		53A4A2B3A4B718F54CB4F8AE /* ModelReasoningGridPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelReasoningGridPicker.swift; sourceTree = "<group>"; };
 		542EA92F5AE167370704AB59 /* MimiRemote.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MimiRemote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		546D87E0EF8B0482759115F4 /* testComposerStatusTrayExpandedWideState.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayExpandedWideState.1.png; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 				469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */,
 				D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */,
 				BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */,
+				5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1178,6 +1181,7 @@
 				FAD77559CF6FDCD943849D7C /* CodexAppServerSessionClients.swift in Sources */,
 				5344C41233BA0E47A0C29FDA /* CodexAppServerSessionRuntime.swift in Sources */,
 				C1F8D4D973088684344C9DB6 /* CodexAppServerTransport.swift in Sources */,
+				45C1DA2766CF0D3F7DB0843C /* CodexAppServerTurnStartObservation.swift in Sources */,
 				E4C5AB826686611C3468FAB8 /* ComposerAttachmentViews.swift in Sources */,
 				0B05C5BFB8B5EFA1A20EFF71 /* ComposerInputExtensions.swift in Sources */,
 				2159AEC10EBC907D803FD5BC /* ComposerModelSelection.swift in Sources */,

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -60,58 +60,6 @@ extension CodexAppServerSessionRuntime {
         return Date().timeIntervalSince(at) < historyDowngradeGraceInterval
     }
 
-    func recordPendingTurnStartBoundary(from notification: CodexAppServerNotification) {
-        guard notification.method == "turn/completed"
-                || notification.method == "thread/closed" else {
-            return
-        }
-        let params = notification.params?.objectValue ?? [:]
-        guard let threadID = params["threadId"]?.stringValue else {
-            return
-        }
-        guard var observation = pendingTurnStartObservationsBySessionID[threadID] else {
-            return
-        }
-        if notification.method == "thread/closed" {
-            observation.threadClosed = true
-        } else if let turnID = completedTurnID(from: params) {
-            observation.terminalTurnIDs.insert(turnID)
-        } else {
-            // 旧 bridge 可能不带 turn ID。此时不能把当前 active turn 当作旧 turn；
-            // 先关联唯一正在等待 ACK 的请求，待 ACK 返回 ID 后再完成精确对账。
-            observation.sawUnidentifiedTerminal = true
-        }
-        pendingTurnStartObservationsBySessionID[threadID] = observation
-    }
-
-    func completedTurnID(from params: [String: CodexAppServerJSONValue]) -> TurnID? {
-        params["turnId"]?.stringValue
-            ?? params["turn"]?.objectValue?["id"]?.stringValue
-    }
-
-    func turnStartObservationMatchesTerminal(
-        _ observation: CodexAppServerPendingTurnStartObservation,
-        turnID: TurnID?
-    ) -> Bool {
-        if observation.threadClosed {
-            return true
-        }
-        guard let turnID else {
-            return false
-        }
-        return observation.terminalTurnIDs.contains(turnID)
-    }
-
-    func responseTurnIsTerminal(_ turn: [String: CodexAppServerJSONValue]?) -> Bool {
-        guard let turn else {
-            return false
-        }
-        if isTerminalHistoryStatus(turn["status"]) {
-            return true
-        }
-        return firstDate(in: turn, keys: ["completedAt", "completed_at"]) != nil
-    }
-
     func emit(_ event: AgentEvent) {
         let sessionID = sessionID(from: event)
         guard let sessionID else {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -60,6 +60,58 @@ extension CodexAppServerSessionRuntime {
         return Date().timeIntervalSince(at) < historyDowngradeGraceInterval
     }
 
+    func recordPendingTurnStartBoundary(from notification: CodexAppServerNotification) {
+        guard notification.method == "turn/completed"
+                || notification.method == "thread/closed" else {
+            return
+        }
+        let params = notification.params?.objectValue ?? [:]
+        guard let threadID = params["threadId"]?.stringValue else {
+            return
+        }
+        guard var observation = pendingTurnStartObservationsBySessionID[threadID] else {
+            return
+        }
+        if notification.method == "thread/closed" {
+            observation.threadClosed = true
+        } else if let turnID = completedTurnID(from: params) {
+            observation.terminalTurnIDs.insert(turnID)
+        } else {
+            // 旧 bridge 可能不带 turn ID。此时不能把当前 active turn 当作旧 turn；
+            // 先关联唯一正在等待 ACK 的请求，待 ACK 返回 ID 后再完成精确对账。
+            observation.sawUnidentifiedTerminal = true
+        }
+        pendingTurnStartObservationsBySessionID[threadID] = observation
+    }
+
+    func completedTurnID(from params: [String: CodexAppServerJSONValue]) -> TurnID? {
+        params["turnId"]?.stringValue
+            ?? params["turn"]?.objectValue?["id"]?.stringValue
+    }
+
+    func turnStartObservationMatchesTerminal(
+        _ observation: CodexAppServerPendingTurnStartObservation,
+        turnID: TurnID?
+    ) -> Bool {
+        if observation.threadClosed {
+            return true
+        }
+        guard let turnID else {
+            return false
+        }
+        return observation.terminalTurnIDs.contains(turnID)
+    }
+
+    func responseTurnIsTerminal(_ turn: [String: CodexAppServerJSONValue]?) -> Bool {
+        guard let turn else {
+            return false
+        }
+        if isTerminalHistoryStatus(turn["status"]) {
+            return true
+        }
+        return firstDate(in: turn, keys: ["completedAt", "completed_at"]) != nil
+    }
+
     func emit(_ event: AgentEvent) {
         let sessionID = sessionID(from: event)
         guard let sessionID else {
@@ -228,6 +280,17 @@ extension CodexAppServerSessionRuntime {
             ))
         case "turn/completed":
             guard let threadID = params["threadId"]?.stringValue else {
+                return
+            }
+            let turnID = completedTurnID(from: params)
+            if runtimeProvider == "claude", turnID == nil {
+                // 无法关联 turn 的完成通知不能直接清理当前 active；handle() 会改走权威历史对账。
+                return
+            }
+            if let activeTurnID = contextsBySessionID[threadID]?.activeTurnID,
+               let turnID,
+               activeTurnID != turnID {
+                // 旧 turn 的完成通知可能晚于下一轮 turn/started；不能因此清掉当前新 turn。
                 return
             }
             _ = withUpdatedSession(threadID) { item in

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
@@ -845,10 +845,14 @@ final class CodexAppServerSessionWebSocketClient: SessionWebSocketClient {
         let outcomeHandler = onTurnSendOutcome
         Task { [runtime] in
             do {
-                let turnID = try await runtime.startTurn(sessionID: sessionID, payload: payload, clientMessageID: clientMessageID)
+                let startOutcome = try await runtime.startTurnOutcome(
+                    sessionID: sessionID,
+                    payload: payload,
+                    clientMessageID: clientMessageID
+                )
                 await MainActor.run {
                     if let outcomeHandler {
-                        outcomeHandler(clientMessageID, .accepted(turnID: turnID))
+                        outcomeHandler(clientMessageID, Self.turnSendOutcome(for: startOutcome))
                     } else {
                         acceptedHandler?(clientMessageID)
                     }
@@ -876,6 +880,24 @@ final class CodexAppServerSessionWebSocketClient: SessionWebSocketClient {
                 sequence,
                 epoch: metadata.replayCursorEpoch
             )
+        }
+    }
+
+    static func turnSendOutcome(
+        for startOutcome: CodexAppServerTurnStartOutcome
+    ) -> TurnSendOutcome {
+        switch startOutcome {
+        case .active(let turnID):
+            return .accepted(turnID: turnID)
+        case .terminal(let turnID):
+            return .acceptedTerminal(turnID: turnID)
+        case .superseded(let turnID, let activeTurnID):
+            return .acceptedSuperseded(
+                turnID: turnID,
+                activeTurnID: activeTurnID
+            )
+        case .threadClosed(let turnID):
+            return .acceptedThreadClosed(turnID: turnID)
         }
     }
 

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -72,6 +72,31 @@ struct CodexAppServerTurnInterruptRecoveryTask {
     let task: Task<Void, Never>
 }
 
+enum CodexAppServerTurnStartOutcome: Equatable {
+    // RPC 已接受，且当前仍是这一轮或尚在等待 turn/started。
+    case active(turnID: TurnID?)
+    // RPC 已接受，但 ACK 到达前已观察到终态；上层应完成发送，不再建立 start barrier。
+    case terminal(turnID: TurnID?)
+    // RPC 已接受，但实时事件已推进到另一轮；上层应绑定权威 active turn。
+    case superseded(turnID: TurnID?, activeTurnID: TurnID)
+    // thread 已关闭；本次发送已由 RPC 接受，但同一 thread 上不能继续自动派发。
+    case threadClosed(turnID: TurnID?)
+
+    var activeTurnID: TurnID? {
+        guard case .active(let turnID) = self else {
+            return nil
+        }
+        return turnID
+    }
+}
+
+struct CodexAppServerPendingTurnStartObservation {
+    let attemptID: UUID
+    var terminalTurnIDs: Set<TurnID> = []
+    var sawUnidentifiedTerminal = false
+    var threadClosed = false
+}
+
 enum CodexAppServerBufferedEventReplayPolicy {
     case all
     case stateOnly
@@ -109,6 +134,11 @@ actor CodexAppServerSessionRuntime {
     // 此时本地还没记上 activeTurnID、状态也可能仍是空闲。这一窗口内到达的审批一定属于刚发起的
     // 新 turn，不能被 isStaleReplayedApproval 误判成过期重放。
     var sessionsStartingTurn: Set<SessionID> = []
+    // Claude bridge 可能先推送 turn/completed，随后才返回 turn/start ACK。只在对应 RPC 真正
+    // 等待回执的窗口记录终态，回执或错误到达后立即清理，避免历史重放污染下一次发送。
+    var pendingTurnStartObservationsBySessionID: [
+        SessionID: CodexAppServerPendingTurnStartObservation
+    ] = [:]
     // 本端这条 runtime 亲自发起过的 turn。app-server 在 resume 时会重放“仍未应答”的审批；只有属于这些
     // turn 的审批才是当前用户真正在等待的，其余（Desktop 发起、或历史里没 terminal 化的旧审批）需要按
     // 过期处理。即使本端的审批挂了很久也不能误杀，所以单列出来优先放行。
@@ -121,7 +151,9 @@ actor CodexAppServerSessionRuntime {
     var stateDBOnlyListUnavailable = false
     var stateDBOnlyScanRequiredCWDs: Set<String> = []
     var recencySortUnavailable = false
-    var turnStartTasksBySessionID: [SessionID: (token: UUID, task: Task<TurnID?, Error>)] = [:]
+    var turnStartTasksBySessionID: [
+        SessionID: (token: UUID, task: Task<CodexAppServerTurnStartOutcome, Error>)
+    ] = [:]
     // turn/interrupt 的 RPC ACK 与 turn/completed 通知是两条独立链路。通知若落在连接切换窗口，
     // SessionStore 会一直保留旧 activeTurnID。按被中断的 turn 去重保存有界恢复任务，
     // 只在权威 turns 快照确认终态后补发完成事件。
@@ -680,15 +712,14 @@ actor CodexAppServerSessionRuntime {
         }
 
         if !turnPayload.isEmpty {
-            let turnID = try await startTurn(
+            _ = try await startTurnOutcome(
                 sessionID: session.id,
                 payload: turnPayload,
                 clientMessageID: payload.clientMessageID
             )
-            session = withUpdatedSession(session.id) { item in
-                item.status = "running"
-                item.activeTurnID = turnID
-            } ?? session
+            // 通知可能在 turn/start ACK 前已经把会话推进到 terminal/closed/下一轮。
+            // 直接采用 Runtime 的最新投影，不能用 ACK 再无条件覆盖。
+            session = contextsBySessionID[session.id]?.session ?? session
         }
 
         return CreateSessionResponse(
@@ -720,6 +751,7 @@ actor CodexAppServerSessionRuntime {
         _ = try await sendRecoveringFromStaleInitialization(spec)
         if archived {
             contextsBySessionID.removeValue(forKey: id)
+            pendingTurnStartObservationsBySessionID.removeValue(forKey: id)
             threadHistoryCacheBySessionID.removeValue(forKey: id)
             threadAuthoritativeCompletedTurnItemsBySessionID.removeValue(forKey: id)
         }
@@ -1544,8 +1576,20 @@ actor CodexAppServerSessionRuntime {
 
     @discardableResult
     func startTurn(sessionID: SessionID, payload: CodexAppServerTurnPayload, clientMessageID: ClientMessageID?) async throws -> TurnID? {
+        try await startTurnOutcome(
+            sessionID: sessionID,
+            payload: payload,
+            clientMessageID: clientMessageID
+        ).activeTurnID
+    }
+
+    func startTurnOutcome(
+        sessionID: SessionID,
+        payload: CodexAppServerTurnPayload,
+        clientMessageID: ClientMessageID?
+    ) async throws -> CodexAppServerTurnStartOutcome {
         guard !payload.isEmpty else {
-            return nil
+            return .active(turnID: nil)
         }
         let previous = turnStartTasksBySessionID[sessionID]?.task
         let token = UUID()
@@ -1567,7 +1611,11 @@ actor CodexAppServerSessionRuntime {
     }
 
     @discardableResult
-    func performStartTurn(sessionID: SessionID, payload: CodexAppServerTurnPayload, clientMessageID: ClientMessageID?) async throws -> TurnID? {
+    func performStartTurn(
+        sessionID: SessionID,
+        payload: CodexAppServerTurnPayload,
+        clientMessageID: ClientMessageID?
+    ) async throws -> CodexAppServerTurnStartOutcome {
         guard let context = contextsBySessionID[sessionID] else {
             throw CodexAppServerSessionRuntimeError.sessionNotFound(sessionID)
         }
@@ -1583,9 +1631,11 @@ actor CodexAppServerSessionRuntime {
         }
         let builder = CodexAppServerRequestBuilder(allowlistedProjects: projectsIncludingSessionContext(try await projects(), context: context))
         let result: CodexAppServerJSONValue?
+        var responseObservation: CodexAppServerPendingTurnStartObservation?
         var didRetryAfterStaleInitialization = false
         while true {
             let connection = try await ensureConnection()
+            var activeAttemptID: UUID?
             do {
                 try await ensureThreadResumedOnConnection(sessionID: sessionID, cwd: context.cwd, builder: builder, connection: connection)
                 if let activeTurnID = contextsBySessionID[sessionID]?.activeTurnID {
@@ -1595,14 +1645,26 @@ actor CodexAppServerSessionRuntime {
                         activeTurnID: activeTurnID
                     )
                 }
+                let attemptID = beginPendingTurnStartObservation(sessionID: sessionID)
+                activeAttemptID = attemptID
                 result = try await connection.send(try builder.turnStart(
                     threadID: sessionID,
                     cwd: context.cwd,
                     payload: payload,
                     clientMessageID: clientMessageID
                 ), timeout: longRunningRequestTimeout)
+                responseObservation = takePendingTurnStartObservation(
+                    sessionID: sessionID,
+                    attemptID: attemptID
+                )
                 break
             } catch {
+                if let activeAttemptID {
+                    _ = takePendingTurnStartObservation(
+                        sessionID: sessionID,
+                        attemptID: activeAttemptID
+                    )
+                }
                 if !didRetryAfterStaleInitialization,
                    await recoverConnectionAfterStaleInitialization(connection, error: error) {
                     didRetryAfterStaleInitialization = true
@@ -1623,15 +1685,87 @@ actor CodexAppServerSessionRuntime {
                 throw error
             }
         }
-        let turnID = result?["turn"]?.objectValue?["id"]?.stringValue
+        let responseTurn = result?["turn"]?.objectValue
+        let turnID = responseTurn?["id"]?.stringValue
         if let turnID {
             turnsStartedByThisRuntime.insert(turnID)
+        }
+        guard let latestContext = contextsBySessionID[sessionID] else {
+            return .threadClosed(turnID: turnID)
+        }
+        let currentActiveTurnID = latestContext.activeTurnID
+        if responseObservation?.threadClosed == true
+            || latestContext.session.status == "closed" {
+            return .threadClosed(turnID: turnID)
+        }
+        if let currentActiveTurnID,
+           turnID == nil || currentActiveTurnID != turnID {
+            // ACK 等待期间已经出现更新 turn；旧 ACK 只完成原消息的发送对账。
+            return .superseded(turnID: turnID, activeTurnID: currentActiveTurnID)
+        }
+        let terminalFromNotification = responseObservation.map {
+            turnStartObservationMatchesTerminal($0, turnID: turnID)
+        } ?? false
+        let terminalFromResponse = responseTurnIsTerminal(responseTurn)
+        if terminalFromNotification || terminalFromResponse {
+            if currentActiveTurnID == nil || currentActiveTurnID == turnID {
+                _ = withUpdatedSession(sessionID) { item in
+                    item.activeTurnID = nil
+                }
+            }
+            let knownTerminalWasAlreadyProjected = turnID.map {
+                responseObservation?.terminalTurnIDs.contains($0) == true
+            } ?? false
+            if !knownTerminalWasAlreadyProjected {
+                let lifecycle = responseTurn.map {
+                    historyTurnLifecycle(
+                        $0,
+                        isInProgress: false,
+                        completedAt: firstDate(in: $0, keys: ["completedAt", "completed_at"])
+                    )
+                } ?? .completed
+                // ACK 自身已终态或旧协议 completion 无 ID 时，补一条可精确关联的完成事件，
+                // 让消息状态与 FIFO 都能收敛，不依赖手动刷新。
+                emit(
+                    .turnCompleted(
+                        metadata(threadID: sessionID, turnID: turnID)
+                            .withTurnLifecycle(lifecycle)
+                    )
+                )
+            }
+            return .terminal(turnID: turnID)
         }
         _ = withUpdatedSession(sessionID) { item in
             item.status = "running"
             item.activeTurnID = turnID
         }
-        return turnID
+        if responseObservation?.sawUnidentifiedTerminal == true,
+           let turnID {
+            // 无 ID completion 可能是连接重放，不能据此宣告本次 turn 已完成。
+            // 先保留 ACK 的 active 状态，再以权威 turns 页有界确认真实终态。
+            scheduleTurnInterruptRecovery(sessionID: sessionID, turnID: turnID)
+        }
+        return .active(turnID: turnID)
+    }
+
+    func beginPendingTurnStartObservation(sessionID: SessionID) -> UUID {
+        let attemptID = UUID()
+        pendingTurnStartObservationsBySessionID[sessionID] = CodexAppServerPendingTurnStartObservation(
+            attemptID: attemptID
+        )
+        return attemptID
+    }
+
+    func takePendingTurnStartObservation(
+        sessionID: SessionID,
+        attemptID: UUID
+    ) -> CodexAppServerPendingTurnStartObservation? {
+        guard let observation = pendingTurnStartObservationsBySessionID[sessionID],
+              observation.attemptID == attemptID else {
+            return nil
+        }
+        pendingTurnStartObservationsBySessionID.removeValue(forKey: sessionID)
+        return observation
     }
 
     nonisolated static func activeTurnIDFromConflict(_ error: Error) -> TurnID? {
@@ -2533,6 +2667,29 @@ actor CodexAppServerSessionRuntime {
             return
         }
         recordLiveSignal(from: notification)
+        recordPendingTurnStartBoundary(from: notification)
+        if runtimeProvider == "claude",
+           notification.method == "turn/completed" {
+            let params = notification.params?.objectValue ?? [:]
+            if let threadID = params["threadId"]?.stringValue,
+               completedTurnID(from: params) == nil {
+                // 无 ID completion 无法安全区分旧 turn 与当前新 turn。禁止猜测 activeTurnID，
+                // 以最新历史页做精确终态对账；若 ACK 仍挂起，则 ACK 还会补出带 ID 的完成事件。
+                if let activeTurnID = contextsBySessionID[threadID]?.activeTurnID {
+                    scheduleTurnInterruptRecovery(
+                        sessionID: threadID,
+                        turnID: activeTurnID
+                    )
+                }
+                if let replaySequence = notification.replaySequence {
+                    acknowledgeAppliedReplayBoundary(
+                        replaySequence,
+                        epoch: replayCursorEpoch
+                    )
+                }
+                return
+            }
+        }
         updateContext(from: notification)
         let resolved = clearResolvedServerRequest(from: notification)
         if notification.method == "serverRequest/resolved",

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
@@ -2,6 +2,12 @@ import Foundation
 
 enum TurnSendOutcome: Equatable {
     case accepted(turnID: TurnID?)
+    case acceptedTerminal(turnID: TurnID?)
+    case acceptedSuperseded(
+        turnID: TurnID?,
+        activeTurnID: TurnID
+    )
+    case acceptedThreadClosed(turnID: TurnID?)
     case activeTurnConflict(activeTurnID: TurnID, message: String)
     case rejected(message: String)
     case uncertain(message: String)

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerTurnStartObservation.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerTurnStartObservation.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// turn/start ACK 等待窗口的终态观察独立维护，避免通知投影继续膨胀。
+extension CodexAppServerSessionRuntime {
+    func recordPendingTurnStartBoundary(from notification: CodexAppServerNotification) {
+        guard notification.method == "turn/completed"
+                || notification.method == "thread/closed" else {
+            return
+        }
+        let params = notification.params?.objectValue ?? [:]
+        guard let threadID = params["threadId"]?.stringValue else {
+            return
+        }
+        guard var observation = pendingTurnStartObservationsBySessionID[threadID] else {
+            return
+        }
+        if notification.method == "thread/closed" {
+            observation.threadClosed = true
+        } else if let turnID = completedTurnID(from: params) {
+            observation.terminalTurnIDs.insert(turnID)
+        } else {
+            // 旧 bridge 可能不带 turn ID。此时不能把当前 active turn 当作旧 turn；
+            // 先关联唯一正在等待 ACK 的请求，待 ACK 返回 ID 后再完成精确对账。
+            observation.sawUnidentifiedTerminal = true
+        }
+        pendingTurnStartObservationsBySessionID[threadID] = observation
+    }
+
+    func completedTurnID(from params: [String: CodexAppServerJSONValue]) -> TurnID? {
+        params["turnId"]?.stringValue
+            ?? params["turn"]?.objectValue?["id"]?.stringValue
+    }
+
+    func turnStartObservationMatchesTerminal(
+        _ observation: CodexAppServerPendingTurnStartObservation,
+        turnID: TurnID?
+    ) -> Bool {
+        if observation.threadClosed {
+            return true
+        }
+        guard let turnID else {
+            return false
+        }
+        return observation.terminalTurnIDs.contains(turnID)
+    }
+
+    func responseTurnIsTerminal(_ turn: [String: CodexAppServerJSONValue]?) -> Bool {
+        guard let turn else {
+            return false
+        }
+        if isTerminalHistoryStatus(turn["status"]) {
+            return true
+        }
+        return firstDate(in: turn, keys: ["completedAt", "completed_at"]) != nil
+    }
+}

--- a/ios/MimiRemote/Sources/State/ConversationStore.swift
+++ b/ios/MimiRemote/Sources/State/ConversationStore.swift
@@ -853,6 +853,13 @@ final class ConversationStore: ObservableObject {
         }
     }
 
+    func turnLifecycle(
+        sessionID: SessionID,
+        turnID: TurnID
+    ) -> ConversationTurnLifecycle? {
+        turnLifecycleBySessionID[scopedSessionID(for: sessionID)]?[turnID]
+    }
+
     private func append(_ message: ConversationMessage, sessionID: String) {
         let scopedSessionID = scopedSessionID(for: sessionID)
         var message = message

--- a/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
@@ -61,8 +61,7 @@ extension SessionStore {
     ) -> Bool {
         guard appStore.activeHostScope == hostScope,
               sessionsByID[sessionID] != nil,
-              case .accepted(let acceptedTurnID) = outcome,
-              let acceptedTurnID else {
+              let acceptedTurnID = acceptedTurnID(from: outcome) else {
             return false
         }
         let normalizedTurnID = acceptedTurnID.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -75,6 +74,21 @@ extension SessionStore {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return externalTurnID == normalizedTurnID ||
             (externalReadOnlySessionIDs.contains(sessionID) && sessionTurnID == normalizedTurnID)
+    }
+
+    func acceptedTurnID(from outcome: TurnSendOutcome) -> TurnID? {
+        switch outcome {
+        case .accepted(let turnID),
+             .acceptedTerminal(let turnID),
+             .acceptedThreadClosed(let turnID):
+            return turnID
+        case .acceptedSuperseded(let turnID, _):
+            return turnID
+        case .activeTurnConflict,
+             .rejected,
+             .uncertain:
+            return nil
+        }
     }
 
     func externalActivityPollingDelayNanoseconds() -> UInt64 {
@@ -298,6 +312,156 @@ extension SessionStore {
             clearWorkspaceUnavailable(projectID)
         } catch {
             // 活动 API 已给出可靠运行态；列表补拉失败时保留已有行，下一次轮询继续重试未知线程。
+        }
+    }
+
+    func handleTurnSendOutcome(
+        clientMessageID: ClientMessageID?,
+        sessionID: SessionID,
+        outcome: TurnSendOutcome
+    ) {
+        let recoveredExternalMisclassification: Bool
+        if case .accepted(let turnID) = outcome, let turnID {
+            recoveredExternalMisclassification = recordLocallyStartedTurn(
+                sessionID: sessionID,
+                turnID: turnID
+            )
+        } else {
+            recoveredExternalMisclassification = false
+        }
+        guard let clientMessageID else { return }
+
+        func finishAccepted(_ disposition: QueuedTurnAcceptedDisposition) {
+            let disposition = reconciledAcceptedDisposition(
+                sessionID: sessionID,
+                disposition: disposition
+            )
+            if !handleQueuedSendAccepted(
+                clientMessageID: clientMessageID,
+                sessionID: sessionID,
+                disposition: disposition
+            ) {
+                conversationStore.updateSendStatus(
+                    clientMessageID: clientMessageID,
+                    sessionID: sessionID,
+                    status: .sent
+                )
+                conversationStore.compactTurnPayloadAfterSendAccepted(
+                    clientMessageID: clientMessageID,
+                    sessionID: sessionID
+                )
+                // 非队列消息同样需要 compare-and-apply，防止 outcome 排队到 MainActor
+                // 期间覆盖已经到达的更新 turn。
+                switch disposition {
+                case .terminal(let turnID):
+                    updateSession(sessionID) { session in
+                        guard session.activeTurnID == nil
+                                || session.activeTurnID == turnID else {
+                            return
+                        }
+                        session.activeTurnID = nil
+                    }
+                case .superseded(let turnID, let activeTurnID):
+                    updateSession(sessionID) { session in
+                        guard session.activeTurnID == nil
+                                || session.activeTurnID == turnID
+                                || session.activeTurnID == activeTurnID else {
+                            return
+                        }
+                        session.status = SessionStatus.running.rawValue
+                        session.activeTurnID = activeTurnID
+                    }
+                case .threadClosed(let turnID):
+                    updateSession(sessionID) { session in
+                        guard session.activeTurnID == nil
+                                || session.activeTurnID == turnID else {
+                            return
+                        }
+                        session.status = "closed"
+                        session.activeTurnID = nil
+                    }
+                case .awaitingStart, .guidance:
+                    break
+                }
+            }
+        }
+
+        switch outcome {
+        case .accepted(let turnID):
+            finishAccepted(.awaitingStart(turnID: turnID))
+            if recoveredExternalMisclassification,
+               selectedSessionID != sessionID,
+               queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false {
+                // external snapshot 会停止后台队列 socket。ACK 对账成功且仍有后续项时，
+                // 重新建立监听，让 FIFO 能在当前 turn 完成后继续派发。
+                ensureQueuedSessionMonitoring(sessionID: sessionID)
+            }
+        case .acceptedTerminal(let turnID):
+            finishAccepted(.terminal(turnID: turnID))
+        case .acceptedSuperseded(let turnID, let activeTurnID):
+            finishAccepted(.superseded(
+                turnID: turnID,
+                activeTurnID: activeTurnID
+            ))
+        case .acceptedThreadClosed(let turnID):
+            finishAccepted(.threadClosed(turnID: turnID))
+        case .activeTurnConflict(let activeTurnID, let message):
+            // 这是“新消息未被接受”，不是原会话失败。恢复权威 active turn，
+            // 并保留已有审批/补充问题；排队项回到等待态，待原 turn 完成后再发。
+            updateSession(sessionID) { item in
+                item.activeTurnID = activeTurnID
+                if item.pendingUserInput != nil {
+                    item.status = "waiting_for_input"
+                } else if item.pendingApproval != nil {
+                    item.status = "waiting_for_approval"
+                } else {
+                    item.status = "running"
+                }
+            }
+            if handleQueuedActiveTurnConflict(
+                clientMessageID: clientMessageID,
+                sessionID: sessionID,
+                activeTurnID: activeTurnID
+            ) {
+                setStatusMessage(L10n.text("ui.saved_to_this_machine_and_will_be_sent"))
+                return
+            }
+            conversationStore.updateSendStatus(
+                clientMessageID: clientMessageID,
+                sessionID: sessionID,
+                status: .failed
+            )
+            setStatusMessage(message)
+        case .rejected(let message):
+            if handleQueuedSendRejected(
+                clientMessageID: clientMessageID,
+                sessionID: sessionID,
+                message: message
+            ) {
+                return
+            }
+            conversationStore.updateSendStatus(
+                clientMessageID: clientMessageID,
+                sessionID: sessionID,
+                status: .failed
+            )
+            clearForegroundActivity(sessionID: sessionID)
+            setErrorMessage(L10n.format("ui.sending_failed_value", message))
+        case .uncertain(let message):
+            if handleQueuedSendFailure(
+                clientMessageID: clientMessageID,
+                sessionID: sessionID,
+                message: message
+            ) {
+                return
+            }
+            conversationStore.updateSendStatus(
+                clientMessageID: clientMessageID,
+                sessionID: sessionID,
+                status: .failed
+            )
+            clearForegroundActivity(sessionID: sessionID)
+            setErrorMessage(L10n.format("ui.the_result_of_the_message_to_be_sent", message))
         }
     }
 }

--- a/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
@@ -321,10 +321,22 @@ extension SessionStore {
         outcome: TurnSendOutcome
     ) {
         let recoveredExternalMisclassification: Bool
-        if case .accepted(let turnID) = outcome, let turnID {
+        if let turnID = acceptedTurnID(from: outcome) {
+            // terminal / superseded 也可能在 ACK 回到 MainActor 前被外部活动轮询误判。
+            // 所有带精确 turnID 的 accepted outcome 都必须先撤销只读 tombstone。
+            let shouldRestoreSelectedConnection: Bool
+            switch outcome {
+            case .accepted, .acceptedSuperseded:
+                shouldRestoreSelectedConnection = true
+            case .acceptedTerminal, .acceptedThreadClosed,
+                 .activeTurnConflict, .rejected, .uncertain:
+                // 已终态或已关闭时不先复活旧连接；若仍有队列，finishAccepted 会按需建链。
+                shouldRestoreSelectedConnection = false
+            }
             recoveredExternalMisclassification = recordLocallyStartedTurn(
                 sessionID: sessionID,
-                turnID: turnID
+                turnID: turnID,
+                restoreSelectedConnection: shouldRestoreSelectedConnection
             )
         } else {
             recoveredExternalMisclassification = false
@@ -354,11 +366,15 @@ extension SessionStore {
                 // 期间覆盖已经到达的更新 turn。
                 switch disposition {
                 case .terminal(let turnID):
+                    let terminalStatus = turnID.flatMap {
+                        conversationStore.turnLifecycle(sessionID: sessionID, turnID: $0)
+                    } == .failed ? SessionStatus.failed : .completed
                     updateSession(sessionID) { session in
                         guard session.activeTurnID == nil
                                 || session.activeTurnID == turnID else {
                             return
                         }
+                        session.status = terminalStatus.rawValue
                         session.activeTurnID = nil
                     }
                 case .superseded(let turnID, let activeTurnID):
@@ -403,6 +419,12 @@ extension SessionStore {
                 turnID: turnID,
                 activeTurnID: activeTurnID
             ))
+            if recoveredExternalMisclassification,
+               selectedSessionID != sessionID,
+               queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false {
+                // external snapshot 已停止后台队列 socket；当前权威 turn 完成前必须恢复监听。
+                ensureQueuedSessionMonitoring(sessionID: sessionID)
+            }
         case .acceptedThreadClosed(let turnID):
             finishAccepted(.threadClosed(turnID: turnID))
         case .activeTurnConflict(let activeTurnID, let message):

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+enum QueuedTurnAcceptedDisposition {
+    case awaitingStart(turnID: TurnID?)
+    case guidance
+    case terminal(turnID: TurnID?)
+    case superseded(
+        turnID: TurnID?,
+        activeTurnID: TurnID
+    )
+    case threadClosed(turnID: TurnID?)
+}
+
 // Runtime 使用量、连接配置、Turn、Goal、审批与队列发送共享同一协调边界。
 extension SessionStore {
     func refreshCodexUsage() async {
@@ -1140,10 +1151,77 @@ extension SessionStore {
         }
     }
 
+    func reconciledAcceptedDisposition(
+        sessionID: SessionID,
+        disposition: QueuedTurnAcceptedDisposition
+    ) -> QueuedTurnAcceptedDisposition {
+        let currentActiveTurnID = sessionsByID[sessionID]?.activeTurnID
+        func isTerminal(_ turnID: TurnID) -> Bool {
+            conversationStore.turnLifecycle(
+                sessionID: sessionID,
+                turnID: turnID
+            )?.isTerminal == true
+        }
+
+        switch disposition {
+        case .awaitingStart(let turnID):
+            if let turnID, isTerminal(turnID) {
+                return .terminal(turnID: turnID)
+            }
+            if let currentActiveTurnID,
+               currentActiveTurnID != turnID {
+                return .superseded(
+                    turnID: turnID,
+                    activeTurnID: currentActiveTurnID
+                )
+            }
+            return disposition
+        case .terminal(let turnID):
+            if let currentActiveTurnID,
+               currentActiveTurnID != turnID {
+                return .superseded(
+                    turnID: turnID,
+                    activeTurnID: currentActiveTurnID
+                )
+            }
+            return disposition
+        case .superseded(let turnID, let reportedActiveTurnID):
+            let effectiveActiveTurnID: TurnID
+            if let currentActiveTurnID,
+               currentActiveTurnID != turnID,
+               currentActiveTurnID != reportedActiveTurnID {
+                effectiveActiveTurnID = currentActiveTurnID
+            } else {
+                effectiveActiveTurnID = reportedActiveTurnID
+            }
+            if isTerminal(effectiveActiveTurnID) {
+                // completed(B) 可能先于 superseded(A,B) 落到 MainActor；lifecycle 是
+                // 不会随 activeTurnID 清空而丢失的终态证据，禁止再次复活 B。
+                return .terminal(turnID: effectiveActiveTurnID)
+            }
+            return .superseded(
+                turnID: turnID,
+                activeTurnID: effectiveActiveTurnID
+            )
+        case .threadClosed(let turnID):
+            if let currentActiveTurnID,
+               currentActiveTurnID != turnID {
+                return .superseded(
+                    turnID: turnID,
+                    activeTurnID: currentActiveTurnID
+                )
+            }
+            return disposition
+        case .guidance:
+            return disposition
+        }
+    }
+
     @discardableResult
     func handleQueuedSendAccepted(
         clientMessageID: ClientMessageID,
-        sessionID: SessionID
+        sessionID: SessionID,
+        disposition explicitDisposition: QueuedTurnAcceptedDisposition? = nil
     ) -> Bool {
         guard let location = queuedTurnLocation(clientMessageID: clientMessageID),
               location.sessionID == sessionID,
@@ -1153,22 +1231,98 @@ extension SessionStore {
             return false
         }
         let wasGuidance = queuedGuidanceDispatchClientMessageIDs.remove(clientMessageID) != nil
+        let disposition = reconciledAcceptedDisposition(
+            sessionID: sessionID,
+            disposition: explicitDisposition
+                ?? (wasGuidance
+                    ? .guidance
+                    : .awaitingStart(turnID: nil))
+        )
 
         guard mutateAndPersistQueuedTurns({
             guard var queue = queuedRunningTurnsBySessionID[sessionID],
                   queue.indices.contains(location.index) else { return }
             queue.remove(at: location.index)
-            if !wasGuidance {
+            switch disposition {
+            case .awaitingStart(let turnID):
                 let blockedCompletionID = queuedTurnBlockedCompletionIDBySessionID[sessionID]
                 for index in queue.indices where queue[index].dispatchState == .waiting {
-                    queue[index].waitsForAcceptedTurnStart = true
-                    queue[index].blockedCompletionID = blockedCompletionID
+                    if let turnID {
+                        queue[index].waitsForAcceptedTurnStart = nil
+                        queue[index].blockedCompletionID = nil
+                        queue[index].expectedTurnID = turnID
+                    } else {
+                        queue[index].waitsForAcceptedTurnStart = true
+                        queue[index].blockedCompletionID = blockedCompletionID
+                        queue[index].expectedTurnID = nil
+                    }
+                }
+            case .superseded(_, let activeTurnID):
+                for index in queue.indices where queue[index].dispatchState == .waiting {
+                    queue[index].waitsForAcceptedTurnStart = nil
+                    queue[index].blockedCompletionID = nil
+                    queue[index].expectedTurnID = activeTurnID
+                }
+            case .terminal:
+                for index in queue.indices where queue[index].dispatchState == .waiting {
+                    queue[index].waitsForAcceptedTurnStart = nil
+                    queue[index].blockedCompletionID = nil
                     queue[index].expectedTurnID = nil
                 }
+            case .threadClosed:
+                for index in queue.indices where queue[index].dispatchState == .waiting {
+                    queue[index].waitsForAcceptedTurnStart = nil
+                    queue[index].blockedCompletionID = nil
+                    queue[index].expectedTurnID = nil
+                }
+            case .guidance:
+                break
             }
             setQueuedTurns(queue, sessionID: sessionID)
         }) else {
             return true
+        }
+        switch disposition {
+        case .awaitingStart(let turnID):
+            if turnID != nil {
+                queuedTurnAwaitingStartSessionIDs.remove(sessionID)
+                queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
+            }
+        case .guidance:
+            break
+        case .terminal(let turnID):
+            queuedTurnAwaitingStartSessionIDs.remove(sessionID)
+            queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
+            updateSession(sessionID) { session in
+                guard session.activeTurnID == nil
+                        || session.activeTurnID == turnID else {
+                    return
+                }
+                session.activeTurnID = nil
+            }
+        case .superseded(let turnID, let activeTurnID):
+            queuedTurnAwaitingStartSessionIDs.remove(sessionID)
+            queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
+            updateSession(sessionID) { session in
+                guard session.activeTurnID == nil
+                        || session.activeTurnID == turnID
+                        || session.activeTurnID == activeTurnID else {
+                    return
+                }
+                session.status = SessionStatus.running.rawValue
+                session.activeTurnID = activeTurnID
+            }
+        case .threadClosed(let turnID):
+            queuedTurnAwaitingStartSessionIDs.remove(sessionID)
+            queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
+            updateSession(sessionID) { session in
+                guard session.activeTurnID == nil
+                        || session.activeTurnID == turnID else {
+                    return
+                }
+                session.status = "closed"
+                session.activeTurnID = nil
+            }
         }
         conversationStore.updateSendStatus(
             clientMessageID: clientMessageID,
@@ -1180,6 +1334,10 @@ extension SessionStore {
             sessionID: sessionID
         )
         stopQueuedSessionMonitoringIfIdle(sessionID: sessionID)
+        if case .terminal = disposition {
+            // 终态早于 ACK 时，对应 completion 已经过去；持久化移除首项后立即推进 FIFO。
+            dispatchNextQueuedRunningTurnIfIdle(sessionID: sessionID)
+        }
         return true
     }
 
@@ -1213,101 +1371,6 @@ extension SessionStore {
         queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
         setErrorMessage(L10n.format("ui.the_result_of_the_message_to_be_sent", message))
         return true
-    }
-
-    func handleTurnSendOutcome(
-        clientMessageID: ClientMessageID?,
-        sessionID: SessionID,
-        outcome: TurnSendOutcome
-    ) {
-        let recoveredExternalMisclassification: Bool
-        if case .accepted(let turnID) = outcome, let turnID {
-            recoveredExternalMisclassification = recordLocallyStartedTurn(
-                sessionID: sessionID,
-                turnID: turnID
-            )
-        } else {
-            recoveredExternalMisclassification = false
-        }
-        guard let clientMessageID else { return }
-        switch outcome {
-        case .accepted:
-            if !handleQueuedSendAccepted(clientMessageID: clientMessageID, sessionID: sessionID) {
-                conversationStore.updateSendStatus(
-                    clientMessageID: clientMessageID,
-                    sessionID: sessionID,
-                    status: .sent
-                )
-                conversationStore.compactTurnPayloadAfterSendAccepted(
-                    clientMessageID: clientMessageID,
-                    sessionID: sessionID
-                )
-            }
-            if recoveredExternalMisclassification,
-               selectedSessionID != sessionID,
-               queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false {
-                // external snapshot 会停止后台队列 socket。ACK 对账成功且仍有后续项时，
-                // 重新建立监听，让 FIFO 能在当前 turn 完成后继续派发。
-                ensureQueuedSessionMonitoring(sessionID: sessionID)
-            }
-        case .activeTurnConflict(let activeTurnID, let message):
-            // 这是“新消息未被接受”，不是原会话失败。恢复权威 active turn，
-            // 并保留已有审批/补充问题；排队项回到等待态，待原 turn 完成后再发。
-            updateSession(sessionID) { item in
-                item.activeTurnID = activeTurnID
-                if item.pendingUserInput != nil {
-                    item.status = "waiting_for_input"
-                } else if item.pendingApproval != nil {
-                    item.status = "waiting_for_approval"
-                } else {
-                    item.status = "running"
-                }
-            }
-            if handleQueuedActiveTurnConflict(
-                clientMessageID: clientMessageID,
-                sessionID: sessionID,
-                activeTurnID: activeTurnID
-            ) {
-                setStatusMessage(L10n.text("ui.saved_to_this_machine_and_will_be_sent"))
-                return
-            }
-            conversationStore.updateSendStatus(
-                clientMessageID: clientMessageID,
-                sessionID: sessionID,
-                status: .failed
-            )
-            setStatusMessage(message)
-        case .rejected(let message):
-            if handleQueuedSendRejected(
-                clientMessageID: clientMessageID,
-                sessionID: sessionID,
-                message: message
-            ) {
-                return
-            }
-            conversationStore.updateSendStatus(
-                clientMessageID: clientMessageID,
-                sessionID: sessionID,
-                status: .failed
-            )
-            clearForegroundActivity(sessionID: sessionID)
-            setErrorMessage(L10n.format("ui.sending_failed_value", message))
-        case .uncertain(let message):
-            if handleQueuedSendFailure(
-                clientMessageID: clientMessageID,
-                sessionID: sessionID,
-                message: message
-            ) {
-                return
-            }
-            conversationStore.updateSendStatus(
-                clientMessageID: clientMessageID,
-                sessionID: sessionID,
-                status: .failed
-            )
-            clearForegroundActivity(sessionID: sessionID)
-            setErrorMessage(L10n.format("ui.the_result_of_the_message_to_be_sent", message))
-        }
     }
 
     @discardableResult

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -1293,11 +1293,16 @@ extension SessionStore {
         case .terminal(let turnID):
             queuedTurnAwaitingStartSessionIDs.remove(sessionID)
             queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
+            let terminalStatus = turnID.flatMap {
+                conversationStore.turnLifecycle(sessionID: sessionID, turnID: $0)
+            } == .failed ? SessionStatus.failed : .completed
             updateSession(sessionID) { session in
                 guard session.activeTurnID == nil
                         || session.activeTurnID == turnID else {
                     return
                 }
+                // external activity 误判可能已把已完成会话重写为 running；ACK 必须恢复终态。
+                session.status = terminalStatus.rawValue
                 session.activeTurnID = nil
             }
         case .superseded(let turnID, let activeTurnID):

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -1530,4 +1530,231 @@ extension ConversationDataFlowTests {
         let fullPage = try await fullTask.value
         XCTAssertEqual(fullPage.loadMode, .full)
     }
+
+    // 回归：Claude bridge 的 turn/completed 可能先于 turn/start ACK。终态通知必须胜出，
+    // 否则迟到 ACK 会复活旧 turn，后续输入只能等到刷新 thread 才能继续。
+    func testClaudeTerminalNotificationBeforeTurnStartACKDoesNotReviveCompletedTurn() async throws {
+        let project = AgentProject(id: "proj_claude_terminal_ack", name: "Claude Terminal ACK", path: "/tmp/claude-terminal-ack")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            runtimeProvider: "claude",
+            transportFactory: { transport },
+            turnInterruptRecoveryDelaysNanoseconds: [],
+            configProvider: {
+                makeDirectAppServerConfig(project: project, channels: [makeClaudeChannelMetadata()])
+            }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+
+        let createTask = Task {
+            try await client.createSession(CreateSessionRequest(
+                projectID: project.id,
+                prompt: "快速完成",
+                resumeID: "",
+                clientMessageID: "client_claude_terminal_1"
+            ))
+        }
+
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-claude-bridge","platformFamily":"macos"}"#
+        )
+
+        let threadStart = try await waitForFakeAppServerRequest(transport, method: "thread/start", after: 1)
+        transportResponse(
+            transport,
+            id: threadStart.id,
+            result: #"{"thread":{"id":"thr_claude_terminal_ack","sessionId":"thr_claude_terminal_ack","preview":"快速完成","ephemeral":false,"modelProvider":"anthropic","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"idle"},"path":null,"cwd":"/tmp/claude-terminal-ack","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"Claude 快速完成","turns":[]}}"#
+        )
+
+        let firstTurnStart = try await waitForFakeAppServerRequest(transport, method: "turn/start", after: 2)
+        XCTAssertEqual(firstTurnStart.params?.objectValue?["threadId"]?.stringValue, "thr_claude_terminal_ack")
+
+        // bridge 使用嵌套 turn.id，且完成通知先于对应 RPC response 到达。
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_claude_terminal_ack","turn":{"id":"turn_claude_terminal_1","status":"completed"}}}"#)
+        transportResponse(
+            transport,
+            id: firstTurnStart.id,
+            result: #"{"turn":{"id":"turn_claude_terminal_1","items":[],"itemsView":{"type":"complete"},"status":"completed","error":null,"startedAt":1780490902,"completedAt":1780490903,"durationMs":1}}"#
+        )
+
+        let created = try await createTask.value
+        XCTAssertNil(created.session.activeTurnID, "迟到 ACK 不得把已完成 turn 重新写回 activeTurnID")
+
+        // 第一轮已终态后应能立即发起下一轮，无需刷新 thread。
+        let messagesBeforeFollowUp = await transport.sentMessages()
+        let followUpTask = Task {
+            try await runtime.startTurn(
+                sessionID: "thr_claude_terminal_ack",
+                payload: CodexAppServerTurnPayload(prompt: "继续"),
+                clientMessageID: "client_claude_terminal_2"
+            )
+        }
+        let followUpStart = try await waitForFakeAppServerRequest(
+            transport,
+            method: "turn/start",
+            after: messagesBeforeFollowUp.count
+        )
+        transportResponse(
+            transport,
+            id: followUpStart.id,
+            result: #"{"turn":{"id":"turn_claude_terminal_2","items":[],"itemsView":{"type":"complete"},"status":"inProgress","error":null,"startedAt":1780490904,"completedAt":null,"durationMs":null}}"#
+        )
+        let followUpTurnID = try await followUpTask.value
+        XCTAssertEqual(followUpTurnID, "turn_claude_terminal_2")
+
+        // 若 ACK 等待期间已经观察到另一轮 turn/started，旧 ACK 同样不能覆盖较新的 active turn。
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_claude_terminal_ack","turnId":"turn_claude_terminal_2"}}"#)
+        for _ in 0..<200 {
+            let activeTurnID = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+            if activeTurnID == nil {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        // 即使 completion 通知丢失，ACK 自身已经是 completed 也必须直接收敛为终态。
+        let messagesBeforeTerminalACK = await transport.sentMessages()
+        let terminalACKTask = Task {
+            try await runtime.startTurnOutcome(
+                sessionID: "thr_claude_terminal_ack",
+                payload: CodexAppServerTurnPayload(prompt: "ACK 已终态"),
+                clientMessageID: "client_claude_terminal_3"
+            )
+        }
+        let terminalACKStart = try await waitForFakeAppServerRequest(
+            transport,
+            method: "turn/start",
+            after: messagesBeforeTerminalACK.count
+        )
+        transportResponse(
+            transport,
+            id: terminalACKStart.id,
+            result: #"{"turn":{"id":"turn_claude_terminal_3","items":[],"itemsView":{"type":"complete"},"status":"completed","error":null,"startedAt":1780490905,"completedAt":1780490906,"durationMs":1}}"#
+        )
+        let terminalACKOutcome = try await terminalACKTask.value
+        XCTAssertEqual(
+            terminalACKOutcome,
+            .terminal(turnID: "turn_claude_terminal_3")
+        )
+        let activeAfterTerminalACK = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+        XCTAssertNil(activeAfterTerminalACK)
+
+        // pending start 窗口里的无 ID completion 可能是连接重放，不能伪造新 turn 已完成。
+        let messagesBeforeUnidentifiedReplay = await transport.sentMessages()
+        let unidentifiedReplayTask = Task {
+            try await runtime.startTurnOutcome(
+                sessionID: "thr_claude_terminal_ack",
+                payload: CodexAppServerTurnPayload(prompt: "忽略旧重放"),
+                clientMessageID: "client_claude_terminal_4"
+            )
+        }
+        let unidentifiedReplayStart = try await waitForFakeAppServerRequest(
+            transport,
+            method: "turn/start",
+            after: messagesBeforeUnidentifiedReplay.count
+        )
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_claude_terminal_ack"}}"#)
+        transportResponse(
+            transport,
+            id: unidentifiedReplayStart.id,
+            result: #"{"turn":{"id":"turn_claude_unidentified_replay","items":[],"itemsView":{"type":"complete"},"status":"inProgress","error":null,"startedAt":1780490907,"completedAt":null,"durationMs":null}}"#
+        )
+        let unidentifiedReplayOutcome = try await unidentifiedReplayTask.value
+        XCTAssertEqual(
+            unidentifiedReplayOutcome,
+            .active(turnID: "turn_claude_unidentified_replay")
+        )
+        let activeAfterUnidentifiedReplay = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+        XCTAssertEqual(activeAfterUnidentifiedReplay, "turn_claude_unidentified_replay")
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_claude_terminal_ack","turnId":"turn_claude_unidentified_replay"}}"#)
+        for _ in 0..<200 {
+            let current = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+            if current == nil {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        let messagesBeforeRacingTurn = await transport.sentMessages()
+        let racingTurnTask = Task {
+            try await runtime.startTurn(
+                sessionID: "thr_claude_terminal_ack",
+                payload: CodexAppServerTurnPayload(prompt: "第三轮"),
+                clientMessageID: "client_claude_terminal_5"
+            )
+        }
+        let racingTurnStart = try await waitForFakeAppServerRequest(
+            transport,
+            method: "turn/start",
+            after: messagesBeforeRacingTurn.count
+        )
+        transport.enqueue(#"{"method":"turn/started","params":{"threadId":"thr_claude_terminal_ack","turn":{"id":"turn_claude_external_new","status":"inProgress"}}}"#)
+        transportResponse(
+            transport,
+            id: racingTurnStart.id,
+            result: #"{"turn":{"id":"turn_claude_terminal_5","items":[],"itemsView":{"type":"complete"},"status":"inProgress","error":null,"startedAt":1780490908,"completedAt":null,"durationMs":null}}"#
+        )
+        let racingTurnID = try await racingTurnTask.value
+        XCTAssertNil(racingTurnID, "迟到 ACK 不应向上层暴露可复活旧状态的 turnID")
+
+        // 更旧 turn 的平铺 turnId 完成通知也不能清掉已经开始的新 turn。
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_claude_terminal_ack","turnId":"turn_claude_older"}}"#)
+        for _ in 0..<200 {
+            let activeTurnID = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+            if activeTurnID == "turn_claude_external_new" {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        var activeTurnID = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+        XCTAssertEqual(activeTurnID, "turn_claude_external_new", "旧完成通知不得清掉当前新 turn")
+
+        // 无 turn ID 的旧协议 completion 也不能再猜测并清空当前新 turn。
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_claude_terminal_ack"}}"#)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        activeTurnID = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+        XCTAssertEqual(activeTurnID, "turn_claude_external_new")
+
+        // thread/closed 是不可继续边界，迟到的 ACK 既不能复活 thread，也不能让 FIFO 自动续发。
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_claude_terminal_ack","turnId":"turn_claude_external_new"}}"#)
+        for _ in 0..<200 {
+            let current = await runtime.contextsBySessionID["thr_claude_terminal_ack"]?.activeTurnID
+            if current == nil {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let messagesBeforeClosedTurn = await transport.sentMessages()
+        let closedTurnTask = Task {
+            try await runtime.startTurnOutcome(
+                sessionID: "thr_claude_terminal_ack",
+                payload: CodexAppServerTurnPayload(prompt: "关闭边界"),
+                clientMessageID: "client_claude_terminal_6"
+            )
+        }
+        let closedTurnStart = try await waitForFakeAppServerRequest(
+            transport,
+            method: "turn/start",
+            after: messagesBeforeClosedTurn.count
+        )
+        transport.enqueue(#"{"method":"thread/closed","params":{"threadId":"thr_claude_terminal_ack"}}"#)
+        transportResponse(
+            transport,
+            id: closedTurnStart.id,
+            result: #"{"turn":{"id":"turn_claude_terminal_6","items":[],"itemsView":{"type":"complete"},"status":"inProgress","error":null,"startedAt":1780490909,"completedAt":null,"durationMs":null}}"#
+        )
+        let closedTurnOutcome = try await closedTurnTask.value
+        XCTAssertEqual(
+            closedTurnOutcome,
+            .threadClosed(turnID: "turn_claude_terminal_6")
+        )
+        let closedContext = await runtime.contextsBySessionID["thr_claude_terminal_ack"]
+        XCTAssertEqual(closedContext?.session.status, "closed")
+        XCTAssertNil(closedContext?.activeTurnID)
+    }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
@@ -221,6 +221,165 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(sockets[0].sentTurns.map(\.payload.textPrompt), ["下一轮第一条", "下一轮第二条"])
     }
 
+    func testTerminalBeforeStartACKImmediatelyAdvancesQueuedFIFO() async throws {
+        let project = makeProject(id: "proj_terminal_before_ack_queue")
+        let running = makeSession(
+            id: "sess_terminal_before_ack_queue",
+            projectID: project.id,
+            title: "Terminal Before ACK",
+            status: SessionStatus.running.rawValue,
+            source: "claude",
+            activeTurnID: "turn_existing"
+        )
+        let appStore = AppStore()
+        appStore.token = "test-token"
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: {
+                MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
+            },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(running)
+        await store.selectSession(running)
+        sockets[0].emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        let acceptedFirst = await store.sendTurn(CodexAppServerTurnPayload(prompt: "快速第一条"))
+        let acceptedSecond = await store.sendTurn(CodexAppServerTurnPayload(prompt: "紧接第二条"))
+        XCTAssertTrue(acceptedFirst)
+        XCTAssertTrue(acceptedSecond)
+        sockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+            seq: 1,
+            sessionID: running.id,
+            turnID: "turn_existing",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )))
+        try await waitForSentTurnCount(1, socket: sockets[0])
+        let firstClientMessageID = try XCTUnwrap(sockets[0].sentTurns.first?.clientMessageID)
+
+        // Claude 的 completion 先到，随后 ACK 才确认这条消息已接受且已终态。
+        sockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+            seq: 2,
+            sessionID: running.id,
+            turnID: "turn_fast",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: firstClientMessageID,
+            revision: nil,
+            createdAt: nil
+        )))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        sockets[0].onTurnSendOutcome?(
+            firstClientMessageID,
+            .acceptedTerminal(turnID: "turn_fast")
+        )
+
+        try await waitForSentTurnCount(2, socket: sockets[0])
+        XCTAssertEqual(
+            sockets[0].sentTurns.map(\.payload.textPrompt),
+            ["快速第一条", "紧接第二条"]
+        )
+        XCTAssertFalse(store.selectedQueuedTurns.first?.waitsForAcceptedTurnStart == true)
+    }
+
+    func testNewTurnBeforeOldACKBindsQueuedFIFOToNewestTurn() async throws {
+        let project = makeProject(id: "proj_new_turn_before_old_ack")
+        let running = makeSession(
+            id: "sess_new_turn_before_old_ack",
+            projectID: project.id,
+            title: "New Turn Before Old ACK",
+            status: SessionStatus.running.rawValue,
+            source: "claude",
+            activeTurnID: "turn_existing"
+        )
+        let appStore = AppStore()
+        appStore.token = "test-token"
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: {
+                MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
+            },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(running)
+        await store.selectSession(running)
+        sockets[0].emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        let acceptedOldACKMessage = await store.sendTurn(CodexAppServerTurnPayload(prompt: "旧 ACK 消息"))
+        let acceptedWaitingMessage = await store.sendTurn(CodexAppServerTurnPayload(prompt: "等待新轮次"))
+        XCTAssertTrue(acceptedOldACKMessage)
+        XCTAssertTrue(acceptedWaitingMessage)
+        sockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+            seq: 1,
+            sessionID: running.id,
+            turnID: "turn_existing",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )))
+        try await waitForSentTurnCount(1, socket: sockets[0])
+        let firstClientMessageID = try XCTUnwrap(sockets[0].sentTurns.first?.clientMessageID)
+        sockets[0].emitEvent(.turnStarted(AgentEventMetadata(
+            seq: 2,
+            sessionID: running.id,
+            turnID: "turn_newest",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )))
+        try await waitForSelectedActiveTurnID("turn_newest", store: store)
+        // B 的完成先落地，随后旧的 superseded(A,B) outcome 才切到 MainActor。
+        sockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+            seq: 3,
+            sessionID: running.id,
+            turnID: "turn_newest",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )))
+        try await waitForSelectedActiveTurnID(nil, store: store)
+        sockets[0].onTurnSendOutcome?(
+            firstClientMessageID,
+            .acceptedSuperseded(
+                turnID: "turn_old_ack",
+                activeTurnID: "turn_newest"
+            )
+        )
+        try await waitForSentTurnCount(2, socket: sockets[0])
+        XCTAssertNil(store.selectedSession?.activeTurnID, "迟到 superseded outcome 不得复活已完成的 B")
+        XCTAssertEqual(sockets[0].sentTurns.last?.payload.textPrompt, "等待新轮次")
+    }
+
     func testQueuedTurnPersistsAcrossStoreRestartAndAmbiguousDispatchRequiresConfirmation() async throws {
         let project = makeProject(id: "proj_queue_restart")
         let running = makeSession(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
@@ -378,7 +378,10 @@ extension ConversationDataFlowTests {
             hostScope: store.appStore.activeHostScope
         ))
 
-        socket.onTurnSendOutcome?(nil, .accepted(turnID: "turn-local-race"))
+        socket.onTurnSendOutcome?(
+            nil,
+            .accepted(turnID: "turn-local-race")
+        )
         for _ in 0..<10 where store.externalActivityBySessionID[threadID] != nil {
             await Task.yield()
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
@@ -455,6 +455,242 @@ extension ConversationDataFlowTests {
         )
     }
 
+    func testTerminalAckAfterExternalMisclassificationDispatchesNextQueuedTurn() async throws {
+        let project = makeProject(id: "proj_external_terminal_ack")
+        let threadID = "thread-terminal-ack"
+        let acceptedClientMessageID = "client-terminal-ack"
+        let nextClientMessageID = "client-terminal-next"
+        let localTurnID = "turn-terminal-local"
+        let session = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "终态 ACK 撤销误判",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID,
+            activeTurnID: localTurnID
+        )
+        let client = MockSessionStoreClient(projects: [project], sessions: [session])
+        let socket = MockWebSocketClient()
+        let store = makeExternalActivityStore(
+            project: project,
+            session: session,
+            client: client,
+            socket: socket
+        )
+        store.sessionControlStateByID[threadID] = .takenOver
+        store.queuedRunningTurnsBySessionID[threadID] = [
+            QueuedTurnEntry(
+                sessionID: threadID,
+                projectID: project.id,
+                payload: CodexAppServerTurnPayload(prompt: "已接受且快速完成"),
+                clientMessageID: acceptedClientMessageID,
+                intent: .standard,
+                dispatchState: .needsConfirmation
+            ),
+            QueuedTurnEntry(
+                sessionID: threadID,
+                projectID: project.id,
+                payload: CodexAppServerTurnPayload(prompt: "终态后继续"),
+                clientMessageID: nextClientMessageID,
+                intent: .standard,
+                expectedTurnID: localTurnID
+            )
+        ]
+        store.externalActivityBySessionID[threadID] = makeExternalActivity(
+            threadID: threadID,
+            projectID: project.id,
+            turnID: localTurnID,
+            revision: "rev-terminal-local"
+        )
+        store.externalReadOnlySessionIDs.insert(threadID)
+
+        store.handleTurnSendOutcome(
+            clientMessageID: acceptedClientMessageID,
+            sessionID: threadID,
+            outcome: .acceptedTerminal(turnID: localTurnID)
+        )
+
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.externalReadOnlySessionIDs.contains(threadID))
+        XCTAssertEqual(store.locallyStartedTurnIDBySessionID[threadID], localTurnID)
+        XCTAssertNil(store.sessionsByID[threadID]?.activeTurnID)
+        XCTAssertEqual(socket.connectedSessionIDs, [threadID])
+
+        socket.emitStatus(.connected)
+        try await waitForSentTurnCount(1, socket: socket)
+        XCTAssertEqual(socket.sentTurns.first?.payload.textPrompt, "终态后继续")
+        XCTAssertEqual(
+            store.queuedRunningTurnsBySessionID[threadID]?.first?.dispatchState,
+            .dispatching
+        )
+    }
+
+    func testTerminalAckAfterLaggingExternalSnapshotRestoresCompletedStatus() async throws {
+        let project = makeProject(id: "proj_external_terminal_status")
+        let threadID = "thread-terminal-status"
+        let clientMessageID = "client-terminal-status"
+        let localTurnID = "turn-terminal-status"
+        let session = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "终态 ACK 恢复完成状态",
+            status: SessionStatus.completed.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let client = MockSessionStoreClient(projects: [project], sessions: [session])
+        let socket = MockWebSocketClient()
+        let store = makeExternalActivityStore(
+            project: project,
+            session: session,
+            client: client,
+            socket: socket
+        )
+        store.sessionControlStateByID[threadID] = .takenOver
+        store.queuedRunningTurnsBySessionID[threadID] = [QueuedTurnEntry(
+            sessionID: threadID,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "已完成但 ACK 迟到"),
+            clientMessageID: clientMessageID,
+            intent: .standard,
+            dispatchState: .needsConfirmation
+        )]
+        store.conversationStore.updateTurnLifecycle(
+            .completed,
+            metadata: AgentEventMetadata(
+                seq: 1,
+                sessionID: threadID,
+                turnID: localTurnID,
+                itemID: nil,
+                messageID: nil,
+                clientMessageID: clientMessageID,
+                revision: nil,
+                createdAt: nil
+            ),
+            fallbackSessionID: threadID
+        )
+
+        // completion 已先投影，随后滞后的外部活动快照又错误复活同一 turn。
+        await store.applyExternalActivitySnapshot(
+            [makeExternalActivity(
+                threadID: threadID,
+                projectID: project.id,
+                turnID: localTurnID,
+                revision: "rev-terminal-status"
+            )],
+            client: client,
+            hostScope: store.appStore.activeHostScope
+        )
+        XCTAssertEqual(store.sessionsByID[threadID]?.status, SessionStatus.running.rawValue)
+        XCTAssertTrue(store.externalReadOnlySessionIDs.contains(threadID))
+
+        store.handleTurnSendOutcome(
+            clientMessageID: clientMessageID,
+            sessionID: threadID,
+            outcome: .acceptedTerminal(turnID: localTurnID)
+        )
+
+        XCTAssertTrue(store.queuedRunningTurnsBySessionID[threadID]?.isEmpty != false)
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.externalReadOnlySessionIDs.contains(threadID))
+        XCTAssertNil(store.sessionsByID[threadID]?.activeTurnID)
+        XCTAssertEqual(store.sessionsByID[threadID]?.status, SessionStatus.completed.rawValue)
+        XCTAssertTrue(socket.connectedSessionIDs.isEmpty, "无后续队列时不应复活已结束连接")
+    }
+
+    func testSupersededAckAfterExternalMisclassificationRestoresBackgroundMonitoring() async throws {
+        let project = makeProject(id: "proj_external_superseded_ack")
+        let threadID = "thread-superseded-ack"
+        let acceptedClientMessageID = "client-superseded-ack"
+        let nextClientMessageID = "client-superseded-next"
+        let localTurnID = "turn-superseded-local"
+        let authoritativeTurnID = "turn-superseded-authoritative"
+        let session = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "新轮次 ACK 撤销误判",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID,
+            activeTurnID: localTurnID
+        )
+        let client = MockSessionStoreClient(projects: [project], sessions: [session])
+        let socket = MockWebSocketClient()
+        let store = makeExternalActivityStore(
+            project: project,
+            session: session,
+            client: client,
+            socket: socket
+        )
+        store.sessionControlStateByID[threadID] = .takenOver
+        store.queuedRunningTurnsBySessionID[threadID] = [
+            QueuedTurnEntry(
+                sessionID: threadID,
+                projectID: project.id,
+                payload: CodexAppServerTurnPayload(prompt: "已被新轮次取代"),
+                clientMessageID: acceptedClientMessageID,
+                intent: .standard,
+                dispatchState: .needsConfirmation
+            ),
+            QueuedTurnEntry(
+                sessionID: threadID,
+                projectID: project.id,
+                payload: CodexAppServerTurnPayload(prompt: "等待权威轮次完成"),
+                clientMessageID: nextClientMessageID,
+                intent: .standard,
+                expectedTurnID: localTurnID
+            )
+        ]
+        store.externalActivityBySessionID[threadID] = makeExternalActivity(
+            threadID: threadID,
+            projectID: project.id,
+            turnID: localTurnID,
+            revision: "rev-superseded-local"
+        )
+        store.externalReadOnlySessionIDs.insert(threadID)
+
+        store.handleTurnSendOutcome(
+            clientMessageID: acceptedClientMessageID,
+            sessionID: threadID,
+            outcome: .acceptedSuperseded(
+                turnID: localTurnID,
+                activeTurnID: authoritativeTurnID
+            )
+        )
+
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.externalReadOnlySessionIDs.contains(threadID))
+        XCTAssertEqual(store.locallyStartedTurnIDBySessionID[threadID], localTurnID)
+        XCTAssertEqual(store.sessionsByID[threadID]?.activeTurnID, authoritativeTurnID)
+        XCTAssertEqual(
+            store.queuedRunningTurnsBySessionID[threadID]?.first?.expectedTurnID,
+            authoritativeTurnID
+        )
+        XCTAssertEqual(socket.connectedSessionIDs, [threadID])
+
+        socket.emitStatus(.connected)
+        socket.emitEvent(.turnCompleted(AgentEventMetadata(
+            seq: 1,
+            sessionID: threadID,
+            turnID: authoritativeTurnID,
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )))
+        try await waitForSentTurnCount(1, socket: socket)
+        XCTAssertEqual(socket.sentTurns.first?.payload.textPrompt, "等待权威轮次完成")
+        XCTAssertEqual(
+            store.queuedRunningTurnsBySessionID[threadID]?.first?.dispatchState,
+            .dispatching
+        )
+    }
+
     func testCompletedLocalTurnIgnoresLaggingSameTurnSnapshot() async throws {
         let project = makeProject(id: "proj_external_terminal_lag")
         let threadID = "thread-terminal-lag"


### PR DESCRIPTION
## 目标

修复 Claude Code 会话中流式事件到达后界面迟迟不更新、需要手动刷新才能看到结果的问题。

Linear: https://linear.app/code89757/issue/MIM-47/claude-code-会话流式回复不及时需手动刷新才能显示

## 根因

Claude bridge 在把输入交给 Claude 后，仍同步等待非关键的会话标题索引落盘才返回 `turn/start` ACK。Claude 事件可能在 ACK 之前完成；客户端 runtime actor 在重入窗口里先清除 active turn，随后又被迟到 ACK 写回旧 turn，造成界面状态与历史不一致。

## 实现

- 标题预览回填改为非阻塞任务，不再延迟 `turn/start` ACK。
- runtime 为每次启动请求记录终态边界，区分 active、terminal、superseded 和 thread closed。
- 兼容 Claude 无 turn ID 的完成事件，通过权威历史对账恢复，禁止直接猜测并清除新 turn。
- Store 按本次请求、被替换的 stale turn 和权威 active turn 收敛状态，防止迟到 ACK 复活旧 turn。
- terminal / superseded ACK 会用精确 turnID 撤销 external activity 轮询造成的本地只读误判，并按需恢复后台 FIFO 监听。
- terminal ACK 会根据已投影的 lifecycle 恢复 completed / failed，避免滞后快照遗留 `running + active=nil`。
- 补齐 terminal-before-ACK、new-turn-before-old-ACK、无 ID 完成、旧完成晚到以及 FIFO 队列推进回归测试。

## 验证

- `cargo test --locked -p alleycat-claude-bridge`：204 个测试通过。
- 11 个 iOS 定向竞态/恢复测试通过，覆盖 terminal / superseded external activity 误判与无后续队列终态收敛。
- `scripts/check-source-size.sh` 通过；turn/start 终态观察已拆到独立文件，事件投影主文件降至 1880 行。
- iPad Pro 13-inch (M5) / iOS 27.0 模拟器两次构建、安装、启动成功；构建无警告无错误，运行界面快照可读取。
- 一次测试 runner 被外部流程 SIGKILL，原测试立即重跑通过；不是断言失败。

## 待验证

- 已准备最小脱敏审查包，但 Codex 内置浏览器 `iab` 当前不可用；按授权边界未改用 Chrome，因此 ChatGPT Pro 独立审查尚未执行。
- 当前模拟器没有可用的真实 Claude 配对会话；真实会话端到端流式体验需在可配对环境补验。
