### PR TITLE
MIM-63 修复 Mac 重命名弹窗与输入校验

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		3942D0F45FDBA6578D875940 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 2EBD11FEEFA3EA7C03993BE1 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png */; };
 		3A6B744D9E0860CE86A994D6 /* SessionStoreExternalActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735BE2C721373586AD49D470 /* SessionStoreExternalActivity.swift */; };
 		3B0E963BB2856F7CDD36EB67 /* MessageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CAFB1927C976C000C9E026 /* MessageStore.swift */; };
+		3CE709A723920DFD80FE96D0 /* ConnectionProfileRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */; };
 		3E93414CD3560843DC67433E /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png in Resources */ = {isa = PBXBuildFile; fileRef = 9143CBABCA38B2E316A221BB /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png */; };
 		3F150075A258BDF73AFB8ED6 /* WorktreeManagementViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7A4F02C5EC7121D1BB6B9 /* WorktreeManagementViews.swift */; };
 		410ECA3E93AE577686A636C0 /* MediaWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4E57C95034C12853D10303 /* MediaWorker.swift */; };
@@ -392,6 +393,7 @@
 		B337007E06BFD01501A0C9BD /* MimiRemoteApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiRemoteApp.swift; sourceTree = "<group>"; };
 		B4C046A065EC50889673C918 /* SessionAPIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAPIModels.swift; sourceTree = "<group>"; };
 		B546C68F6A4EDDA47CD25FD7 /* LegalDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalDocumentView.swift; sourceTree = "<group>"; };
+		B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionProfileRenameTests.swift; sourceTree = "<group>"; };
 		B87B13F0356B9B4613FFBA94 /* MimiRemoteTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MimiRemoteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B923E4207A9FD4C35766E4CA /* SessionContextStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContextStore.swift; sourceTree = "<group>"; };
 		B9CAFB1927C976C000C9E026 /* MessageStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStore.swift; sourceTree = "<group>"; };
@@ -568,6 +570,7 @@
 				554F31B0074B97074AE97B31 /* AppExternalLinksTests.swift */,
 				54AAB784C642D2B0234E48BA /* CameraAttachmentTests.swift */,
 				FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */,
+				B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */,
 				86B6C2FC1CE749D7A8268F85 /* ConversationComposerHistoryTests.swift */,
 				18F186EFB2A8BEC6E258B00D /* ConversationComposerSubmissionAndPendingInputTests.swift */,
 				81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */,
@@ -1143,6 +1146,7 @@
 				FA451031EB72AE10C3552C3F /* AppExternalLinksTests.swift in Sources */,
 				03E7996441667D59DF2F9E3A /* CameraAttachmentTests.swift in Sources */,
 				523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */,
+				3CE709A723920DFD80FE96D0 /* ConnectionProfileRenameTests.swift in Sources */,
 				042B8AE52871708DD3606659 /* ConversationComposerHistoryTests.swift in Sources */,
 				77E8FB23786675B2947013E9 /* ConversationComposerSubmissionAndPendingInputTests.swift in Sources */,
 				AD2BA4EB75791D6DA68D6A46 /* ConversationConnectionRecoveryTests.swift in Sources */,

--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -128,7 +128,6 @@ struct InitialConnectionSettingsSections: View {
     @State private var isAddingConnectionProfile = false
     @State private var profileDisplayName = ""
     @State private var profileOperationID: String?
-    @State private var profileRenameTarget: ConnectionProfile?
     @State private var pendingRemovalConfirmation: ConnectionCredentialRemovalConfirmation?
     @State private var isShowingAdvancedManualConnection = false
     @State private var localError: String?
@@ -136,6 +135,8 @@ struct InitialConnectionSettingsSections: View {
     @State private var copiedConnectionProfileID: String?
     @State private var copyConnectionTask: Task<Void, Never>?
     @State private var copyFeedbackTask: Task<Void, Never>?
+
+    let onRequestProfileRename: (ConnectionProfile) -> Void
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
@@ -397,12 +398,6 @@ struct InitialConnectionSettingsSections: View {
         }
         // 真正的相机 Cover 由 SettingsView 根层呈现，避免 Form.Section 重建后丢失 presenter。
         .onAppear(perform: configureQRCodeScannerPresentation)
-        .sheet(item: $profileRenameTarget) { profile in
-            ConnectionProfileRenameSheet(profile: profile) { displayName in
-                try appStore.renameConnectionProfile(id: profile.id, displayName: displayName)
-                localError = nil
-            }
-        }
         .confirmationDialog(
             pendingRemovalConfirmation?.title ?? L10n.text("ui.confirm_to_delete_connection_credentials"),
             isPresented: removalConfirmationBinding,
@@ -611,7 +606,8 @@ struct InitialConnectionSettingsSections: View {
 
             Menu {
                 Button(L10n.text("ui.rename")) {
-                    profileRenameTarget = item.profile
+                    localError = nil
+                    onRequestProfileRename(item.profile)
                 }
                 .accessibilityIdentifier("settings.profile.rename.\(item.id)")
 

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
@@ -1,67 +1,51 @@
 import SwiftUI
 import UIKit
 
-// 设置详情组件保持值、Binding 与回调输入，不额外引入状态层。
-struct ConnectionProfileRenameSheet: View {
-    @Environment(\.dismiss) private var dismiss
+struct ConnectionProfileRenameRoute: Identifiable, Equatable {
+    let profileID: String
+    let initialDisplayName: String
 
-    let profile: ConnectionProfile
-    let onRename: (String) throws -> Void
-    @State private var displayName: String
-    @State private var submitError: String?
+    var id: String { profileID }
 
-    init(profile: ConnectionProfile, onRename: @escaping (String) throws -> Void) {
-        self.profile = profile
-        self.onRename = onRename
-        _displayName = State(initialValue: profile.displayName)
+    init(profile: ConnectionProfile) {
+        profileID = profile.id
+        initialDisplayName = profile.displayName
+    }
+}
+
+struct ConnectionProfileRenamePresentationState: Equatable {
+    private(set) var route: ConnectionProfileRenameRoute?
+
+    mutating func present(_ profile: ConnectionProfile) {
+        // 一个根级 item 只对应一个 presenter；Sheet 未关闭前不替换编辑目标。
+        guard route == nil else { return }
+        route = ConnectionProfileRenameRoute(profile: profile)
     }
 
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section {
-                    TextField(L10n.text("ui.mac_name"), text: $displayName)
-                        .textInputAutocapitalization(.words)
-                        .submitLabel(.done)
-                        .onSubmit(rename)
-                        .accessibilityIdentifier("settings.profile.rename.name")
-                } footer: {
-                    Text(validationMessage ?? L10n.format("ui.up_to_value_characters_only_the_local_display", AppStore.connectionProfileDisplayNameLimit))
-                        .foregroundStyle(validationMessage == nil ? Color.secondary : Color.red)
-                }
+    mutating func dismiss() {
+        route = nil
+    }
+}
 
-                if let submitError {
-                    Section {
-                        Text(submitError)
-                            .foregroundStyle(.red)
-                            .accessibilityIdentifier("settings.profile.rename.error")
-                    }
-                }
-            }
-            .navigationTitle(L10n.text("ui.rename_mac"))
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(L10n.text("ui.cancel")) { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(L10n.text("ui.save"), action: rename)
-                        .disabled(validationMessage != nil)
-                        .accessibilityIdentifier("settings.profile.rename.save")
-                }
-            }
-            .onChange(of: displayName) { _, _ in
-                submitError = nil
-            }
-        }
-        .presentationDetents([.medium])
+enum ConnectionProfileRenameAction {
+    case cancel
+    case save
+}
+
+@MainActor
+struct ConnectionProfileRenameDraft: Equatable {
+    private(set) var displayName: String
+    private(set) var submitError: String?
+
+    init(displayName: String) {
+        self.displayName = displayName
     }
 
-    private var normalizedDisplayName: String {
+    var normalizedDisplayName: String {
         displayName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private var validationMessage: String? {
+    var validationMessage: String? {
         if normalizedDisplayName.isEmpty {
             return ConnectionProfileError.invalidDisplayName.localizedDescription
         }
@@ -73,14 +57,163 @@ struct ConnectionProfileRenameSheet: View {
         return nil
     }
 
-    private func rename() {
-        guard validationMessage == nil else { return }
-        do {
-            try onRename(displayName)
+    var canSubmit: Bool {
+        validationMessage == nil
+    }
+
+    mutating func updateDisplayName(_ nextValue: String) {
+        displayName = nextValue
+        submitError = nil
+    }
+
+    /// 返回值只表示 Sheet 是否应关闭；取消不会触发保存，保存失败则保留草稿和错误。
+    mutating func perform(
+        _ action: ConnectionProfileRenameAction,
+        onRename: (String) throws -> Void
+    ) -> Bool {
+        switch action {
+        case .cancel:
+            return true
+        case .save:
+            guard canSubmit else { return false }
+            do {
+                try onRename(displayName)
+                return true
+            } catch {
+                submitError = error.localizedDescription
+                return false
+            }
+        }
+    }
+}
+
+// 设置详情组件只持有局部值草稿、Binding 与回调，不引入额外引用状态层。
+struct ConnectionProfileRenameSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let route: ConnectionProfileRenameRoute
+    let onRename: (String) throws -> Void
+    @State private var draft: ConnectionProfileRenameDraft
+
+    init(route: ConnectionProfileRenameRoute, onRename: @escaping (String) throws -> Void) {
+        self.route = route
+        self.onRename = onRename
+        _draft = State(initialValue: ConnectionProfileRenameDraft(displayName: route.initialDisplayName))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    ConnectionProfileNameTextField(
+                        placeholder: L10n.text("ui.mac_name"),
+                        text: Binding(
+                            get: { draft.displayName },
+                            set: { draft.updateDisplayName($0) }
+                        ),
+                        onSubmit: { perform(.save) }
+                    )
+                        .frame(minHeight: 28)
+                        .accessibilityIdentifier("settings.profile.rename.name")
+                } footer: {
+                    Text(draft.validationMessage ?? L10n.format("ui.up_to_value_characters_only_the_local_display", AppStore.connectionProfileDisplayNameLimit))
+                        .foregroundStyle(draft.validationMessage == nil ? Color.secondary : Color.red)
+                }
+
+                if let submitError = draft.submitError {
+                    Section {
+                        Text(submitError)
+                            .foregroundStyle(.red)
+                            .accessibilityIdentifier("settings.profile.rename.error")
+                    }
+                }
+            }
+            .navigationTitle(L10n.text("ui.rename_mac"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.text("ui.cancel")) { perform(.cancel) }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.text("ui.save")) { perform(.save) }
+                        .disabled(!draft.canSubmit)
+                        .accessibilityIdentifier("settings.profile.rename.save")
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+
+    private func perform(_ action: ConnectionProfileRenameAction) {
+        if draft.perform(action, onRename: onRename) {
             dismiss()
-        } catch {
-            // 档案若在 Sheet 展示期间被其它操作移除，保留输入并明确展示失败原因。
-            submitError = error.localizedDescription
+        }
+    }
+}
+
+/// 只服务 Mac 名称重命名：editingChanged 会包含输入法仍在组合中的可见文本。
+/// Coordinator 先写回 SwiftUI 草稿，并阻止 updateUIView 反写 marked text，避免打断候选输入。
+struct ConnectionProfileNameTextField: UIViewRepresentable {
+    let placeholder: String
+    @Binding var text: String
+    let onSubmit: () -> Void
+
+    func makeUIView(context: Context) -> UITextField {
+        let textField = UITextField()
+        textField.placeholder = placeholder
+        textField.text = text
+        textField.font = .preferredFont(forTextStyle: .body)
+        textField.adjustsFontForContentSizeCategory = true
+        textField.autocapitalizationType = .words
+        textField.returnKeyType = .done
+        textField.clearButtonMode = .whileEditing
+        textField.delegate = context.coordinator
+        textField.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.textDidChange(_:)),
+            for: .editingChanged
+        )
+        context.coordinator.lastSyncedText = text
+        return textField
+    }
+
+    func updateUIView(_ textField: UITextField, context: Context) {
+        context.coordinator.parent = self
+        textField.placeholder = placeholder
+
+        // 拼音等输入法的预编辑文本已经可见，但系统尚未提交；此时反写会破坏 marked range。
+        guard textField.markedTextRange == nil,
+              context.coordinator.lastSyncedText != text
+        else {
+            return
+        }
+        textField.text = text
+        context.coordinator.lastSyncedText = text
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: ConnectionProfileNameTextField
+        var lastSyncedText = ""
+
+        init(_ parent: ConnectionProfileNameTextField) {
+            self.parent = parent
+        }
+
+        @objc func textDidChange(_ textField: UITextField) {
+            let visibleText = textField.text ?? ""
+            guard visibleText != lastSyncedText else { return }
+            lastSyncedText = visibleText
+            parent.text = visibleText
+        }
+
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            parent.onSubmit()
+            textField.resignFirstResponder()
+            return true
         }
     }
 }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -232,6 +232,7 @@ struct SettingsView: View {
     @AppStorage(VoiceInputProvider.storageKey) private var voiceInputProviderRawValue = VoiceInputProvider.codex.rawValue
     @AppStorage(ComposerPermissionMode.defaultStorageKey) private var defaultPermissionModeID = ComposerPermissionMode.defaultMode.rawValue
     @StateObject private var qrScannerPresentation = ConnectionQRCodeScannerPresentation()
+    @State private var profileRenamePresentation = ConnectionProfileRenamePresentationState()
 
     var body: some View {
         let systemColorScheme = themeSystemColorScheme ?? colorScheme
@@ -263,13 +264,25 @@ struct SettingsView: View {
                 }
             )
         }
+        // 重命名路由固定由设置根层持有，Form.Section 刷新不会销毁唯一的 sheet presenter。
+        .sheet(
+            item: profileRenameRouteBinding,
+            onDismiss: { profileRenamePresentation.dismiss() }
+        ) { route in
+            ConnectionProfileRenameSheet(route: route) { displayName in
+                try appStore.renameConnectionProfile(id: route.profileID, displayName: displayName)
+            }
+        }
     }
 
     @ViewBuilder
     private func settingsContent(tokens: ThemeTokens, resolvedColorScheme: ColorScheme) -> some View {
         Group {
             if isInitialSetup {
-                InitialPairingView(qrScannerPresentation: qrScannerPresentation)
+                InitialPairingView(
+                    qrScannerPresentation: qrScannerPresentation,
+                    onRequestProfileRename: { profileRenamePresentation.present($0) }
+                )
             } else {
                 settingsForm(tokens: tokens)
                     .frame(maxWidth: 920)
@@ -299,6 +312,18 @@ struct SettingsView: View {
     private var initialNavigationTitleDisplayMode: NavigationBarItem.TitleDisplayMode {
         // iPhone 的一级“我的”保留系统大标题；iPad detail 使用紧凑标题，避免与居中内容断裂。
         horizontalSizeClass == .compact ? .large : .inline
+    }
+
+    private var profileRenameRouteBinding: Binding<ConnectionProfileRenameRoute?> {
+        Binding(
+            get: { profileRenamePresentation.route },
+            set: { route in
+                // item-driven sheet 关闭时由 SwiftUI 写回 nil；新目标只允许经 present(_:) 进入。
+                if route == nil {
+                    profileRenamePresentation.dismiss()
+                }
+            }
+        )
     }
 
     private func settingsForm(tokens: ThemeTokens) -> some View {
@@ -393,7 +418,10 @@ struct SettingsView: View {
 
             Section {
                 NavigationLink {
-                    ConnectionManagementView(qrScannerPresentation: qrScannerPresentation)
+                    ConnectionManagementView(
+                        qrScannerPresentation: qrScannerPresentation,
+                        onRequestProfileRename: { profileRenamePresentation.present($0) }
+                    )
                 } label: {
                     SettingsMacDevicesSummaryLabel(
                         currentDevice: currentMacDisplayName,
@@ -730,10 +758,14 @@ private struct ConnectionManagementView: View {
     @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var themeStore: ThemeStore
     @ObservedObject var qrScannerPresentation: ConnectionQRCodeScannerPresentation
+    let onRequestProfileRename: (ConnectionProfile) -> Void
 
     var body: some View {
         Form {
-            InitialConnectionSettingsSections(qrScannerPresentation: qrScannerPresentation)
+            InitialConnectionSettingsSections(
+                qrScannerPresentation: qrScannerPresentation,
+                onRequestProfileRename: onRequestProfileRename
+            )
         }
         .themedSettingsForm(tokens: themeStore.tokens(for: colorScheme))
         .frame(maxWidth: 720)
@@ -1732,12 +1764,16 @@ private struct InitialPairingView: View {
     @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var themeStore: ThemeStore
     @ObservedObject var qrScannerPresentation: ConnectionQRCodeScannerPresentation
+    let onRequestProfileRename: (ConnectionProfile) -> Void
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         Form {
-            InitialConnectionSettingsSections(qrScannerPresentation: qrScannerPresentation)
+            InitialConnectionSettingsSections(
+                qrScannerPresentation: qrScannerPresentation,
+                onRequestProfileRename: onRequestProfileRename
+            )
         }
         .themedSettingsForm(tokens: tokens)
         // 连接是短表单而不是数据表；宽窗口里限制行长，按钮和输入框不会被拉成整屏。

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConnectionProfileRenameTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConnectionProfileRenameTests.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class ConnectionProfileRenameTests: XCTestCase {
+    func testPresentationKeepsOneRouteUntilExplicitDismissal() {
+        let first = makeProfile(id: "mac-a", displayName: "Mac A")
+        let second = makeProfile(id: "mac-b", displayName: "Mac B")
+        var presentation = ConnectionProfileRenamePresentationState()
+
+        presentation.present(first)
+        XCTAssertEqual(
+            presentation.route,
+            ConnectionProfileRenameRoute(profile: first)
+        )
+
+        presentation.present(second)
+        XCTAssertEqual(presentation.route?.profileID, first.id, "已有 Sheet 时不能替换其编辑目标")
+
+        presentation.dismiss()
+        XCTAssertNil(presentation.route)
+        presentation.present(second)
+        XCTAssertEqual(presentation.route?.profileID, second.id)
+    }
+
+    func testMarkedTextEditingChangedImmediatelyUpdatesDraftValidation() {
+        let box = RenameDraftBox(ConnectionProfileRenameDraft(displayName: ""))
+        let field = ConnectionProfileNameTextField(
+            placeholder: "电脑名称",
+            text: Binding(
+                get: { box.draft.displayName },
+                set: { box.draft.updateDisplayName($0) }
+            ),
+            onSubmit: {}
+        )
+        let coordinator = ConnectionProfileNameTextField.Coordinator(field)
+        let textField = MarkedTextField()
+        textField.text = "win"
+
+        XCTAssertNotNil(textField.markedTextRange, "用例必须模拟输入法尚未提交的可见文本")
+        coordinator.textDidChange(textField)
+
+        XCTAssertEqual(box.draft.displayName, "win")
+        XCTAssertNil(box.draft.validationMessage)
+        XCTAssertTrue(box.draft.canSubmit)
+    }
+
+    func testDraftValidationTracksEmptyValidAndTooLongNames() {
+        var draft = ConnectionProfileRenameDraft(displayName: "旧名称")
+        XCTAssertTrue(draft.canSubmit)
+
+        draft.updateDisplayName("   \n")
+        XCTAssertEqual(
+            draft.validationMessage,
+            ConnectionProfileError.invalidDisplayName.localizedDescription
+        )
+        XCTAssertFalse(draft.canSubmit)
+
+        draft.updateDisplayName("win")
+        XCTAssertNil(draft.validationMessage)
+        XCTAssertTrue(draft.canSubmit)
+
+        draft.updateDisplayName(String(repeating: "a", count: AppStore.connectionProfileDisplayNameLimit + 1))
+        XCTAssertEqual(
+            draft.validationMessage,
+            ConnectionProfileError.displayNameTooLong(
+                maximum: AppStore.connectionProfileDisplayNameLimit
+            ).localizedDescription
+        )
+        XCTAssertFalse(draft.canSubmit)
+    }
+
+    func testSaveAndCancelActionsControlDismissalWithoutCrossWriting() {
+        var draft = ConnectionProfileRenameDraft(displayName: "新 Mac")
+        var savedNames: [String] = []
+
+        XCTAssertTrue(draft.perform(.cancel) { savedNames.append($0) })
+        XCTAssertTrue(savedNames.isEmpty, "取消不能修改原名称")
+
+        XCTAssertTrue(draft.perform(.save) { savedNames.append($0) })
+        XCTAssertEqual(savedNames, ["新 Mac"])
+
+        draft.updateDisplayName("   ")
+        XCTAssertFalse(draft.perform(.save) { savedNames.append($0) })
+        XCTAssertEqual(savedNames, ["新 Mac"], "无效名称不能进入保存回调")
+    }
+
+    func testSaveFailureKeepsDraftAndEditingClearsError() {
+        var draft = ConnectionProfileRenameDraft(displayName: "仍需保留")
+
+        XCTAssertFalse(draft.perform(.save) { _ in throw RenameFailure() })
+        XCTAssertEqual(draft.displayName, "仍需保留")
+        XCTAssertEqual(draft.submitError, "保存失败")
+
+        draft.updateDisplayName("继续编辑")
+        XCTAssertNil(draft.submitError)
+        XCTAssertEqual(draft.displayName, "继续编辑")
+    }
+
+    private func makeProfile(id: String, displayName: String) -> ConnectionProfile {
+        ConnectionProfile(
+            id: id,
+            displayName: displayName,
+            endpoint: "http://100.64.0.10:8787",
+            lastSuccessfulAt: nil
+        )
+    }
+}
+
+private final class RenameDraftBox {
+    var draft: ConnectionProfileRenameDraft
+
+    init(_ draft: ConnectionProfileRenameDraft) {
+        self.draft = draft
+    }
+}
+
+private struct RenameFailure: LocalizedError {
+    var errorDescription: String? { "保存失败" }
+}
+
+private final class MarkedTextField: UITextField {
+    private let simulatedMarkedTextRange = SimulatedTextRange()
+
+    override var markedTextRange: UITextRange? {
+        simulatedMarkedTextRange
+    }
+}
+
+private final class SimulatedTextPosition: UITextPosition {}
+
+private final class SimulatedTextRange: UITextRange {
+    private let lowerBound = SimulatedTextPosition()
+    private let upperBound = SimulatedTextPosition()
+
+    override var start: UITextPosition { lowerBound }
+    override var end: UITextPosition { upperBound }
+    override var isEmpty: Bool { false }
+}


### PR DESCRIPTION
## 目标

修复 iPad 已保存 Mac 连接的重命名弹窗自动收回，以及中文输入法预编辑文本已可见但校验仍判空的问题。

## 根因

- `.sheet(item:)` 挂在条件渲染的 `Form.Section` 上，Section 重建时 presenter 会丢失。
- 拼音等输入法的 marked text 已显示在原生文本框中，但 SwiftUI Binding 尚未提交，校验仍读取旧值。

## 改动

- 将唯一的重命名 item 路由上移到 `SettingsView` 根层，保持稳定 presenter。
- 使用局部 `UITextField` bridge 通过 `editingChanged` 同步可见文本；marked text 存在时不从 SwiftUI 反写，避免打断候选输入。
- 用值类型草稿统一名称校验、保存失败与取消语义。
- 增加 5 个回归测试，覆盖呈现生命周期、marked-text、空白/超长名称、保存、取消和失败保留草稿。

## 验证

- `ConnectionProfileRenameTests`：固定 `iPad Pro 13-inch (M5)` Simulator，5/5 passed，0 failed/skip。
- `bash ./scripts/check-source-size.sh`：通过。
- `bash ./scripts/check-ios-localization.sh`：通过。
- `git diff --check origin/main...HEAD`：通过。
- 固定 M5 iPad Simulator 运行态：连续 3 次打开 Sheet 均稳定；清空后错误出现且保存禁用；中文拼音预编辑直接输入 `win`、不按空格时，错误立即消失且保存启用；保存后列表即时更新为 `win`；再次清空并取消后仍保留 `win`。

## 影响边界

只修改 iOS/iPadOS 已保存 Mac 的重命名呈现、输入同步和校验，不改变配对、连接切换、删除或访问码逻辑。

Linear: MIM-63
