### PR TITLE
MIM-74 修复新会话初始化错误提示

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -26419,13 +26419,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The complete history failed to load. The content may be too large."
+            "value" : "The complete history failed to load. Please try again."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "完整历史加载失败，可能是内容过大。"
+            "value" : "完整历史加载失败，请重试。"
           }
         }
       }

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -1323,6 +1323,14 @@ final class SessionStore: ObservableObject {
         if isExternalReadOnlySession(session) || isProtocolReadOnlySession(session) {
             return .observing
         }
+        if session.isRunning,
+           session.id.hasPrefix("local:"),
+           session.source == Self.optimisticSessionSource,
+           session.resumeID == nil {
+            // 新会话首发时会先发布 local:* 的 running 占位，再等待 thread/start 返回真实 ID。
+            // 该占位由本机刚刚创建，应保持可控；这里只做内存态判定，避免把临时 ID 持久化到控制权存储。
+            return .ipadOwned
+        }
         if let state = sessionControlStateByID[session.id] {
             return state
         }

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -179,10 +179,9 @@ extension SessionStore {
                 )
             }
 
-            // 历史 resume 必须先补齐上下文，再追加本次用户输入，避免“发完历史没了”；
-            // 带首轮 prompt 的新会话也保留 thread/read 快照，用它校准后续事件回放。
-            // 新建空交互会话没有历史可补；启动后立刻请求完整历史容易撞上后端 thread/read
-            // 初始化窗口并误报“大历史加载失败”，因此只跳过这类空会话的首屏补拉。
+            // 历史 resume 必须先补齐上下文，再追加本次用户输入，避免“发完历史没了”。
+            // 新线程的首轮内容由本地回显和 buffered event replay 承接；turn/start 刚 ACK 时 rollout
+            // 可能尚未可读，此时同步请求完整历史只会制造 no-rollout/超时竞态。
             let didLoadInitialHistory: Bool
             if responseSelectionLease == nil {
                 // 用户已经切走：保留服务端创建结果和本地投影，历史在再次打开时按需补拉。
@@ -190,14 +189,18 @@ extension SessionStore {
             } else if hasLoadedFullHistorySnapshot(sessionID: responseSession.id) {
                 // 用户刚从历史列表进入时可复用已有快照，避免同一会话立刻再打一次 full。
                 didLoadInitialHistory = true
-            } else if resume != nil || !payload.isEmpty {
+            } else if resume != nil {
                 didLoadInitialHistory = await loadHistoryIfNeeded(for: responseSession)
-            } else {
+            } else if payload.isEmpty {
                 // 新建空 thread 在首个 turn 前没有 rollout。把当前空快照标成已加载，前台恢复时
                 // 就不会误打 thread/turns/list 并把 no-rollout 错报成“大历史加载失败”；首个 turn
                 // 会改变 updatedAt/revision/lastSeq，届时签名自然失效并允许正常补拉。
                 markEmptyHistoryLoaded(for: responseSession)
                 didLoadInitialHistory = true
+            } else {
+                // 非空新线程不能标成“已加载空历史”，否则重新进入时可能跳过真正的历史补拉。
+                // 保持未加载状态，当前首轮直接连接事件流，后续刷新或重新进入再做权威对账。
+                didLoadInitialHistory = false
             }
             if !prompt.isEmpty {
                 if let clientMessageID {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1486,8 +1486,22 @@ extension ConversationDataFlowTests {
             configProvider: { config }
         )
         let client = CodexAppServerSessionAPIClient(runtime: runtime)
-        let appStore = AppStore()
-        appStore.token = "test-token"
+        let suiteName = "ConversationDataFlowTests.StoreDirect.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let profile = ConnectionProfile(
+            id: "store-direct",
+            displayName: "Store Direct",
+            endpoint: "http://127.0.0.1:8787",
+            lastSuccessfulAt: nil
+        )
+        defaults.set(try JSONEncoder().encode([profile]), forKey: "agentd.connectionProfiles.v1")
+        defaults.set(profile.id, forKey: "agentd.activeConnectionProfileID.v1")
+        defaults.set(profile.endpoint, forKey: "agentd.endpoint")
+        let keychain = TestKeychainOperations()
+        keychain.setData(Data("test-token".utf8), account: "agentd-profile.\(profile.id)")
+        let appStore = AppStore(defaults: defaults, tokenStore: TokenStore(keychain: keychain))
         let conversationStore = ConversationStore()
         let logStore = LogStore()
         let contextStore = SessionContextStore()
@@ -1534,12 +1548,27 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(collaborationMode["mode"]?.stringValue, "default")
         XCTAssertEqual(collaborationMode["settings"]?.objectValue?["model"]?.stringValue, "gpt-store-default")
         transport.enqueue(#"{"id":\#(try jsonFragment(for: turnStart.id)),"result":{"turn":{"id":"turn_store_direct","items":[],"itemsView":{"type":"complete"},"status":"inProgress","error":null,"startedAt":1780490102,"completedAt":null,"durationMs":null}}}"#)
-        let historyMessages = try await waitForFakeAppServerMessages(transport, count: 7)
-        let historyRead = try decodeAppServerRequest(historyMessages[6])
-        XCTAssertEqual(historyRead.method, "thread/read")
-        transport.enqueue(#"{"id":\#(try jsonFragment(for: historyRead.id)),"result":{"thread":{"id":"thr_store_direct","sessionId":"thr_store_direct","preview":"帮我验收 direct Store","ephemeral":false,"modelProvider":"openai","createdAt":1780490100,"updatedAt":1780490102,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/store-direct","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"Store 直连","turns":[]}}}"#)
+        // 新线程首轮由本地回显和 buffered event replay 承接，不能在 rollout 尚未就绪时
+        // 追加 thread/read；若未来回归到旧行为，先响应请求让 sendTask 能退出，再给出明确断言。
+        for _ in 0..<20 {
+            if (await transport.sentMessages()).count > 6 {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let requestsAfterTurnStart = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        let unexpectedHistoryRead = requestsAfterTurnStart.first { $0.method == "thread/read" }
+        if let unexpectedHistoryRead {
+            transport.enqueue(#"{"id":\#(try jsonFragment(for: unexpectedHistoryRead.id)),"result":{"thread":{"id":"thr_store_direct","sessionId":"thr_store_direct","preview":"帮我验收 direct Store","ephemeral":false,"modelProvider":"openai","createdAt":1780490100,"updatedAt":1780490102,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/store-direct","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"Store 直连","turns":[]}}}"#)
+        }
         let didSend = await sendTask.value
         XCTAssertTrue(didSend)
+        XCTAssertNil(unexpectedHistoryRead, "新线程首轮 ACK 后不能同步读取尚未就绪的 rollout")
+        XCTAssertFalse(conversationStore.hasLoadedHistory(sessionID: "thr_store_direct"))
+        XCTAssertEqual(store.selectedSession?.status, "running")
+        XCTAssertEqual(store.connectedSessionID, "thr_store_direct")
+        XCTAssertNotNil(store.webSocket)
+        XCTAssertNotNil(appStore.authenticatedCredentialFingerprint)
         try await waitForWebSocketStatus(.connected, store: store)
         XCTAssertEqual(store.selectedSessionID, "thr_store_direct")
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -1898,7 +1898,12 @@ extension ConversationDataFlowTests {
         await client.waitForCreateRequestCount(1)
 
         let optimisticSessionID = try XCTUnwrap(store.selectedSessionID)
+        let optimisticSession = try XCTUnwrap(store.selectedSession)
         XCTAssertTrue(optimisticSessionID.hasPrefix("local:"))
+        XCTAssertEqual(store.controlState(for: optimisticSession), .ipadOwned)
+        XCTAssertTrue(store.canControlSession(optimisticSession))
+        XCTAssertFalse(store.isSelectedSessionObserving)
+        XCTAssertNil(store.selectedSessionControlNotice)
         XCTAssertEqual(conversationStore.messages(for: optimisticSessionID).map(\.content), ["帮我检查项目"])
         XCTAssertEqual(conversationStore.messages(for: optimisticSessionID).first?.sendStatus, .sending)
 
@@ -1920,6 +1925,9 @@ extension ConversationDataFlowTests {
         let sendSucceeded = await sendTask.value
         XCTAssertTrue(sendSucceeded)
         XCTAssertEqual(store.selectedSessionID, created.id)
+        XCTAssertEqual(store.controlState(for: try XCTUnwrap(store.selectedSession)), .ipadOwned)
+        XCTAssertFalse(store.isSelectedSessionObserving)
+        XCTAssertNil(store.selectedSessionControlNotice)
         XCTAssertEqual(
             store.lastSelectionCommit?.reason,
             .identityReplacement(previousID: optimisticSessionID)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -1848,7 +1848,7 @@ extension ConversationDataFlowTests {
             sessions: [],
             projectSessions: [project.id: []],
             createSessionResponse: try makeCreateSessionResponse(session: created),
-            messagesResult: []
+            messagesError: AgentAPIError.server(status: 404, message: "no rollout found")
         )
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []
@@ -1889,7 +1889,12 @@ extension ConversationDataFlowTests {
         XCTAssertFalse(store.sessions.contains { $0.id == draftID })
         XCTAssertTrue(conversationStore.messages(for: draftID).isEmpty)
         XCTAssertTrue(conversationStore.messages(for: created.id).contains { $0.content == "轮询后发送第一条消息" })
+        XCTAssertFalse(conversationStore.hasLoadedHistory(sessionID: created.id), "运行中的新线程不能被标记成已加载空历史")
+        XCTAssertTrue(client.requestedMessageSessionIDs.isEmpty, "首轮 ACK 后应直接接入事件流，不能同步读取尚未就绪的 rollout")
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+        XCTAssertNil(store.errorMessage)
         XCTAssertEqual(sockets.count, 1)
+        XCTAssertEqual(sockets.first?.replayBufferedEventsByConnect, [true])
     }
 
     // 回归：新建草稿必须保留入口选择的 runtime，直到首条消息真正创建远端会话。
@@ -3319,7 +3324,11 @@ extension ConversationDataFlowTests {
         client.failHistoryRequest(at: 1, with: MockError.timeout)
         await manualRefreshTask.value
 
-        XCTAssertEqual(store.selectedHistorySavingsNotice?.kind, .fullFailed)
+        let notice = try XCTUnwrap(store.selectedHistorySavingsNotice)
+        XCTAssertEqual(notice.kind, .fullFailed)
+        XCTAssertEqual(notice.message, L10n.text("ui.the_complete_history_failed_to_load_the_content"))
+        XCTAssertFalse(notice.message.contains("过大"), "普通超时不能推断为内容过大")
+        XCTAssertFalse(notice.message.localizedCaseInsensitiveContains("too large"), "Generic failures must not imply oversized history")
         XCTAssertEqual(
             store.statusMessage,
             L10n.format("ui.full_history_loading_failed_value", MockError.timeout.localizedDescription)


### PR DESCRIPTION
## 变更内容

- 将本机新建会话的 `local:*` optimistic running 占位判定为 iPad 可控状态，避免首发期间闪现“仅观察”。
- 新线程首轮 ACK 后不再同步读取尚未就绪的 rollout，改由本地回显与 buffered event replay 承接；历史 resume 仍保持同步补齐。
- 通用完整历史加载失败文案不再错误暗示“内容过大”，真实超限历史的降级策略保持不变。
- 增加新会话控制权、首轮历史竞态和失败文案回归测试。

## 原因与影响

新会话首发时会先发布本地 running 占位，但未知 running 会话的默认控制状态是 observing；同时，服务端返回真实 thread 后立刻读取完整历史会撞上 rollout 初始化窗口。这两个竞态分别造成“仅观察”闪现和错误的历史失败横幅。

修复后，新建短会话从本地占位到真实 thread 的控制权保持一致，首轮消息通过事件流连续展示；真实外部 Mac 会话仍只读，真实大历史保护不变。

## 验证

- `bash ./scripts/ios-dev.sh build`：通过（固定 iPad Pro 13-inch (M5) Simulator）。
- 问题回归与控制权/历史策略安全测试：8/8 通过。
- iOS 本地化静态检查及 String Catalog 编译：通过。
- 提交后 App 已安装启动，并连接现有主机完成真实新会话首发：会话正常完成，未出现历史失败横幅。
- 全量 XCTest 汇总：867 tests、1 skipped、24 failures；失败为本次范围外的既有路径规范化和快照基线问题，本次相关测试无失败。

Linear: MIM-74
