### PR TITLE
MIM-58 统一顶层导航图标状态

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -57,10 +57,14 @@ enum CompactWorkbenchTab: Hashable {
     }
 
     var systemImage: String {
+        navigationIcon.normalSystemName
+    }
+
+    var navigationIcon: WorkbenchNavigationIcon {
         switch self {
-        case .sessions: return "bubble.left.and.bubble.right"
-        case .workspaces: return "folder"
-        case .me: return "person.crop.circle"
+        case .sessions: return .sessions
+        case .workspaces: return .workspaces
+        case .me: return .me
         }
     }
 }
@@ -740,14 +744,14 @@ struct UnifiedWorkbenchShell: View {
                     sidebarDestinationRow(
                         destination: .sessions,
                         title: L10n.text("ui.session"),
-                        systemImage: "bubble.left.and.bubble.right",
+                        icon: .sessions,
                         tokens: tokens,
                         layout: layout
                     )
                     sidebarDestinationRow(
                         destination: .workspaces,
                         title: L10n.text("ui.workspace"),
-                        systemImage: "folder",
+                        icon: .workspaces,
                         tokens: tokens,
                         layout: layout
                     )
@@ -885,7 +889,7 @@ struct UnifiedWorkbenchShell: View {
     private func sidebarDestinationRow(
         destination: AppDestination,
         title: String,
-        systemImage: String,
+        icon: WorkbenchNavigationIcon,
         tokens: ThemeTokens,
         layout: WorkbenchLayout
     ) -> some View {
@@ -893,7 +897,7 @@ struct UnifiedWorkbenchShell: View {
 
         return WorkbenchSidebarDestinationButton(
             title: title,
-            systemImage: systemImage,
+            icon: icon,
             isSelected: isSelected,
             tokens: tokens,
             action: { open(destination, layout: layout) }

--- a/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
@@ -1,11 +1,38 @@
 import SwiftUI
 
+/// 顶层导航只维护语义与 outline / fill 配对，避免 iPhone Tab 与 iPad 侧栏各自挑选图标。
+enum WorkbenchNavigationIcon {
+    case sessions
+    case workspaces
+    case me
+
+    var normalSystemName: String {
+        switch self {
+        case .sessions: return "bubble.left.and.bubble.right"
+        case .workspaces: return "folder"
+        case .me: return "person.crop.circle"
+        }
+    }
+
+    var selectedSystemName: String {
+        switch self {
+        case .sessions: return "bubble.left.and.bubble.right.fill"
+        case .workspaces: return "folder.fill"
+        case .me: return "person.crop.circle.fill"
+        }
+    }
+
+    func systemName(isSelected: Bool) -> String {
+        isSelected ? selectedSystemName : normalSystemName
+    }
+}
+
 /// 固定导航入口自绘选中态，避免 iOS 26 SidebarListStyle 自动套用过圆的胶囊背景。
 struct WorkbenchSidebarDestinationButton: View {
     @EnvironmentObject private var themeStore: ThemeStore
 
     let title: String
-    let systemImage: String
+    let icon: WorkbenchNavigationIcon
     let isSelected: Bool
     let tokens: ThemeTokens
     let action: () -> Void
@@ -13,8 +40,9 @@ struct WorkbenchSidebarDestinationButton: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
-                Image(systemName: systemImage)
+                Image(systemName: icon.systemName(isSelected: isSelected))
                     .font(themeStore.uiFont(size: 18, weight: isSelected ? .semibold : .medium))
+                    .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(tokens.primaryAction)
                     .frame(width: 24)
 
@@ -81,21 +109,35 @@ struct WorkbenchSidebarFooter: View {
 
         HStack {
             Button(action: onOpenSettings) {
-                Label(L10n.text("ui.me"), systemImage: "person.crop.circle")
-                    .font(themeStore.uiFont(.subheadline, weight: .medium))
-                    .padding(.horizontal, 12)
-                    .frame(height: 44)
+                HStack(spacing: 10) {
+                    Image(
+                        systemName: WorkbenchNavigationIcon.me.systemName(
+                            isSelected: isMeSelected
+                        )
+                    )
+                    .font(themeStore.uiFont(size: 18, weight: isMeSelected ? .semibold : .medium))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(tokens.primaryAction)
+                    .frame(width: 24)
+
+                    Text(L10n.text("ui.me"))
+                        .font(
+                            themeStore.uiFont(
+                                .body,
+                                weight: isMeSelected ? .semibold : .medium
+                            )
+                        )
+                        .foregroundStyle(tokens.primaryText)
+                }
+                .padding(.horizontal, 12)
+                .frame(height: 44)
+                .background(
+                    isMeSelected ? tokens.selectionFill : Color.clear,
+                    in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
             }
             .buttonStyle(.plain)
-            .foregroundStyle(isMeSelected ? tokens.primaryAction : tokens.secondaryText)
-            .background(
-                isMeSelected ? tokens.selectionFill : tokens.surface.opacity(0.72),
-                in: Capsule()
-            )
-            .overlay {
-                Capsule()
-                    .stroke(tokens.border.opacity(0.6), lineWidth: 1)
-            }
             .accessibilityLabel(L10n.text("ui.me"))
             .accessibilityValue(
                 isMeSelected ? L10n.text("ui.selected") : L10n.text("ui.not_selected")

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
@@ -1384,14 +1384,14 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                 Section {
                     WorkbenchSidebarDestinationButton(
                         title: "会话",
-                        systemImage: "bubble.left.and.bubble.right",
+                        icon: .sessions,
                         isSelected: true,
                         tokens: tokens,
                         action: {}
                     )
                     WorkbenchSidebarDestinationButton(
                         title: "工作区",
-                        systemImage: "folder",
+                        icon: .workspaces,
                         isSelected: false,
                         tokens: tokens,
                         action: {}
@@ -1426,6 +1426,33 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                     layout: .fixed(width: 340, height: 768)
                 )
             )
+        )
+    }
+
+    func testWorkbenchNavigationIconPairs() {
+        XCTAssertEqual(
+            WorkbenchNavigationIcon.sessions.systemName(isSelected: false),
+            "bubble.left.and.bubble.right"
+        )
+        XCTAssertEqual(
+            WorkbenchNavigationIcon.sessions.systemName(isSelected: true),
+            "bubble.left.and.bubble.right.fill"
+        )
+        XCTAssertEqual(
+            WorkbenchNavigationIcon.workspaces.systemName(isSelected: false),
+            "folder"
+        )
+        XCTAssertEqual(
+            WorkbenchNavigationIcon.workspaces.systemName(isSelected: true),
+            "folder.fill"
+        )
+        XCTAssertEqual(
+            WorkbenchNavigationIcon.me.systemName(isSelected: false),
+            "person.crop.circle"
+        )
+        XCTAssertEqual(
+            WorkbenchNavigationIcon.me.systemName(isSelected: true),
+            "person.crop.circle.fill"
         )
     }
 


### PR DESCRIPTION
## 目标
统一 iPhone Tab 与 iPad 侧栏的顶层导航图标语义，并为 iPad 自绘侧栏提供明确的 outline / fill 选中态。

## 实现
- 集中维护会话、工作区、我的三组 SF Symbols normal / selected 映射
- iPhone 继续交给原生 TabView 处理选中态
- iPad 侧栏选中项切换为 fill symbol，并统一 hierarchical rendering
- 底部“我的”移除独立描边胶囊，改用与顶层导航一致的圆角选中态
- 保留既有业务逻辑、设置项信息架构和 44pt 触控区域

## 验证
- `bash ./scripts/ios-dev.sh build`：iPad mini 真机构建成功
- 固定 iPad Pro 13-inch (M5) Simulator：图标映射单测与侧栏视觉快照通过
- 固定 M5 iPad 运行态：会话 / 工作区 / 我的 normal-selected 状态及浅色界面检查通过

Linear: MIM-58