### PR TITLE
MIM-74 修复验收测试的认证夹具

### DIFF
--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -1852,8 +1852,24 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
-        appStore.token = "test-token"
+        let suiteName = "ConversationDataFlowTests.EmptyOptimistic.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let profile = ConnectionProfile(
+            id: "empty-optimistic",
+            displayName: "Empty Optimistic",
+            endpoint: "http://127.0.0.1:8787",
+            lastSuccessfulAt: nil
+        )
+        defaults.set(try JSONEncoder().encode([profile]), forKey: "agentd.connectionProfiles.v1")
+        defaults.set(profile.id, forKey: "agentd.activeConnectionProfileID.v1")
+        defaults.set(profile.endpoint, forKey: "agentd.endpoint")
+        let keychain = TestKeychainOperations()
+        keychain.setData(Data("test-token".utf8), account: "agentd-profile.\(profile.id)")
+        // 生产代码要求连接档案与 Keychain 凭据同时存在；测试夹具也必须建立同一认证状态。
+        let appStore = AppStore(defaults: defaults, tokenStore: TokenStore(keychain: keychain))
+        XCTAssertNotNil(appStore.authenticatedCredentialFingerprint)
         let store = SessionStore(
             appStore: appStore,
             conversationStore: conversationStore,


### PR DESCRIPTION
## 目标

修复 MIM-74 合并后独立验收中暴露的过期测试夹具，不修改生产逻辑或认证保护。

## 修改

- 使用独立 UserDefaults suite 建立连接档案、active profile 与 endpoint
- 使用测试 Keychain 保存 profile 对应 token
- 通过 AppStore 正常初始化路径恢复 authenticatedCredentialFingerprint
- 保留 SessionStore、认证 guard 与 MIM-74 生产实现不变

## 验证

- 原失败用例连续运行 2 次：2/2 通过
- MIM-74 相关验收矩阵：11/11 通过
- git diff --check：通过
- ChatGPT Pro 最终验收：GO，0 blocker/high/medium/low
  https://chatgpt.com/c/6a6db882-f448-83ea-9d22-4992a066c9a0

## 边界

真实工作区加载仍出现 Swift.CancellationError，将独立归档；该问题不属于 MIM-74 的会话控制权和历史状态机。