### PR TITLE
MIM-54 Reconcile gateway turns after agentd restart

### DIFF
--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -1008,7 +1008,29 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 		OutputBuffer: cfg.Session.OutputBufferBytes,
 	})
 
-	apiHandler, apiRouter := httpapi.NewRouterWithRuntimeAndInstallationID(cfg, registry, manager, checker, version, installationID, nil)
+	configDir, err := config.UserConfigDir()
+	if err != nil {
+		manager.Shutdown()
+		if appServerWSProcess != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), serveRuntimeShutdownTimeout)
+			_ = appServerWSProcess.Shutdown(ctx)
+			cancel()
+		}
+		return fmt.Errorf("解析 agentd 私有状态目录失败：%w", err)
+	}
+	gatewayTurnClaimStorePath := filepath.Join(configDir, "state", "gateway-turn-claims.json")
+	apiHandler, apiRouter := httpapi.NewRouterWithRuntimeInstallationIDAndOptions(
+		cfg,
+		registry,
+		manager,
+		checker,
+		version,
+		installationID,
+		nil,
+		httpapi.RouterOptions{
+			GatewayTurnClaimStorePath: gatewayTurnClaimStorePath,
+		},
+	)
 	if appServerWSProcess != nil {
 		apiRouter.SetCodexRuntimeStartedAt(appServerWSProcess.StartedAt())
 	}

--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -27,10 +27,12 @@ const (
 	gatewayTurnRegistrationLimit = 512
 	gatewayTurnRegistrationIDMax = 256
 	gatewayTurnEventClockSkew    = 2 * time.Second
-	// task_started 与 user_message 是同一次 turn/start 的相邻生命周期事件。
-	// 除了都要落在 registration TTL 内，两者还必须足够接近，避免失败请求的
-	// user_message 证据错误归属给稍后真正由 Mac 发起的 turn。
-	gatewayTurnLifecycleWindow = 10 * time.Second
+	// gateway 在写入 upstream 前登记；task_started 应很快出现。真实 app-server
+	// 冷启动时 user_message 可能比 task_started 晚十几秒落盘，因此不能再用
+	// 两个 rollout 事件的短间隔判断归属。改为要求 task_started 靠近登记时刻，
+	// 同时保留精确 Thread+client ID 和 2 分钟总 TTL。
+	gatewayTurnStartWindow     = 30 * time.Second
+	gatewayTurnLifecycleWindow = gatewayTurnRegistrationTTL
 )
 
 // ExternalActivity 是允许返回给移动端的最小只读快照。
@@ -51,6 +53,8 @@ type ExternalActivityDiagnostics struct {
 	CacheHits        int `json:"cache_hits"`
 	MalformedLines   int `json:"malformed_lines"`
 	OversizedLines   int `json:"oversized_lines"`
+	ClaimStoreWrites int `json:"claim_store_writes"`
+	ClaimStoreErrors int `json:"claim_store_errors"`
 }
 
 type externalActivityCandidate struct {
@@ -121,25 +125,54 @@ type ExternalActivityTracker struct {
 	candidates   []externalActivityCandidate
 	files        map[string]externalRolloutCacheEntry
 	gatewayTurns map[string]gatewayTurnRegistration
-	diagnostics  ExternalActivityDiagnostics
+	// ownedGatewayTurns 是精确的 Thread+Turn 归属证据。生产环境可为它配置
+	// 私有 claim store，使 managed app-server 被重启强杀后，新 Tracker 仍能
+	// 区分旧 iPad turn 与真正的新 Mac turn。
+	ownedGatewayTurns   map[string]gatewayOwnedTurnClaim
+	gatewayClaimStore   *gatewayTurnClaimStore
+	gatewayClaimsLoaded bool
+	gatewayClaimsDirty  bool
+	diagnostics         ExternalActivityDiagnostics
 }
 
 func NewExternalActivityTracker(db string, registry *projects.Registry) *ExternalActivityTracker {
 	return &ExternalActivityTracker{
-		store:        NewThreadStore(db),
-		registry:     registry,
-		staleAfter:   defaultExternalActivityStaleAfter,
-		now:          time.Now,
-		stat:         os.Stat,
-		open:         os.Open,
-		query:        sqliteQueryFunc,
-		files:        map[string]externalRolloutCacheEntry{},
-		gatewayTurns: map[string]gatewayTurnRegistration{},
+		store:               NewThreadStore(db),
+		registry:            registry,
+		staleAfter:          defaultExternalActivityStaleAfter,
+		now:                 time.Now,
+		stat:                os.Stat,
+		open:                os.Open,
+		query:               sqliteQueryFunc,
+		files:               map[string]externalRolloutCacheEntry{},
+		gatewayTurns:        map[string]gatewayTurnRegistration{},
+		ownedGatewayTurns:   map[string]gatewayOwnedTurnClaim{},
+		gatewayClaimsLoaded: true,
 	}
 }
 
 func NewDefaultExternalActivityTracker(registry *projects.Registry) *ExternalActivityTracker {
 	return NewExternalActivityTracker("", registry)
+}
+
+// NewExternalActivityTrackerWithClaimStore 只为生产入口和重启回归测试启用持久化。
+// 普通 Router/单元测试继续使用纯内存构造器，避免污染当前用户的状态目录。
+func NewExternalActivityTrackerWithClaimStore(
+	db string,
+	registry *projects.Registry,
+	claimStorePath string,
+) *ExternalActivityTracker {
+	tracker := NewExternalActivityTracker(db, registry)
+	tracker.gatewayClaimStore = newGatewayTurnClaimStore(claimStorePath)
+	tracker.gatewayClaimsLoaded = tracker.gatewayClaimStore == nil
+	return tracker
+}
+
+func NewDefaultExternalActivityTrackerWithClaimStore(
+	registry *projects.Registry,
+	claimStorePath string,
+) *ExternalActivityTracker {
+	return NewExternalActivityTrackerWithClaimStore("", registry, claimStorePath)
 }
 
 func (t *ExternalActivityTracker) Diagnostics() ExternalActivityDiagnostics {
@@ -165,13 +198,17 @@ func (t *ExternalActivityTracker) RegisterGatewayTurnStart(threadID string, clie
 	defer t.mu.Unlock()
 
 	now := t.now().UTC()
+	t.ensureGatewayTurnClaimsLoaded(now)
 	t.pruneGatewayTurnRegistrations(now)
+	t.pruneGatewayOwnedTurnClaims(now)
 	if t.gatewayTurns == nil {
 		t.gatewayTurns = map[string]gatewayTurnRegistration{}
 	}
 	key := gatewayTurnRegistrationKey(threadID, clientUserMessageID)
 	t.gatewayTurns[key] = gatewayTurnRegistration{registeredAt: now}
-	t.trimGatewayTurnRegistrations()
+	t.gatewayClaimsDirty = true
+	t.trimGatewayTurnClaims()
+	t.persistGatewayTurnClaims()
 }
 
 // Snapshot 只返回仍有外部 turn 运行证据的白名单项目线程。
@@ -183,13 +220,17 @@ func (t *ExternalActivityTracker) Snapshot() ([]ExternalActivity, error) {
 	if t.registry == nil {
 		return []ExternalActivity{}, nil
 	}
+	now := t.now().UTC()
+	t.ensureGatewayTurnClaimsLoaded(now)
+	t.pruneGatewayTurnRegistrations(now)
+	t.pruneGatewayOwnedTurnClaims(now)
+	defer t.persistGatewayTurnClaims()
+
 	candidates, err := t.loadCandidates()
 	if err != nil {
 		return nil, err
 	}
 
-	now := t.now()
-	t.pruneGatewayTurnRegistrations(now.UTC())
 	activities := make([]ExternalActivity, 0, len(candidates))
 	knownPaths := make(map[string]struct{}, len(candidates))
 	for _, candidate := range candidates {
@@ -210,8 +251,23 @@ func (t *ExternalActivityTracker) Snapshot() ([]ExternalActivity, error) {
 		if err != nil {
 			continue
 		}
-		if expireGatewayTurnPending(&entry, now.UTC()) {
+		if entry.gatewayOwned &&
+			!t.hasGatewayOwnedTurnClaim(entry.metaThreadID, entry.turnID) {
+			// claim TTL/容量裁剪已经失效时，不能让内存 rollout cache 继续隐藏 turn。
+			// 此时若文件仍新鲜，安全降级为 external；若文件也已 stale，则自然不返回。
+			entry.gatewayOwned = false
 			t.files[path] = entry
+		}
+		if expireGatewayTurnPending(&entry, now) {
+			t.files[path] = entry
+		}
+		if entry.active && entry.gatewayOwned {
+			t.refreshGatewayOwnedTurnClaim(
+				entry.metaThreadID,
+				entry.turnID,
+				info.ModTime().UTC(),
+				now,
+			)
 		}
 		if !isCodexDesktopOriginator(entry.originator) ||
 			entry.metaThreadID != candidate.ThreadID ||
@@ -473,6 +529,11 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 				entry.active &&
 				gatewayTurnEvidenceMatchesTaskStart(evidence, entry.turnStartedAt) {
 				entry.gatewayOwned = true
+				t.setGatewayOwnedTurnClaim(
+					entry.metaThreadID,
+					entry.turnID,
+					evidence.eventAt,
+				)
 			} else if matched && !entry.active {
 				entry.gatewayTurnPending = true
 				entry.gatewayTurnPendingAt = evidence.eventAt
@@ -483,7 +544,7 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 			entry.active = true
 			entry.turnID = turnID
 			entry.turnStartedAt = turnStartedAt
-			entry.gatewayOwned = entry.gatewayTurnPending &&
+			pendingOwned := entry.gatewayTurnPending &&
 				gatewayTurnEvidenceMatchesTaskStart(
 					gatewayTurnEvidence{
 						registeredAt: entry.gatewayTurnPendingRegisteredAt,
@@ -491,8 +552,30 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 					},
 					turnStartedAt,
 				)
+			if pendingOwned {
+				t.setGatewayOwnedTurnClaim(
+					entry.metaThreadID,
+					turnID,
+					entry.gatewayTurnPendingAt,
+				)
+			}
+			entry.gatewayOwned = pendingOwned ||
+				t.hasGatewayOwnedTurnClaim(entry.metaThreadID, turnID)
+			// 全量重扫会先经过历史 turn，不能让历史 task_started 删除时间更晚的
+			// 持久化 claim。只有时间上不早于 claim 的不同 turn 才能证明控制边界
+			// 已前进；没有 exact claim 的新 Mac turn 仍会恢复 external 只读保护。
+			t.removeSupersededGatewayOwnedTurnClaims(
+				entry.metaThreadID,
+				turnID,
+				turnStartedAt,
+			)
 			clearGatewayTurnPending(entry)
 		case "task_complete", "turn_aborted":
+			terminalTurnID := turnID
+			if terminalTurnID == "" {
+				terminalTurnID = entry.turnID
+			}
+			t.removeGatewayOwnedTurnClaim(entry.metaThreadID, terminalTurnID)
 			// 旧 turn 的迟到 terminal 不能终止已经开始的新 turn。
 			if turnID == "" || entry.turnID == "" || turnID == entry.turnID {
 				entry.active = false
@@ -546,6 +629,7 @@ func (t *ExternalActivityTracker) consumeGatewayTurnRegistration(
 	// 同一个 client id 只能消费一次。即使时间校验失败也删除，避免恶意或损坏
 	// rollout 在稍后的重复行中重新尝试命中。
 	delete(t.gatewayTurns, key)
+	t.gatewayClaimsDirty = true
 	if eventAt.Before(registration.registeredAt.Add(-gatewayTurnEventClockSkew)) {
 		return gatewayTurnEvidence{}, false
 	}
@@ -571,7 +655,7 @@ func gatewayTurnEvidenceMatchesTaskStart(evidence gatewayTurnEvidence, turnStart
 		return false
 	}
 	if turnStartedAt.Before(evidence.registeredAt.Add(-gatewayTurnEventClockSkew)) ||
-		turnStartedAt.After(evidence.registeredAt.Add(gatewayTurnRegistrationTTL)) {
+		turnStartedAt.After(evidence.registeredAt.Add(gatewayTurnStartWindow)) {
 		return false
 	}
 	delta := turnStartedAt.Sub(evidence.eventAt)
@@ -585,26 +669,8 @@ func (t *ExternalActivityTracker) pruneGatewayTurnRegistrations(now time.Time) {
 	for key, registration := range t.gatewayTurns {
 		if now.After(registration.registeredAt.Add(gatewayTurnRegistrationTTL)) {
 			delete(t.gatewayTurns, key)
+			t.gatewayClaimsDirty = true
 		}
-	}
-}
-
-func (t *ExternalActivityTracker) trimGatewayTurnRegistrations() {
-	for len(t.gatewayTurns) > gatewayTurnRegistrationLimit {
-		var oldestKey string
-		var oldestAt time.Time
-		for key, registration := range t.gatewayTurns {
-			if oldestKey == "" ||
-				registration.registeredAt.Before(oldestAt) ||
-				(registration.registeredAt.Equal(oldestAt) && key < oldestKey) {
-				oldestKey = key
-				oldestAt = registration.registeredAt
-			}
-		}
-		if oldestKey == "" {
-			return
-		}
-		delete(t.gatewayTurns, oldestKey)
 	}
 }
 

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -238,6 +239,73 @@ func TestExternalActivityExcludesExactGatewayOwnedTurn(t *testing.T) {
 	}
 }
 
+func TestExternalActivityDelayedUserMessageAfterTaskStartedStillClaimsGatewayTurn(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
+	path := fixture.writeRollout(
+		"thread-ipad",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(now.Add(time.Second), "task_started", "turn-ipad"),
+		// managed app-server 冷启动时真实观察到 user_message 比 task_started
+		// 晚约 13 秒落盘；精确 client ID 不能因此被当成 Mac external。
+		externalUserMessageLine(now.Add(15*time.Second), "client-ipad"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-ipad", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("延迟落盘的精确 gateway 消息不应被识别为 Desktop external：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if !entry.active || !entry.gatewayOwned || entry.turnID != "turn-ipad" {
+		t.Fatalf("延迟 user_message 应恢复精确 gateway 归属：%+v", entry)
+	}
+}
+
+func TestExternalActivityExactMessageCannotClaimTurnStartedOutsideGatewayWindow(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+	path := fixture.writeRollout(
+		"thread-1",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(
+			now.Add(gatewayTurnStartWindow+time.Second),
+			"task_started",
+			"turn-desktop",
+		),
+		externalUserMessageLine(
+			now.Add(gatewayTurnStartWindow+2*time.Second),
+			"client-ipad",
+		),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+		t.Fatalf("登记窗口外的新 turn 必须保持 external 只读：%+v", got)
+	}
+	if entry := fixture.tracker.files[path]; entry.gatewayOwned || entry.gatewayTurnPending {
+		t.Fatalf("登记窗口外的 turn 不得吸收失败 gateway 请求证据：%+v", entry)
+	}
+}
+
 func TestExternalActivityAlsoSupportsUserMessageBeforeTaskStarted(t *testing.T) {
 	fixture := newExternalActivityTrackerFixture(t)
 	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
@@ -441,6 +509,262 @@ func TestExternalActivityNewDesktopTurnResetsGatewayOwnership(t *testing.T) {
 	}
 }
 
+func TestExternalActivityPersistentClaimSurvivesTrackerRestartAndCandidateGap(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 31, 1, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "private-state", "gateway-turn-claims.json")
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+	fixture.tracker.RegisterGatewayTurnStart("thread-restart", "client-restart")
+	path := fixture.writeRollout(
+		"thread-restart",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(now.Add(-time.Minute), "task_started", "turn-history"),
+		externalEventLineAt(now.Add(-50*time.Second), "task_complete", "turn-history"),
+		externalEventLineAt(now.Add(100*time.Millisecond), "task_started", "turn-ipad"),
+		externalUserMessageLine(now.Add(500*time.Millisecond), "client-restart"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	row := externalActivityTestRow{
+		ID: "thread-restart", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}
+	fixture.rows = []externalActivityTestRow{row}
+
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("首个 Tracker 应确认 iPad-owned turn：%+v", got)
+	}
+	if len(fixture.tracker.ownedGatewayTurns) != 1 {
+		t.Fatalf("精确 Thread+Turn claim 应提升并落盘：%+v", fixture.tracker.ownedGatewayTurns)
+	}
+	if runtime.GOOS != "windows" {
+		dirInfo, err := os.Stat(filepath.Dir(claimPath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileInfo, err := os.Stat(claimPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := dirInfo.Mode().Perm(); got != 0o700 {
+			t.Fatalf("claim 目录权限必须是 0700，got=%o", got)
+		}
+		if got := fileInfo.Mode().Perm(); got != 0o600 {
+			t.Fatalf("claim 文件权限必须是 0600，got=%o", got)
+		}
+	}
+
+	// 模拟第二个 Router/Tracker 启动时列表短暂缺页。缺页不能删除 claim。
+	fixture.rows = nil
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now.Add(time.Second) })
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("候选缺页不应制造外部活动：%+v", got)
+	}
+	storedAfterGap, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(storedAfterGap.Owned) != 1 ||
+		storedAfterGap.Owned[0].ThreadID != "thread-restart" ||
+		storedAfterGap.Owned[0].TurnID != "turn-ipad" {
+		t.Fatalf("候选缺页必须保留精确 claim：%+v", storedAfterGap)
+	}
+
+	// 列表恢复后，新 Tracker 从包含历史旧 turn 的同一 rollout 全量重扫。
+	// 历史 task_started 不能提前删除时间更晚的持久化 claim。
+	fixture.rows = []externalActivityTestRow{row}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now.Add(2 * time.Second) })
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("重启后的 Tracker 应恢复 gateway-owned 证据：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if !entry.active || !entry.gatewayOwned || entry.turnID != "turn-ipad" {
+		t.Fatalf("重建 rollout cache 后归属异常：%+v", entry)
+	}
+
+	// 同一 Thread 后续出现没有 gateway 证据的新 Mac turn，必须立即清旧 claim，
+	// 恢复仅观察保护；再重启一次也不能被旧 claim 隐藏。
+	now = now.Add(3 * time.Second)
+	fixture.appendLine(path, externalEventLineAt(now, "task_started", "turn-mac-next"))
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-mac-next" {
+		t.Fatalf("真正的新 Mac turn 必须保持 external 只读：%+v", got)
+	}
+	now = now.Add(time.Second)
+	fixture.appendLine(path, externalEventLineAt(now, "task_complete", "turn-ipad"))
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	got = fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-mac-next" {
+		t.Fatalf("旧 gateway turn 的迟到 terminal 不能结束或隐藏新 Mac turn：%+v", got)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now.Add(time.Second) })
+	got = fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-mac-next" {
+		t.Fatalf("清理旧 claim 后再次重启仍应识别新 Mac turn：%+v", got)
+	}
+	storedAfterMacTurn, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(storedAfterMacTurn.Owned) != 0 {
+		t.Fatalf("不同的新 turn 必须清理旧 owned claim：%+v", storedAfterMacTurn.Owned)
+	}
+}
+
+func TestExternalActivityPersistentClaimClearsOnTerminalAndTTL(t *testing.T) {
+	tests := []struct {
+		name       string
+		finishTurn func(*externalActivityTrackerFixture, string, *time.Time)
+	}{
+		{
+			name: "matching terminal",
+			finishTurn: func(fixture *externalActivityTrackerFixture, path string, now *time.Time) {
+				*now = now.Add(time.Second)
+				fixture.appendLine(path, externalEventLineAt(*now, "turn_aborted", "turn-ipad"))
+				if err := os.Chtimes(path, *now, *now); err != nil {
+					fixture.t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "ttl after rollout stale",
+			finishTurn: func(_ *externalActivityTrackerFixture, _ string, now *time.Time) {
+				*now = now.Add(gatewayOwnedTurnClaimTTL + time.Second)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newExternalActivityTrackerFixture(t)
+			now := time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC)
+			claimPath := filepath.Join(t.TempDir(), "state", "claims.json")
+			fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+			fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
+			path := fixture.writeRollout(
+				"thread-ipad",
+				"Codex Desktop",
+				fixture.projectDir,
+				externalEventLineAt(now.Add(100*time.Millisecond), "task_started", "turn-ipad"),
+				externalUserMessageLine(now.Add(500*time.Millisecond), "client-ipad"),
+			)
+			if err := os.Chtimes(path, now, now); err != nil {
+				t.Fatal(err)
+			}
+			fixture.rows = []externalActivityTestRow{{
+				ID: "thread-ipad", CWD: fixture.projectDir, Source: "vscode",
+				ThreadSource: "user", RolloutPath: path,
+			}}
+			if got := fixture.snapshot(t); len(got) != 0 {
+				t.Fatalf("iPad turn 不应是 external：%+v", got)
+			}
+
+			tc.finishTurn(fixture, path, &now)
+			if got := fixture.snapshot(t); len(got) != 0 {
+				t.Fatalf("terminal/TTL 后不应返回 external：%+v", got)
+			}
+			if len(fixture.tracker.ownedGatewayTurns) != 0 {
+				t.Fatalf("terminal/TTL 后必须清理内存 claim：%+v", fixture.tracker.ownedGatewayTurns)
+			}
+			stored, err := newGatewayTurnClaimStore(claimPath).load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(stored.Owned) != 0 {
+				t.Fatalf("terminal/TTL 后必须清理落盘 claim：%+v", stored.Owned)
+			}
+		})
+	}
+}
+
+func TestExternalActivityExpiredClaimWithFreshRolloutFailsClosedAsExternal(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 31, 3, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "state", "claims.json")
+	expiredEvidenceAt := now.Add(-gatewayOwnedTurnClaimTTL - time.Second)
+	if err := newGatewayTurnClaimStore(claimPath).save(gatewayTurnClaimStoreFile{
+		Owned: []gatewayTurnOwnedClaimStoreEntry{{
+			ThreadID:       "thread-expired",
+			TurnID:         "turn-expired",
+			LastEvidenceAt: expiredEvidenceAt,
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+	path := fixture.writeRollout(
+		"thread-expired",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(expiredEvidenceAt, "task_started", "turn-expired"),
+	)
+	// 即使 rollout 因其他落盘动作仍处于 fresh 窗口，过期 claim 也不能继续
+	// 放宽控制；必须 fail-closed 恢复为真正的 external 只读活动。
+	if err := os.Chtimes(path, now.Add(-5*time.Minute), now.Add(-5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-expired", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-expired" {
+		t.Fatalf("过期 claim + fresh rollout 必须保持 external 只读：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if entry.gatewayOwned {
+		t.Fatalf("过期 claim 不得恢复 gateway ownership：%+v", entry)
+	}
+	stored, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored.Owned) != 0 {
+		t.Fatalf("过期 claim 应从落盘状态清理：%+v", stored.Owned)
+	}
+}
+
+func TestExternalActivityCorruptClaimStoreFailsClosed(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 31, 3, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "state", "claims.json")
+	if err := os.MkdirAll(filepath.Dir(claimPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(claimPath, []byte(`{"version":1,"owned":[`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+	path := fixture.writeRollout(
+		"thread-desktop",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(now, "task_started", "turn-desktop"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-desktop", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+		t.Fatalf("损坏 claim store 必须 fail-closed 保留 external：%+v", got)
+	}
+	if fixture.tracker.Diagnostics().ClaimStoreErrors != 1 {
+		t.Fatalf("损坏 claim store 应记录一次脱敏诊断：%+v", fixture.tracker.Diagnostics())
+	}
+}
+
 func TestGatewayTurnRegistrationsAreBoundedAndExpire(t *testing.T) {
 	fixture := newExternalActivityTrackerFixture(t)
 	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
@@ -517,6 +841,21 @@ func newExternalActivityTrackerFixture(t *testing.T) *externalActivityTrackerFix
 		return json.Marshal(fixture.rows)
 	}
 	return fixture
+}
+
+func (f *externalActivityTrackerFixture) replaceTrackerWithClaimStore(
+	claimStorePath string,
+	now func() time.Time,
+) {
+	f.t.Helper()
+	query := f.tracker.query
+	f.tracker = NewExternalActivityTrackerWithClaimStore(
+		f.db,
+		f.tracker.registry,
+		claimStorePath,
+	)
+	f.tracker.query = query
+	f.tracker.now = now
 }
 
 func (f *externalActivityTrackerFixture) writeRollout(threadID, originator, cwd string, lines ...string) string {

--- a/internal/codexhistory/gateway_turn_claim_store.go
+++ b/internal/codexhistory/gateway_turn_claim_store.go
@@ -1,0 +1,466 @@
+package codexhistory
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	gatewayTurnClaimStoreVersion  = 1
+	gatewayTurnClaimStoreMaxBytes = 512 * 1024
+	gatewayTurnClaimStoreLimit    = 512
+	// owned claim 的 TTL 必须长于 rollout 的外部活动 stale 窗口。这样被 managed
+	// app-server 重启终止的静止 rollout 在 claim 过期时也已经 stale，不会重新锁住 iOS。
+	gatewayOwnedTurnClaimTTL = defaultExternalActivityStaleAfter + 10*time.Minute
+	// 长 turn 只在 rollout 确实继续写入时延长证据，且限制落盘频率，避免流式事件导致频繁 fsync。
+	gatewayOwnedTurnClaimRefreshInterval = time.Minute
+)
+
+type gatewayOwnedTurnClaim struct {
+	threadID       string
+	turnID         string
+	lastEvidenceAt time.Time
+}
+
+type gatewayTurnClaimStoreFile struct {
+	Version int                                 `json:"version"`
+	Pending []gatewayTurnPendingClaimStoreEntry `json:"pending,omitempty"`
+	Owned   []gatewayTurnOwnedClaimStoreEntry   `json:"owned,omitempty"`
+}
+
+type gatewayTurnPendingClaimStoreEntry struct {
+	ThreadID            string    `json:"thread_id"`
+	ClientUserMessageID string    `json:"client_user_message_id"`
+	RegisteredAt        time.Time `json:"registered_at"`
+}
+
+type gatewayTurnOwnedClaimStoreEntry struct {
+	ThreadID       string    `json:"thread_id"`
+	TurnID         string    `json:"turn_id"`
+	LastEvidenceAt time.Time `json:"last_evidence_at"`
+}
+
+type gatewayTurnClaimStore struct {
+	path string
+}
+
+// 生产环境同一时间只运行一个 agentd；这个锁仍能避免同进程测试或未来多 Router
+// 在原子 rename 前交错写临时文件。跨进程读取始终只会看到完整旧文件或完整新文件。
+var gatewayTurnClaimStoreWriteMu sync.Mutex
+
+func newGatewayTurnClaimStore(path string) *gatewayTurnClaimStore {
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) {
+		return nil
+	}
+	return &gatewayTurnClaimStore{path: filepath.Clean(path)}
+}
+
+func (s *gatewayTurnClaimStore) load() (gatewayTurnClaimStoreFile, error) {
+	if s == nil || strings.TrimSpace(s.path) == "" {
+		return gatewayTurnClaimStoreFile{Version: gatewayTurnClaimStoreVersion}, nil
+	}
+	info, err := os.Lstat(s.path)
+	if err != nil {
+		return gatewayTurnClaimStoreFile{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 不是普通文件")
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 权限过宽")
+	}
+	if info.Size() <= 0 || info.Size() > gatewayTurnClaimStoreMaxBytes {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 大小无效")
+	}
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		return gatewayTurnClaimStoreFile{}, err
+	}
+	if len(raw) <= 0 || len(raw) > gatewayTurnClaimStoreMaxBytes {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 读取大小无效")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var stored gatewayTurnClaimStoreFile
+	if err := decoder.Decode(&stored); err != nil {
+		return gatewayTurnClaimStoreFile{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 包含尾随内容")
+	}
+	if stored.Version != gatewayTurnClaimStoreVersion {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("不支持的 gateway turn claim store 版本 %d", stored.Version)
+	}
+	if len(stored.Pending)+len(stored.Owned) > gatewayTurnClaimStoreLimit {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 超过数量上限")
+	}
+	return stored, nil
+}
+
+func (s *gatewayTurnClaimStore) save(stored gatewayTurnClaimStoreFile) (resultErr error) {
+	if s == nil || strings.TrimSpace(s.path) == "" {
+		return nil
+	}
+	stored.Version = gatewayTurnClaimStoreVersion
+	raw, err := json.Marshal(stored)
+	if err != nil {
+		return err
+	}
+	if len(raw)+1 > gatewayTurnClaimStoreMaxBytes {
+		return fmt.Errorf("gateway turn claim store 编码后超过大小上限")
+	}
+
+	gatewayTurnClaimStoreWriteMu.Lock()
+	defer gatewayTurnClaimStoreWriteMu.Unlock()
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	dirInfo, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if !dirInfo.IsDir() || dirInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("gateway turn claim store 目录无效")
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	staged, err := os.CreateTemp(dir, ".gateway-turn-claims-*.tmp")
+	if err != nil {
+		return err
+	}
+	stagedPath := staged.Name()
+	defer func() {
+		_ = staged.Close()
+		if resultErr != nil {
+			_ = os.Remove(stagedPath)
+		}
+	}()
+	if runtime.GOOS != "windows" {
+		if err := staged.Chmod(0o600); err != nil {
+			return err
+		}
+	}
+	if _, err := staged.Write(append(raw, '\n')); err != nil {
+		return err
+	}
+	if err := staged.Sync(); err != nil {
+		return err
+	}
+	if err := staged.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(stagedPath, s.path); err != nil {
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(s.path, 0o600); err != nil {
+			return err
+		}
+		dirFile, err := os.Open(dir)
+		if err != nil {
+			return err
+		}
+		syncErr := dirFile.Sync()
+		closeErr := dirFile.Close()
+		if syncErr != nil {
+			return syncErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+	}
+	return nil
+}
+
+func (t *ExternalActivityTracker) ensureGatewayTurnClaimsLoaded(now time.Time) {
+	if t.gatewayClaimsLoaded {
+		return
+	}
+	t.gatewayClaimsLoaded = true
+	if t.gatewayTurns == nil {
+		t.gatewayTurns = map[string]gatewayTurnRegistration{}
+	}
+	if t.ownedGatewayTurns == nil {
+		t.ownedGatewayTurns = map[string]gatewayOwnedTurnClaim{}
+	}
+	if t.gatewayClaimStore == nil {
+		return
+	}
+	stored, err := t.gatewayClaimStore.load()
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			t.diagnostics.ClaimStoreErrors++
+		}
+		// 文件损坏、版本不支持或权限失败时不采用任何 claim，宁可保留只读保护。
+		return
+	}
+
+	seen := map[string]struct{}{}
+	for _, pending := range stored.Pending {
+		key := gatewayTurnRegistrationKey(pending.ThreadID, pending.ClientUserMessageID)
+		registeredAt := pending.RegisteredAt.UTC()
+		if !validGatewayClaimID(pending.ThreadID) ||
+			!validGatewayClaimID(pending.ClientUserMessageID) ||
+			registeredAt.IsZero() ||
+			registeredAt.After(now.Add(gatewayTurnEventClockSkew)) ||
+			now.After(registeredAt.Add(gatewayTurnRegistrationTTL)) {
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		if _, duplicate := seen["pending\x00"+key]; duplicate {
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		seen["pending\x00"+key] = struct{}{}
+		t.gatewayTurns[key] = gatewayTurnRegistration{registeredAt: registeredAt}
+	}
+	for _, owned := range stored.Owned {
+		key := gatewayOwnedTurnClaimKey(owned.ThreadID, owned.TurnID)
+		lastEvidenceAt := owned.LastEvidenceAt.UTC()
+		if !validGatewayClaimID(owned.ThreadID) ||
+			!validGatewayClaimID(owned.TurnID) ||
+			lastEvidenceAt.IsZero() ||
+			lastEvidenceAt.After(now.Add(gatewayTurnEventClockSkew)) ||
+			now.After(lastEvidenceAt.Add(gatewayOwnedTurnClaimTTL)) {
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		if _, duplicate := seen["owned\x00"+key]; duplicate {
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		seen["owned\x00"+key] = struct{}{}
+		t.ownedGatewayTurns[key] = gatewayOwnedTurnClaim{
+			threadID:       strings.TrimSpace(owned.ThreadID),
+			turnID:         strings.TrimSpace(owned.TurnID),
+			lastEvidenceAt: lastEvidenceAt,
+		}
+	}
+	t.trimGatewayTurnClaims()
+}
+
+func (t *ExternalActivityTracker) persistGatewayTurnClaims() {
+	if !t.gatewayClaimsDirty || t.gatewayClaimStore == nil {
+		return
+	}
+	stored := gatewayTurnClaimStoreFile{
+		Version: gatewayTurnClaimStoreVersion,
+		Pending: make([]gatewayTurnPendingClaimStoreEntry, 0, len(t.gatewayTurns)),
+		Owned:   make([]gatewayTurnOwnedClaimStoreEntry, 0, len(t.ownedGatewayTurns)),
+	}
+	for key, registration := range t.gatewayTurns {
+		threadID, clientID, ok := splitGatewayTurnClaimKey(key)
+		if !ok {
+			continue
+		}
+		stored.Pending = append(stored.Pending, gatewayTurnPendingClaimStoreEntry{
+			ThreadID:            threadID,
+			ClientUserMessageID: clientID,
+			RegisteredAt:        registration.registeredAt.UTC(),
+		})
+	}
+	for _, owned := range t.ownedGatewayTurns {
+		stored.Owned = append(stored.Owned, gatewayTurnOwnedClaimStoreEntry{
+			ThreadID:       owned.threadID,
+			TurnID:         owned.turnID,
+			LastEvidenceAt: owned.lastEvidenceAt.UTC(),
+		})
+	}
+	sort.Slice(stored.Pending, func(i, j int) bool {
+		if stored.Pending[i].RegisteredAt.Equal(stored.Pending[j].RegisteredAt) {
+			if stored.Pending[i].ThreadID == stored.Pending[j].ThreadID {
+				return stored.Pending[i].ClientUserMessageID < stored.Pending[j].ClientUserMessageID
+			}
+			return stored.Pending[i].ThreadID < stored.Pending[j].ThreadID
+		}
+		return stored.Pending[i].RegisteredAt.Before(stored.Pending[j].RegisteredAt)
+	})
+	sort.Slice(stored.Owned, func(i, j int) bool {
+		if stored.Owned[i].LastEvidenceAt.Equal(stored.Owned[j].LastEvidenceAt) {
+			if stored.Owned[i].ThreadID == stored.Owned[j].ThreadID {
+				return stored.Owned[i].TurnID < stored.Owned[j].TurnID
+			}
+			return stored.Owned[i].ThreadID < stored.Owned[j].ThreadID
+		}
+		return stored.Owned[i].LastEvidenceAt.Before(stored.Owned[j].LastEvidenceAt)
+	})
+	if err := t.gatewayClaimStore.save(stored); err != nil {
+		t.diagnostics.ClaimStoreErrors++
+		return
+	}
+	t.gatewayClaimsDirty = false
+	t.diagnostics.ClaimStoreWrites++
+}
+
+func (t *ExternalActivityTracker) setGatewayOwnedTurnClaim(threadID string, turnID string, evidenceAt time.Time) {
+	threadID = strings.TrimSpace(threadID)
+	turnID = strings.TrimSpace(turnID)
+	if !validGatewayClaimID(threadID) || !validGatewayClaimID(turnID) || evidenceAt.IsZero() {
+		return
+	}
+	evidenceAt = evidenceAt.UTC()
+	key := gatewayOwnedTurnClaimKey(threadID, turnID)
+	existing, ok := t.ownedGatewayTurns[key]
+	if ok && !evidenceAt.After(existing.lastEvidenceAt) {
+		return
+	}
+	t.ownedGatewayTurns[key] = gatewayOwnedTurnClaim{
+		threadID:       threadID,
+		turnID:         turnID,
+		lastEvidenceAt: evidenceAt,
+	}
+	t.gatewayClaimsDirty = true
+	t.removeOtherGatewayOwnedTurnClaims(threadID, turnID)
+	t.trimGatewayTurnClaims()
+}
+
+func (t *ExternalActivityTracker) refreshGatewayOwnedTurnClaim(
+	threadID string,
+	turnID string,
+	evidenceAt time.Time,
+	now time.Time,
+) {
+	key := gatewayOwnedTurnClaimKey(threadID, turnID)
+	existing, ok := t.ownedGatewayTurns[key]
+	if !ok || evidenceAt.IsZero() {
+		return
+	}
+	evidenceAt = evidenceAt.UTC()
+	now = now.UTC()
+	if evidenceAt.After(now) {
+		evidenceAt = now
+	}
+	if !evidenceAt.After(existing.lastEvidenceAt.Add(gatewayOwnedTurnClaimRefreshInterval)) {
+		return
+	}
+	existing.lastEvidenceAt = evidenceAt
+	t.ownedGatewayTurns[key] = existing
+	t.gatewayClaimsDirty = true
+}
+
+func (t *ExternalActivityTracker) hasGatewayOwnedTurnClaim(threadID string, turnID string) bool {
+	_, ok := t.ownedGatewayTurns[gatewayOwnedTurnClaimKey(threadID, turnID)]
+	return ok
+}
+
+func (t *ExternalActivityTracker) removeGatewayOwnedTurnClaim(threadID string, turnID string) {
+	key := gatewayOwnedTurnClaimKey(threadID, turnID)
+	if _, ok := t.ownedGatewayTurns[key]; !ok {
+		return
+	}
+	delete(t.ownedGatewayTurns, key)
+	t.gatewayClaimsDirty = true
+}
+
+func (t *ExternalActivityTracker) removeOtherGatewayOwnedTurnClaims(threadID string, keepTurnID string) {
+	threadID = strings.TrimSpace(threadID)
+	keepTurnID = strings.TrimSpace(keepTurnID)
+	for key, claim := range t.ownedGatewayTurns {
+		if claim.threadID == threadID && claim.turnID != keepTurnID {
+			delete(t.ownedGatewayTurns, key)
+			t.gatewayClaimsDirty = true
+		}
+	}
+}
+
+func (t *ExternalActivityTracker) removeSupersededGatewayOwnedTurnClaims(
+	threadID string,
+	keepTurnID string,
+	turnStartedAt time.Time,
+) {
+	threadID = strings.TrimSpace(threadID)
+	keepTurnID = strings.TrimSpace(keepTurnID)
+	turnStartedAt = turnStartedAt.UTC()
+	for key, claim := range t.ownedGatewayTurns {
+		if claim.threadID != threadID || claim.turnID == keepTurnID {
+			continue
+		}
+		if !turnStartedAt.IsZero() && turnStartedAt.Before(claim.lastEvidenceAt) {
+			// Router/Tracker 重建后的全量扫描会先看到历史 turn；只有时间
+			// 前进的不同 turn 才能撤销当前 claim。
+			continue
+		}
+		delete(t.ownedGatewayTurns, key)
+		t.gatewayClaimsDirty = true
+	}
+}
+
+func (t *ExternalActivityTracker) pruneGatewayOwnedTurnClaims(now time.Time) {
+	for key, claim := range t.ownedGatewayTurns {
+		if now.After(claim.lastEvidenceAt.Add(gatewayOwnedTurnClaimTTL)) {
+			delete(t.ownedGatewayTurns, key)
+			t.gatewayClaimsDirty = true
+		}
+	}
+}
+
+func (t *ExternalActivityTracker) trimGatewayTurnClaims() {
+	for len(t.gatewayTurns)+len(t.ownedGatewayTurns) > gatewayTurnClaimStoreLimit {
+		var oldestPendingKey string
+		var oldestPendingAt time.Time
+		for key, registration := range t.gatewayTurns {
+			if oldestPendingKey == "" ||
+				registration.registeredAt.Before(oldestPendingAt) ||
+				(registration.registeredAt.Equal(oldestPendingAt) && key < oldestPendingKey) {
+				oldestPendingKey = key
+				oldestPendingAt = registration.registeredAt
+			}
+		}
+		var oldestOwnedKey string
+		var oldestOwnedAt time.Time
+		for key, owned := range t.ownedGatewayTurns {
+			if oldestOwnedKey == "" ||
+				owned.lastEvidenceAt.Before(oldestOwnedAt) ||
+				(owned.lastEvidenceAt.Equal(oldestOwnedAt) && key < oldestOwnedKey) {
+				oldestOwnedKey = key
+				oldestOwnedAt = owned.lastEvidenceAt
+			}
+		}
+		switch {
+		case oldestPendingKey != "" &&
+			(oldestOwnedKey == "" || !oldestPendingAt.After(oldestOwnedAt)):
+			delete(t.gatewayTurns, oldestPendingKey)
+		case oldestOwnedKey != "":
+			delete(t.ownedGatewayTurns, oldestOwnedKey)
+		default:
+			return
+		}
+		t.gatewayClaimsDirty = true
+	}
+}
+
+func validGatewayClaimID(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" &&
+		len(value) <= gatewayTurnRegistrationIDMax &&
+		!strings.ContainsRune(value, '\x00')
+}
+
+func gatewayOwnedTurnClaimKey(threadID string, turnID string) string {
+	return strings.TrimSpace(threadID) + "\x00" + strings.TrimSpace(turnID)
+}
+
+func splitGatewayTurnClaimKey(key string) (string, string, bool) {
+	parts := strings.Split(key, "\x00")
+	if len(parts) != 2 || !validGatewayClaimID(parts[0]) || !validGatewayClaimID(parts[1]) {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -98,6 +98,12 @@ type Router struct {
 	gitTestFlightJobs map[string]*gitTestFlightReleaseJob
 }
 
+// RouterOptions 只承载必须在构造时固定的进程级资源路径。
+// 空 GatewayTurnClaimStorePath 保持纯内存行为，供普通测试和嵌入式调用使用。
+type RouterOptions struct {
+	GatewayTurnClaimStorePath string
+}
+
 func NewRouter(cfg config.Config, registry *projects.Registry, manager *session.Manager, checker *doctor.Checker, version string) http.Handler {
 	handler, _ := NewRouterWithRuntime(cfg, registry, manager, checker, version, nil)
 	return handler
@@ -121,6 +127,37 @@ func NewRouterWithRuntime(cfg config.Config, registry *projects.Registry, manage
 // NewRouterWithRuntimeAndInstallationID 同时注入 runtime 与稳定安装身份。
 // 保留旧构造器作为兼容包装，现有测试和内部调用无需一次性迁移。
 func NewRouterWithRuntimeAndInstallationID(cfg config.Config, registry *projects.Registry, manager *session.Manager, checker *doctor.Checker, version string, installationID string, runtime SessionRuntime) (http.Handler, *Router) {
+	return NewRouterWithRuntimeInstallationIDAndOptions(
+		cfg,
+		registry,
+		manager,
+		checker,
+		version,
+		installationID,
+		runtime,
+		RouterOptions{},
+	)
+}
+
+// NewRouterWithRuntimeInstallationIDAndOptions 由 agentd 生产入口显式注入私有状态路径。
+// 旧构造器保持纯内存默认值，避免单元测试意外读写当前用户目录。
+func NewRouterWithRuntimeInstallationIDAndOptions(
+	cfg config.Config,
+	registry *projects.Registry,
+	manager *session.Manager,
+	checker *doctor.Checker,
+	version string,
+	installationID string,
+	runtime SessionRuntime,
+	options RouterOptions,
+) (http.Handler, *Router) {
+	externalActivity := externalActivitySource(codexhistory.NewDefaultExternalActivityTracker(registry))
+	if strings.TrimSpace(options.GatewayTurnClaimStorePath) != "" {
+		externalActivity = codexhistory.NewDefaultExternalActivityTrackerWithClaimStore(
+			registry,
+			options.GatewayTurnClaimStorePath,
+		)
+	}
 	r := &Router{
 		cfg:            cfg,
 		projects:       registry,
@@ -138,7 +175,7 @@ func NewRouterWithRuntimeAndInstallationID(cfg config.Config, registry *projects
 		monitor:                     newRelayMonitor(),
 		historyMedia:                newAppServerHistoryMediaStore(),
 		fileUploads:                 newFileUploadStore(defaultFileUploadRoot()),
-		externalActivity:            codexhistory.NewDefaultExternalActivityTracker(registry),
+		externalActivity:            externalActivity,
 		tailscalePathLookup:         defaultTailscaleNetworkPathLookup,
 		gatewayThreads:              map[string]appServerGatewayAllowedThread{},
 		managedWorktrees:            map[string]managedWorktree{},

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
@@ -490,6 +490,82 @@ extension ConversationDataFlowTests {
         XCTAssertFalse(store.isExternalReadOnlySession(completed))
     }
 
+    func testAgentDRestartEmptySnapshotClearsZombieTurnRuntimeActivityAndReadOnlyTombstone() async throws {
+        let project = makeProject(id: "proj_agentd_restart_reconcile")
+        let threadID = "thread-agentd-restart"
+        let turnID = "turn-managed-before-restart"
+        let running = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "重启前由 iPad 发起",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID,
+            activeTurnID: turnID
+        )
+        let authoritativeIdle = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "重启后恢复",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [authoritativeIdle],
+            workspacePages: [
+                project.id: SessionsPage(sessions: [authoritativeIdle])
+            ],
+            historyPages: [
+                threadID: HistoryMessagesPage(messages: [])
+            ],
+            externalActivityResponses: [
+                ExternalActivityResponse(activities: [], scannedAt: Date())
+            ]
+        )
+        let store = makeExternalActivityStore(
+            project: project,
+            session: running,
+            client: client
+        )
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+        store.sessionControlStateByID[threadID] = .takenOver
+        store.externalActivityBySessionID[threadID] = makeExternalActivity(
+            threadID: threadID,
+            projectID: project.id,
+            turnID: turnID,
+            revision: "rev-zombie-before-restart"
+        )
+        store.externalReadOnlySessionIDs.insert(threadID)
+        store.recordRuntimeActivity(
+            sessionID: threadID,
+            turnStartedAt: Date(timeIntervalSince1970: 100),
+            activityAt: Date(timeIntervalSince1970: 101)
+        )
+
+        let refreshed = await store.refreshExternalActivities(client: client)
+
+        XCTAssertTrue(refreshed)
+        let reconciled = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertEqual(reconciled.status, SessionStatus.history.rawValue)
+        XCTAssertNil(reconciled.activeTurnID)
+        XCTAssertNil(store.runtimeActivitySnapshot(for: threadID))
+        XCTAssertNil(store.externalActivityBySessionID[threadID])
+        XCTAssertFalse(store.externalReadOnlySessionIDs.contains(threadID))
+        XCTAssertFalse(store.isExternalReadOnlySession(reconciled))
+        XCTAssertEqual(store.controlState(for: reconciled), .takenOver)
+        XCTAssertTrue(store.canControlSession(reconciled))
+        XCTAssertEqual(
+            client.requestedMessageSessionIDs,
+            [threadID],
+            "权威空快照应自动完成一次最终历史对账，无需用户手动刷新"
+        )
+    }
+
     func testExternalActivityPollingStopsWhenOldAgentDDoesNotAdvertiseCapability() async {
         let project = makeProject(id: "proj_external_legacy")
         let history = makeSession(


### PR DESCRIPTION
## 目标

修复 agentd / managed Codex app-server 重启后，iPhone/iPad 发起的 turn 因旧运行时无 terminal、gateway ownership 丢失而被误报为 external running，导致 iOS 长期停在“处理中 / 仅观察”的问题。

## 方案

- 为 gateway-owned Thread+Turn 增加最小持久化：只保存必要 ID 与时间，原子写入，目录 0700、文件 0600，带版本、TTL、数量和大小上限；损坏或权限异常时 fail-closed。
- Tracker 重建时按精确 Thread+Turn 恢复 ownership；允许短暂 rollout 缺页，同时用时间顺序防止历史 task_started 清掉当前 claim。
- terminal、更新的不同 turn、切 Host 或 TTL 到期时清理 claim；真正由独立 Mac Codex 发起的新 turn 继续报告 external，仅观察保护不放宽。
- iOS 沿用 authoritative empty snapshot 的既有恢复路径，并增加回归测试，验证清除 activeTurnID、runtime activity 与 external tombstone，恢复发送和安全接管。

## 验证

- go test ./... -count=1
- go test -race ./internal/codexhistory -count=1
- go vet ./internal/codexhistory ./internal/httpapi ./cmd/agentd
- bash ./scripts/check-source-size.sh
- bash ./scripts/check-public-repo-safety.sh
- bash ./scripts/restart-agentd-dev-macos.sh --self-test
- 固定 iPad Pro 13-inch (M5) Simulator 定向 4 个 iOS 回归测试：4 passed, 0 failed
- 真实 agentd 重启：gateway turn 无 terminal 时重启，ready 后旧 turn 未被误报 external，持久化 ownership 成功重建；随后新 terminal 正常清理 claim。

## 安全审查

通过 Codex 内置浏览器让 ChatGPT Pro 独立审查跨进程恢复和权限边界，结论为无 P0 / P1，可提交。审查未改变所有 external 会话的接管策略。

Linear: MIM-54