### PR TITLE
MIM-65 统一用户单图媒体卡样式

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/MarkdownBlockView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/MarkdownBlockView.swift
@@ -612,9 +612,11 @@ private struct ConversationImagePreviewContent: View {
                 maxHeight: maxHeight,
                 alignment: fillsAvailableWidth ? .center : .leading
             )
-            .padding(fillsAvailableWidth ? 4 : 0)
+            // 单图与多图统一成中性媒体卡：4pt 内边距把图像从描边内缩，
+            // 白底截图不再顶死边框，圆角也能稳稳咬住内容，避免“图与框对不齐”。
+            .padding(4)
             .background(
-                fillsAvailableWidth ? style.tableBackground : Color.clear,
+                style.tableBackground,
                 in: RoundedRectangle(cornerRadius: 8, style: .continuous)
             )
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))


### PR DESCRIPTION
关联 Linear：MIM-65。统一用户单图与多图媒体卡的边框、背景和留白；已在固定 iPad Pro 13-inch (M5) 集成分支完成构建、启动和富文本快照回归。