### PR TITLE
MIM-62 支持无线真机三级回退

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,8 @@
 
 ### 默认链路
 
-- 日常 `build` / `run` 采用确定性自动选择：优先 available、paired、USB 连接且未占用的 iOS/iPadOS 真机；设备忙时按固定顺序跳过，最后使用未占用的 `iPad Pro 13-inch (M5)` Simulator。
-- 同时连接多台 USB 真机时先按名称 `iPad Pro`、再按设备名和 UDID 排序；不得依赖列表顺序或随机选择。
+- 日常 `build` / `run` 采用确定性自动选择：优先 available、paired、USB 连接且未占用的 iOS/iPadOS 真机，其次是 available、paired、本地网络可达且未占用的真机，最后使用未占用的 `iPad Pro 13-inch (M5)` Simulator。
+- 同一连接类型下的多台真机先按名称 `iPad Pro`、再按设备名和 UDID 排序；不得依赖列表顺序或随机选择。
 - `build-for-testing`、`test`、视觉快照和 CI 精确固定 `iPad Pro 13-inch (M5)` Simulator；目标缺失或忙时等待或明确失败，禁止回退 iPad mini、其他 iPad 或 iPhone。
 - 所有入口固定使用 `MimiRemote` Scheme 和 `Debug` 配置。
 - 命令行统一通过 `bash ./scripts/ios-dev.sh` 执行：
@@ -103,8 +103,8 @@
 
 ### 设备用途
 
-- available、paired、USB 连接的真机是日常 `build` / `run` 第一优先级；仅通过本地网络可见或历史配对的设备不算“连接到电脑”。
-- 没有可用 USB 真机时，`iPad Pro 13-inch (M5)` 是唯一 Simulator fallback。
+- available、paired、USB 连接的真机是日常 `build` / `run` 第一优先级；没有可用 wired 真机时，可使用 available、paired 且当前本地网络可达的真机。仅保留历史配对记录、当前不可达的设备不参与选择。
+- 没有可用 USB 或本地网络真机时，`iPad Pro 13-inch (M5)` 是唯一 Simulator fallback。同一真机无论通过 wired 还是 localNetwork 连接，均按 UDID 共用租约和 DerivedData。
 - `iPhone 17 Pro` 只用于明确的 iPhone 布局验收，`iPhone 17e` 只用于小屏兼容验收。切换时显式设置 `IOS_SIMULATOR_NAME`，完成后恢复默认 iPad。
 - 相机、通知、Keychain、Tailscale/弱网、性能以及发布前验证仍必须使用真机；自动 fallback 到 Simulator 时不得把这些专项验证标记为完成。
 - Simulator 通过不代表真机专项验收完成，真机结果也不替代日常 Simulator 回归。

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ open ios/MimiRemote/MimiRemote.xcodeproj
 
 In Xcode, select the `MimiRemote` scheme, your development team, and an iPhone or iPad target, then Run. On first launch, scan the QR code printed by `agentd up` or `agentd pair`. The signed QR ticket can be reused during its 10-minute lifetime and never contains the long-lived token. Manual connection is available as a fallback.
 
-Command-line `build` and `run` lease an available, paired USB iOS device and skip busy targets before falling back to the fixed `iPad Pro 13-inch (M5)` Simulator. Tests, snapshots, and CI require that exact Simulator and never fall back to iPad mini. Run `bash ./scripts/ios-dev.sh leases` to inspect cross-worktree leases and external `xcodebuild` usage:
+Command-line `build` and `run` deterministically lease an available, paired USB iOS device first, then a currently reachable local-network device, and finally the fixed `iPad Pro 13-inch (M5)` Simulator. Explicit `IOS_DEVICE_ID` and `IOS_DEVICE_NAME` selections support either physical-device transport and fail clearly when that device is not reachable. A physical device keeps the same UDID-scoped lease and DerivedData across transport changes. Tests, snapshots, and CI still require the exact M5 Simulator and never fall back to iPad mini. Run `bash ./scripts/ios-dev.sh leases` to inspect wired/wireless devices, cross-worktree leases, and external `xcodebuild` usage:
 
 ```bash
 bash ./scripts/ios-dev.sh build-for-testing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -392,7 +392,7 @@ xcodegen generate \
 bash ./scripts/ios-dev.sh build-for-testing
 ```
 
-日常 `build` / `run` 优先租用 available、paired、USB 连接的真机，跳过占用设备后才使用固定 iPad Simulator；测试、视觉快照与 CI 精确固定 `iPad Pro 13-inch (M5)`，不会回退 iPad mini。设备占用可通过 `bash ./scripts/ios-dev.sh leases` 查看。iOS 工程结构、运行命令、Catalyst 和真机验收见 [iOS 开发说明](ios/MimiRemote/README.md)。
+日常 `build` / `run` 按 available、paired 且未占用的 USB 真机 → 当前本地网络可达的真机 → 固定 iPad Simulator 确定性回退。显式 `IOS_DEVICE_ID` / `IOS_DEVICE_NAME` 同时支持有线与无线真机，设备不可达时会明确失败；同一 UDID 切换连接方式时仍共用租约和 DerivedData。测试、视觉快照与 CI 精确固定 `iPad Pro 13-inch (M5)`，不会回退 iPad mini。设备连接方式和占用可通过 `bash ./scripts/ios-dev.sh leases` 查看。iOS 工程结构、运行命令、Catalyst 和真机验收见 [iOS 开发说明](ios/MimiRemote/README.md)。
 
 ### Claude bridge
 

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -27,6 +27,7 @@ SELECTED_ID=""
 SELECTED_NAME=""
 SELECTED_DESTINATION=""
 SELECTED_DERIVED_DATA=""
+SELECTED_TRANSPORT=""
 
 usage() {
   cat <<'EOF'
@@ -39,15 +40,15 @@ usage() {
   bash ./scripts/ios-dev.sh leases
 
 默认目标：
-  build/run: USB 真机优先；设备已占用时跳过，最后回退固定 iPad Simulator
+  build/run: USB 真机 → 本地网络真机 → 固定 iPad Simulator
   test:      精确固定 iPad Pro 13-inch (M5)，忙或缺失时明确失败
   Scheme:    MimiRemote
   Config:    Debug
 
 可选覆盖：
   IOS_TARGET_MODE         auto（默认）、device 或 simulator
-  IOS_DEVICE_NAME         普通 build/run 优先的 USB 真机名，默认 iPad Pro
-  IOS_DEVICE_ID           用 UDID 明确选择普通 build/run 的 USB 真机
+  IOS_DEVICE_NAME         用名称明确选择 USB 或本地网络真机；默认排序优先 iPad Pro
+  IOS_DEVICE_ID           用 UDID 明确选择 USB 或本地网络真机
   IOS_SIMULATOR_NAME      普通 build/run 显式选择兼容性 Simulator
   IOS_SIMULATOR_ID        普通 build/run 用 UDID 选择 Simulator
   IOS_TEST_DESTINATION    CI 解析一次的测试 destination；设备必须仍是固定 M5 iPad
@@ -165,28 +166,54 @@ physical_device_records() {
       restrict_name = ENV.fetch("IOS_RESTRICT_DEVICE_NAME") == "1"
       devices = JSON.parse(STDIN.read).fetch("result").fetch("devices")
       candidates = devices.map do |device|
-        properties = device.fetch("properties", {})
-        connection = properties.fetch("connection", {})
-        hardware = properties.fetch("hardware", {})
-        state = properties.fetch("state", {})
-        next unless hardware["platform"] == "iOS" && hardware["reality"] == "physical"
-        next unless connection["transportType"] == "wired"
-        next unless connection["state"] == "connected" && connection["pairingState"] == "paired"
-        udid = hardware["udid"]
-        name = state["name"]
+        legacy = device.fetch("properties", {})
+        legacy_connection = legacy.fetch("connection", {})
+        legacy_hardware = legacy.fetch("hardware", {})
+        legacy_state = legacy.fetch("state", {})
+        connection = device.fetch("connectionProperties", {})
+        hardware = device.fetch("hardwareProperties", {})
+        state = device.fetch("deviceProperties", {})
+        first_value = ->(*values) { values.find { |value| !value.nil? && !value.to_s.empty? } }
+
+        # Xcode 26 新版 devicectl 把字段提到顶层，旧版则放在
+        # properties.* 下。只在传输已连接且已配对时才视为可达。
+        platform = first_value.call(hardware["platform"], legacy_hardware["platform"])
+        reality = first_value.call(hardware["reality"], legacy_hardware["reality"])
+        transport = first_value.call(connection["transportType"], legacy_connection["transportType"])
+        connection_state = first_value.call(
+          connection["tunnelState"], connection["state"],
+          legacy_connection["tunnelState"], legacy_connection["state"]
+        )
+        pairing_state = first_value.call(connection["pairingState"], legacy_connection["pairingState"])
+        next unless ["iOS", "iPadOS"].include?(platform) && reality == "physical"
+        next unless ["wired", "localNetwork"].include?(transport)
+        next unless connection_state == "connected" && pairing_state == "paired"
+        udid = first_value.call(hardware["udid"], legacy_hardware["udid"])
+        name = first_value.call(state["name"], legacy_state["name"])
         next if udid.to_s.empty? || name.to_s.empty?
         next if !requested_id.empty? && udid != requested_id
         next if requested_id.empty? && restrict_name && name != requested_name
-        [udid, name]
+        [udid, name, transport]
       end.compact
-      candidates.sort_by! { |udid, name| [name == requested_name ? 0 : 1, name, udid] }
-      candidates.each { |udid, name| puts [udid, name].join("\t") }
+      # 同一 UDID 可能在连接切换期间出现多条记录；先排序再去重，
+      # 确保 wired 始终优先，同时共用该 UDID 的租约和 DerivedData。
+      transport_rank = { "wired" => 0, "localNetwork" => 1 }
+      candidates.sort_by! do |udid, name, transport|
+        [transport_rank.fetch(transport), name == requested_name ? 0 : 1, name, udid]
+      end
+      seen = {}
+      candidates.each do |udid, name, transport|
+        next if seen[udid]
+        seen[udid] = true
+        puts [udid, name, transport].join("\t")
+      end
     '
 }
 
 observable_device_records() {
-  physical_device_records 1 | while IFS=$'\t' read -r device_id device_name; do
-    [[ -n "$device_id" ]] && printf 'device\t%s\t%s\n' "$device_id" "$device_name"
+  physical_device_records 1 | while IFS=$'\t' read -r device_id device_name device_transport; do
+    [[ -n "$device_id" ]] && printf 'device\t%s\t%s\t%s\n' \
+      "$device_id" "$device_name" "$device_transport"
   done
   "$XCRUN_BIN" simctl list devices available -j | ruby -rjson -e '
     records = JSON.parse(STDIN.read).fetch("devices").flat_map do |runtime, devices|
@@ -226,9 +253,11 @@ select_target() {
   local kind="$1"
   local device_id="$2"
   local device_name="$3"
+  local device_transport="${4:-}"
   SELECTED_KIND="$kind"
   SELECTED_ID="$device_id"
   SELECTED_NAME="$device_name"
+  SELECTED_TRANSPORT="$device_transport"
   if [[ "$kind" == "device" ]]; then
     SELECTED_DESTINATION="platform=iOS,id=$device_id"
     SELECTED_DERIVED_DATA="$(device_derived_data_path "$device_id")"
@@ -257,7 +286,7 @@ effective_target_mode() {
 }
 
 select_available_build_target() {
-  local effective_mode physical_records record device_id device_name simulator_record_value
+  local effective_mode physical_records device_id device_name device_transport simulator_record_value
   effective_mode="$(effective_target_mode)" || return
 
   if [[ "$effective_mode" == "simulator" ]]; then
@@ -274,18 +303,20 @@ select_available_build_target() {
 
   physical_records="$(physical_device_records)"
   if [[ -n "$DEVICE_ID" && -z "$physical_records" ]]; then
-    echo "找不到 available、paired、USB 连接的真机：$DEVICE_ID" >&2
+    echo "指定真机不可达或未配对（USB 或本地网络）：$DEVICE_ID" >&2
+    echo "设备可能已断开，或只保留了历史配对记录。" >&2
     return 4
   fi
   if [[ -n "${IOS_DEVICE_NAME:-}" && -z "$physical_records" ]]; then
-    echo "找不到 available、paired、USB 连接的真机：$IOS_DEVICE_NAME" >&2
+    echo "指定真机不可达或未配对（USB 或本地网络）：$IOS_DEVICE_NAME" >&2
+    echo "设备可能已断开，或只保留了历史配对记录。" >&2
     return 4
   fi
 
-  while IFS=$'\t' read -r device_id device_name; do
+  while IFS=$'\t' read -r device_id device_name device_transport; do
     [[ -n "$device_id" ]] || continue
     if ios_lease_device_is_available device "$device_id" "$device_name"; then
-      select_target device "$device_id" "$device_name"
+      select_target device "$device_id" "$device_name" "$device_transport"
       return
     fi
     echo "==> 跳过占用设备：$device_name ($device_id) · $IOS_DEVICE_LEASE_BUSY_DETAIL" >&2
@@ -293,9 +324,9 @@ select_available_build_target() {
 
   if [[ "$effective_mode" == "device" ]]; then
     if [[ -z "$physical_records" ]]; then
-      echo "没有检测到 available、paired、USB 连接的 iOS 真机。" >&2
+      echo "没有检测到 available、paired、可达的 iOS 真机（USB 或本地网络）。" >&2
     else
-      echo "所有匹配的 USB 真机都在使用中。" >&2
+      echo "所有匹配的 USB 或本地网络真机都在使用中。" >&2
     fi
     return 75
   fi
@@ -303,7 +334,7 @@ select_available_build_target() {
   simulator_record_value="$(resolve_simulator_record "" "$DEFAULT_SIMULATOR_NAME" 1)" || return
   IFS=$'\t' read -r device_id device_name <<< "$simulator_record_value"
   if ! ios_lease_device_is_available simulator "$device_id" "$device_name"; then
-    echo "USB 真机不可用，固定 fallback Simulator 也正在使用：$device_name ($device_id)" >&2
+    echo "USB 和本地网络真机不可用，固定 fallback Simulator 也正在使用：$device_name ($device_id)" >&2
     echo "$IOS_DEVICE_LEASE_BUSY_DETAIL" >&2
     return 75
   fi
@@ -383,7 +414,9 @@ run_xcodebuild() {
 run_device_action() {
   local action="$1"
   shift
-  echo "==> 使用已租用 USB 真机：$SELECTED_NAME ($SELECTED_ID)"
+  local transport_label="USB"
+  [[ "$SELECTED_TRANSPORT" == "localNetwork" ]] && transport_label="本地网络"
+  echo "==> 使用已租用${transport_label}真机：$SELECTED_NAME ($SELECTED_ID)"
   if [[ "$action" == "build" ]]; then
     DEVICE_ID="$SELECTED_ID" \
       DEVICE_NAME="$SELECTED_NAME" \
@@ -402,11 +435,13 @@ run_device_action() {
 }
 
 print_lease_status() {
-  local record kind device_id device_name found=0
-  while IFS=$'\t' read -r kind device_id device_name; do
+  local record kind device_id device_name device_transport found=0
+  while IFS=$'\t' read -r kind device_id device_name device_transport; do
     [[ -n "$device_id" ]] || continue
     found=1
     ios_lease_print_status "$kind" "$device_id" "$device_name"
+    [[ "$kind" == "device" && -n "$device_transport" ]] \
+      && printf '  connection:  %s\n' "$device_transport"
   done < <(observable_device_records)
   [[ "$found" -eq 1 ]] || echo "当前没有可观察的 iOS 真机或 Simulator。"
 }
@@ -431,6 +466,7 @@ case "$command_name" in
     require_command ruby
     select_available_build_target
     printf '%s: %s (%s)\n' "$SELECTED_KIND" "$SELECTED_NAME" "$SELECTED_ID"
+    [[ "$SELECTED_KIND" == "device" ]] && printf 'Connection: %s\n' "$SELECTED_TRANSPORT"
     printf 'DerivedData: %s\n' "$SELECTED_DERIVED_DATA"
     ;;
   derived-data-path)

--- a/scripts/test-ios-device-management.sh
+++ b/scripts/test-ios-device-management.sh
@@ -95,18 +95,131 @@ assert_contains "$(cat "$mini_destination_output")" "指定 UDID 不是可用的
 target_output="$(bash "$ROOT_DIR/scripts/ios-dev.sh" target)"
 assert_contains "$target_output" "device: iPad Pro (PHYSICAL-PRO-UDID)" \
   "普通 build/run 默认优先 USB iPad Pro"
+assert_contains "$target_output" "Connection: wired" \
+  "新版 devicectl 字段必须能识别 wired 真机"
 assert_contains "$target_output" "dev-device-derived/PHYSICAL-PRO-UDID" \
   "真机 DerivedData 必须按 UDID 隔离"
 
+wireless_id_target="$(
+  IOS_TARGET_MODE=device \
+  IOS_DEVICE_ID="NETWORK-PRO-UDID" \
+  bash "$ROOT_DIR/scripts/ios-dev.sh" target
+)"
+assert_contains "$wireless_id_target" "device: iPad Pro (NETWORK-PRO-UDID)" \
+  "IOS_DEVICE_ID 必须能明确选择新字段格式的本地网络真机"
+assert_contains "$wireless_id_target" "Connection: localNetwork" \
+  "本地网络真机必须显示连接方式"
+assert_contains "$wireless_id_target" "dev-device-derived/NETWORK-PRO-UDID" \
+  "无线真机必须和有线真机一样按 UDID 隔离 DerivedData"
+
+wireless_name_target="$(
+  IOS_DEVICE_NAME="Network iPhone" \
+  bash "$ROOT_DIR/scripts/ios-dev.sh" target
+)"
+assert_contains "$wireless_name_target" "device: Network iPhone (NETWORK-ONLY-UDID)" \
+  "IOS_DEVICE_NAME 必须能明确选择旧字段格式的本地网络真机"
+assert_contains "$wireless_name_target" "Connection: localNetwork" \
+  "旧版 devicectl 字段必须能识别本地网络真机"
+
+unreachable_output="$TEMP_DIR/unreachable-device.log"
+set +e
+IOS_TARGET_MODE=device \
+IOS_DEVICE_ID="OFFLINE-PAIRED-UDID" \
+bash "$ROOT_DIR/scripts/ios-dev.sh" target >"$unreachable_output" 2>&1
+unreachable_status=$?
+set -e
+assert_equal "4" "$unreachable_status" \
+  "明确选择不可达的无线真机时必须失败"
+assert_contains "$(cat "$unreachable_output")" "真机不可达或未配对" \
+  "指定真机不可达时必须输出可操作原因"
+
+lease_inventory="$(bash "$ROOT_DIR/scripts/ios-dev.sh" leases)"
+assert_contains "$lease_inventory" "Network iPhone (NETWORK-ONLY-UDID)" \
+  "leases 必须展示可达的无线真机"
+assert_contains "$lease_inventory" "connection:  localNetwork" \
+  "leases 必须标记无线真机连接方式"
+
+: > "$TEMP_DIR/wireless-build-xcodebuild.log"
+wireless_build_output="$(
+  IOS_TARGET_MODE=device \
+  IOS_DEVICE_ID="NETWORK-PRO-UDID" \
+  IOS_DEVICE_DERIVED_DATA_PATH="$TEMP_DIR/wireless-derived" \
+  IOS_TEST_XCODEBUILD_LOG="$TEMP_DIR/wireless-build-xcodebuild.log" \
+  IOS_TEST_CREATE_APP=1 \
+  bash "$ROOT_DIR/scripts/ios-dev.sh" build
+)"
+assert_contains "$wireless_build_output" "使用已租用本地网络真机：iPad Pro (NETWORK-PRO-UDID)" \
+  "显式无线 build 必须进入真机部署链路"
+assert_contains "$(cat "$TEMP_DIR/wireless-build-xcodebuild.log")" \
+  "-destination platform=iOS,id=NETWORK-PRO-UDID" \
+  "无线 build 必须把选中 UDID 传入 xcodebuild"
+assert_contains "$(cat "$TEMP_DIR/wireless-build-xcodebuild.log")" \
+  "-derivedDataPath $TEMP_DIR/wireless-derived" \
+  "无线 build 必须使用该 UDID 的独立 DerivedData"
+[[ ! -d "$IOS_DEVICE_LEASE_ROOT/NETWORK-PRO-UDID.lease" ]] \
+  || fail "无线 build 结束后必须释放按 UDID 建立的租约"
+
+duplicate_target="$(
+  IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/duplicate-device-transports.json" \
+  IOS_TARGET_MODE=device \
+  IOS_DEVICE_ID="SHARED-TRANSPORT-UDID" \
+  bash "$ROOT_DIR/scripts/ios-dev.sh" target
+)"
+assert_contains "$duplicate_target" "Connection: wired" \
+  "同一 UDID 同时报告 wired/localNetwork 时必须去重并优先 wired"
+assert_contains "$duplicate_target" "dev-device-derived/SHARED-TRANSPORT-UDID" \
+  "同一 UDID 不得按 transport 拆分 DerivedData"
+duplicate_inventory="$(
+  IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/duplicate-device-transports.json" \
+  bash "$ROOT_DIR/scripts/ios-dev.sh" leases
+)"
+assert_equal "1" "$(printf '%s\n' "$duplicate_inventory" | awk 'index($0, "SHARED-TRANSPORT-UDID") { count += 1 } END { print count + 0 }')" \
+  "leases 必须将同一 UDID 的两种 transport 去重为一台设备"
+
 owner_start="$(/bin/ps -p "$$" -o lstart= | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+write_lease_metadata "SHARED-TRANSPORT-UDID" "$$" "$owner_start"
+duplicate_busy_output="$TEMP_DIR/duplicate-transport-busy.log"
+set +e
+IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/duplicate-device-transports.json" \
+IOS_TARGET_MODE=device \
+IOS_DEVICE_ID="SHARED-TRANSPORT-UDID" \
+bash "$ROOT_DIR/scripts/ios-dev.sh" target >"$duplicate_busy_output" 2>&1
+duplicate_busy_status=$?
+set -e
+assert_equal "75" "$duplicate_busy_status" \
+  "同一 UDID 的 wired/localNetwork 必须共用一份租约"
+assert_contains "$(cat "$duplicate_busy_output")" "SHARED-TRANSPORT-UDID" \
+  "transport 共用租约时必须输出占用设备"
+rm -f "$IOS_DEVICE_LEASE_ROOT/SHARED-TRANSPORT-UDID.lease/metadata"
+rmdir "$IOS_DEVICE_LEASE_ROOT/SHARED-TRANSPORT-UDID.lease"
+
 write_lease_metadata "PHYSICAL-PRO-UDID" "$$" "$owner_start"
 target_output="$(bash "$ROOT_DIR/scripts/ios-dev.sh" target 2>"$TEMP_DIR/skip-live.log")"
 assert_contains "$target_output" "device: iPad mini (PHYSICAL-MINI-UDID)" \
   "主力真机已有活租约时必须选择下一台空闲 USB 真机"
 assert_contains "$(cat "$TEMP_DIR/skip-live.log")" "跳过占用设备：iPad Pro" \
   "跳过租约设备时必须输出可见原因"
+write_lease_metadata "PHYSICAL-MINI-UDID" "$$" "$owner_start"
+wireless_fallback_target="$(bash "$ROOT_DIR/scripts/ios-dev.sh" target 2>"$TEMP_DIR/wireless-fallback.log")"
+assert_contains "$wireless_fallback_target" "device: iPad Pro (NETWORK-PRO-UDID)" \
+  "所有 wired 真机忙时必须先回退本地网络真机"
+assert_contains "$wireless_fallback_target" "Connection: localNetwork" \
+  "本地网络回退必须可观测"
+write_lease_metadata "NETWORK-PRO-UDID" "$$" "$owner_start"
+write_lease_metadata "NETWORK-ONLY-UDID" "$$" "$owner_start"
+simulator_fallback_target="$(bash "$ROOT_DIR/scripts/ios-dev.sh" target 2>"$TEMP_DIR/simulator-fallback.log")"
+assert_contains "$simulator_fallback_target" "simulator: iPad Pro 13-inch (M5) (M5-27-UDID)" \
+  "wired 和 localNetwork 真机都忙时必须回退固定 M5 Simulator"
+assert_contains "$simulator_fallback_target" "dev-simulator-derived/M5-27-UDID" \
+  "真机全部忙时 Simulator fallback 仍必须按 UDID 隔离 DerivedData"
 rm -f "$IOS_DEVICE_LEASE_ROOT/PHYSICAL-PRO-UDID.lease/metadata"
 rmdir "$IOS_DEVICE_LEASE_ROOT/PHYSICAL-PRO-UDID.lease"
+rm -f "$IOS_DEVICE_LEASE_ROOT/PHYSICAL-MINI-UDID.lease/metadata"
+rmdir "$IOS_DEVICE_LEASE_ROOT/PHYSICAL-MINI-UDID.lease"
+rm -f "$IOS_DEVICE_LEASE_ROOT/NETWORK-PRO-UDID.lease/metadata"
+rmdir "$IOS_DEVICE_LEASE_ROOT/NETWORK-PRO-UDID.lease"
+rm -f "$IOS_DEVICE_LEASE_ROOT/NETWORK-ONLY-UDID.lease/metadata"
+rmdir "$IOS_DEVICE_LEASE_ROOT/NETWORK-ONLY-UDID.lease"
 
 mkdir "$IOS_DEVICE_LEASE_ROOT/PHYSICAL-PRO-UDID.lease"
 acquiring_target="$(bash "$ROOT_DIR/scripts/ios-dev.sh" target 2>"$TEMP_DIR/acquiring.log")"

--- a/scripts/testdata/ios-device-management/duplicate-device-transports.json
+++ b/scripts/testdata/ios-device-management/duplicate-device-transports.json
@@ -1,0 +1,38 @@
+{
+  "result": {
+    "devices": [
+      {
+        "connectionProperties": {
+          "transportType": "localNetwork",
+          "tunnelState": "connected",
+          "pairingState": "paired"
+        },
+        "hardwareProperties": {
+          "platform": "iOS",
+          "reality": "physical",
+          "udid": "SHARED-TRANSPORT-UDID"
+        },
+        "deviceProperties": {
+          "name": "Shared iPad"
+        }
+      },
+      {
+        "properties": {
+          "connection": {
+            "transportType": "wired",
+            "state": "connected",
+            "pairingState": "paired"
+          },
+          "hardware": {
+            "platform": "iOS",
+            "reality": "physical",
+            "udid": "SHARED-TRANSPORT-UDID"
+          },
+          "state": {
+            "name": "Shared iPad"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/scripts/testdata/ios-device-management/fake-xcodebuild.sh
+++ b/scripts/testdata/ios-device-management/fake-xcodebuild.sh
@@ -4,6 +4,23 @@ set -euo pipefail
 if [[ -n "${IOS_TEST_XCODEBUILD_LOG:-}" ]]; then
   printf '%s\n' "$*" >> "$IOS_TEST_XCODEBUILD_LOG"
 fi
+if [[ "${IOS_TEST_CREATE_APP:-0}" == "1" ]]; then
+  derived_data_path=""
+  destination=""
+  previous_argument=""
+  for argument in "$@"; do
+    case "$previous_argument" in
+      -derivedDataPath) derived_data_path="$argument" ;;
+      -destination) destination="$argument" ;;
+    esac
+    previous_argument="$argument"
+  done
+  if [[ -n "$derived_data_path" ]]; then
+    product_suffix="iphoneos"
+    [[ "$destination" == *"iOS Simulator"* ]] && product_suffix="iphonesimulator"
+    mkdir -p "$derived_data_path/Build/Products/Debug-${product_suffix}/MimiRemote.app"
+  fi
+fi
 if [[ -n "${IOS_TEST_XCODEBUILD_STARTED:-}" ]]; then
   printf '%s\n' "$$" > "$IOS_TEST_XCODEBUILD_STARTED"
 fi

--- a/scripts/testdata/ios-device-management/physical-devices.json
+++ b/scripts/testdata/ios-device-management/physical-devices.json
@@ -2,20 +2,18 @@
   "result": {
     "devices": [
       {
-        "properties": {
-          "connection": {
-            "transportType": "wired",
-            "state": "connected",
-            "pairingState": "paired"
-          },
-          "hardware": {
-            "platform": "iOS",
-            "reality": "physical",
-            "udid": "PHYSICAL-PRO-UDID"
-          },
-          "state": {
-            "name": "iPad Pro"
-          }
+        "connectionProperties": {
+          "transportType": "wired",
+          "tunnelState": "connected",
+          "pairingState": "paired"
+        },
+        "hardwareProperties": {
+          "platform": "iOS",
+          "reality": "physical",
+          "udid": "PHYSICAL-PRO-UDID"
+        },
+        "deviceProperties": {
+          "name": "iPad Pro"
         }
       },
       {
@@ -36,6 +34,21 @@
         }
       },
       {
+        "connectionProperties": {
+          "transportType": "localNetwork",
+          "tunnelState": "connected",
+          "pairingState": "paired"
+        },
+        "hardwareProperties": {
+          "platform": "iOS",
+          "reality": "physical",
+          "udid": "NETWORK-PRO-UDID"
+        },
+        "deviceProperties": {
+          "name": "iPad Pro"
+        }
+      },
+      {
         "properties": {
           "connection": {
             "transportType": "localNetwork",
@@ -50,6 +63,35 @@
           "state": {
             "name": "Network iPhone"
           }
+        }
+      },
+      {
+        "connectionProperties": {
+          "pairingState": "paired",
+          "tunnelState": "unavailable"
+        },
+        "hardwareProperties": {
+          "platform": "iOS",
+          "reality": "physical",
+          "udid": "OFFLINE-PAIRED-UDID"
+        },
+        "deviceProperties": {
+          "name": "Offline paired iPad"
+        }
+      },
+      {
+        "connectionProperties": {
+          "transportType": "localNetwork",
+          "tunnelState": "connected",
+          "pairingState": "unpaired"
+        },
+        "hardwareProperties": {
+          "platform": "iOS",
+          "reality": "physical",
+          "udid": "UNPAIRED-NETWORK-UDID"
+        },
+        "deviceProperties": {
+          "name": "Unpaired network iPad"
         }
       }
     ]


### PR DESCRIPTION
## 目标

让统一 iOS 开发脚本在日常 `build` / `run` 中按 wired 真机 → localNetwork 真机 → 固定 M5 Simulator 确定性回退。

## 根因

脚本只读取旧版 `properties.connection/hardware/state`，且只接受 `transportType == wired`；新版 `devicectl` 的顶层字段与已配对、当前可达的无线真机都会被忽略。

## 改动

- 同时解析新版 `connectionProperties` / `hardwareProperties` / `deviceProperties` 和旧版 `properties.*`。
- 只接受 physical iOS/iPadOS、paired、connected 且 transport 为 wired 或 localNetwork 的设备。
- 先按 transport 保证 wired 全局优先，再按 `iPad Pro`、设备名、UDID 固定排序。
- 同一 UDID 的双 transport 记录去重，继续共用同一租约与 DerivedData。
- 显式 ID/名称支持无线设备；不可达时明确失败，不回退其他目标。
- `target` / `leases` 展示连接方式；`test` / `build-for-testing` 仍固定 M5 Simulator。
- 同步 README、中文 README、AGENTS.md 与脚本帮助。

## 验证

- `bash ./scripts/test-ios-device-management.sh`：通过；覆盖新旧 schema、显式无线 fake build 进入 deploy/xcodebuild、不可达失败、wired→localNetwork→Simulator 回退、重复 UDID 单租约。
- `bash -n`：通过。
- fixture JSON parse：通过。
- `git diff --check`：通过。
- `bash ./scripts/check-source-size.sh`：通过。
- 真实固定 `iPad Pro 13-inch (M5)` Simulator Debug build：`BUILD SUCCEEDED`。
- 当前机器没有可达 wired/localNetwork 真机，最终分支上的真实无线 install/launch 未重跑；Issue 原始证据已确认相同 deploy 链路在临时接受 localNetwork 后可完成无线构建、签名、安装和启动。

## 影响边界

只调整本地 iOS 设备探测、选择、租约观测、测试夹具和文档；不修改 App 业务逻辑，不改变快照/CI 固定 Simulator 的规则。

Linear: MIM-62
