### PR TITLE
MIM-44 引导未打开工作区的会话空态

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -13530,6 +13530,23 @@
         }
       }
     },
+    "ui.loading_sessions" : {
+      "comment" : "Loading state shown while the session index is being prepared.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading sessions…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载会话…"
+          }
+        }
+      }
+    },
     "ui.loading_recent_conversations" : {
       "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations" : {
@@ -16583,6 +16600,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开"
+          }
+        }
+      }
+    },
+    "ui.open_a_workspace_to_load_its_sessions" : {
+      "comment" : "Explains the relationship between workspace directories and the session index for first-time users.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sessions are loaded by workspace directory. Go to Workspace and open or add a directory first."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会话按工作区目录加载。请先前往工作区打开或加入一个目录。"
           }
         }
       }
@@ -22893,6 +22927,23 @@
         }
       }
     },
+    "ui.session_loading_failed" : {
+      "comment" : "Title shown when a session index request fails after a workspace has been opened.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load sessions"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会话加载失败"
+          }
+        }
+      }
+    },
     "ui.session_name" : {
       "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations" : {
@@ -23112,6 +23163,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "会话已恢复显示全部工作区"
+          }
+        }
+      }
+    },
+    "ui.session_runtime_unavailable" : {
+      "comment" : "Title shown when the connected Mac cannot provide the session runtime.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session service unavailable"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会话服务不可用"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -283,8 +283,66 @@ struct SessionListPartition: Equatable {
     }
 }
 
+/// 会话页空态必须依赖“已打开工作区”与连接状态，不能用会话数量反推目录是否存在。
+/// 这里集中定义优先级，避免加载或错误被首次使用引导覆盖。
+enum SessionListPresentationState: Equatable {
+    case content
+    case loading
+    case searching
+    case needsWorkspace
+    case noSessions
+    case noMatches
+    case networkUnavailable
+    case runtimeUnavailable(String)
+    case loadFailed(String)
+
+    static func resolve(
+        hasVisibleSessions: Bool,
+        hasOpenedWorkspace: Bool,
+        isLoading: Bool,
+        isSearching: Bool,
+        isFiltering: Bool,
+        isNetworkUnavailable: Bool,
+        errorMessage: String?,
+        connectionStatus: ConnectionStatus
+    ) -> Self {
+        guard !hasVisibleSessions else { return .content }
+
+        if case .failed(let message) = connectionStatus {
+            return .runtimeUnavailable(message)
+        }
+        if isNetworkUnavailable {
+            return .networkUnavailable
+        }
+        if let message = errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !message.isEmpty {
+            return .loadFailed(message)
+        }
+        if isLoading {
+            return .loading
+        }
+        switch connectionStatus {
+        case .idle, .testing:
+            return .loading
+        case .connected, .failed:
+            break
+        }
+        if isSearching {
+            return .searching
+        }
+        if isFiltering {
+            return .noMatches
+        }
+        if !hasOpenedWorkspace {
+            return .needsWorkspace
+        }
+        return .noSessions
+    }
+}
+
 /// 完整会话库只展示轻量索引；消息历史仍在用户选中会话后按需加载。
 struct SessionListView: View {
+    @EnvironmentObject private var appStore: AppStore
     @EnvironmentObject private var sessionStore: SessionStore
     @EnvironmentObject private var themeStore: ThemeStore
     @Environment(\.colorScheme) private var colorScheme
@@ -293,6 +351,7 @@ struct SessionListView: View {
 
     var onNewSession: (() -> Void)?
     var onSelectSession: ((AgentSession) -> Void)?
+    var onOpenWorkspaces: (() -> Void)?
     var manageConnections: (() -> Void)?
     var placesFilterInTrailingToolbar = false
 
@@ -300,33 +359,7 @@ struct SessionListView: View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         List {
-            if visibleSessions.isEmpty && !sessionStore.isLoading {
-                if sessionStore.isSessionSearchActive && sessionStore.isSearchingRemoteSessionResults {
-                    VStack(spacing: 10) {
-                        ProgressView()
-                        Text(L10n.text("ui.searching_historical_conversations"))
-                            .font(themeStore.uiFont(size: 13, weight: .medium))
-                            .foregroundStyle(tokens.secondaryText)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 24)
-                    .accessibilityIdentifier("sessions.search.initialLoading")
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                } else {
-                    ContentUnavailableView {
-                        Label(L10n.text("ui.no_matching_session"), systemImage: "bubble.left.and.bubble.right")
-                    } description: {
-                        Text(sessionStore.isSessionSearchActive ? L10n.text("ui.try_changing_keywords_or_filter_conditions") : L10n.text("ui.new_sessions_created_from_a_workspace_appear_here"))
-                    } actions: {
-                        Button(L10n.text("ui.new_session"), action: presentNewSession)
-                            .buttonStyle(.borderedProminent)
-                            .tint(tokens.primaryAction)
-                    }
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                }
-            } else {
+            if presentationState == .content {
                 if !sessionPartition.active.isEmpty {
                     Section {
                         sessionRows(sessionPartition.active)
@@ -352,6 +385,11 @@ struct SessionListView: View {
                         )
                     }
                 }
+            } else {
+                sessionListUnavailableContent(state: presentationState, tokens: tokens)
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
             }
 
             // Gateway 过滤后当前页可能没有可见结果但仍给出 nextCursor，入口必须独立于空态展示。
@@ -465,6 +503,131 @@ struct SessionListView: View {
 
     private var sessionPartition: SessionListPartition {
         SessionListPartition(sessions: visibleSessions)
+    }
+
+    private var presentationState: SessionListPresentationState {
+        SessionListPresentationState.resolve(
+            hasVisibleSessions: !visibleSessions.isEmpty,
+            // sidebarProjects 只包含 rememberWorkspace 记录的已打开目录，不包含后端候选项目。
+            hasOpenedWorkspace: !sessionStore.sidebarProjects.isEmpty,
+            isLoading: sessionStore.isLoading,
+            isSearching: sessionStore.isSessionSearchActive && sessionStore.isSearchingRemoteSessionResults,
+            isFiltering: sessionStore.isSessionSearchActive || selectedWorkspaceID != "all" || selectedStatus != .all,
+            isNetworkUnavailable: sessionStore.isNetworkUnavailable,
+            errorMessage: sessionStore.errorMessage,
+            connectionStatus: appStore.connectionStatus
+        )
+    }
+
+    @ViewBuilder
+    private func sessionListUnavailableContent(
+        state: SessionListPresentationState,
+        tokens: ThemeTokens
+    ) -> some View {
+        switch state {
+        case .content:
+            EmptyView()
+        case .loading:
+            VStack(spacing: 10) {
+                ProgressView()
+                Text(L10n.text("ui.loading_sessions"))
+                    .font(themeStore.uiFont(size: 13, weight: .medium))
+                    .foregroundStyle(tokens.secondaryText)
+            }
+            .padding(.vertical, 32)
+            .accessibilityIdentifier("sessions.loading")
+        case .searching:
+            VStack(spacing: 10) {
+                ProgressView()
+                Text(L10n.text("ui.searching_historical_conversations"))
+                    .font(themeStore.uiFont(size: 13, weight: .medium))
+                    .foregroundStyle(tokens.secondaryText)
+            }
+            .padding(.vertical, 24)
+            .accessibilityIdentifier("sessions.search.initialLoading")
+        case .needsWorkspace:
+            ContentUnavailableView {
+                Label(L10n.text("ui.no_workspace_has_been_opened_yet"), systemImage: "folder.badge.plus")
+            } description: {
+                Text(L10n.text("ui.open_a_workspace_to_load_its_sessions"))
+            } actions: {
+                Button(L10n.text("ui.go_to_work_area")) {
+                    onOpenWorkspaces?()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .tint(tokens.primaryAction)
+                .accessibilityIdentifier("sessions.empty.openWorkspaces")
+            }
+            .accessibilityIdentifier("sessions.empty.needsWorkspace")
+        case .noSessions:
+            ContentUnavailableView {
+                Label(L10n.text("ui.no_sessions_yet"), systemImage: "bubble.left.and.bubble.right")
+            } description: {
+                Text(L10n.text("ui.new_sessions_created_from_a_workspace_appear_here"))
+            } actions: {
+                Button(L10n.text("ui.new_session"), action: presentNewSession)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .tint(tokens.primaryAction)
+            }
+            .accessibilityIdentifier("sessions.empty.noSessions")
+        case .noMatches:
+            ContentUnavailableView {
+                Label(L10n.text("ui.no_matching_session"), systemImage: "magnifyingglass")
+            } description: {
+                Text(L10n.text("ui.try_changing_keywords_or_filter_conditions"))
+            }
+            .accessibilityIdentifier("sessions.empty.noMatches")
+        case .networkUnavailable:
+            sessionFailureContent(
+                title: L10n.text("ui.network_is_unavailable"),
+                message: L10n.text("ui.the_network_is_unavailable_and_synchronization_has_been"),
+                systemImage: "wifi.slash",
+                tokens: tokens
+            )
+        case .runtimeUnavailable(let message):
+            sessionFailureContent(
+                title: L10n.text("ui.session_runtime_unavailable"),
+                message: message,
+                systemImage: "exclamationmark.triangle",
+                tokens: tokens
+            )
+        case .loadFailed(let message):
+            sessionFailureContent(
+                title: L10n.text("ui.session_loading_failed"),
+                message: message,
+                systemImage: "exclamationmark.triangle",
+                tokens: tokens
+            )
+        }
+    }
+
+    private func sessionFailureContent(
+        title: String,
+        message: String,
+        systemImage: String,
+        tokens: ThemeTokens
+    ) -> some View {
+        ContentUnavailableView {
+            Label(title, systemImage: systemImage)
+        } description: {
+            Text(message)
+        } actions: {
+            Button(L10n.text("ui.try_again"), action: retrySessionList)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .tint(tokens.primaryAction)
+                .accessibilityIdentifier("sessions.empty.retry")
+        }
+        .accessibilityIdentifier("sessions.empty.failure")
+    }
+
+    private func retrySessionList() {
+        Task {
+            await appStore.preflightConnection()
+            await sessionStore.refreshSessionLibraryIndex(authoritative: true)
+        }
     }
 
     @ViewBuilder

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -728,6 +728,10 @@ struct UnifiedWorkbenchShell: View {
             onSelectSession: { session in
                 openSession(session, source: .sessions, layout: layout)
             },
+            onOpenWorkspaces: {
+                // 首次使用空态与侧栏共用同一路由，紧凑布局切 Tab，宽屏切换详情列。
+                open(.workspaces, layout: layout)
+            },
             manageConnections: manageConnections,
             placesFilterInTrailingToolbar: layout.usesFloatingSidebarSurface
         )

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -1066,6 +1066,99 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertTrue(SessionLibraryStatusFilter.needsAttention.includes(sessions[2]))
     }
 
+    func testSessionListPresentationRequiresOpenedWorkspaceOnlyAfterConnectionSucceeds() {
+        let state = SessionListPresentationState.resolve(
+            hasVisibleSessions: false,
+            hasOpenedWorkspace: false,
+            isLoading: false,
+            isSearching: false,
+            isFiltering: false,
+            isNetworkUnavailable: false,
+            errorMessage: nil,
+            connectionStatus: .connected("Mac")
+        )
+
+        XCTAssertEqual(state, .needsWorkspace)
+    }
+
+    func testSessionListPresentationKeepsNoSessionsDistinctFromMissingWorkspace() {
+        let state = SessionListPresentationState.resolve(
+            hasVisibleSessions: false,
+            hasOpenedWorkspace: true,
+            isLoading: false,
+            isSearching: false,
+            isFiltering: false,
+            isNetworkUnavailable: false,
+            errorMessage: nil,
+            connectionStatus: .connected("Mac")
+        )
+
+        XCTAssertEqual(state, .noSessions)
+    }
+
+    func testSessionListPresentationDoesNotCoverLoadingOrFailuresWithWorkspaceGuidance() {
+        let loading = SessionListPresentationState.resolve(
+            hasVisibleSessions: false,
+            hasOpenedWorkspace: false,
+            isLoading: true,
+            isSearching: false,
+            isFiltering: false,
+            isNetworkUnavailable: false,
+            errorMessage: nil,
+            connectionStatus: .connected("Mac")
+        )
+        let loadFailure = SessionListPresentationState.resolve(
+            hasVisibleSessions: false,
+            hasOpenedWorkspace: false,
+            isLoading: false,
+            isSearching: false,
+            isFiltering: false,
+            isNetworkUnavailable: false,
+            errorMessage: "thread/list failed",
+            connectionStatus: .connected("Mac")
+        )
+        let runtimeFailure = SessionListPresentationState.resolve(
+            hasVisibleSessions: false,
+            hasOpenedWorkspace: false,
+            isLoading: false,
+            isSearching: false,
+            isFiltering: false,
+            isNetworkUnavailable: false,
+            errorMessage: "stale list error",
+            connectionStatus: .failed("Runtime unavailable")
+        )
+        let networkFailure = SessionListPresentationState.resolve(
+            hasVisibleSessions: false,
+            hasOpenedWorkspace: false,
+            isLoading: false,
+            isSearching: false,
+            isFiltering: false,
+            isNetworkUnavailable: true,
+            errorMessage: nil,
+            connectionStatus: .connected("Mac")
+        )
+
+        XCTAssertEqual(loading, .loading)
+        XCTAssertEqual(loadFailure, .loadFailed("thread/list failed"))
+        XCTAssertEqual(runtimeFailure, .runtimeUnavailable("Runtime unavailable"))
+        XCTAssertEqual(networkFailure, .networkUnavailable)
+    }
+
+    func testSessionListPresentationKeepsFilteredEmptyStateDistinct() {
+        let state = SessionListPresentationState.resolve(
+            hasVisibleSessions: false,
+            hasOpenedWorkspace: true,
+            isLoading: false,
+            isSearching: false,
+            isFiltering: true,
+            isNetworkUnavailable: false,
+            errorMessage: nil,
+            connectionStatus: .connected("Mac")
+        )
+
+        XCTAssertEqual(state, .noMatches)
+    }
+
     func testConversationFileReferenceDetectorFindsPreviewableAbsolutePaths() {
         let text = """
         已生成：

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -1966,6 +1966,26 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(state.compactWorkspacePath.isEmpty)
     }
 
+    func testWorkbenchNavigationWorkspaceEmptyStateActionOpensWorkspaceInBothLayouts() {
+        for usesCompactNavigation in [true, false] {
+            var state = WorkbenchNavigationState(route: .sessions)
+
+            let effect = state.reduce(
+                .open(.workspaces, source: nil),
+                usesCompactNavigation: usesCompactNavigation,
+                selectedSessionID: nil
+            )
+
+            XCTAssertEqual(effect, .returnToSessionList)
+            XCTAssertEqual(state.route, .workspaces)
+            XCTAssertEqual(state.selection, .workspaces)
+            if usesCompactNavigation {
+                XCTAssertEqual(state.compactSelectedTab, .workspaces)
+                XCTAssertTrue(state.compactWorkspacePath.isEmpty)
+            }
+        }
+    }
+
     func testWorkbenchNavigationRestoresSessionIntoItsSourceStack() {
         var state = WorkbenchNavigationState()
         let route = WorkbenchRestorationRoute.session(


### PR DESCRIPTION
## 目标

已连接宿主但尚未打开工作区时，解释会话按目录加载，并提供一步进入工作区的操作。

## 实现

- 集中定义会话列表展示状态与优先级
- 只在连接成功、非加载/搜索/网络/Runtime/加载错误且已打开工作区为空时显示首次引导
- 区分普通无会话、筛选无结果、网络错误、Runtime 不可用与加载失败
- 复用 UnifiedWorkbenchShell.open(.workspaces)：紧凑布局切 Workspace Tab，宽屏切详情列
- 补齐中英文 String Catalog 与状态/导航单测

## 验证

- 固定 M5：状态判定 4/4、导航 1/1、网络失败补充 1/1，0 failure
- 固定 M5 build/install/launch 成功；debug seed 正常会话列表无回归
- iOS 本地化静态检查 1724 keys，String Catalog 编译通过
- git diff、源码体积、公开仓库安全、第三方许可与 PR Gate 自检通过

## 说明

现有 debug seed 总会注入工作区，因此未扩大 Debug 配置来制造无工作区截图；新分支的状态判定和路由闭环由聚焦测试覆盖。

Linear: MIM-44