### PR TITLE
MIM-52 去重同路径最近工作区并迁移旧 ID 状态

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -629,6 +629,13 @@ struct WorkspaceRootView: View {
            projects.contains(where: { $0.id == selectedWorkspaceID }) {
             return
         }
+        if let selectedWorkspaceID {
+            let retainedID = sessionStore.retainedWorkspaceID(for: selectedWorkspaceID)
+            if projects.contains(where: { $0.id == retainedID }) {
+                self.selectedWorkspaceID = retainedID
+                return
+            }
+        }
         selectedWorkspaceID = sessionStore.selectedProjectID.flatMap { selectedID in
             projects.contains(where: { $0.id == selectedID }) ? selectedID : nil
         } ?? projects.first?.id

--- a/ios/MimiRemote/Sources/MimiRemoteApp.swift
+++ b/ios/MimiRemote/Sources/MimiRemoteApp.swift
@@ -181,7 +181,8 @@ struct MimiRemoteApp: App {
             appStore: appStore,
             conversationStore: conversationStore,
             logStore: logStore,
-            contextStore: contextStore
+            contextStore: contextStore,
+            workspaceAppearanceStore: workspaceAppearanceStore
         ))
         // 尽早注册 delegate；冷启动点击会先进入 adapter 的 pendingRoute，等 RootView 消费。
         UNUserNotificationCenter.current().delegate = notificationResponseAdapter

--- a/ios/MimiRemote/Sources/State/RecentWorkspaceStore.swift
+++ b/ios/MimiRemote/Sources/State/RecentWorkspaceStore.swift
@@ -1,5 +1,63 @@
 import Foundation
 
+struct RecentWorkspaceReconciliation: Equatable {
+    let workspaces: [AgentWorkspace]
+    let replacedWorkspaceIDs: [String: String]
+
+    static var empty: RecentWorkspaceReconciliation {
+        RecentWorkspaceReconciliation(
+            workspaces: [],
+            replacedWorkspaceIDs: [:]
+        )
+    }
+}
+
+enum WorkspacePathIdentity {
+    /// 工作区路径属于远端 Mac，不能在 iPad 上调用 resolvingSymlinksInPath。
+    /// 这里只做不会访问本地文件系统的词法归一化；符号链接等价关系由 agentd resolve
+    /// 返回的 canonical path 与本次用户输入路径共同补充。
+    static func normalizedPath(_ rawPath: String) -> String {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return ""
+        }
+        guard trimmed.hasPrefix("/") else {
+            return normalizedNonPOSIXPath(trimmed)
+        }
+
+        var components: [Substring] = []
+        for component in trimmed.split(separator: "/", omittingEmptySubsequences: true) {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                if !components.isEmpty {
+                    components.removeLast()
+                }
+            default:
+                components.append(component)
+            }
+        }
+
+        var path = "/" + components.joined(separator: "/")
+        // macOS 上 /var、/tmp、/etc 是 /private 下目录的系统级别名。agentd realpath
+        // 返回 /private/...，旧客户端缓存则可能仍保存短路径，需要在离线迁移时视为同一目录。
+        for alias in ["/var", "/tmp", "/etc"] where path == alias || path.hasPrefix(alias + "/") {
+            path = "/private" + path
+            break
+        }
+        return path
+    }
+
+    private static func normalizedNonPOSIXPath(_ rawPath: String) -> String {
+        var path = rawPath
+        while path.count > 1, path.last == "/" || path.last == "\\" {
+            path.removeLast()
+        }
+        return path
+    }
+}
+
 struct RecentWorkspaceStore {
     private typealias Storage = ProfileScopedStorage<[AgentWorkspace]>
 
@@ -14,15 +72,37 @@ struct RecentWorkspaceStore {
     }
 
     func load(endpoint: String) -> [AgentWorkspace] {
-        storage().byEndpoint[normalizedEndpoint(endpoint)]?
-            .sorted(by: Self.workspaceSort)
-            ?? []
+        loadReconciled(endpoint: endpoint).workspaces
+    }
+
+    func loadReconciled(endpoint: String) -> RecentWorkspaceReconciliation {
+        var storage = storage()
+        let endpointKey = normalizedEndpoint(endpoint)
+        guard let stored = storage.byEndpoint[endpointKey] else {
+            return .empty
+        }
+        let reconciliation = boundedReconciliation(stored)
+        if stored != reconciliation.workspaces {
+            storage.byEndpoint[endpointKey] = reconciliation.workspaces
+            persist(storage)
+        }
+        return reconciliation
     }
 
     func save(_ workspaces: [AgentWorkspace], endpoint: String) {
+        _ = saveReconciled(workspaces, endpoint: endpoint)
+    }
+
+    @discardableResult
+    func saveReconciled(
+        _ workspaces: [AgentWorkspace],
+        endpoint: String
+    ) -> RecentWorkspaceReconciliation {
         var storage = storage()
-        storage.byEndpoint[normalizedEndpoint(endpoint)] = bounded(workspaces)
+        let reconciliation = boundedReconciliation(workspaces)
+        storage.byEndpoint[normalizedEndpoint(endpoint)] = reconciliation.workspaces
         persist(storage)
+        return reconciliation
     }
 
     func load(
@@ -30,55 +110,121 @@ struct RecentWorkspaceStore {
         legacyEndpoint: String,
         profiles: [ConnectionProfile]
     ) -> [AgentWorkspace] {
+        loadReconciled(
+            profileID: profileID,
+            legacyEndpoint: legacyEndpoint,
+            profiles: profiles
+        ).workspaces
+    }
+
+    func loadReconciled(
+        profileID: String,
+        legacyEndpoint: String,
+        profiles: [ConnectionProfile]
+    ) -> RecentWorkspaceReconciliation {
         var storage = storage()
         let didMigrate = storage.migrateLegacyValueIfUnique(
             profileID: profileID,
             endpoint: legacyEndpoint,
             profiles: profiles
         )
-        if didMigrate {
-            persist(storage)
-        }
         guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID) else {
-            return []
+            return .empty
         }
         if let workspaces = storage.byProfileID[profileKey] {
-            return workspaces.sorted(by: Self.workspaceSort)
+            let reconciliation = boundedReconciliation(workspaces)
+            if didMigrate || workspaces != reconciliation.workspaces {
+                storage.byProfileID[profileKey] = reconciliation.workspaces
+                persist(storage)
+            }
+            return reconciliation
         }
         // 测试、调试和迁移失败后的单连接可以继续只读旧值；只有唯一 Profile 才会持久化复制。
         if profiles.isEmpty {
-            return storage.byEndpoint[normalizedEndpoint(legacyEndpoint)]?
-                .sorted(by: Self.workspaceSort)
-                ?? []
+            guard let legacy = storage.byEndpoint[normalizedEndpoint(legacyEndpoint)] else {
+                return .empty
+            }
+            return boundedReconciliation(legacy)
         }
-        return []
+        if didMigrate {
+            persist(storage)
+        }
+        return .empty
     }
 
     func load(profileID: String) -> [AgentWorkspace] {
+        loadReconciled(profileID: profileID).workspaces
+    }
+
+    func loadReconciled(profileID: String) -> RecentWorkspaceReconciliation {
         guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID) else {
-            return []
+            return .empty
         }
-        return storage().byProfileID[profileKey]?
-            .sorted(by: Self.workspaceSort)
-            ?? []
+        var storage = storage()
+        guard let stored = storage.byProfileID[profileKey] else {
+            return .empty
+        }
+        let reconciliation = boundedReconciliation(stored)
+        if stored != reconciliation.workspaces {
+            storage.byProfileID[profileKey] = reconciliation.workspaces
+            persist(storage)
+        }
+        return reconciliation
     }
 
     func save(_ workspaces: [AgentWorkspace], profileID: String) {
+        _ = saveReconciled(workspaces, profileID: profileID)
+    }
+
+    @discardableResult
+    func saveReconciled(
+        _ workspaces: [AgentWorkspace],
+        profileID: String
+    ) -> RecentWorkspaceReconciliation {
         guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID) else {
-            return
+            return .empty
         }
         var storage = storage()
-        storage.byProfileID[profileKey] = bounded(workspaces)
+        let reconciliation = boundedReconciliation(workspaces)
+        storage.byProfileID[profileKey] = reconciliation.workspaces
         persist(storage)
+        return reconciliation
     }
 
     func upsert(_ workspace: AgentWorkspace, endpoint: String, openedAt: Date = Date()) -> [AgentWorkspace] {
-        var items = load(endpoint: endpoint)
-        items.removeAll { $0.id == workspace.id }
-        items.insert(workspace.opened(at: openedAt), at: 0)
-        let next = bounded(items)
-        save(next, endpoint: endpoint)
-        return next
+        upsertReconciled(
+            workspace,
+            endpoint: endpoint,
+            openedAt: openedAt
+        ).workspaces
+    }
+
+    func upsertReconciled(
+        _ workspace: AgentWorkspace,
+        endpoint: String,
+        openedAt: Date = Date(),
+        equivalentPaths: [String] = [],
+        prefersIncomingIdentity: Bool = true
+    ) -> RecentWorkspaceReconciliation {
+        let loaded = loadReconciled(endpoint: endpoint)
+        let updated = reconcile(
+            [workspace.opened(at: openedAt)] + loaded.workspaces,
+            preferredWorkspaceID: prefersIncomingIdentity ? workspace.id : nil,
+            equivalentPaths: equivalentPaths
+        )
+        let next = boundedReconciliation(updated.workspaces)
+        let combined = RecentWorkspaceReconciliation(
+            workspaces: next.workspaces,
+            replacedWorkspaceIDs: Self.combinedReplacements(
+                loaded.replacedWorkspaceIDs,
+                updated.replacedWorkspaceIDs,
+                next.replacedWorkspaceIDs
+            )
+        )
+        var storage = storage()
+        storage.byEndpoint[normalizedEndpoint(endpoint)] = combined.workspaces
+        persist(storage)
+        return combined
     }
 
     func upsert(
@@ -86,12 +232,42 @@ struct RecentWorkspaceStore {
         profileID: String,
         openedAt: Date = Date()
     ) -> [AgentWorkspace] {
-        var items = load(profileID: profileID)
-        items.removeAll { $0.id == workspace.id }
-        items.insert(workspace.opened(at: openedAt), at: 0)
-        let next = bounded(items)
-        save(next, profileID: profileID)
-        return next
+        upsertReconciled(
+            workspace,
+            profileID: profileID,
+            openedAt: openedAt
+        ).workspaces
+    }
+
+    func upsertReconciled(
+        _ workspace: AgentWorkspace,
+        profileID: String,
+        openedAt: Date = Date(),
+        equivalentPaths: [String] = [],
+        prefersIncomingIdentity: Bool = true
+    ) -> RecentWorkspaceReconciliation {
+        guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID) else {
+            return .empty
+        }
+        let loaded = loadReconciled(profileID: profileID)
+        let updated = reconcile(
+            [workspace.opened(at: openedAt)] + loaded.workspaces,
+            preferredWorkspaceID: prefersIncomingIdentity ? workspace.id : nil,
+            equivalentPaths: equivalentPaths
+        )
+        let next = boundedReconciliation(updated.workspaces)
+        let combined = RecentWorkspaceReconciliation(
+            workspaces: next.workspaces,
+            replacedWorkspaceIDs: Self.combinedReplacements(
+                loaded.replacedWorkspaceIDs,
+                updated.replacedWorkspaceIDs,
+                next.replacedWorkspaceIDs
+            )
+        )
+        var storage = storage()
+        storage.byProfileID[profileKey] = combined.workspaces
+        persist(storage)
+        return combined
     }
 
     func forget(id: String, endpoint: String) -> [AgentWorkspace] {
@@ -117,8 +293,187 @@ struct RecentWorkspaceStore {
         persist(storage)
     }
 
-    private func bounded(_ workspaces: [AgentWorkspace]) -> [AgentWorkspace] {
-        Array(workspaces.sorted(by: Self.workspaceSort).prefix(limit))
+    private func boundedReconciliation(
+        _ workspaces: [AgentWorkspace]
+    ) -> RecentWorkspaceReconciliation {
+        let reconciliation = reconcile(workspaces)
+        return RecentWorkspaceReconciliation(
+            workspaces: Array(reconciliation.workspaces.prefix(limit)),
+            replacedWorkspaceIDs: reconciliation.replacedWorkspaceIDs
+        )
+    }
+
+    private func reconcile(
+        _ workspaces: [AgentWorkspace],
+        preferredWorkspaceID: String? = nil,
+        equivalentPaths: [String] = []
+    ) -> RecentWorkspaceReconciliation {
+        var remaining = workspaces
+            .map(Self.normalizedWorkspace)
+            .filter { !$0.id.isEmpty && !$0.path.isEmpty }
+            .sorted {
+                Self.workspacePrecedes(
+                    $0,
+                    $1,
+                    preferredWorkspaceID: preferredWorkspaceID
+                )
+            }
+        var merged: [AgentWorkspace] = []
+        var replacements: [String: String] = [:]
+        let preferredAliases = Set(equivalentPaths.map(WorkspacePathIdentity.normalizedPath))
+            .filter { !$0.isEmpty }
+
+        while !remaining.isEmpty {
+            let winner = remaining.removeFirst()
+            var group = [winner]
+            var claimedIDs = Set([winner.id])
+            var claimedPaths = Set([WorkspacePathIdentity.normalizedPath(winner.path)])
+            if winner.id == preferredWorkspaceID {
+                claimedPaths.formUnion(preferredAliases)
+            }
+
+            var foundMatch = true
+            while foundMatch {
+                foundMatch = false
+                var unmatched: [AgentWorkspace] = []
+                for candidate in remaining {
+                    let candidatePath = WorkspacePathIdentity.normalizedPath(candidate.path)
+                    if claimedIDs.contains(candidate.id) || claimedPaths.contains(candidatePath) {
+                        group.append(candidate)
+                        claimedIDs.insert(candidate.id)
+                        claimedPaths.insert(candidatePath)
+                        foundMatch = true
+                    } else {
+                        unmatched.append(candidate)
+                    }
+                }
+                remaining = unmatched
+            }
+
+            var combined = winner
+            for duplicate in group.dropFirst() {
+                combined = Self.mergedWorkspace(preferred: combined, fallback: duplicate)
+                if duplicate.id != combined.id {
+                    replacements[duplicate.id] = combined.id
+                }
+            }
+            merged.append(combined)
+        }
+
+        return RecentWorkspaceReconciliation(
+            workspaces: merged.sorted(by: Self.workspaceSort),
+            replacedWorkspaceIDs: Self.flattenedReplacements(replacements)
+        )
+    }
+
+    private static func normalizedWorkspace(_ workspace: AgentWorkspace) -> AgentWorkspace {
+        AgentWorkspace(
+            id: workspace.id.trimmingCharacters(in: .whitespacesAndNewlines),
+            name: workspace.name,
+            path: WorkspacePathIdentity.normalizedPath(workspace.path),
+            rootProjectID: normalizedOptional(workspace.rootProjectID),
+            rootProjectName: normalizedOptional(workspace.rootProjectName),
+            rootProjectPath: workspace.rootProjectPath.map(WorkspacePathIdentity.normalizedPath),
+            lastOpenedAt: workspace.lastOpenedAt
+        )
+    }
+
+    private static func mergedWorkspace(
+        preferred: AgentWorkspace,
+        fallback: AgentWorkspace
+    ) -> AgentWorkspace {
+        AgentWorkspace(
+            id: preferred.id,
+            name: preferred.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? fallback.name
+                : preferred.name,
+            path: preferred.path,
+            rootProjectID: preferred.rootProjectID ?? fallback.rootProjectID,
+            rootProjectName: preferred.rootProjectName ?? fallback.rootProjectName,
+            rootProjectPath: preferred.rootProjectPath ?? fallback.rootProjectPath,
+            lastOpenedAt: maxDate(preferred.lastOpenedAt, fallback.lastOpenedAt)
+        )
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func maxDate(_ lhs: Date?, _ rhs: Date?) -> Date? {
+        switch (lhs, rhs) {
+        case (.some(let lhs), .some(let rhs)):
+            return max(lhs, rhs)
+        case (.some(let lhs), .none):
+            return lhs
+        case (.none, .some(let rhs)):
+            return rhs
+        case (.none, .none):
+            return nil
+        }
+    }
+
+    private static func workspacePrecedes(
+        _ lhs: AgentWorkspace,
+        _ rhs: AgentWorkspace,
+        preferredWorkspaceID: String?
+    ) -> Bool {
+        let lhsIsPreferred = lhs.id == preferredWorkspaceID
+        let rhsIsPreferred = rhs.id == preferredWorkspaceID
+        if lhsIsPreferred != rhsIsPreferred {
+            return lhsIsPreferred
+        }
+
+        // 被动读取旧数据时稳定 ws_<path hash> 优先于兼容 project ID，避免下次
+        // agentd resolve 又把 identity 切回去；显式打开时 preferredWorkspaceID 优先级更高。
+        let lhsIsCanonical = lhs.id.hasPrefix("ws_")
+        let rhsIsCanonical = rhs.id.hasPrefix("ws_")
+        if lhsIsCanonical != rhsIsCanonical {
+            return lhsIsCanonical
+        }
+        if lhs.lastOpenedAt != rhs.lastOpenedAt {
+            return (lhs.lastOpenedAt ?? .distantPast) > (rhs.lastOpenedAt ?? .distantPast)
+        }
+        return lhs.id.localizedStandardCompare(rhs.id) == .orderedAscending
+    }
+
+    private static func combinedReplacements(
+        _ replacements: [String: String]...
+    ) -> [String: String] {
+        var combined: [String: String] = [:]
+        for replacement in replacements {
+            for (oldID, newID) in replacement {
+                combined[oldID] = newID
+                let chainedOldIDs = combined.compactMap { existingOldID, existingNewID in
+                    existingNewID == oldID ? existingOldID : nil
+                }
+                for existingOldID in chainedOldIDs {
+                    combined[existingOldID] = newID
+                }
+            }
+        }
+        return flattenedReplacements(combined)
+    }
+
+    private static func flattenedReplacements(
+        _ replacements: [String: String]
+    ) -> [String: String] {
+        var flattened: [String: String] = [:]
+        for oldID in replacements.keys {
+            var targetID = replacements[oldID] ?? oldID
+            var visited = Set([oldID])
+            while let nextID = replacements[targetID], !visited.contains(targetID) {
+                visited.insert(targetID)
+                targetID = nextID
+            }
+            if oldID != targetID {
+                flattened[oldID] = targetID
+            }
+        }
+        return flattened
     }
 
     private static func workspaceSort(lhs: AgentWorkspace, rhs: AgentWorkspace) -> Bool {

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -167,6 +167,7 @@ final class SessionStore: ObservableObject {
     let contextStore: SessionContextStore
     let eventReducer: EventReducer
     let recentWorkspaceStore: RecentWorkspaceStore
+    let workspaceAppearanceStore: WorkspaceAppearanceStore
     let sessionListPreferenceStore: SessionListPreferenceStore
     let sessionHistoryReadStateStore: SessionHistoryReadStateStore
     let sessionControlStateStore: SessionControlStateStore
@@ -284,6 +285,9 @@ final class SessionStore: ObservableObject {
     var queuedCommandActionRuns: [QueuedCommandActionRun] = []
     var projectsByID: [String: AgentProject] = [:]
     var workspacesByID: [String: AgentWorkspace] = [:]
+    // 工作区页维护独立的本地浏览选择；保留当前 Profile 内的旧→新 ID，
+    // 让卡片列表去重时能原位切换到幸存卡片，而不是跳到全局会话所在工作区。
+    var workspaceIdentityReplacementByOldID: [String: String] = [:]
     var sidebarProjectsByID: [String: AgentProject] = [:]
     var sessionsByID: [SessionID: AgentSession] = [:]
     var sessionIndexByID: [SessionID: Int] = [:]
@@ -370,6 +374,7 @@ final class SessionStore: ObservableObject {
         logStore: LogStore,
         contextStore: SessionContextStore? = nil,
         recentWorkspaceStore: RecentWorkspaceStore? = nil,
+        workspaceAppearanceStore: WorkspaceAppearanceStore? = nil,
         sessionListPreferenceStore: SessionListPreferenceStore? = nil,
         sessionHistoryReadStateStore: SessionHistoryReadStateStore? = nil,
         sessionControlStateStore: SessionControlStateStore? = nil,
@@ -420,6 +425,16 @@ final class SessionStore: ObservableObject {
             self.recentWorkspaceStore = RecentWorkspaceStore(defaults: defaults)
         } else {
             self.recentWorkspaceStore = RecentWorkspaceStore()
+        }
+        if let workspaceAppearanceStore {
+            self.workspaceAppearanceStore = workspaceAppearanceStore
+        } else if clientFactory != nil {
+            let defaults = UserDefaults(
+                suiteName: "SessionStore.WorkspaceAppearance.\(UUID().uuidString)"
+            ) ?? .standard
+            self.workspaceAppearanceStore = WorkspaceAppearanceStore(defaults: defaults)
+        } else {
+            self.workspaceAppearanceStore = WorkspaceAppearanceStore()
         }
         if let sessionListPreferenceStore {
             self.sessionListPreferenceStore = sessionListPreferenceStore

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -1234,8 +1234,8 @@ extension SessionStore {
     }
 
     func reloadRecentWorkspaces() {
-        setRecentWorkspacesIfChanged(
-            recentWorkspaceStore.load(
+        applyRecentWorkspaceReconciliation(
+            recentWorkspaceStore.loadReconciled(
                 profileID: appStore.notificationRoutingProfileID,
                 legacyEndpoint: appStore.endpoint,
                 profiles: appStore.connectionProfiles
@@ -1247,13 +1247,159 @@ extension SessionStore {
         reloadSessionReminders()
     }
 
+    /// 最近工作区合并后，所有仍在内存中的 workspace ID 引用必须在同一个 MainActor
+    /// 事务里一起迁移。否则卡片虽然去重，当前选择、已加载会话或头像仍会留在旧 ID。
+    func applyRecentWorkspaceReconciliation(
+        _ reconciliation: RecentWorkspaceReconciliation
+    ) {
+        let replacements = reconciliation.replacedWorkspaceIDs
+        let previousSessionWorkspaceIDs = sessionWorkspaceIDs.map {
+            remappedWorkspaceIDs($0, replacements: replacements)
+        }
+        let previousSelectedProjectID = selectedProjectID.map {
+            replacements[$0] ?? $0
+        }
+        let migratedExpandedProjectIDs = remappedWorkspaceIDs(
+            expandedProjectIDs,
+            replacements: replacements
+        )
+        let migratedShowingAllProjectIDs = remappedWorkspaceIDs(
+            showingAllSessionProjectIDs,
+            replacements: replacements
+        )
+        let migratedVisibleLimits = remappedWorkspaceValues(
+            sessionVisibleLimitByProjectID,
+            replacements: replacements
+        )
+
+        for (oldID, newID) in replacements.sorted(by: { $0.key < $1.key }) {
+            let chainedOldIDs = workspaceIdentityReplacementByOldID.compactMap {
+                existingOldID,
+                existingNewID in
+                existingNewID == oldID ? existingOldID : nil
+            }
+            for chainedOldID in chainedOldIDs {
+                workspaceIdentityReplacementByOldID[chainedOldID] = newID
+            }
+            workspaceIdentityReplacementByOldID[oldID] = newID
+            workspaceAppearanceStore.migrateProjectIdentity(
+                profileID: appStore.notificationRoutingProfileID,
+                from: oldID,
+                to: newID
+            )
+        }
+
+        setRecentWorkspacesIfChanged(reconciliation.workspaces)
+        guard !replacements.isEmpty else {
+            return
+        }
+
+        setSelectedProjectID(previousSelectedProjectID)
+        setExpandedProjectIDs(migratedExpandedProjectIDs)
+        setShowingAllSessionProjectIDs(migratedShowingAllProjectIDs)
+        sessionVisibleLimitByProjectID = migratedVisibleLimits.filter {
+            migratedShowingAllProjectIDs.contains($0.key)
+        }
+        setSessionWorkspaceIDs(previousSessionWorkspaceIDs)
+
+        unavailableWorkspaceIDs = remappedWorkspaceIDs(
+            unavailableWorkspaceIDs,
+            replacements: replacements
+        )
+        sessionPageCursorByProjectID = remappedWorkspaceValues(
+            sessionPageCursorByProjectID,
+            replacements: replacements
+        )
+        sessionHasMoreByProjectID = remappedWorkspaceValues(
+            sessionHasMoreByProjectID,
+            replacements: replacements
+        )
+        sessionProjectsWithAdditionalPages = remappedWorkspaceIDs(
+            sessionProjectsWithAdditionalPages,
+            replacements: replacements
+        )
+
+        // 旧 identity 下正在进行的列表请求不能改名后继续回写；取消并丢弃即可，
+        // 随后的显式 open/refresh 会针对保留 ID 建立新请求。
+        for oldID in replacements.keys {
+            sessionPageRequestTokenByProjectID.removeValue(forKey: oldID)
+            sessionPageLoadingTokenByProjectID.removeValue(forKey: oldID)
+            sessionListReconciliationTasksByProjectID.removeValue(forKey: oldID)?.cancel()
+        }
+        let obsoleteFirstPageRequestKeys = sessionListFirstPageInFlightByKey.keys.filter {
+            replacements[$0.workspaceID] != nil
+        }
+        for key in obsoleteFirstPageRequestKeys {
+            sessionListFirstPageInFlightByKey[key]?.task.cancel()
+            sessionListFirstPageInFlightByKey.removeValue(forKey: key)
+        }
+        sessionListFirstPageCacheByKey = sessionListFirstPageCacheByKey.filter {
+            replacements[$0.key.workspaceID] == nil
+        }
+
+        let workspacesByID = Dictionary(
+            uniqueKeysWithValues: reconciliation.workspaces.map { ($0.id, $0) }
+        )
+        let migratedSessions = sessions.map { item in
+            guard let newID = replacements[item.projectID],
+                  let workspace = workspacesByID[newID] else {
+                return item
+            }
+            return session(item, in: workspace)
+        }
+        if migratedSessions != sessions {
+            sessions = migratedSessions
+        }
+
+        let migratedRemoteSessions = remoteSessionSearchResults.map { item in
+            guard let newID = replacements[item.projectID],
+                  let workspace = workspacesByID[newID] else {
+                return item
+            }
+            return session(item, in: workspace)
+        }
+        if migratedRemoteSessions != remoteSessionSearchResults {
+            remoteSessionSearchResults = migratedRemoteSessions
+        }
+
+        externalActivityBySessionID = externalActivityBySessionID.mapValues { activity in
+            guard let newID = replacements[activity.projectID] else {
+                return activity
+            }
+            return ExternalSessionActivity(
+                threadID: activity.threadID,
+                projectID: newID,
+                source: activity.source,
+                state: activity.state,
+                turnID: activity.turnID,
+                revision: activity.revision,
+                lastActivityAt: activity.lastActivityAt
+            )
+        }
+        missingRunningSessionStateByID = missingRunningSessionStateByID.mapValues { state in
+            MissingRunningSessionState(
+                projectID: replacements[state.projectID] ?? state.projectID,
+                consecutiveRefreshMisses: state.consecutiveRefreshMisses
+            )
+        }
+    }
+
+    func retainedWorkspaceID(for workspaceID: String) -> String {
+        workspaceIdentityReplacementByOldID[workspaceID] ?? workspaceID
+    }
+
     func reloadSessionListPreferences() {
         let preferences = sessionListPreferenceStore.load(
             profileID: appStore.notificationRoutingProfileID,
             legacyEndpoint: appStore.endpoint,
             profiles: appStore.connectionProfiles
         )
-        let loadedSessionWorkspaceIDs = normalizedSessionWorkspaceIDs(preferences.sessionWorkspaceIDs)
+        // 冷启动升级时 recent workspace 会先完成去重，筛选偏好随后才读取。
+        // 在校验有效 ID 前先迁移，否则旧 ID 会被误判为已删除并静默丢失。
+        let migratedSessionWorkspaceIDs = preferences.sessionWorkspaceIDs.map { workspaceIDs in
+            Set(workspaceIDs.map(retainedWorkspaceID))
+        }
+        let loadedSessionWorkspaceIDs = normalizedSessionWorkspaceIDs(migratedSessionWorkspaceIDs)
         guard pinnedSessionIDs != preferences.pinnedSessionIDs
             || archivedSessionIDs != preferences.archivedSessionIDs
             || sessionWorkspaceIDs != loadedSessionWorkspaceIDs
@@ -1419,6 +1565,11 @@ extension SessionStore {
         guard let value else {
             return nil
         }
+        // SessionStore 初始化时 recent workspaces 尚未加载；此时不能把持久化筛选当作
+        // 无效 ID 清空。等工作区索引就绪后再做交集和“全选 = nil”归一化。
+        guard !validProjectIDs.isEmpty else {
+            return value.isEmpty ? nil : value
+        }
         let selectedIDs = value.intersection(validProjectIDs)
         // 全选和默认显示全部是同一个语义，归一成 nil，避免 UI 出现多余的“恢复全部显示”按钮。
         return selectedIDs == validProjectIDs ? nil : selectedIDs
@@ -1523,12 +1674,28 @@ extension SessionStore {
         saveSessionReminders()
     }
 
-    func rememberWorkspace(_ workspace: AgentWorkspace) {
-        let next = recentWorkspaceStore.upsert(
+    @discardableResult
+    func rememberWorkspace(
+        _ workspace: AgentWorkspace,
+        equivalentPaths: [String] = [],
+        prefersIncomingIdentity: Bool = true
+    ) -> AgentWorkspace {
+        let reconciliation = recentWorkspaceStore.upsertReconciled(
             workspace,
-            profileID: appStore.notificationRoutingProfileID
+            profileID: appStore.notificationRoutingProfileID,
+            equivalentPaths: equivalentPaths,
+            prefersIncomingIdentity: prefersIncomingIdentity
         )
-        setRecentWorkspacesIfChanged(next)
+        applyRecentWorkspaceReconciliation(reconciliation)
+
+        let matchingPaths = Set(
+            ([workspace.path] + equivalentPaths)
+                .map(WorkspacePathIdentity.normalizedPath)
+        )
+        return reconciliation.workspaces.first {
+            $0.id == workspace.id
+                || matchingPaths.contains(WorkspacePathIdentity.normalizedPath($0.path))
+        } ?? workspace
     }
 
     func upsertManagedWorktree(_ item: WorktreeListItem) {
@@ -1595,8 +1762,7 @@ extension SessionStore {
             return workspace
         }
         let workspace = AgentWorkspace(project: project)
-        rememberWorkspace(workspace)
-        return workspacesByID[workspace.id] ?? workspace
+        return rememberWorkspace(workspace, prefersIncomingIdentity: false)
     }
 
     func ensureWorkspaceForKnownProjectID(_ projectID: String) -> AgentWorkspace? {
@@ -1929,6 +2095,7 @@ extension SessionStore {
         )
         setProjectsIfChanged([])
         setRecentWorkspacesIfChanged([])
+        workspaceIdentityReplacementByOldID = [:]
         setSidebarProjectsIfChanged([])
         sessionWorkspaceIDs = nil
         pinnedSessionIDs = []
@@ -2488,4 +2655,25 @@ extension SessionStore {
             foregroundActivityBySessionID.removeValue(forKey: sessionID)
         }
     }
+}
+
+private func remappedWorkspaceIDs(
+    _ ids: Set<String>,
+    replacements: [String: String]
+) -> Set<String> {
+    Set(ids.map { replacements[$0] ?? $0 })
+}
+
+/// 目标 ID 已有状态时保留目标值；只有目标为空才承接旧 ID 的值。
+private func remappedWorkspaceValues<Value>(
+    _ values: [String: Value],
+    replacements: [String: String]
+) -> [String: Value] {
+    var remapped = values.filter { replacements[$0.key] == nil }
+    for (oldID, newID) in replacements.sorted(by: { $0.key < $1.key }) {
+        if remapped[newID] == nil, let value = values[oldID] {
+            remapped[newID] = value
+        }
+    }
+    return remapped
 }

--- a/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
@@ -90,7 +90,7 @@ extension SessionStore {
         sessionControlStateStore.remove(profileID: profileID)
         sessionReminderStore.remove(profileID: profileID)
         sessionReminderScheduler.cancel(profileID: profileID)
-        WorkspaceAppearanceStore().remove(profileID: profileID)
+        workspaceAppearanceStore.remove(profileID: profileID)
         do {
             try queuedTurnStore.remove(profileID: profileID)
             queuedTurnStorageErrorMessage = nil

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -638,11 +638,11 @@ extension SessionStore {
                 }
                 return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
-        recentWorkspaceStore.save(
+        let reconciliation = recentWorkspaceStore.saveReconciled(
             nextWorkspaces,
             profileID: appStore.notificationRoutingProfileID
         )
-        setRecentWorkspacesIfChanged(nextWorkspaces)
+        applyRecentWorkspaceReconciliation(reconciliation)
     }
 
     /// 刷新工作区页正在浏览的会话，但不改变全局会话选择或 WebSocket。
@@ -706,8 +706,13 @@ extension SessionStore {
         do {
             // 走 clientFactory（与会话请求同一个注入点）而不是 appStore.client()，
             // 让 resolve 和后续会话加载共用一条可测试链路。
-            let workspace = try await clientFactory().resolveWorkspace(path: trimmed)
-            rememberWorkspace(workspace)
+            let resolvedWorkspace = try await clientFactory().resolveWorkspace(path: trimmed)
+            // resolve 的返回路径是 agentd realpath；同时带上用户输入路径，才能把旧版保存的
+            // 符号链接路径安全迁移到同一 canonical workspace，而不猜测其他同名目录。
+            let workspace = rememberWorkspace(
+                resolvedWorkspace,
+                equivalentPaths: [trimmed]
+            )
             clearWorkspaceUnavailable(workspace.id)
             insertExpandedProjectID(workspace.id)
             let selectionLease = commitSelection(
@@ -751,9 +756,8 @@ extension SessionStore {
                 base: base?.trimmingCharacters(in: .whitespacesAndNewlines),
                 branch: branch?.trimmingCharacters(in: .whitespacesAndNewlines)
             )
-            let workspace = response.workspace
+            let workspace = rememberWorkspace(response.workspace)
             // Worktree 成功创建后作为一个普通 workspace 接入，后续 thread/list 和 thread/start 复用现有 cwd 安全链路。
-            rememberWorkspace(workspace)
             upsertManagedWorktree(WorktreeListItem(workspace: workspace, worktree: response.worktree))
             clearWorkspaceUnavailable(workspace.id)
             insertExpandedProjectID(workspace.id)
@@ -826,7 +830,7 @@ extension SessionStore {
             }
             guard appStore.activeHostScope == hostScope else { return false }
 
-            rememberWorkspace(workspace)
+            _ = rememberWorkspace(workspace)
             clearWorkspaceUnavailable(workspace.id)
             upsert(responseSession)
             insertExpandedProjectID(responseSession.projectID)
@@ -901,8 +905,7 @@ extension SessionStore {
                 base: normalizedOptional(base),
                 branch: normalizedOptional(branch)
             )
-            let workspace = response.workspace
-            rememberWorkspace(workspace)
+            let workspace = rememberWorkspace(response.workspace)
             upsertManagedWorktree(WorktreeListItem(workspace: workspace, worktree: response.worktree))
             clearWorkspaceUnavailable(workspace.id)
             insertExpandedProjectID(workspace.id)
@@ -1206,8 +1209,7 @@ extension SessionStore {
 
     @discardableResult
     func openManagedWorktree(_ item: WorktreeListItem) async -> Bool {
-        let workspace = item.workspace
-        rememberWorkspace(workspace)
+        let workspace = rememberWorkspace(item.workspace)
         clearWorkspaceUnavailable(workspace.id)
         let selectionLease = commitSelection(
             projectID: workspace.id,

--- a/ios/MimiRemote/Sources/State/WorkspaceAppearanceStore.swift
+++ b/ios/MimiRemote/Sources/State/WorkspaceAppearanceStore.swift
@@ -596,6 +596,45 @@ final class WorkspaceAppearanceStore: ObservableObject {
         save(preferences, profileKey: profileKey)
     }
 
+    /// 同一路径的旧 workspace ID 被稳定 ID 替代时迁移本机自定义头像。
+    ///
+    /// 新 ID 上已经存在的明确选择优先；否则复制旧 ID 的选择，随后删除旧键。
+    /// 自动分配值不落盘，无需迁移，后续会直接按稳定 ID 重新计算。
+    func migrateProjectIdentity(
+        profileID: String,
+        from oldProjectID: String,
+        to newProjectID: String
+    ) {
+        guard oldProjectID != newProjectID,
+              let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID),
+              var preferences = storage.byProfileID[profileKey]
+        else {
+            return
+        }
+
+        if preferences.characterIDsByProject[newProjectID] == nil {
+            preferences.characterIDsByProject[newProjectID] =
+                preferences.characterIDsByProject[oldProjectID]
+        }
+        preferences.characterIDsByProject.removeValue(forKey: oldProjectID)
+
+        if preferences.emojiByProject[newProjectID] == nil {
+            preferences.emojiByProject[newProjectID] = preferences.emojiByProject[oldProjectID]
+        }
+        preferences.emojiByProject.removeValue(forKey: oldProjectID)
+
+        for styleID in Array(preferences.characterIDsByStyleAndProject.keys) {
+            var choices = preferences.characterIDsByStyleAndProject[styleID] ?? [:]
+            if choices[newProjectID] == nil {
+                choices[newProjectID] = choices[oldProjectID]
+            }
+            choices.removeValue(forKey: oldProjectID)
+            preferences.characterIDsByStyleAndProject[styleID] =
+                choices.isEmpty ? nil : choices
+        }
+        save(preferences, profileKey: profileKey)
+    }
+
     func remove(profileID: String) {
         guard let profileKey = ProfileScopedPersistence.normalizedProfileID(profileID),
               storage.byProfileID.removeValue(forKey: profileKey) != nil else {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -2717,6 +2717,86 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.load(endpoint: "http://mac-b.local:8787").map(\.id), [second.id])
     }
 
+    func testRecentWorkspaceStoreMigratesDuplicatePathToCanonicalWorkspaceID() throws {
+        let suiteName = "RecentWorkspaceStoreTests.DuplicatePath.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let profileID = "mac-a"
+        let canonical = AgentWorkspace(
+            id: "ws_canonical",
+            name: "chat-archive",
+            path: "/Users/me/code/chat-archive",
+            lastOpenedAt: Date(timeIntervalSince1970: 10)
+        )
+        let legacy = AgentWorkspace(
+            id: "legacy-project-id",
+            name: "旧名称",
+            path: "/Users/me/code/chat-archive/",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+        var rawStorage = ProfileScopedStorage<[AgentWorkspace]>()
+        rawStorage.byProfileID[profileID] = [legacy, canonical]
+        defaults.set(
+            try JSONEncoder().encode(rawStorage),
+            forKey: "agentd.recentWorkspaces"
+        )
+        let store = RecentWorkspaceStore(defaults: defaults)
+
+        let migration = store.loadReconciled(profileID: profileID)
+
+        // ws_<path hash> 是 agentd 的稳定 identity，即使旧 project ID 时间更晚也不能反向降级。
+        XCTAssertEqual(migration.workspaces.map(\.id), [canonical.id])
+        XCTAssertEqual(
+            migration.workspaces.first?.lastOpenedAt,
+            legacy.lastOpenedAt,
+            "合并后仍保留两条记录中的最近打开时间"
+        )
+        XCTAssertEqual(migration.replacedWorkspaceIDs, [legacy.id: canonical.id])
+        XCTAssertEqual(store.load(profileID: profileID), migration.workspaces)
+    }
+
+    func testRecentWorkspaceStoreTreatsDarwinVarAliasAsSamePath() {
+        let profileID = "mac-a"
+        let store = makeRecentWorkspaceStore(workspaces: [], endpoint: "http://mac-a.local:8787")
+        let legacy = AgentWorkspace(
+            id: "legacy-var",
+            name: "缓存",
+            path: "/var/folders/example"
+        )
+        let canonical = AgentWorkspace(
+            id: "ws_var",
+            name: "缓存",
+            path: "/private/var/folders/example"
+        )
+
+        store.save([legacy, canonical], profileID: profileID)
+
+        let loaded = store.load(profileID: profileID)
+        XCTAssertEqual(loaded.map(\.id), [canonical.id])
+        XCTAssertEqual(loaded.first?.path, "/private/var/folders/example")
+    }
+
+    func testRecentWorkspaceStoreDoesNotMergeSameNameAtDifferentPaths() {
+        let profileID = "mac-a"
+        let store = makeRecentWorkspaceStore(workspaces: [], endpoint: "http://mac-a.local:8787")
+        let first = AgentWorkspace(
+            id: "ws_first",
+            name: "chat-archive",
+            path: "/Users/me/code/chat-archive"
+        )
+        let second = AgentWorkspace(
+            id: "ws_second",
+            name: "chat-archive",
+            path: "/Users/me/archive/chat-archive"
+        )
+
+        store.save([first, second], profileID: profileID)
+
+        XCTAssertEqual(Set(store.load(profileID: profileID).map(\.id)), [first.id, second.id])
+    }
+
     func testSessionListPreferenceStoreScopesByEndpoint() {
         let store = makeSessionListPreferenceStore()
         store.save(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -3516,6 +3516,204 @@ extension ConversationDataFlowTests {
         XCTAssertNil(store.capabilityErrorMessage)
     }
 
+    func testRememberWorkspaceMigratesLegacySelectionSessionsAndCustomAvatar() throws {
+        let suiteName = "WorkspaceIdentityMigrationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let appStore = AppStore(defaults: defaults)
+        let legacy = AgentWorkspace(
+            id: "legacy-project-id",
+            name: "chat-archive",
+            path: "/Users/me/code/chat-archive-link",
+            lastOpenedAt: Date(timeIntervalSince1970: 10)
+        )
+        let canonical = AgentWorkspace(
+            id: "ws_canonical",
+            name: "chat-archive",
+            path: "/Users/me/code/chat-archive",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+        let other = AgentWorkspace(
+            id: "ws_other",
+            name: "other",
+            path: "/Users/me/code/other",
+            lastOpenedAt: Date(timeIntervalSince1970: 5)
+        )
+        let recentStore = RecentWorkspaceStore(defaults: defaults)
+        recentStore.save(
+            [legacy, other],
+            profileID: appStore.notificationRoutingProfileID
+        )
+        let appearanceStore = WorkspaceAppearanceStore(defaults: defaults)
+        appearanceStore.setCustomCharacterID(
+            "nezha",
+            profileID: appStore.notificationRoutingProfileID,
+            projectID: legacy.id
+        )
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: recentStore,
+            workspaceAppearanceStore: appearanceStore,
+            clientFactory: {
+                MockSessionStoreClient(projects: [], sessions: [])
+            }
+        )
+        store.reloadRecentWorkspaces()
+        store.sessions = [
+            AgentSession(
+                id: "session-legacy",
+                projectID: legacy.id,
+                project: legacy.name,
+                dir: legacy.path,
+                title: "历史会话",
+                status: "history",
+                source: "codex",
+                resumeID: "thread-legacy",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: 2)
+            )
+        ]
+        store.setSelectedProjectID(legacy.id)
+        store.setSessionWorkspaceIDs([legacy.id])
+        store.insertExpandedProjectID(legacy.id)
+
+        let remembered = store.rememberWorkspace(
+            canonical,
+            equivalentPaths: [legacy.path]
+        )
+
+        XCTAssertEqual(remembered.id, canonical.id)
+        XCTAssertEqual(store.recentWorkspaces.map(\.id), [canonical.id, other.id])
+        XCTAssertEqual(store.sidebarProjects.map(\.id), [canonical.id, other.id])
+        XCTAssertEqual(store.selectedProjectID, canonical.id)
+        XCTAssertEqual(store.retainedWorkspaceID(for: legacy.id), canonical.id)
+        XCTAssertEqual(store.sessions.map(\.projectID), [canonical.id])
+        XCTAssertEqual(store.sessionWorkspaceIDs, Set([canonical.id]))
+        XCTAssertEqual(store.expandedProjectIDs, Set([canonical.id]))
+        XCTAssertEqual(
+            appearanceStore.customCharacterID(
+                profileID: appStore.notificationRoutingProfileID,
+                projectID: canonical.id
+            ),
+            "nezha"
+        )
+        XCTAssertNil(
+            appearanceStore.customCharacterID(
+                profileID: appStore.notificationRoutingProfileID,
+                projectID: legacy.id
+            )
+        )
+    }
+
+    func testColdLaunchWorkspaceMigrationPreservesPersistedWorkspaceFilter() throws {
+        let suiteName = "ColdLaunchWorkspaceIdentityMigrationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let appStore = AppStore(defaults: defaults)
+        let profileID = appStore.notificationRoutingProfileID
+        let legacy = AgentWorkspace(
+            id: "legacy-project-id",
+            name: "chat-archive",
+            path: "/Users/me/code/chat-archive/",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+        let canonical = AgentWorkspace(
+            id: "ws_canonical",
+            name: "chat-archive",
+            path: "/Users/me/code/chat-archive",
+            lastOpenedAt: Date(timeIntervalSince1970: 10)
+        )
+        let other = AgentWorkspace(
+            id: "ws_other",
+            name: "other",
+            path: "/Users/me/code/other",
+            lastOpenedAt: Date(timeIntervalSince1970: 5)
+        )
+        var rawStorage = ProfileScopedStorage<[AgentWorkspace]>()
+        rawStorage.byProfileID[profileID] = [legacy, canonical, other]
+        defaults.set(
+            try JSONEncoder().encode(rawStorage),
+            forKey: "agentd.recentWorkspaces"
+        )
+        let preferenceStore = SessionListPreferenceStore(defaults: defaults)
+        preferenceStore.save(
+            SessionListPreferences(sessionWorkspaceIDs: [legacy.id]),
+            profileID: profileID
+        )
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: RecentWorkspaceStore(defaults: defaults),
+            sessionListPreferenceStore: preferenceStore,
+            clientFactory: {
+                MockSessionStoreClient(projects: [], sessions: [])
+            }
+        )
+
+        XCTAssertEqual(store.sessionWorkspaceIDs, Set([legacy.id]))
+        store.reloadRecentWorkspaces()
+
+        XCTAssertEqual(store.recentWorkspaces.map(\.id), [canonical.id, other.id])
+        XCTAssertEqual(store.sessionWorkspaceIDs, Set([canonical.id]))
+        XCTAssertEqual(
+            preferenceStore.load(profileID: profileID).sessionWorkspaceIDs,
+            Set([canonical.id])
+        )
+    }
+
+    func testOpeningSameResolvedDirectoryTwiceReusesWorkspaceAndSelection() async {
+        let appStore = AppStore()
+        appStore.token = "test-token"
+        let typedPath = "/Users/me/code/chat-archive"
+        let workspace = AgentWorkspace(
+            id: "ws_canonical",
+            name: "chat-archive",
+            path: typedPath,
+            rootProjectID: "project-root",
+            rootProjectName: "chat-archive",
+            rootProjectPath: typedPath
+        )
+        let recentStore = makeRecentWorkspaceStore(
+            workspaces: [],
+            endpoint: appStore.endpoint
+        )
+        let client = MockSessionStoreClient(
+            projects: [],
+            sessions: [],
+            workspaceSessions: [workspace.id: []],
+            resolveResults: [typedPath: .success(workspace)]
+        )
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: recentStore,
+            clientFactory: { client }
+        )
+
+        let firstOpenSucceeded = await store.openWorkspace(path: typedPath)
+        XCTAssertTrue(firstOpenSucceeded)
+        let firstOpenedAt = store.recentWorkspaces.first?.lastOpenedAt
+        let secondOpenSucceeded = await store.openWorkspace(path: typedPath)
+        XCTAssertTrue(secondOpenSucceeded)
+
+        XCTAssertEqual(client.requestedResolvePaths, [typedPath, typedPath])
+        XCTAssertEqual(store.recentWorkspaces.map(\.id), [workspace.id])
+        XCTAssertEqual(store.selectedProjectID, workspace.id)
+        XCTAssertNotNil(firstOpenedAt)
+        XCTAssertGreaterThanOrEqual(
+            store.recentWorkspaces.first?.lastOpenedAt ?? .distantPast,
+            firstOpenedAt ?? .distantFuture
+        )
+    }
+
 }
 
 private actor GitStatusResponseGate {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceAppearanceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceAppearanceStoreTests.swift
@@ -481,4 +481,58 @@ final class WorkspaceAppearanceStoreTests: XCTestCase {
         store.setCustomCharacterID("unknown-character", profileID: "mac-a", projectID: "project-1")
         XCTAssertNil(store.customCharacterID(profileID: "mac-a", projectID: "project-1"))
     }
+
+    func testWorkspaceIdentityMigrationKeepsDestinationCustomPreferences() {
+        let store = WorkspaceAppearanceStore(defaults: defaults)
+        let profileID = "mac-a"
+        let oldID = "legacy-project"
+        let newID = "ws_canonical"
+        store.setCustomCharacterID("nezha", profileID: profileID, projectID: oldID)
+        store.setCustomCharacterID("guanyin", profileID: profileID, projectID: newID)
+        store.setCustomCharacterID(
+            "three-guan-yu",
+            style: .threeKingdoms,
+            profileID: profileID,
+            projectID: oldID
+        )
+        store.setCustomCharacterID(
+            "three-zhuge-liang",
+            style: .threeKingdoms,
+            profileID: profileID,
+            projectID: newID
+        )
+        store.setCustomEmoji("🐱", profileID: profileID, projectID: oldID)
+        store.setCustomEmoji("🤖", profileID: profileID, projectID: newID)
+
+        store.migrateProjectIdentity(
+            profileID: profileID,
+            from: oldID,
+            to: newID
+        )
+
+        XCTAssertEqual(
+            store.customCharacterID(style: .journey, profileID: profileID, projectID: newID),
+            "guanyin"
+        )
+        XCTAssertEqual(
+            store.customCharacterID(
+                style: .threeKingdoms,
+                profileID: profileID,
+                projectID: newID
+            ),
+            "three-zhuge-liang"
+        )
+        XCTAssertEqual(store.customEmoji(profileID: profileID, projectID: newID), "🤖")
+        XCTAssertNil(
+            store.customCharacterID(style: .journey, profileID: profileID, projectID: oldID)
+        )
+        XCTAssertNil(
+            store.customCharacterID(
+                style: .threeKingdoms,
+                profileID: profileID,
+                projectID: oldID
+            )
+        )
+        XCTAssertNil(store.customEmoji(profileID: profileID, projectID: oldID))
+    }
 }


### PR DESCRIPTION
## 目标

修复同一连接 Profile 下，同一个 canonical filesystem path 生成多张最近工作区卡片的问题。

Linear: https://linear.app/code89757/issue/MIM-52/同一路径的工作区会重复出现在卡片列表

## 方案

- 在 iOS RecentWorkspaceStore 建立远端路径 identity 归一化与去重，处理尾随分隔符、`.` / `..`、`/var` 与 `/private/var` 等 macOS 系统别名。
- 显式 agentd resolve 时以返回的 workspace ID 为权威，并携带用户输入路径合并符号链接旧记录；被动升级旧数据时优先保留 `ws_<path hash>`，其次按最近打开时间和稳定 ID 排序。
- 同一 MainActor 事务迁移当前选择、工作区筛选、展开态、分页状态、已加载会话关联、外部活动和自定义头像。目标 ID 已有状态时保留目标值，旧值只填空缺。
- 工作区页本地卡片选择通过旧 ID 到保留 ID 的映射继续指向原卡片，不回退到第一张卡片。

## 验证

- `bash ./scripts/ios-dev.sh test` 定向 7 项：全部通过；覆盖重复 path 不同 ID、连续打开、冷启动升级、`/var` 别名、符号链接输入、同名不同路径、头像优先级。
- 相关原有回归 30 项：全部通过；覆盖 Profile 隔离、目录刷新和 WorkspaceAppearanceStore 全套。
- `bash ./scripts/ios-dev.sh run`：iPad Pro 13-inch (M5) Debug build 成功，安装并启动成功。
- 运行态 Debug seed：真实 iPad 容器显示两张不同路径卡片，当前卡片保持已选择；可访问性树依次暴露卡片、图标入口和工作区操作入口。操作源继续使用 44×44 frame，本次未修改卡片布局和 VoiceOver 结构。
- `bash ./scripts/check-critical-regressions.sh`：通过。
- `bash ./scripts/check-source-size.sh`：通过。
- `git diff --check` 与 Swift 解析：通过。

## 风险与边界

- 不在 iPad 本地解析远端 Mac 的 symlink；只有 agentd resolve 返回 canonical path 时，才用本次输入路径建立安全等价关系。
- 未改 agentd workspace ID 算法，服务端 identity 重构不在本 Issue 范围。