### PR TITLE
MIM-48 Raise full history response cap to 5 MiB

### DIFF
--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -53,13 +53,13 @@ var (
 	appServerGatewayPendingServerRequestMax             = 256
 	appServerGatewayPendingHistoryRequestTTL            = 2 * time.Minute
 	appServerGatewayPendingHistoryRequestMax            = 256
-	appServerGatewayHistoryResponseCapBytes             = 2 << 20
+	appServerGatewayHistoryResponseCapBytes             = 5 << 20
 	appServerGatewayHistoryBudgetWindow                 = 15 * time.Second
 	appServerGatewayHistoryBudgetMaxRequests            = 6
 	appServerGatewayHistoryBudgetMaxRequestBytes        = int64(64 << 10)
 	appServerGatewayHistoryBudgetMaxResponseBytes       = int64(8 << 20)
-	// 5 Mbps 链路 15 秒理论可传约 8.9 MiB；取 8 MiB 给协议和控制流量留出余量。
-	// 单次历史响应仍受 2 MiB cap 约束，避免一个大响应独占链路。
+	// 5 Mbps 链路下单次 5 MiB payload 理论约需 8.4 秒；15 秒窗口保留协议和弱网余量。
+	// 8 MiB 总预算继续限制同一窗口内的重复大响应，避免放宽单次 cap 后独占链路。
 	appServerGatewayHistoryGlobalMaxResponseBytes int64 = 8 << 20
 	appServerGatewayHistoryGlobalWindow                 = appServerGatewayHistoryBudgetWindow
 )

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -1717,6 +1717,31 @@ func TestGatewayThreadResumeRejectsUnsafeInitialTurnsPage(t *testing.T) {
 	}
 }
 
+func TestAppServerGatewayHistoryResponseCapDefaultsToFiveMiB(t *testing.T) {
+	if got, want := appServerGatewayHistoryResponseCapBytes, 5<<20; got != want {
+		t.Fatalf("单次 full 历史响应 cap 应为 5 MiB，got=%d want=%d", got, want)
+	}
+	if got, want := appServerGatewayHistoryBudgetWindow, 15*time.Second; got != want {
+		t.Fatalf("单连接历史预算窗口应保持 15 秒，got=%s want=%s", got, want)
+	}
+	if got, want := appServerGatewayHistoryBudgetMaxResponseBytes, int64(8<<20); got != want {
+		t.Fatalf("单连接历史响应总预算应保持 8 MiB，got=%d want=%d", got, want)
+	}
+	if got, want := appServerGatewayHistoryGlobalWindow, 15*time.Second; got != want {
+		t.Fatalf("全局历史预算窗口应保持 15 秒，got=%s want=%s", got, want)
+	}
+	if got, want := appServerGatewayHistoryGlobalMaxResponseBytes, int64(8<<20); got != want {
+		t.Fatalf("全局历史响应总预算应保持 8 MiB，got=%d want=%d", got, want)
+	}
+	if int64(appServerGatewayHistoryResponseCapBytes) > appServerGatewayHistoryGlobalMaxResponseBytes {
+		t.Fatalf(
+			"单次历史响应 cap 不应超过 15 秒全局预算，cap=%d budget=%d",
+			appServerGatewayHistoryResponseCapBytes,
+			appServerGatewayHistoryGlobalMaxResponseBytes,
+		)
+	}
+}
+
 func TestAppServerGatewayCapsOversizedHistoryResponses(t *testing.T) {
 	oldCap := appServerGatewayHistoryResponseCapBytes
 	oldBudgetBytes := appServerGatewayHistoryBudgetMaxResponseBytes


### PR DESCRIPTION
## What changed

- raise the default single full-history response cap from 2 MiB to 5 MiB
- keep the existing 8 MiB response budgets and 15-second windows unchanged
- update the bandwidth rationale in the gateway comments
- add regression coverage for the 5 MiB cap and both local/global 8 MiB / 15-second budget defaults

## Why

MIM-48 identified a real `thread/turns/list itemsView=full` response that reached 3,950,273 bytes after inline images had already been externalized. The previous 2 MiB cap forced the iPad client into summary history even though the response fits the existing bandwidth window.

Sampling the current workspace's latest full-history pages showed a post-redaction maximum of about 4.20 MiB. A 5 MiB cap covers that head case while the unchanged 8 MiB budgets continue to limit repeated large responses.

## Impact

Running long sessions can load a larger complete recent-history page before falling back to summary mode. Requests above 5 MiB remain blocked, and the existing request deduplication and response budgets remain in effect.

## Validation

- `go test ./internal/httpapi -run 'TestAppServerGateway(HistoryResponseCapDefaultsToFiveMiB|CapsOversizedHistoryResponses|RedactsInlineHistoryImagesBeforeCap)$' -count=1`
- `go test ./internal/... -count=1`
- `go build ./...`
- `git diff --check origin/main...HEAD`

All checks passed after rebasing onto the latest `origin/main`.

## Runtime validation

This is a backend-only default limit change. No iOS/Xcode/Simulator validation was needed. A live agentd process has not been rebuilt or restarted from this branch, so deployment behavior remains to be verified after merge/release.

Related: MIM-48
