### PR TITLE
MIM-76 修复 Simulator 配对验证并收紧发布结论

### DIFF
--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -3,6 +3,20 @@ import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
 
+enum InitialConnectionErrorClassifier {
+    static func isCredentialRejection(_ raw: String) -> Bool {
+        let lowercased = raw.lowercased()
+        if lowercased.contains("unauthorized") {
+            return true
+        }
+        // 401 必须是独立状态码；Keychain 的 -34018 等 OSStatus 不能被子串误判为鉴权失败。
+        return raw.range(
+            of: #"(^|\D)401(\D|$)"#,
+            options: .regularExpression
+        ) != nil
+    }
+}
+
 enum ConnectionQRCodeScanIntent: Equatable, Identifiable {
     case initialConnection
     case addConnectionProfile
@@ -959,7 +973,7 @@ struct InitialConnectionSettingsSections: View {
         if lowercased.contains("expired") || raw.contains("过期") {
             return L10n.text("ui.the_pairing_qr_code_has_expired_please_re")
         }
-        if lowercased.contains("unauthorized") || lowercased.contains("401") {
+        if InitialConnectionErrorClassifier.isCredentialRejection(raw) {
             return L10n.text("ui.this_device_has_not_been_verified_by_mac")
         }
         if lowercased.contains("timed out") || lowercased.contains("cannot connect") || raw.contains("无法连接") {

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -878,7 +878,12 @@ final class AppStore: ObservableObject {
             )
         }
 
-        var nextProfiles = connectionProfiles.filter { $0.id != targetProfile.id }
+        // 临时开发档案从未持久化凭据；切到其它档案时必须在同一次提交中淘汰，
+        // 否则稍后切回会把“只有内存 Token”的档案误写成可恢复的持久档案。
+        let previousEphemeralProfileID = ephemeralLocalProfileID
+        var nextProfiles = connectionProfiles.filter {
+            $0.id != targetProfile.id && $0.id != previousEphemeralProfileID
+        }
         nextProfiles.append(targetProfile)
         let encodedProfiles = try JSONEncoder().encode(nextProfiles)
         let didChange = normalizedEndpoint != endpoint ||
@@ -893,7 +898,7 @@ final class AppStore: ObservableObject {
         let credentialReceipt: HostCredentialWriteReceipt
         let usesEphemeralLocalCredential: Bool
         let isContinuingEphemeralCredential =
-            ephemeralLocalProfileID == targetProfile.id &&
+            previousEphemeralProfileID == targetProfile.id &&
             HostConnectionEndpointPolicy.isEligibleEphemeralCredentialEndpoint(normalizedEndpoint)
         if isContinuingEphemeralCredential {
             credentialReceipt = await credentialVault.rememberInMemory(prepared.token, for: targetProfile.id)
@@ -903,7 +908,7 @@ final class AppStore: ObservableObject {
                 credentialReceipt = try await credentialVault.save(
                     prepared.token,
                     for: targetProfile.id,
-                    forcePersistence: ephemeralLocalProfileID == targetProfile.id
+                    forcePersistence: previousEphemeralProfileID == targetProfile.id
                 )
                 usesEphemeralLocalCredential = false
             } catch {
@@ -948,6 +953,11 @@ final class AppStore: ObservableObject {
         token = prepared.token
         connectionProfiles = nextProfiles
         activeConnectionProfileID = targetProfile.id
+        if let previousEphemeralProfileID,
+           previousEphemeralProfileID != targetProfile.id {
+            // 旧临时档案没有 Keychain 项，只清理进程内 Token，避免 entitlement 错误扩大失败面。
+            await credentialVault.forgetMemory(profileID: previousEphemeralProfileID)
+        }
         connectionTermination = nil
         // 每次提交都开启新的连接代次。即使地址没变，旧异步结果也必须失效。
         connectionGeneration += 1

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -304,7 +304,7 @@ final class AppStore: ObservableObject {
         self.routeProbeTimeout = routeProbeTimeout
         self.prefersLocalConnection = prefersLocalConnection ?? Self.isRunningOnMacCatalyst
         self.allowsEphemeralLocalCredentialFallback =
-            allowsEphemeralLocalCredentialFallback ?? Self.isRunningOnMacCatalyst
+            allowsEphemeralLocalCredentialFallback ?? Self.allowsDevelopmentEphemeralCredentialFallback
         self.localAgentProbe = localAgentProbe ?? Self.defaultLocalAgentProbe
         self.localAgentPairingClaim = localAgentPairingClaim ?? Self.defaultLocalAgentPairingClaim
         self.routeProbe = routeProbe ?? Self.defaultConnectionRouteProbe
@@ -563,8 +563,8 @@ final class AppStore: ObservableObject {
     /// Profile 元数据仍在，回前台只恢复当前 Profile，不会触碰其它 Mac。
     func suspendCredentialsForBackground() {
         if activeConnectionProfileID == ephemeralLocalProfileID {
-            // macOS 本地 Debug 包没有可恢复的 Keychain 项；桌面端后台保留同机短期凭据，
-            // 进程退出后自然清空，下一次启动重新向 loopback agentd 领取。
+            // 开发包没有可恢复的 Keychain 项；后台保留本进程短期凭据，
+            // 进程退出后自然清空，下一次启动必须重新向 agentd 领取。
             return
         }
         credentialLifecycleGeneration &+= 1
@@ -886,14 +886,14 @@ final class AppStore: ObservableObject {
             targetProfile.hostPlatform != activeConnectionProfile?.hostPlatform
 
         // Token 优先按档案经 Vault actor 写入 Keychain；MainActor 不执行安全框架 I/O。
-        // 未签入 provisioning profile 的 Catalyst 本机 Debug 包只在 loopback + -34018 时使用进程内凭据。
+        // 未签入 provisioning profile 的开发包只在受限私网 + -34018 时使用进程内凭据。
         let credentialLifecycle = credentialLifecycleGeneration
         let credentialReceipt: HostCredentialWriteReceipt
         let usesEphemeralLocalCredential: Bool
-        let isContinuingEphemeralLoopback =
+        let isContinuingEphemeralCredential =
             ephemeralLocalProfileID == targetProfile.id &&
-            Self.isLoopbackEndpoint(normalizedEndpoint)
-        if isContinuingEphemeralLoopback {
+            Self.isEligibleEphemeralCredentialEndpoint(normalizedEndpoint)
+        if isContinuingEphemeralCredential {
             credentialReceipt = await credentialVault.rememberInMemory(prepared.token, for: targetProfile.id)
             usesEphemeralLocalCredential = true
         } else {
@@ -907,13 +907,13 @@ final class AppStore: ObservableObject {
             } catch {
                 let canUseEphemeralLocalCredential =
                     allowsEphemeralLocalCredentialFallback &&
-                    Self.isLoopbackEndpoint(normalizedEndpoint) &&
+                    Self.isEligibleEphemeralCredentialEndpoint(normalizedEndpoint) &&
                     (error as? TokenStoreError)?.isMissingEntitlement == true
                 guard canUseEphemeralLocalCredential else {
                     throw error
                 }
-                // 仅降级同机 loopback，且只接受明确的 Keychain entitlement 缺失。
-                // Token 不进入 UserDefaults；进程退出后由下一次本机自动配对重新领取。
+                // Catalyst 仅允许同机 loopback；Debug Simulator 允许用于本地验收的私网 HTTP。
+                // Token 不进入 UserDefaults，进程退出即失效；Release / TestFlight 不启用此降级。
                 credentialReceipt = await credentialVault.rememberInMemory(
                     prepared.token,
                     for: targetProfile.id
@@ -995,7 +995,7 @@ final class AppStore: ObservableObject {
     }
 
     func clearPairing() async throws {
-        // 持久化凭据必须先完成 Keychain 删除；临时 loopback 凭据只需清理进程内缓存。
+        // 持久化凭据必须先完成 Keychain 删除；临时开发凭据只需清理进程内缓存。
         // 否则系统暂时禁止 Keychain 访问时，下一次启动会变成“旧 Token + 默认 Endpoint”的半提交状态。
         let nextProfiles: [ConnectionProfile]
         if let activeConnectionProfileID {
@@ -1062,7 +1062,7 @@ final class AppStore: ObservableObject {
     }
 
     /// 只修改非敏感显示名称，不进入连接切换事务，也不读取或写入 Keychain。
-    /// 临时 loopback 档案保持进程内；其它档案先完成编码再发布，避免出现半提交名称。
+    /// 临时开发档案保持进程内；其它档案先完成编码再发布，避免出现半提交名称。
     @discardableResult
     func renameConnectionProfile(id: String, displayName rawDisplayName: String) throws -> Bool {
         guard let profileIndex = connectionProfiles.firstIndex(where: { $0.id == id }) else {
@@ -1946,6 +1946,31 @@ final class AppStore: ObservableObject {
         true
 #else
         false
+#endif
+    }
+
+    /// Catalyst 未签名开发包维持既有 loopback 降级；Simulator 仅在 Debug 构建启用，
+    /// 确保 TestFlight / App Store 包始终要求可用的系统 Keychain。
+    private static var allowsDevelopmentEphemeralCredentialFallback: Bool {
+#if targetEnvironment(macCatalyst)
+        true
+#elseif DEBUG && targetEnvironment(simulator)
+        true
+#else
+        false
+#endif
+    }
+
+    private static func isEligibleEphemeralCredentialEndpoint(_ endpoint: String) -> Bool {
+        if isLoopbackEndpoint(endpoint) {
+            return true
+        }
+#if DEBUG && targetEnvironment(simulator)
+        // Simulator 无法直接访问宿主机 loopback；只放行传输策略已经确认的私网 HTTP，
+        // 公网 HTTPS 即使 Keychain 缺 entitlement 也必须失败，避免扩大凭据驻留范围。
+        return EndpointTransportPolicy.assess(endpoint).status == .allowedPrivateHTTP
+#else
+        return false
 #endif
     }
 

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -302,9 +302,11 @@ final class AppStore: ObservableObject {
         self.tokenStore = tokenStore
         credentialVault = HostCredentialVault(tokenStore: tokenStore)
         self.routeProbeTimeout = routeProbeTimeout
-        self.prefersLocalConnection = prefersLocalConnection ?? Self.isRunningOnMacCatalyst
+        self.prefersLocalConnection =
+            prefersLocalConnection ?? HostConnectionEndpointPolicy.prefersLocalConnectionByDefault
         self.allowsEphemeralLocalCredentialFallback =
-            allowsEphemeralLocalCredentialFallback ?? Self.allowsDevelopmentEphemeralCredentialFallback
+            allowsEphemeralLocalCredentialFallback ??
+                HostConnectionEndpointPolicy.allowsDevelopmentEphemeralCredentialFallback
         self.localAgentProbe = localAgentProbe ?? Self.defaultLocalAgentProbe
         self.localAgentPairingClaim = localAgentPairingClaim ?? Self.defaultLocalAgentPairingClaim
         self.routeProbe = routeProbe ?? Self.defaultConnectionRouteProbe
@@ -892,7 +894,7 @@ final class AppStore: ObservableObject {
         let usesEphemeralLocalCredential: Bool
         let isContinuingEphemeralCredential =
             ephemeralLocalProfileID == targetProfile.id &&
-            Self.isEligibleEphemeralCredentialEndpoint(normalizedEndpoint)
+            HostConnectionEndpointPolicy.isEligibleEphemeralCredentialEndpoint(normalizedEndpoint)
         if isContinuingEphemeralCredential {
             credentialReceipt = await credentialVault.rememberInMemory(prepared.token, for: targetProfile.id)
             usesEphemeralLocalCredential = true
@@ -907,7 +909,7 @@ final class AppStore: ObservableObject {
             } catch {
                 let canUseEphemeralLocalCredential =
                     allowsEphemeralLocalCredentialFallback &&
-                    Self.isEligibleEphemeralCredentialEndpoint(normalizedEndpoint) &&
+                    HostConnectionEndpointPolicy.isEligibleEphemeralCredentialEndpoint(normalizedEndpoint) &&
                     (error as? TokenStoreError)?.isMissingEntitlement == true
                 guard canUseEphemeralLocalCredential else {
                     throw error
@@ -1375,7 +1377,8 @@ final class AppStore: ObservableObject {
                 timeout: min(routeProbeTimeout, 1.5)
             ))
         }
-        let configuredRoute: ActiveConnectionRoute = Self.isLoopbackEndpoint(normalizedEndpoint) ? .local : .configured
+        let configuredRoute: ActiveConnectionRoute =
+            HostConnectionEndpointPolicy.isLoopbackEndpoint(normalizedEndpoint) ? .local : .configured
         candidates.append((endpoint: normalizedEndpoint, route: configuredRoute, timeout: routeProbeTimeout))
 
         var configuredRouteError: Error?
@@ -1939,46 +1942,6 @@ final class AppStore: ObservableObject {
         connectionTermination = nil
         connectionStatus = .connected(ActiveConnectionRoute.local.statusTitle)
         lastError = nil
-    }
-
-    private static var isRunningOnMacCatalyst: Bool {
-#if targetEnvironment(macCatalyst)
-        true
-#else
-        false
-#endif
-    }
-
-    /// Catalyst 未签名开发包维持既有 loopback 降级；Simulator 仅在 Debug 构建启用，
-    /// 确保 TestFlight / App Store 包始终要求可用的系统 Keychain。
-    private static var allowsDevelopmentEphemeralCredentialFallback: Bool {
-#if targetEnvironment(macCatalyst)
-        true
-#elseif DEBUG && targetEnvironment(simulator)
-        true
-#else
-        false
-#endif
-    }
-
-    private static func isEligibleEphemeralCredentialEndpoint(_ endpoint: String) -> Bool {
-        if isLoopbackEndpoint(endpoint) {
-            return true
-        }
-#if DEBUG && targetEnvironment(simulator)
-        // Simulator 无法直接访问宿主机 loopback；只放行传输策略已经确认的私网 HTTP，
-        // 公网 HTTPS 即使 Keychain 缺 entitlement 也必须失败，避免扩大凭据驻留范围。
-        return EndpointTransportPolicy.assess(endpoint).status == .allowedPrivateHTTP
-#else
-        return false
-#endif
-    }
-
-    private static func isLoopbackEndpoint(_ endpoint: String) -> Bool {
-        guard let host = URLComponents(string: endpoint)?.host?.lowercased() else {
-            return false
-        }
-        return host == "localhost" || host == "127.0.0.1" || host == "::1"
     }
 
     private func activateConnectionRoute(_ route: ActiveConnectionRoute, endpoint: String) {

--- a/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
+++ b/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
@@ -48,7 +48,7 @@ actor HostCredentialVault {
         if !forcePersistence, let cached = memoryTokens[profileID] {
             previousToken = cached
         } else {
-            // 临时 loopback 档案转为远端连接时必须重新读取 Keychain，
+            // 临时开发档案转为持久连接时必须重新读取 Keychain，
             // 不能把仅存在于内存的 Token 误判为已经持久化。
             previousToken = try tokenStore.load(profileID: profileID)
         }
@@ -61,8 +61,8 @@ actor HostCredentialVault {
         return previousToken.isEmpty ? .inserted : .replaced(previousToken: previousToken)
     }
 
-    /// 未签入 Catalyst provisioning profile 的本地 Debug 包无法访问数据保护 Keychain。
-    /// loopback 自动配对可以安全地只保留进程内凭据，重启后再向同机 agentd 领取。
+    /// 未签入 provisioning profile 的 Catalyst / Simulator Debug 包可能无法访问 Keychain。
+    /// 受限本地验收连接只保留进程内凭据，重启后必须重新向 agentd 领取。
     func rememberInMemory(_ token: String, for profileID: String) -> HostCredentialWriteReceipt {
         guard let previousToken = memoryTokens.updateValue(token, forKey: profileID) else {
             return .inserted

--- a/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
+++ b/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
@@ -15,6 +15,48 @@ enum HostCredentialWriteReceipt: Sendable {
     case replaced(previousToken: String)
 }
 
+enum HostConnectionEndpointPolicy {
+    static var prefersLocalConnectionByDefault: Bool {
+#if targetEnvironment(macCatalyst)
+        true
+#else
+        false
+#endif
+    }
+
+    /// Catalyst 未签名开发包维持既有 loopback 降级；Simulator 仅在 Debug 构建启用，
+    /// 确保 TestFlight / App Store 包始终要求可用的系统 Keychain。
+    static var allowsDevelopmentEphemeralCredentialFallback: Bool {
+#if targetEnvironment(macCatalyst)
+        true
+#elseif DEBUG && targetEnvironment(simulator)
+        true
+#else
+        false
+#endif
+    }
+
+    static func isEligibleEphemeralCredentialEndpoint(_ endpoint: String) -> Bool {
+        if isLoopbackEndpoint(endpoint) {
+            return true
+        }
+#if DEBUG && targetEnvironment(simulator)
+        // Simulator 无法直接访问宿主机 loopback；只放行传输策略已经确认的私网 HTTP，
+        // 公网 HTTPS 即使 Keychain 缺 entitlement 也必须失败，避免扩大凭据驻留范围。
+        return EndpointTransportPolicy.assess(endpoint).status == .allowedPrivateHTTP
+#else
+        return false
+#endif
+    }
+
+    static func isLoopbackEndpoint(_ endpoint: String) -> Bool {
+        guard let host = URLComponents(string: endpoint)?.host?.lowercased() else {
+            return false
+        }
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
+    }
+}
+
 /// Keychain 访问串行化到独立 actor。主线程只提交/接收短字符串，不直接参与非当前主机探活的读取。
 actor HostCredentialVault {
     private let tokenStore: TokenStore

--- a/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
@@ -240,6 +240,98 @@ final class PairingLinkTests: XCTestCase {
         XCTAssertNil(defaults.string(forKey: "agentd.endpoint"))
     }
 
+    func testSwitchingFromEphemeralProfileRemovesItsMetadataAndMemoryCredential() async throws {
+        let suiteName = "PairingLinkTests.EphemeralSwitchCleanup.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let keychain = TestKeychainOperations(forcedCopyStatus: errSecMissingEntitlement)
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: keychain),
+            allowsEphemeralLocalCredentialFallback: true
+        )
+
+        _ = try await store.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "http://192.168.1.20:8787",
+            token: "ephemeral-token"
+        ))
+        let ephemeralProfileID = try XCTUnwrap(store.activeConnectionProfileID)
+
+        keychain.forcedCopyStatus = nil
+        _ = try await store.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "https://agent.example.com",
+            token: "persistent-token",
+            profileTarget: .newProfile(id: "mac-b", displayName: "远程 Mac")
+        ))
+
+        XCTAssertEqual(store.connectionProfiles.map(\.id), ["mac-b"])
+        let persistedData = try XCTUnwrap(defaults.data(forKey: "agentd.connectionProfiles.v2"))
+        XCTAssertEqual(try JSONDecoder().decode([ConnectionProfile].self, from: persistedData).map(\.id), ["mac-b"])
+        XCTAssertNil(keychain.data(account: "agentd-profile.\(ephemeralProfileID)"))
+        await XCTAssertThrowsErrorAsync(try await store.prepareConnectionProfileSwitch(id: ephemeralProfileID)) { error in
+            XCTAssertEqual(error as? ConnectionProfileError, .notFound)
+        }
+
+        let relaunchedStore = AppStore(defaults: defaults, tokenStore: TokenStore(keychain: keychain))
+        XCTAssertEqual(relaunchedStore.connectionProfiles.map(\.id), ["mac-b"])
+        XCTAssertEqual(relaunchedStore.activeConnectionProfileID, "mac-b")
+        XCTAssertEqual(relaunchedStore.token, "persistent-token")
+
+        // 复用同一个 ID 时必须重新写入 Keychain；若旧内存 Token 未清理，Vault 会误判 unchanged。
+        _ = try await store.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "https://replacement.example.com",
+            token: "ephemeral-token",
+            profileTarget: .newProfile(id: ephemeralProfileID, displayName: "重新添加")
+        ))
+        XCTAssertEqual(
+            keychain.data(account: "agentd-profile.\(ephemeralProfileID)"),
+            Data("ephemeral-token".utf8)
+        )
+    }
+
+    func testEphemeralProfilePersistsOnlyAfterKeychainRecovers() async throws {
+        let suiteName = "PairingLinkTests.EphemeralPersistenceTransition.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let keychain = TestKeychainOperations(forcedCopyStatus: errSecMissingEntitlement)
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: keychain),
+            allowsEphemeralLocalCredentialFallback: true
+        )
+
+        _ = try await store.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "http://192.168.1.20:8787",
+            token: "ephemeral-token"
+        ))
+        let profileID = try XCTUnwrap(store.activeConnectionProfileID)
+
+        await XCTAssertThrowsErrorAsync(try await store.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "https://agent.example.com",
+            token: "ephemeral-token",
+            profileTarget: .existingProfile(id: profileID)
+        ))) { error in
+            XCTAssertTrue((error as? TokenStoreError)?.isMissingEntitlement == true)
+        }
+        XCTAssertEqual(store.activeConnectionProfile?.endpoint, "http://192.168.1.20:8787")
+        XCTAssertEqual(store.token, "ephemeral-token")
+        XCTAssertNil(defaults.data(forKey: "agentd.connectionProfiles.v2"))
+
+        keychain.forcedCopyStatus = nil
+        _ = try await store.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "https://agent.example.com",
+            token: "ephemeral-token",
+            profileTarget: .existingProfile(id: profileID)
+        ))
+
+        XCTAssertEqual(store.activeConnectionProfile?.endpoint, "https://agent.example.com")
+        XCTAssertEqual(keychain.data(account: "agentd-profile.\(profileID)"), Data("ephemeral-token".utf8))
+        let persistedData = try XCTUnwrap(defaults.data(forKey: "agentd.connectionProfiles.v2"))
+        XCTAssertEqual(try JSONDecoder().decode([ConnectionProfile].self, from: persistedData).map(\.id), [profileID])
+    }
+
     func testMissingKeychainEntitlementNeverFallsBackForPublicEndpoint() async throws {
         let suiteName = "PairingLinkTests.RemoteCredential.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
@@ -215,7 +215,32 @@ final class PairingLinkTests: XCTestCase {
         XCTAssertTrue(try JSONDecoder().decode([ConnectionProfile].self, from: persistedProfiles).isEmpty)
     }
 
-    func testMissingKeychainEntitlementNeverFallsBackForRemoteEndpoint() async throws {
+    func testPrivateSimulatorConnectionUsesMemoryWhenKeychainEntitlementIsMissing() async throws {
+        let suiteName = "PairingLinkTests.EphemeralSimulatorCredential.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let keychain = TestKeychainOperations(forcedCopyStatus: errSecMissingEntitlement)
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: keychain),
+            allowsEphemeralLocalCredentialFallback: true
+        )
+
+        _ = try await store.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "http://192.168.1.20:8787",
+            token: "simulator-token"
+        ))
+
+        XCTAssertTrue(store.isConfigured)
+        XCTAssertEqual(store.token, "simulator-token")
+        XCTAssertEqual(store.activeConnectionProfile?.endpoint, "http://192.168.1.20:8787")
+        XCTAssertNil(defaults.data(forKey: "agentd.connectionProfiles.v2"))
+        XCTAssertNil(defaults.string(forKey: "agentd.activeConnectionProfileID.v1"))
+        XCTAssertNil(defaults.string(forKey: "agentd.endpoint"))
+    }
+
+    func testMissingKeychainEntitlementNeverFallsBackForPublicEndpoint() async throws {
         let suiteName = "PairingLinkTests.RemoteCredential.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
@@ -229,16 +254,23 @@ final class PairingLinkTests: XCTestCase {
 
         do {
             _ = try await store.commitConnectionSettings(PreparedConnectionSettings(
-                endpoint: "http://192.168.1.20:8787",
+                endpoint: "https://agent.example.com",
                 token: "remote-token"
             ))
-            XCTFail("远端地址不得降级为进程内凭据")
+            XCTFail("公网地址不得降级为进程内凭据")
         } catch let error as TokenStoreError {
             XCTAssertTrue(error.isMissingEntitlement)
         }
 
         XCTAssertFalse(store.isConfigured)
         XCTAssertTrue(store.connectionProfiles.isEmpty)
+    }
+
+    func testInitialConnectionErrorClassifierRequiresStandaloneHTTP401() {
+        XCTAssertTrue(InitialConnectionErrorClassifier.isCredentialRejection("HTTP 401 Unauthorized"))
+        XCTAssertTrue(InitialConnectionErrorClassifier.isCredentialRejection("unauthorized"))
+        XCTAssertFalse(InitialConnectionErrorClassifier.isCredentialRejection("OSStatus -34018"))
+        XCTAssertFalse(InitialConnectionErrorClassifier.isCredentialRejection("request 14018 failed"))
     }
 
     func testLegacySingleConnectionMigratesWithoutWritingTokenToDefaults() throws {


### PR DESCRIPTION
## 变更

- 在 Debug Simulator 遇到明确的 Keychain entitlement 缺失时，只对私网 HTTP 连接使用进程内临时凭据。
- Release / TestFlight 仍强制使用系统 Keychain；公网 HTTPS 不允许降级。
- 将 `401` 判断收紧为独立 HTTP 状态码，避免把 Keychain `OSStatus -34018` 误报成“设备未验证”。
- 补充私网降级、公网拒绝和错误分类回归测试。

## 原因与影响

Xcode 27 beta 下的 ad-hoc Simulator 包没有 `application-identifier` / `keychain-access-groups` entitlement，配对凭据写入 Keychain 会返回 `-34018`。原错误提示又把其中的 `401` 子串误判为 HTTP 401，导致干净安装后的本地验收无法进入工作台。

该修复只改善本地 Debug Simulator 的发布前验证链路，不改变 TestFlight / App Store 的凭据安全边界。

## 验证

- `PairingLinkTests`：85 passed，0 failed。
- 失败 selector `testApprovalDecisionSendsThroughCurrentWebSocket` 隔离重跑：1 passed；组合回归中仍有现有顺序/运行器波动，PR 保持 Draft。
- iPad M5 Simulator 干净卸载、重新安装、扫码配对、会话列表、创建会话、消息回复端到端通过。
- 最新 main iOS 客户端连接 GitHub Release / Homebrew `agentd 0.2.10` 通过。
- `bash ./scripts/check-critical-regressions.sh` 通过。
- `bash ./scripts/check-packaging.sh` 通过。
- `go test ./... -count=1` 通过。
- Claude bridge `cargo fmt --all -- --check` 与 workspace tests 通过。

## 发布结论

- TestFlight `1.1 (100069)` 当前仅内部测试，外部状态为 `READY_FOR_BETA_SUBMISSION`，尚未提交 Beta App Review。
- 最新 main 已包含晚于 `v0.2.10` 的后端变更，需生成新后端 Release 后再推进外部公测。
- `v0.2.10` DMG 已通过签名、公证和 checksum 校验，但本机首次启动内置 SMAppService 未拉起；Homebrew 安装链路正常。

Linear: MIM-76
