### PR TITLE
MIM-56 区分会话时间线的工具活动语义

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		26F460F34C7BA2C10839F2CA /* testComposerStatusTrayCrowdedCompactWidth.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */; };
 		2988A74079D67A66B14DFF98 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92342D7DF3BBF2BC0BF24FC /* SettingsView.swift */; };
 		2B372F78E1EC09D8E4B7210F /* ConversationRuntimeTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A1F29F52DC5CC790708ACC /* ConversationRuntimeTestSupport.swift */; };
+		B8E2C4A9D7F1036B5C8A21E4 /* ConversationAppServerProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B1D0C7A9E4B2D8C6F1043 /* ConversationAppServerProjectorTests.swift */; };
 		2D6CA662D1D655CE6BE05CF0 /* FileUploadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D89DB26E0A1CA68C63E07D /* FileUploadStore.swift */; };
 		2EE9AF7AEF490C9B6832C118 /* ConversationTurnQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CF7E66AAB73235912C1990 /* ConversationTurnQueueTests.swift */; };
 		31B351EE974251896BA43252 /* SessionStoreHostSwitching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3369A709F1AC9D2CF790753C /* SessionStoreHostSwitching.swift */; };
@@ -296,6 +297,7 @@
 		3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationGuidanceFallbackTests.swift; sourceTree = "<group>"; };
 		3CF761429383D479BD96FC52 /* AgentAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAPIClient.swift; sourceTree = "<group>"; };
 		3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeHistoryTests.swift; sourceTree = "<group>"; };
+		F35B1D0C7A9E4B2D8C6F1043 /* ConversationAppServerProjectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationAppServerProjectorTests.swift; sourceTree = "<group>"; };
 		3DA20088DF3CC377CBB6D7B4 /* HostConnectionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConnectionSupport.swift; sourceTree = "<group>"; };
 		3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreSupport.swift; sourceTree = "<group>"; };
 		40A98707004C8DC4ED81CBCD /* ComposerVoiceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceSupport.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */,
 				315746F97ABB8E16D93F98A4 /* ConversationDataFlowTests.swift */,
 				078AEE7E4BDAC1751244A05A /* ConversationDataFlowTestSupport.swift */,
+				F35B1D0C7A9E4B2D8C6F1043 /* ConversationAppServerProjectorTests.swift */,
 				3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */,
 				025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */,
 				3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */,
@@ -1139,6 +1142,7 @@
 				AD2BA4EB75791D6DA68D6A46 /* ConversationConnectionRecoveryTests.swift in Sources */,
 				467ED9D49A463D5F5AF02A3C /* ConversationDataFlowTestSupport.swift in Sources */,
 				10BF43237408412ED651F5B4 /* ConversationDataFlowTests.swift in Sources */,
+				B8E2C4A9D7F1036B5C8A21E4 /* ConversationAppServerProjectorTests.swift in Sources */,
 				759158BB4175D405D74CD30A /* ConversationDirectRuntimeHistoryTests.swift in Sources */,
 				E790247242197F065BB1F1DE /* ConversationDirectRuntimeTests.swift in Sources */,
 				699762120516E7B19DB681E9 /* ConversationGuidanceFallbackTests.swift in Sources */,

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -3469,6 +3469,363 @@
         }
       }
     },
+    "ui.continue_subagent" : {
+      "comment" : "User-facing UI text for continuing an actual collaboration subagent, distinct from resuming an independent Codex task.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue subagent"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续子 Agent"
+          }
+        }
+      }
+    },
+    "ui.interrupt_subagent" : {
+      "comment" : "User-facing UI text for interrupting an actual collaboration subagent.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interrupt subagent"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中断子 Agent"
+          }
+        }
+      }
+    },
+    "ui.interrupted_status" : {
+      "comment" : "User-facing terminal status for an interrupted activity.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interrupted"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已中断"
+          }
+        }
+      }
+    },
+    "ui.perform_subagent_collaboration" : {
+      "comment" : "User-facing UI text for a collaboration subagent action whose exact operation is unavailable.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coordinate subagents"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "执行子 Agent 协作"
+          }
+        }
+      }
+    },
+    "ui.query_linear" : {
+      "comment" : "User-facing UI text for a safe generic Linear query.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query Linear"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询 Linear"
+          }
+        }
+      }
+    },
+    "ui.query_linear_issues" : {
+      "comment" : "User-facing UI text for listing or searching Linear issues.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query Linear issues"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询 Linear Issue"
+          }
+        }
+      }
+    },
+    "ui.query_subagents" : {
+      "comment" : "User-facing UI text for listing actual collaboration subagents.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query subagents"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询子 Agent"
+          }
+        }
+      }
+    },
+    "ui.query_task_list" : {
+      "comment" : "User-facing UI text for listing independent Codex tasks.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query task list"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询任务列表"
+          }
+        }
+      }
+    },
+    "ui.read_independent_task" : {
+      "comment" : "User-facing UI text for reading an independent Codex task.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read independent task"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "读取独立任务"
+          }
+        }
+      }
+    },
+    "ui.read_issue_comments" : {
+      "comment" : "User-facing UI text for reading Linear issue comments.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read issue comments"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "读取 Issue 评论"
+          }
+        }
+      }
+    },
+    "ui.read_linear" : {
+      "comment" : "User-facing UI text for a safe generic Linear read.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read Linear data"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "读取 Linear"
+          }
+        }
+      }
+    },
+    "ui.read_linear_issue" : {
+      "comment" : "User-facing UI text for reading one Linear issue.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read Linear issue"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "读取 Linear Issue"
+          }
+        }
+      }
+    },
+    "ui.resume_independent_task" : {
+      "comment" : "User-facing UI text for resuming or continuing an independent Codex task.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resume independent task"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复独立任务"
+          }
+        }
+      }
+    },
+    "ui.start_independent_task" : {
+      "comment" : "User-facing UI text for starting a separate Codex task, distinct from a collaboration subagent.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start independent task"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动独立任务"
+          }
+        }
+      }
+    },
+    "ui.start_subagent" : {
+      "comment" : "User-facing UI text for starting an actual collaboration subagent.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start subagent"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动子 Agent"
+          }
+        }
+      }
+    },
+    "ui.timed_out_status" : {
+      "comment" : "User-facing terminal status for a timed-out activity.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timed out"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已超时"
+          }
+        }
+      }
+    },
+    "ui.update_issue_comments" : {
+      "comment" : "User-facing UI text for creating or updating Linear issue comments.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update issue comments"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 Issue 评论"
+          }
+        }
+      }
+    },
+    "ui.update_linear" : {
+      "comment" : "User-facing UI text for a safe generic Linear write.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Linear"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 Linear"
+          }
+        }
+      }
+    },
+    "ui.update_linear_issue" : {
+      "comment" : "User-facing UI text for creating or updating a Linear issue.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Linear issue"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 Linear Issue"
+          }
+        }
+      }
+    },
+    "ui.wait_for_subagent_result" : {
+      "comment" : "User-facing UI text for waiting on an actual collaboration subagent.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wait for subagent result"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待子 Agent 结果"
+          }
+        }
+      }
+    },
+    "ui.wait_for_task_results" : {
+      "comment" : "User-facing UI text for waiting on independent Codex tasks.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wait for task results"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待任务结果"
+          }
+        }
+      }
+    },
     "ui.can_be_used_for_session_tasks_after_configuration" : {
       "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations" : {

--- a/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
@@ -771,7 +771,7 @@ struct CodexAppServerEventProjector {
             )
         case "item/started":
             rememberAgentMessageKind(from: params, metadata: metadata)
-            return startedCommandItemEvent(params: params, metadata: metadata)
+            return startedProcessItemEvent(params: params, metadata: metadata)
                 ?? itemContextEvent(params: params, metadata: metadata)
         case "item/completed":
             let event = completedAgentMessageEvent(params: params, metadata: metadata)
@@ -1254,17 +1254,25 @@ struct CodexAppServerEventProjector {
         return .processItemCompleted(message, context, metadata)
     }
 
-    private func startedCommandItemEvent(
+    private func startedProcessItemEvent(
         params: [String: CodexAppServerJSONValue],
         metadata: AgentEventMetadata
     ) -> AgentEvent? {
         guard var item = params["item"]?.objectValue,
-              firstString(in: item, keys: ["type"]) == "commandExecution"
+              let type = firstString(in: item, keys: ["type"]),
+              [
+                "commandExecution",
+                "fileChange",
+                "mcpToolCall",
+                "dynamicToolCall",
+                "collabAgentToolCall",
+                "webSearch",
+              ].contains(type)
         else {
             return nil
         }
-        // started 可能早于 status 字段到达。先投影一条可见的运行中消息，completed 再用
-        // 同一 stable message ID 原位覆盖，避免长命令期间页面看起来没有反馈。
+        // started 可能早于 status 字段到达。命令、Tool 与子 Agent 都先投影可见的运行中消息，
+        // completed 再用同一 stable message ID 原位覆盖，避免查询或等待期间页面看起来卡住。
         if firstString(in: item, keys: ["status"]) == nil {
             item["status"] = .string("inProgress")
         }

--- a/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
@@ -1648,6 +1648,43 @@ enum ConversationCommandPresentationKind: String, Codable, Hashable {
     case execution
 }
 
+/// Tool 活动的用户语义只来自受信任的 namespace / tool 白名单。
+/// 不从 arguments、prompt 或原始输出拼标题，避免把 Token、账号、路径和用户内容带进时间线。
+enum ConversationToolPresentationKind: String, Codable, Hashable {
+    case linearQuery = "linear_query"
+    case linearComment = "linear_comment"
+    case linearUpdate = "linear_update"
+    case independentTaskQuery = "independent_task_query"
+    case independentTaskStart = "independent_task_start"
+    case independentTaskResume = "independent_task_resume"
+    case independentTaskWait = "independent_task_wait"
+    case subagent
+    case generic
+
+    var systemImageName: String {
+        switch self {
+        case .linearQuery:
+            return "checklist"
+        case .linearComment:
+            return "text.bubble"
+        case .linearUpdate:
+            return "square.and.pencil"
+        case .independentTaskQuery:
+            return "list.bullet.rectangle"
+        case .independentTaskStart:
+            return "arrow.up.right.square"
+        case .independentTaskResume:
+            return "arrow.clockwise"
+        case .independentTaskWait:
+            return "hourglass"
+        case .subagent:
+            return "person.2.fill"
+        case .generic:
+            return "wrench.and.screwdriver"
+        }
+    }
+}
+
 struct ConversationActivityPayload: Codable, Hashable {
     let category: ConversationActivityCategory
     let displayTitle: String
@@ -1662,6 +1699,7 @@ struct ConversationActivityPayload: Codable, Hashable {
     let outputDigest: UInt64?
     let outputByteCount: Int?
     let commandPresentationKind: ConversationCommandPresentationKind?
+    let toolPresentationKind: ConversationToolPresentationKind?
 
     enum CodingKeys: String, CodingKey {
         case category
@@ -1677,6 +1715,7 @@ struct ConversationActivityPayload: Codable, Hashable {
         case outputDigest = "output_digest"
         case outputByteCount = "output_byte_count"
         case commandPresentationKind = "command_presentation_kind"
+        case toolPresentationKind = "tool_presentation_kind"
     }
 
     init(
@@ -1692,7 +1731,8 @@ struct ConversationActivityPayload: Codable, Hashable {
         outputPreview: String? = nil,
         outputDigest: UInt64? = nil,
         outputByteCount: Int? = nil,
-        commandPresentationKind: ConversationCommandPresentationKind? = nil
+        commandPresentationKind: ConversationCommandPresentationKind? = nil,
+        toolPresentationKind: ConversationToolPresentationKind? = nil
     ) {
         self.category = category
         self.displayTitle = displayTitle
@@ -1707,6 +1747,7 @@ struct ConversationActivityPayload: Codable, Hashable {
         self.outputDigest = outputDigest
         self.outputByteCount = outputByteCount
         self.commandPresentationKind = commandPresentationKind
+        self.toolPresentationKind = toolPresentationKind
     }
 
     init(from decoder: Decoder) throws {
@@ -1728,6 +1769,11 @@ struct ConversationActivityPayload: Codable, Hashable {
             commandPresentationKind = ConversationCommandPresentationKind(rawValue: rawKind) ?? .execution
         } else {
             commandPresentationKind = nil
+        }
+        if let rawKind = try container.decodeIfPresent(String.self, forKey: .toolPresentationKind) {
+            toolPresentationKind = ConversationToolPresentationKind(rawValue: rawKind) ?? .generic
+        } else {
+            toolPresentationKind = nil
         }
     }
 
@@ -1782,14 +1828,15 @@ struct ConversationActivityPayload: Codable, Hashable {
 
         case "mcpToolCall", "dynamicToolCall", "collabAgentToolCall", "webSearch":
             let identifier = Self.toolIdentifier(from: item, type: type)
-            let title = Self.toolTitle(from: item, type: type)
+            let presentation = Self.toolPresentation(from: item, type: type, identifier: identifier)
             let status = Self.firstString(in: item, keys: ["status"])?.trimmedNonEmpty
             self.init(
                 category: .toolCall,
-                displayTitle: title,
-                subtitle: nil,
+                displayTitle: presentation.title,
+                subtitle: presentation.subtitle,
                 status: status,
-                toolName: identifier
+                toolName: identifier,
+                toolPresentationKind: presentation.kind
             )
 
         default:
@@ -1841,6 +1888,10 @@ struct ConversationActivityPayload: Codable, Hashable {
             return L10n.text("ui.waiting")
         case "cancelled", "canceled":
             return L10n.text("ui.canceled")
+        case "interrupted", "aborted", "stopped":
+            return L10n.text("ui.interrupted_status")
+        case "timeout", "timedout":
+            return L10n.text("ui.timed_out_status")
         case "modified":
             return L10n.text("ui.modified")
         case "added", "created":
@@ -1866,11 +1917,32 @@ struct ConversationActivityPayload: Codable, Hashable {
             return true
         }
         switch normalizedStatus {
-        case "failed", "failure", "error":
+        case "failed", "failure", "error", "timeout", "timedout":
             return true
         default:
             return false
         }
+    }
+
+    var isInterrupted: Bool {
+        switch normalizedStatus {
+        case "interrupted", "aborted", "stopped", "cancelled", "canceled":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// VoiceOver 始终读出具体动作、安全目标摘要和终态；完成态不能因为视觉上省略状态而丢失语义。
+    var accessibilityDescription: String {
+        var parts = [displayTitle]
+        if let subtitle = subtitle?.trimmedNonEmpty, subtitle != displayTitle {
+            parts.append(subtitle)
+        }
+        if let displayStatusText {
+            parts.append(displayStatusText)
+        }
+        return parts.joined(separator: L10n.text("ui.list_separator"))
     }
 
     /// 过程行不是 Markdown 正文。这里移除最常见的强调和行内代码标记，
@@ -1915,6 +1987,7 @@ struct ConversationActivityPayload: Codable, Hashable {
             && lhs.outputDigest == rhs.outputDigest
             && lhs.outputByteCount == rhs.outputByteCount
             && lhs.commandPresentationKind == rhs.commandPresentationKind
+            && lhs.toolPresentationKind == rhs.toolPresentationKind
     }
 
     func hash(into hasher: inout Hasher) {
@@ -1930,6 +2003,7 @@ struct ConversationActivityPayload: Codable, Hashable {
         hasher.combine(outputDigest)
         hasher.combine(outputByteCount)
         hasher.combine(commandPresentationKind)
+        hasher.combine(toolPresentationKind)
     }
 
     private var commandSummaryText: String {
@@ -2085,81 +2159,211 @@ struct ConversationActivityPayload: Codable, Hashable {
             .trimmedNonEmpty
     }
 
-    private static func toolTitle(from item: [String: CodexAppServerJSONValue], type: String) -> String {
+    private struct ToolPresentation {
+        let title: String
+        let subtitle: String?
+        let kind: ConversationToolPresentationKind
+    }
+
+    private static func toolPresentation(
+        from item: [String: CodexAppServerJSONValue],
+        type: String,
+        identifier: String?
+    ) -> ToolPresentation {
         if type == "webSearch" {
-            if let query = firstString(in: item, keys: ["query"])?.trimmedNonEmpty {
-                return L10n.format("ui.internet_search_value", query)
-            }
-            return L10n.text("ui.web_search")
+            // 搜索词属于用户内容，过程时间线只说明动作，不回显原始 query。
+            return ToolPresentation(title: L10n.text("ui.web_search"), subtitle: nil, kind: .generic)
         }
 
         let namespace = firstString(in: item, keys: ["server", "namespace"])?.trimmedNonEmpty
         let tool = firstString(in: item, keys: ["tool", "name"])?.trimmedNonEmpty
-        switch tool?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-            .replacingOccurrences(of: "-", with: "_") {
-        case "session_set_defaults": return L10n.text("ui.configure_an_xcode_session")
-        case "test_sim": return L10n.text("ui.run_emulator_tests")
-        case "test_device": return L10n.text("ui.run_real_device_tests")
-        case "build_sim": return L10n.text("ui.build_emulator_version")
-        case "build_device": return L10n.text("ui.build_a_real_device_version")
-        case "build_run_sim": return L10n.text("ui.build_and_run_the_app")
-        case "launch_app_sim": return L10n.text("ui.launch_the_app")
-        case "stop_app_sim": return L10n.text("ui.stop_app")
-        case "clean": return L10n.text("ui.clean_build_artifacts")
-        case "screenshot": return L10n.text("ui.interception_interface")
-        case "ui_describe_all": return L10n.text("ui.read_interface_structure")
-        case "tap": return L10n.text("ui.click_interface")
-        case "swipe": return L10n.text("ui.sliding_interface")
-        case "type_text": return L10n.text("ui.enter_text")
-        case "key_press": return L10n.text("ui.press_button")
-        case "open", "navigate": return namespace?.lowercased() == "browser" ? L10n.text("ui.open_web_page") : L10n.text("ui.open_content")
-        case "click": return L10n.text("ui.click_page")
-        case "find": return L10n.text("ui.find_page_content")
-        case "search", "search_query": return L10n.text("ui.search_the_web")
-        case "view_image": return L10n.text("ui.view_pictures")
-        case "imagegen": return L10n.text("ui.generate_pictures")
-        case "apply_patch": return L10n.text("ui.modify_files_action")
-        case "exec_command": return L10n.text("ui.run_command")
-        case "wait": return L10n.text("ui.wait_for_task_to_complete")
-        case "update_plan": return L10n.text("ui.update_plan")
-        case "request_user_input": return L10n.text("ui.request_additional_information")
-        case "read_mcp_resource": return L10n.text("ui.read_resources")
-        case "list_mcp_resources", "list_mcp_resource_templates": return L10n.text("ui.list_resources")
-        case "spawn_agent": return L10n.text("ui.start_subtask")
-        case "send_message": return L10n.text("ui.send_collaboration_message")
+        let normalizedNamespace = normalizedToolComponent(namespace)
+        let normalizedTool = normalizedToolComponent(tool)
+
+        // collabAgentToolCall 与 collaboration namespace 表示真实子 Agent；
+        // create_thread 等 Codex App 工具表示独立任务，两者必须先于通用工具映射判断。
+        let isSubagentTool = type == "collabAgentToolCall"
+            || normalizedNamespace == "collaboration"
+            || normalizedTool.map {
+                [
+                    "spawn_agent",
+                    "followup_task",
+                    "wait_agent",
+                    "list_agents",
+                    "interrupt_agent",
+                ].contains($0)
+            } == true
+        if isSubagentTool {
+            let title: String
+            switch normalizedTool {
+            case "spawn_agent":
+                title = L10n.text("ui.start_subagent")
+            case "followup_task", "send_message":
+                title = L10n.text("ui.continue_subagent")
+            case "wait_agent":
+                title = L10n.text("ui.wait_for_subagent_result")
+            case "list_agents":
+                title = L10n.text("ui.query_subagents")
+            case "interrupt_agent":
+                title = L10n.text("ui.interrupt_subagent")
+            default:
+                title = type == "collabAgentToolCall"
+                    ? L10n.text("ui.start_subagent")
+                    : L10n.text("ui.perform_subagent_collaboration")
+            }
+            return ToolPresentation(title: title, subtitle: nil, kind: .subagent)
+        }
+
+        if normalizedNamespace == "linear" || normalizedNamespace?.hasSuffix("__linear") == true {
+            switch normalizedTool {
+            case "list_issues", "search_issues":
+                return ToolPresentation(title: L10n.text("ui.query_linear_issues"), subtitle: nil, kind: .linearQuery)
+            case "get_issue":
+                return ToolPresentation(title: L10n.text("ui.read_linear_issue"), subtitle: nil, kind: .linearQuery)
+            case "list_comments", "get_comment":
+                return ToolPresentation(title: L10n.text("ui.read_issue_comments"), subtitle: nil, kind: .linearComment)
+            case "save_issue", "create_issue", "update_issue":
+                return ToolPresentation(title: L10n.text("ui.update_linear_issue"), subtitle: nil, kind: .linearUpdate)
+            case "save_comment", "create_comment", "update_comment", "delete_comment":
+                return ToolPresentation(title: L10n.text("ui.update_issue_comments"), subtitle: nil, kind: .linearUpdate)
+            default:
+                if normalizedTool?.hasPrefix("list_") == true {
+                    return ToolPresentation(title: L10n.text("ui.query_linear"), subtitle: nil, kind: .linearQuery)
+                }
+                if normalizedTool?.hasPrefix("get_") == true {
+                    return ToolPresentation(title: L10n.text("ui.read_linear"), subtitle: nil, kind: .linearQuery)
+                }
+                if ["save_", "create_", "update_", "delete_"].contains(where: { normalizedTool?.hasPrefix($0) == true }) {
+                    return ToolPresentation(title: L10n.text("ui.update_linear"), subtitle: nil, kind: .linearUpdate)
+                }
+            }
+        }
+
+        switch normalizedTool {
+        case "list_threads":
+            return ToolPresentation(title: L10n.text("ui.query_task_list"), subtitle: nil, kind: .independentTaskQuery)
+        case "create_thread":
+            return ToolPresentation(title: L10n.text("ui.start_independent_task"), subtitle: nil, kind: .independentTaskStart)
+        case "read_thread":
+            return ToolPresentation(title: L10n.text("ui.read_independent_task"), subtitle: nil, kind: .independentTaskQuery)
+        case "send_message_to_thread":
+            return ToolPresentation(title: L10n.text("ui.resume_independent_task"), subtitle: nil, kind: .independentTaskResume)
+        case "wait_threads":
+            return ToolPresentation(title: L10n.text("ui.wait_for_task_results"), subtitle: nil, kind: .independentTaskWait)
+        case "session_set_defaults":
+            return ToolPresentation(title: L10n.text("ui.configure_an_xcode_session"), subtitle: nil, kind: .generic)
+        case "test_sim":
+            return ToolPresentation(title: L10n.text("ui.run_emulator_tests"), subtitle: nil, kind: .generic)
+        case "test_device":
+            return ToolPresentation(title: L10n.text("ui.run_real_device_tests"), subtitle: nil, kind: .generic)
+        case "build_sim":
+            return ToolPresentation(title: L10n.text("ui.build_emulator_version"), subtitle: nil, kind: .generic)
+        case "build_device":
+            return ToolPresentation(title: L10n.text("ui.build_a_real_device_version"), subtitle: nil, kind: .generic)
+        case "build_run_sim":
+            return ToolPresentation(title: L10n.text("ui.build_and_run_the_app"), subtitle: nil, kind: .generic)
+        case "launch_app_sim":
+            return ToolPresentation(title: L10n.text("ui.launch_the_app"), subtitle: nil, kind: .generic)
+        case "stop_app_sim":
+            return ToolPresentation(title: L10n.text("ui.stop_app"), subtitle: nil, kind: .generic)
+        case "clean":
+            return ToolPresentation(title: L10n.text("ui.clean_build_artifacts"), subtitle: nil, kind: .generic)
+        case "screenshot":
+            return ToolPresentation(title: L10n.text("ui.interception_interface"), subtitle: nil, kind: .generic)
+        case "ui_describe_all":
+            return ToolPresentation(title: L10n.text("ui.read_interface_structure"), subtitle: nil, kind: .generic)
+        case "tap":
+            return ToolPresentation(title: L10n.text("ui.click_interface"), subtitle: nil, kind: .generic)
+        case "swipe":
+            return ToolPresentation(title: L10n.text("ui.sliding_interface"), subtitle: nil, kind: .generic)
+        case "type_text":
+            return ToolPresentation(title: L10n.text("ui.enter_text"), subtitle: nil, kind: .generic)
+        case "key_press":
+            return ToolPresentation(title: L10n.text("ui.press_button"), subtitle: nil, kind: .generic)
+        case "open", "navigate":
+            let title = normalizedNamespace == "browser" ? L10n.text("ui.open_web_page") : L10n.text("ui.open_content")
+            return ToolPresentation(title: title, subtitle: nil, kind: .generic)
+        case "click":
+            return ToolPresentation(title: L10n.text("ui.click_page"), subtitle: nil, kind: .generic)
+        case "find":
+            return ToolPresentation(title: L10n.text("ui.find_page_content"), subtitle: nil, kind: .generic)
+        case "search", "search_query":
+            return ToolPresentation(title: L10n.text("ui.search_the_web"), subtitle: nil, kind: .generic)
+        case "view_image":
+            return ToolPresentation(title: L10n.text("ui.view_pictures"), subtitle: nil, kind: .generic)
+        case "imagegen":
+            return ToolPresentation(title: L10n.text("ui.generate_pictures"), subtitle: nil, kind: .generic)
+        case "apply_patch":
+            return ToolPresentation(title: L10n.text("ui.modify_files_action"), subtitle: nil, kind: .generic)
+        case "exec_command":
+            return ToolPresentation(title: L10n.text("ui.run_command"), subtitle: nil, kind: .generic)
+        case "wait":
+            return ToolPresentation(title: L10n.text("ui.wait_for_task_to_complete"), subtitle: nil, kind: .generic)
+        case "update_plan":
+            return ToolPresentation(title: L10n.text("ui.update_plan"), subtitle: nil, kind: .generic)
+        case "request_user_input":
+            return ToolPresentation(title: L10n.text("ui.request_additional_information"), subtitle: nil, kind: .generic)
+        case "read_mcp_resource":
+            return ToolPresentation(title: L10n.text("ui.read_resources"), subtitle: nil, kind: .generic)
+        case "list_mcp_resources", "list_mcp_resource_templates":
+            return ToolPresentation(title: L10n.text("ui.list_resources"), subtitle: nil, kind: .generic)
         default:
             break
         }
 
-        switch namespace?.lowercased() {
-        case "xcodebuildmcp": return L10n.text("ui.run_xcode_tools")
-        case "browser": return L10n.text("ui.manipulate_the_web_page")
-        case "image_gen", "imagegen": return L10n.text("ui.generate_pictures")
-        default: return type == "collabAgentToolCall" ? L10n.text("ui.perform_collaborative_tasks") : L10n.text("ui.call_tool")
+        switch normalizedNamespace {
+        case "xcodebuildmcp":
+            return ToolPresentation(title: L10n.text("ui.run_xcode_tools"), subtitle: nil, kind: .generic)
+        case "browser":
+            return ToolPresentation(title: L10n.text("ui.manipulate_the_web_page"), subtitle: nil, kind: .generic)
+        case "image_gen", "imagegen":
+            return ToolPresentation(title: L10n.text("ui.generate_pictures"), subtitle: nil, kind: .generic)
+        default:
+            // 未知工具只展示严格白名单后的 namespace/tool 标识，不显示 arguments 或结果。
+            return ToolPresentation(title: L10n.text("ui.call_tool"), subtitle: identifier, kind: .generic)
         }
     }
 
     private static func toolIdentifier(from item: [String: CodexAppServerJSONValue], type: String) -> String? {
+        let components: [String?]
         switch type {
         case "mcpToolCall":
-            return [firstString(in: item, keys: ["server"]), firstString(in: item, keys: ["tool"])]
-                .compactMap { $0?.trimmedNonEmpty }
-                .joined(separator: ".")
-                .trimmedNonEmpty
+            components = [firstString(in: item, keys: ["server"]), firstString(in: item, keys: ["tool"])]
         case "dynamicToolCall":
-            return [firstString(in: item, keys: ["namespace"]), firstString(in: item, keys: ["tool"])]
-                .compactMap { $0?.trimmedNonEmpty }
-                .joined(separator: ".")
-                .trimmedNonEmpty
+            components = [firstString(in: item, keys: ["namespace"]), firstString(in: item, keys: ["tool"])]
         case "collabAgentToolCall":
-            return firstString(in: item, keys: ["tool", "agentNickname", "nickname"])?.trimmedNonEmpty
+            components = ["collaboration", firstString(in: item, keys: ["tool"])]
         case "webSearch":
             return "web.search"
         default:
             return nil
         }
+        return components
+            .compactMap(safeToolIdentifierComponent)
+            .joined(separator: ".")
+            .trimmedNonEmpty
+    }
+
+    private static func normalizedToolComponent(_ value: String?) -> String? {
+        value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .trimmedNonEmpty
+    }
+
+    private static func safeToolIdentifierComponent(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              value.utf8.count <= 64
+        else {
+            return nil
+        }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.")
+        guard value.unicodeScalars.allSatisfy(allowed.contains) else {
+            return nil
+        }
+        return value
     }
 
     private static func filePaths(from changes: [[String: CodexAppServerJSONValue]]) -> [String] {

--- a/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageAccessories.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageAccessories.swift
@@ -166,7 +166,7 @@ struct RuntimeSummaryCard: View {
                 if let toolName = payload.toolName, payload.category == .toolCall {
                     activityDetailRow(L10n.text("ui.tools"), value: toolName, monospaced: true)
                 }
-                let statusText = [payload.status.map { L10n.format("ui.status_value", $0) }, payload.exitCode.map { L10n.format("ui.exit_code_value", $0) }]
+                let statusText = [payload.displayStatusText.map { L10n.format("ui.status_value", $0) }, payload.exitCode.map { L10n.format("ui.exit_code_value", $0) }]
                     .compactMap { $0 }
                     .joined(separator: " · ")
                 if !statusText.isEmpty {
@@ -273,8 +273,8 @@ struct RuntimeSummaryCard: View {
     }
 
     private var symbolName: String {
-        if let category = message.activityPayload?.category {
-            return ProcessedActivitySymbol.symbolName(for: category)
+        if let payload = message.activityPayload {
+            return ProcessedActivitySymbol.symbolName(for: payload)
         }
         switch message.kind {
         case .commentary:

--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationActivityRows.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationActivityRows.swift
@@ -146,6 +146,10 @@ struct ConversationActivityBatchRow: View, Equatable {
 struct ConversationActivityRow: View, Equatable {
     @EnvironmentObject private var themeStore: ThemeStore
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ScaledMetric(relativeTo: .body) private var activityTitleSize: CGFloat = 14
+    @ScaledMetric(relativeTo: .footnote) private var activityDetailSize: CGFloat = 12
+    @ScaledMetric(relativeTo: .caption) private var activityMarkerSize: CGFloat = 11
     let message: ConversationMessage
     let layout: ConversationLayout
     let isExpanded: Bool
@@ -180,7 +184,7 @@ struct ConversationActivityRow: View, Equatable {
                 rowContent
             }
             .buttonStyle(.plain)
-            .accessibilityLabel(activityTitle)
+            .accessibilityLabel(activityAccessibilityDescription)
             .accessibilityValue(isExpanded ? L10n.text("ui.expanded") : L10n.text("ui.collected"))
             .accessibilityHint(isExpanded ? L10n.text("ui.collapse_current_process_details") : L10n.text("ui.expand_current_process_details"))
         } else {
@@ -194,7 +198,7 @@ struct ConversationActivityRow: View, Equatable {
 
             if isReasoning {
                 Text(reasoningText)
-                    .font(themeStore.uiFont(size: 14))
+                    .font(themeStore.uiFont(size: activityTitleSize))
                     .italic()
                     .foregroundStyle(tokens.secondaryText)
                     .lineLimit(isExpanded ? nil : 3)
@@ -203,15 +207,15 @@ struct ConversationActivityRow: View, Equatable {
             } else {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(activityTitle)
-                        .font(themeStore.uiFont(size: 14, weight: .medium))
+                        .font(themeStore.uiFont(size: activityTitleSize, weight: .medium))
                         .foregroundStyle(activityTint)
-                        .lineLimit(1)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 1)
                         .truncationMode(.middle)
                     if let detail = activityDetail {
                         Text(detail)
-                            .font(themeStore.uiFont(size: 12))
+                            .font(themeStore.uiFont(size: activityDetailSize))
                             .foregroundStyle(tokens.secondaryText.opacity(0.84))
-                            .lineLimit(1)
+                            .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 1)
                             .truncationMode(.middle)
                     }
                     if isExpanded {
@@ -230,9 +234,11 @@ struct ConversationActivityRow: View, Equatable {
                     .rotationEffect(.degrees(isExpanded ? 90 : 0))
             }
         }
-        .frame(minHeight: 28)
+        // 只有可展开行是操作控件；视觉仍保持紧凑，但触控区至少 44pt。
+        .frame(minHeight: hasExpandableDetails ? 44 : 28)
         .contentShape(Rectangle())
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(activityAccessibilityDescription)
     }
 
     @ViewBuilder
@@ -290,7 +296,10 @@ struct ConversationActivityRow: View, Equatable {
                 .frame(width: 14, height: 16)
         } else {
             Image(systemName: markerSymbol)
-                .font(themeStore.uiFont(size: markerSymbol == "circle.fill" ? 5 : 11, weight: .semibold))
+                .font(themeStore.uiFont(
+                    size: markerSymbol == "circle.fill" ? activityMarkerSize * 0.45 : activityMarkerSize,
+                    weight: .semibold
+                ))
                 .foregroundStyle(activityTint)
                 .frame(width: 14, height: 16)
         }
@@ -345,7 +354,13 @@ struct ConversationActivityRow: View, Equatable {
             }
             return payload.cwd
         case .toolCall:
-            return payload.displayStatusText == L10n.text("ui.completed_status") ? nil : payload.displayStatusText
+            return [
+                payload.subtitle?.conversationActivityTrimmedNonEmpty,
+                payload.displayStatusText == L10n.text("ui.completed_status") ? nil : payload.displayStatusText,
+            ]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+                .conversationActivityTrimmedNonEmpty
         case .thinking, .plan, .error:
             return payload.subtitle.map(ConversationActivityPayload.plainProgressText)
         }
@@ -383,9 +398,25 @@ struct ConversationActivityRow: View, Equatable {
         message.activityPayload?.isFailure == true
     }
 
+    private var isInterrupted: Bool {
+        message.activityPayload?.isInterrupted == true
+    }
+
+    private var activityAccessibilityDescription: String {
+        message.activityPayload?.accessibilityDescription ?? [
+            activityTitle,
+            activityDetail,
+        ]
+            .compactMap { $0?.conversationActivityTrimmedNonEmpty }
+            .joined(separator: L10n.text("ui.list_separator"))
+    }
+
     private var markerSymbol: String {
         if isFailure {
             return "exclamationmark.circle.fill"
+        }
+        if isInterrupted {
+            return "stop.circle.fill"
         }
         if isApprovedInteraction || (message.kind == .userInput && !isSkippedInteraction) {
             return "checkmark.circle.fill"
@@ -395,6 +426,9 @@ struct ConversationActivityRow: View, Equatable {
         }
         if message.activityPayload?.category == .editFile {
             return "pencil"
+        }
+        if let toolKind = message.activityPayload?.toolPresentationKind {
+            return toolKind.systemImageName
         }
         return "circle.fill"
     }
@@ -437,6 +471,13 @@ struct ConversationActivityRow: View, Equatable {
 }
 
 enum ProcessedActivitySymbol {
+    static func symbolName(for payload: ConversationActivityPayload) -> String {
+        if let toolKind = payload.toolPresentationKind {
+            return toolKind.systemImageName
+        }
+        return symbolName(for: payload.category)
+    }
+
     static func symbolName(for category: ConversationActivityCategory) -> String {
         switch category {
         case .thinking:

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationAppServerProjectorTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationAppServerProjectorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testCodexAppServerProjectorKeepsLiveToolActionAndLifecycleSemantics() throws {
+        var projector = CodexAppServerEventProjector()
+
+        let started = try decodeAppServerNotification(#"{"method":"item/started","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"task_list","namespace":"codex_app","tool":"list_threads"}}}"#)
+        guard case .processItemCompleted(let runningMessage, let runningContext, let runningMetadata) = try XCTUnwrap(projector.project(started)) else {
+            return XCTFail("Tool started 应立即投影为可见过程行")
+        }
+        XCTAssertEqual(runningMessage.activityPayload?.displayTitle, L10n.text("ui.query_task_list"))
+        XCTAssertEqual(runningMessage.activityPayload?.displayStatusText, L10n.text("ui.in_progress"))
+        XCTAssertEqual(runningMessage.activityPayload?.toolPresentationKind, .independentTaskQuery)
+        XCTAssertEqual(runningContext?.tasks.first?.status, "inProgress")
+
+        let completed = try decodeAppServerNotification(#"{"method":"item/completed","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"task_list","namespace":"codex_app","tool":"list_threads","status":"completed"}}}"#)
+        guard case .processItemCompleted(let completedMessage, _, let completedMetadata) = try XCTUnwrap(projector.project(completed)) else {
+            return XCTFail("Tool completed 应原位更新过程行")
+        }
+        XCTAssertEqual(completedMessage.id, runningMessage.id)
+        XCTAssertEqual(completedMetadata.messageID, runningMetadata.messageID)
+        XCTAssertEqual(completedMessage.activityPayload?.displayStatusText, L10n.text("ui.completed_status"))
+
+        let terminalCases: [(id: String, tool: String, status: String, statusKey: String)] = [
+            ("task_start", "create_thread", "failed", "ui.failed_status"),
+            ("task_wait", "wait_threads", "timed_out", "ui.timed_out_status"),
+            ("task_resume", "send_message_to_thread", "interrupted", "ui.interrupted_status"),
+        ]
+        for terminalCase in terminalCases {
+            let event = try decodeAppServerNotification(
+                #"{"method":"item/completed","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"\#(terminalCase.id)","namespace":"codex_app","tool":"\#(terminalCase.tool)","status":"\#(terminalCase.status)"}}}"#
+            )
+            guard case .processItemCompleted(let message, _, _) = try XCTUnwrap(projector.project(event)) else {
+                return XCTFail("Expected visible \(terminalCase.tool) event")
+            }
+            XCTAssertEqual(message.activityPayload?.displayStatusText, L10n.text(terminalCase.statusKey))
+            XCTAssertTrue(message.activityPayload?.accessibilityDescription.contains(L10n.text(terminalCase.statusKey)) == true)
+            XCTAssertNotEqual(message.activityPayload?.displayTitle, L10n.text("ui.call_tool"))
+        }
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -858,6 +858,7 @@ final class ConversationDataFlowTests: XCTestCase {
 
         XCTAssertEqual(payload.category, .runCommand)
         XCTAssertNil(payload.commandPresentationKind)
+        XCTAssertNil(payload.toolPresentationKind)
     }
 
     func testActivityPayloadToleratesFutureCommandPresentationKind() throws {
@@ -866,6 +867,14 @@ final class ConversationDataFlowTests: XCTestCase {
         let payload = try JSONDecoder().decode(ConversationActivityPayload.self, from: data)
 
         XCTAssertEqual(payload.commandPresentationKind, .execution)
+    }
+
+    func testActivityPayloadToleratesFutureToolPresentationKind() throws {
+        let data = Data(#"{"category":"tool_call","display_title":"调用工具","status":"completed","tool_name":"future_runtime.unknown_action","file_paths":[],"tool_presentation_kind":"future_kind"}"#.utf8)
+
+        let payload = try JSONDecoder().decode(ConversationActivityPayload.self, from: data)
+
+        XCTAssertEqual(payload.toolPresentationKind, .generic)
     }
 
     func testActivityPresentationHidesProtocolNoiseAndKeepsRawDiagnostics() throws {
@@ -900,12 +909,192 @@ final class ConversationDataFlowTests: XCTestCase {
         let futurePayload = try XCTUnwrap(ConversationActivityPayload(item: futureStatus))
 
         XCTAssertEqual(futurePayload.displayTitle, L10n.text("ui.call_tool"))
+        XCTAssertEqual(futurePayload.subtitle, "future_runtime.unknown_action")
+        XCTAssertEqual(futurePayload.toolName, "future_runtime.unknown_action")
         XCTAssertNil(futurePayload.displayStatusText)
         XCTAssertFalse(futurePayload.summaryText.lowercased().contains("unknown"))
         XCTAssertEqual(
             ConversationActivityPayload.plainProgressText("**Planning release build**\n`ENABLE_TESTABILITY=YES`"),
             "Planning release build\nENABLE_TESTABILITY=YES"
         )
+    }
+
+    func testToolActivityUsesTrustedLinearTaskAndSubagentSemantics() throws {
+        let cases: [(
+            type: String,
+            namespaceKey: String,
+            namespace: String,
+            tool: String,
+            titleKey: String,
+            kind: ConversationToolPresentationKind
+        )] = [
+            ("mcpToolCall", "server", "linear", "list_issues", "ui.query_linear_issues", .linearQuery),
+            ("mcpToolCall", "server", "linear", "get_issue", "ui.read_linear_issue", .linearQuery),
+            ("mcpToolCall", "server", "linear", "list_comments", "ui.read_issue_comments", .linearComment),
+            ("mcpToolCall", "server", "linear", "save_issue", "ui.update_linear_issue", .linearUpdate),
+            ("mcpToolCall", "server", "linear", "save_comment", "ui.update_issue_comments", .linearUpdate),
+            ("dynamicToolCall", "namespace", "codex_app", "list_threads", "ui.query_task_list", .independentTaskQuery),
+            ("dynamicToolCall", "namespace", "codex_app", "create_thread", "ui.start_independent_task", .independentTaskStart),
+            ("dynamicToolCall", "namespace", "codex_app", "send_message_to_thread", "ui.resume_independent_task", .independentTaskResume),
+            ("dynamicToolCall", "namespace", "codex_app", "wait_threads", "ui.wait_for_task_results", .independentTaskWait),
+            ("collabAgentToolCall", "namespace", "collaboration", "spawn_agent", "ui.start_subagent", .subagent),
+        ]
+
+        for testCase in cases {
+            let item: [String: CodexAppServerJSONValue] = [
+                "type": .string(testCase.type),
+                testCase.namespaceKey: .string(testCase.namespace),
+                "tool": .string(testCase.tool),
+                "status": .string("completed"),
+                // 真实样本包含 prompt/body/path 等参数；标题映射不得读取它们。
+                "arguments": .object([
+                    "prompt": .string("private user prompt"),
+                    "path": .string("/Users/private/project"),
+                    "token": .string("secret-token"),
+                ]),
+            ]
+
+            let payload = try XCTUnwrap(ConversationActivityPayload(item: item))
+
+            XCTAssertEqual(payload.displayTitle, L10n.text(testCase.titleKey), testCase.tool)
+            XCTAssertEqual(payload.toolPresentationKind, testCase.kind, testCase.tool)
+            XCTAssertEqual(payload.displayStatusText, L10n.text("ui.completed_status"), testCase.tool)
+            XCTAssertTrue(payload.accessibilityDescription.contains(L10n.text("ui.completed_status")), testCase.tool)
+            XCTAssertFalse(payload.summaryText.contains("private user prompt"), testCase.tool)
+            XCTAssertFalse(payload.summaryText.contains("secret-token"), testCase.tool)
+            XCTAssertFalse(payload.summaryText.contains("/Users/private"), testCase.tool)
+        }
+        XCTAssertNotEqual(
+            ConversationToolPresentationKind.independentTaskStart.systemImageName,
+            ConversationToolPresentationKind.subagent.systemImageName,
+            "独立 Codex 任务与真实子 Agent 必须有不同图标语义"
+        )
+    }
+
+    func testToolActivityKeepsSpecificFailureTimeoutAndInterruptionStates() throws {
+        let cases: [(tool: String, status: String, expectedKey: String, failure: Bool, interrupted: Bool)] = [
+            ("list_threads", "inProgress", "ui.in_progress", false, false),
+            ("create_thread", "failed", "ui.failed_status", true, false),
+            ("wait_threads", "timed_out", "ui.timed_out_status", true, false),
+            ("send_message_to_thread", "interrupted", "ui.interrupted_status", false, true),
+        ]
+
+        for testCase in cases {
+            let payload = try XCTUnwrap(ConversationActivityPayload(item: [
+                "type": .string("dynamicToolCall"),
+                "namespace": .string("codex_app"),
+                "tool": .string(testCase.tool),
+                "status": .string(testCase.status),
+            ]))
+
+            XCTAssertEqual(payload.displayStatusText, L10n.text(testCase.expectedKey), testCase.tool)
+            XCTAssertEqual(payload.isFailure, testCase.failure, testCase.tool)
+            XCTAssertEqual(payload.isInterrupted, testCase.interrupted, testCase.tool)
+            XCTAssertTrue(payload.accessibilityDescription.contains(L10n.text(testCase.expectedKey)), testCase.tool)
+            XCTAssertNotEqual(payload.displayTitle, L10n.text("ui.call_tool"), testCase.tool)
+        }
+    }
+
+    func testHistoryProjectionReplaysToolActionsAcrossAllLifecycleStates() async throws {
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "test"
+        )
+        let cases: [(
+            item: [String: CodexAppServerJSONValue],
+            titleKey: String,
+            statusKey: String
+        )] = [
+            ([
+                "type": .string("mcpToolCall"),
+                "id": .string("linear_done"),
+                "server": .string("linear"),
+                "tool": .string("list_issues"),
+                "status": .string("completed"),
+            ], "ui.query_linear_issues", "ui.completed_status"),
+            ([
+                "type": .string("dynamicToolCall"),
+                "id": .string("tasks_running"),
+                "namespace": .string("codex_app"),
+                "tool": .string("list_threads"),
+                "status": .string("inProgress"),
+            ], "ui.query_task_list", "ui.in_progress"),
+            ([
+                "type": .string("dynamicToolCall"),
+                "id": .string("task_failed"),
+                "namespace": .string("codex_app"),
+                "tool": .string("create_thread"),
+                "status": .string("failed"),
+            ], "ui.start_independent_task", "ui.failed_status"),
+            ([
+                "type": .string("dynamicToolCall"),
+                "id": .string("task_timeout"),
+                "namespace": .string("codex_app"),
+                "tool": .string("wait_threads"),
+                "status": .string("timed_out"),
+            ], "ui.wait_for_task_results", "ui.timed_out_status"),
+            ([
+                "type": .string("dynamicToolCall"),
+                "id": .string("task_interrupted"),
+                "namespace": .string("codex_app"),
+                "tool": .string("send_message_to_thread"),
+                "status": .string("interrupted"),
+            ], "ui.resume_independent_task", "ui.interrupted_status"),
+        ]
+
+        for (index, testCase) in cases.enumerated() {
+            let projected = await runtime.historyMessage(
+                from: testCase.item,
+                sessionID: "history_tools",
+                turnID: "turn_tools",
+                timelineOrdinal: Int64(index),
+                isInjectedUserMessage: false,
+                startedAt: Date(timeIntervalSince1970: 100),
+                completedAt: Date(timeIntervalSince1970: 101),
+                estimatedAt: nil,
+                turnIsInProgress: testCase.statusKey == "ui.in_progress",
+                snapshotReadAt: Date(timeIntervalSince1970: 102)
+            )
+            let message = try XCTUnwrap(projected)
+
+            XCTAssertEqual(message.activityPayload?.displayTitle, L10n.text(testCase.titleKey))
+            XCTAssertEqual(message.activityPayload?.displayStatusText, L10n.text(testCase.statusKey))
+            XCTAssertTrue(message.activityPayload?.accessibilityDescription.contains(L10n.text(testCase.statusKey)) == true)
+        }
+    }
+
+    func testUnknownToolOnlyExposesSanitizedIdentifier() throws {
+        let safePayload = try XCTUnwrap(ConversationActivityPayload(item: [
+            "type": .string("dynamicToolCall"),
+            "namespace": .string("future_runtime"),
+            "tool": .string("unknown_action"),
+            "status": .string("completed"),
+            "arguments": .object(["account": .string("person@example.com")]),
+        ]))
+        XCTAssertEqual(safePayload.subtitle, "future_runtime.unknown_action")
+        XCTAssertFalse(safePayload.accessibilityDescription.contains("person@example.com"))
+
+        let unsafePayload = try XCTUnwrap(ConversationActivityPayload(item: [
+            "type": .string("dynamicToolCall"),
+            "namespace": .string("/Users/private/runtime"),
+            "tool": .string("read@person.example"),
+            "status": .string("completed"),
+            "arguments": .object(["token": .string("secret-token")]),
+        ]))
+        XCTAssertNil(unsafePayload.toolName)
+        XCTAssertNil(unsafePayload.subtitle)
+        XCTAssertEqual(unsafePayload.displayTitle, L10n.text("ui.call_tool"))
+        XCTAssertFalse(unsafePayload.summaryText.contains("private"))
+        XCTAssertFalse(unsafePayload.summaryText.contains("secret-token"))
+
+        let webSearchPayload = try XCTUnwrap(ConversationActivityPayload(item: [
+            "type": .string("webSearch"),
+            "query": .string("private account person@example.com token secret-token"),
+            "status": .string("completed"),
+        ]))
+        XCTAssertEqual(webSearchPayload.displayTitle, L10n.text("ui.web_search"))
+        XCTAssertFalse(webSearchPayload.summaryText.contains("person@example.com"))
+        XCTAssertFalse(webSearchPayload.accessibilityDescription.contains("secret-token"))
     }
 
     func testUnknownCommandActionUsesGenericTitleButKeepsCommandDetails() throws {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1981,44 +1981,6 @@ extension ConversationDataFlowTests {
         }
     }
 
-    func testCodexAppServerProjectorKeepsLiveToolActionAndLifecycleSemantics() throws {
-        var projector = CodexAppServerEventProjector()
-
-        let started = try decodeAppServerNotification(#"{"method":"item/started","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"task_list","namespace":"codex_app","tool":"list_threads"}}}"#)
-        guard case .processItemCompleted(let runningMessage, let runningContext, let runningMetadata) = try XCTUnwrap(projector.project(started)) else {
-            return XCTFail("Tool started 应立即投影为可见过程行")
-        }
-        XCTAssertEqual(runningMessage.activityPayload?.displayTitle, L10n.text("ui.query_task_list"))
-        XCTAssertEqual(runningMessage.activityPayload?.displayStatusText, L10n.text("ui.in_progress"))
-        XCTAssertEqual(runningMessage.activityPayload?.toolPresentationKind, .independentTaskQuery)
-        XCTAssertEqual(runningContext?.tasks.first?.status, "inProgress")
-
-        let completed = try decodeAppServerNotification(#"{"method":"item/completed","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"task_list","namespace":"codex_app","tool":"list_threads","status":"completed"}}}"#)
-        guard case .processItemCompleted(let completedMessage, _, let completedMetadata) = try XCTUnwrap(projector.project(completed)) else {
-            return XCTFail("Tool completed 应原位更新过程行")
-        }
-        XCTAssertEqual(completedMessage.id, runningMessage.id)
-        XCTAssertEqual(completedMetadata.messageID, runningMetadata.messageID)
-        XCTAssertEqual(completedMessage.activityPayload?.displayStatusText, L10n.text("ui.completed_status"))
-
-        let terminalCases: [(id: String, tool: String, status: String, statusKey: String)] = [
-            ("task_start", "create_thread", "failed", "ui.failed_status"),
-            ("task_wait", "wait_threads", "timed_out", "ui.timed_out_status"),
-            ("task_resume", "send_message_to_thread", "interrupted", "ui.interrupted_status"),
-        ]
-        for terminalCase in terminalCases {
-            let event = try decodeAppServerNotification(
-                #"{"method":"item/completed","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"\#(terminalCase.id)","namespace":"codex_app","tool":"\#(terminalCase.tool)","status":"\#(terminalCase.status)"}}}"#
-            )
-            guard case .processItemCompleted(let message, _, _) = try XCTUnwrap(projector.project(event)) else {
-                return XCTFail("Expected visible \(terminalCase.tool) event")
-            }
-            XCTAssertEqual(message.activityPayload?.displayStatusText, L10n.text(terminalCase.statusKey))
-            XCTAssertTrue(message.activityPayload?.accessibilityDescription.contains(L10n.text(terminalCase.statusKey)) == true)
-            XCTAssertNotEqual(message.activityPayload?.displayTitle, L10n.text("ui.call_tool"))
-        }
-    }
-
     func testAgentEventDecodesSessionContextAlternateKeys() throws {
         let event = try AgentAPIClient.decoder.decode(
             AgentEvent.self,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1981,6 +1981,44 @@ extension ConversationDataFlowTests {
         }
     }
 
+    func testCodexAppServerProjectorKeepsLiveToolActionAndLifecycleSemantics() throws {
+        var projector = CodexAppServerEventProjector()
+
+        let started = try decodeAppServerNotification(#"{"method":"item/started","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"task_list","namespace":"codex_app","tool":"list_threads"}}}"#)
+        guard case .processItemCompleted(let runningMessage, let runningContext, let runningMetadata) = try XCTUnwrap(projector.project(started)) else {
+            return XCTFail("Tool started 应立即投影为可见过程行")
+        }
+        XCTAssertEqual(runningMessage.activityPayload?.displayTitle, L10n.text("ui.query_task_list"))
+        XCTAssertEqual(runningMessage.activityPayload?.displayStatusText, L10n.text("ui.in_progress"))
+        XCTAssertEqual(runningMessage.activityPayload?.toolPresentationKind, .independentTaskQuery)
+        XCTAssertEqual(runningContext?.tasks.first?.status, "inProgress")
+
+        let completed = try decodeAppServerNotification(#"{"method":"item/completed","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"task_list","namespace":"codex_app","tool":"list_threads","status":"completed"}}}"#)
+        guard case .processItemCompleted(let completedMessage, _, let completedMetadata) = try XCTUnwrap(projector.project(completed)) else {
+            return XCTFail("Tool completed 应原位更新过程行")
+        }
+        XCTAssertEqual(completedMessage.id, runningMessage.id)
+        XCTAssertEqual(completedMetadata.messageID, runningMetadata.messageID)
+        XCTAssertEqual(completedMessage.activityPayload?.displayStatusText, L10n.text("ui.completed_status"))
+
+        let terminalCases: [(id: String, tool: String, status: String, statusKey: String)] = [
+            ("task_start", "create_thread", "failed", "ui.failed_status"),
+            ("task_wait", "wait_threads", "timed_out", "ui.timed_out_status"),
+            ("task_resume", "send_message_to_thread", "interrupted", "ui.interrupted_status"),
+        ]
+        for terminalCase in terminalCases {
+            let event = try decodeAppServerNotification(
+                #"{"method":"item/completed","params":{"threadId":"thr_tools","turnId":"turn_tools","item":{"type":"dynamicToolCall","id":"\#(terminalCase.id)","namespace":"codex_app","tool":"\#(terminalCase.tool)","status":"\#(terminalCase.status)"}}}"#
+            )
+            guard case .processItemCompleted(let message, _, _) = try XCTUnwrap(projector.project(event)) else {
+                return XCTFail("Expected visible \(terminalCase.tool) event")
+            }
+            XCTAssertEqual(message.activityPayload?.displayStatusText, L10n.text(terminalCase.statusKey))
+            XCTAssertTrue(message.activityPayload?.accessibilityDescription.contains(L10n.text(terminalCase.statusKey)) == true)
+            XCTAssertNotEqual(message.activityPayload?.displayTitle, L10n.text("ui.call_tool"))
+        }
+    }
+
     func testAgentEventDecodesSessionContextAlternateKeys() throws {
         let event = try AgentAPIClient.decoder.decode(
             AgentEvent.self,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationProcessGrouperTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationProcessGrouperTests.swift
@@ -49,6 +49,55 @@ final class ConversationProcessGrouperTests: XCTestCase {
         XCTAssertEqual(completedItems.count, 2)
     }
 
+    func testRepeatedLinearQueriesFoldButKeepEveryExpandedActionAndStatus() throws {
+        let turnID = "turn-linear-queries"
+        let reasoning = makeReasoning(id: "reasoning-linear", turnID: turnID, text: "核对 Linear 账本")
+        let tools = try [
+            ("linear-list-1", "list_issues", "completed"),
+            ("linear-list-2", "list_issues", "failed"),
+            ("linear-list-3", "list_issues", "timed_out"),
+        ].map { entry in
+            let (id, tool, status) = entry
+            let payload = try XCTUnwrap(ConversationActivityPayload(item: [
+                "type": .string("mcpToolCall"),
+                "id": .string(id),
+                "server": .string("linear"),
+                "tool": .string(tool),
+                "status": .string(status),
+            ]))
+            return makeActivity(
+                id: id,
+                turnID: turnID,
+                kind: .commandSummary,
+                payload: payload
+            )
+        }
+
+        let items = ConversationTimelineItemBuilder.items(from: [
+            reasoning,
+            tools[0],
+            tools[1],
+            tools[2],
+            makeAssistant(id: "linear-final", turnID: turnID),
+        ])
+
+        let workGroup = try workGroup(in: items, at: 0)
+        let processGroup = try processGroup(in: workGroup.entries, at: 0)
+        XCTAssertEqual(processGroup.activities.count, 3, "折叠只改变容器，不合并或丢弃重复查询")
+        XCTAssertEqual(
+            processGroup.activities.compactMap(\.activityPayload?.displayTitle),
+            Array(repeating: L10n.text("ui.query_linear_issues"), count: 3)
+        )
+        XCTAssertEqual(
+            processGroup.activities.compactMap(\.activityPayload?.displayStatusText),
+            [
+                L10n.text("ui.completed_status"),
+                L10n.text("ui.failed_status"),
+                L10n.text("ui.timed_out_status"),
+            ]
+        )
+    }
+
     func testCommentaryAndCommandFormOuterWorkGroupInSourceOrder() throws {
         let commentary = ConversationMessage(
             stableID: "commentary-1",

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
@@ -55,6 +55,26 @@ final class LocalizationTests: XCTestCase {
         XCTAssertEqual(L10n.text("ui.settings", language: .simplifiedChinese), "设置")
     }
 
+    func testToolActivitySemanticLabelsAreLocalized() {
+        let expectedValues: [(String, String, String)] = [
+            ("ui.query_linear_issues", "Query Linear issues", "查询 Linear Issue"),
+            ("ui.read_issue_comments", "Read issue comments", "读取 Issue 评论"),
+            ("ui.update_linear_issue", "Update Linear issue", "更新 Linear Issue"),
+            ("ui.query_task_list", "Query task list", "查询任务列表"),
+            ("ui.start_independent_task", "Start independent task", "启动独立任务"),
+            ("ui.resume_independent_task", "Resume independent task", "恢复独立任务"),
+            ("ui.wait_for_task_results", "Wait for task results", "等待任务结果"),
+            ("ui.start_subagent", "Start subagent", "启动子 Agent"),
+            ("ui.timed_out_status", "Timed out", "已超时"),
+            ("ui.interrupted_status", "Interrupted", "已中断"),
+        ]
+
+        for (key, english, simplifiedChinese) in expectedValues {
+            XCTAssertEqual(L10n.text(key, language: .english), english)
+            XCTAssertEqual(L10n.text(key, language: .simplifiedChinese), simplifiedChinese)
+        }
+    }
+
     func testSettingsInformationArchitectureLabelsAreLocalized() {
         let expectedValues: [(String, String, String)] = [
             ("ui.me", "Me", "我的"),


### PR DESCRIPTION
## 目标

让 iPhone/iPad 会话时间线准确区分 Linear 查询/评论/更新、独立 Codex 任务查询/启动/恢复/等待，以及真实子 Agent 协作。

## 实现

- 基于受信任的 namespace/tool 白名单生成活动语义，不读取工具参数或原始输出。
- 为 Linear、独立任务和子 Agent 提供独立文案与 SF Symbols；未知工具只显示经过严格字符白名单过滤的标识。
- `item/started` 立即投影 Tool/子 Agent 的运行中活动，完成事件使用稳定 ID 原位更新。
- 保留失败、超时、中断和运行中状态；历史回放与实时事件使用相同 payload。
- 折叠组保留同类重复动作，展开后逐项显示。
- VoiceOver 读出动作、安全目标语义和状态；可展开操作区至少 44pt，并支持 Dynamic Type 与 Reduce Motion。
- Web 搜索活动不回显原始搜索词，避免泄漏账号、Token 或用户内容。

## 根因

原实现只为少量通用工具提供标题，Linear 与任务派发工具都落入“调用工具”；同时 `item/started` 仅即时投影命令执行，查询和等待在完成前不可见。

## 验证

- `bash ./scripts/ios-dev.sh test ...`：11 个 MIM-56 定向测试通过，覆盖成功、运行中、失败、超时、中断、历史回放、实时事件、重复折叠、脱敏、本地化和 payload 兼容性。
- iPad Pro 13-inch (M5)，600×800：折叠/展开和 8 类动作运行态通过。
- iPhone 17 Pro，368×800：窄屏无动作名截断；辅助功能超大字号下动作纵向增长。
- 运行态语义快照确认折叠按钮包含动作数量，失败/进行中/中断/超时状态可见，独立任务与子 Agent 可区分。
- 两台 Simulator 已恢复默认设置并关闭，设备租约全部释放。

Linear: MIM-56