### PR TITLE
MIM-79 修复工作区取消后永久加载与错误泄露

### DIFF
--- a/ios/MimiRemote/Sources/Core/API/AgentAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/AgentAPIClient.swift
@@ -19,6 +19,18 @@ func credentialFingerprintRejectedByError(_ error: Error) -> String? {
     (error as? any CredentialInvalidatingError)?.rejectedCredentialFingerprint
 }
 
+/// 只识别传输层明确表达的取消；超时、断网和 HTTP 错误仍是需要用户处理的真实失败。
+func isCancellationError(_ error: Error) -> Bool {
+    if error is CancellationError {
+        return true
+    }
+    if let urlError = error as? URLError {
+        return urlError.code == .cancelled
+    }
+    let cocoaError = error as NSError
+    return cocoaError.domain == NSURLErrorDomain && cocoaError.code == NSURLErrorCancelled
+}
+
 /// 只比较不可逆摘要，既能淘汰旧请求，又不会把长期访问码带进错误、日志或诊断状态。
 func connectionCredentialFingerprint(_ token: String) -> String {
     SHA256.hash(data: Data(token.utf8))

--- a/ios/MimiRemote/Sources/Features/Projects/ProjectSidebarView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/ProjectSidebarView.swift
@@ -787,6 +787,10 @@ struct OpenWorkspaceSheet: View {
             guard requestID == browseRequestID else {
                 return
             }
+            guard !Task.isCancelled else {
+                isBrowsing = false
+                return
+            }
             browsePath = response.path
             browseParentPath = response.parentPath
             browseEntries = response.entries
@@ -797,8 +801,11 @@ struct OpenWorkspaceSheet: View {
             guard requestID == browseRequestID else {
                 return
             }
-            browseError = userFacingBrowseError(error)
             isBrowsing = false
+            guard !isCancellationError(error) else {
+                return
+            }
+            browseError = userFacingBrowseError(error)
         }
     }
 
@@ -827,6 +834,9 @@ struct OpenWorkspaceSheet: View {
         do {
             previewURL = try await sessionStore.previewFile(path: targetPath)
         } catch {
+            guard !isCancellationError(error) else {
+                return
+            }
             previewError = userFacingPreviewError(error)
         }
     }
@@ -853,13 +863,15 @@ struct OpenWorkspaceSheet: View {
         isOpening = true
         localError = nil
         defer { isOpening = false }
-        if await sessionStore.openWorkspace(path: targetPath) {
-            if let openedWorkspaceID = sessionStore.selectedProjectID {
-                onOpened(openedWorkspaceID)
-            }
+        switch await sessionStore.openWorkspaceOutcome(path: targetPath) {
+        case .opened(let workspaceID):
+            onOpened(workspaceID)
             dismiss()
-        } else {
-            localError = userFacingOpenWorkspaceError(sessionStore.errorMessage, path: targetPath)
+        case .cancelled:
+            // 关闭 Sheet、切主机或后台凭据挂起都属于生命周期取消；保留输入供用户恢复后重试。
+            return
+        case .failed(let message):
+            localError = userFacingOpenWorkspaceError(message, path: targetPath)
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -159,6 +159,16 @@ enum WorkspaceCatalogLoadResult: Equatable {
     case failed(String)
 }
 
+enum WorkspaceSessionLoadFailureDisposition: Equatable {
+    case cancelled
+    case failed(String)
+}
+
+/// Session 首屏和 catalog/open 使用同一套明确取消分类，避免 URL transport 取消落入用户错误态。
+func workspaceSessionLoadFailureDisposition(_ error: Error) -> WorkspaceSessionLoadFailureDisposition {
+    isCancellationError(error) ? .cancelled : .failed(error.localizedDescription)
+}
+
 struct WorkspaceCatalogRefreshScope: Equatable {
     let hostScope: HostScope
     let credentialsSuspended: Bool
@@ -771,16 +781,16 @@ struct WorkspaceRootView: View {
                 return
             }
             sessionLoadStates[projectID] = .loaded
-        } catch is CancellationError {
-            guard sessionLoadInvocationTokens.isCurrent(invocationID, for: projectID) else {
-                return
-            }
-            sessionLoadStates[projectID] = fallbackSessionLoadState(for: projectID)
         } catch {
             guard sessionLoadInvocationTokens.isCurrent(invocationID, for: projectID) else {
                 return
             }
-            sessionLoadStates[projectID] = .failed(error.localizedDescription)
+            switch workspaceSessionLoadFailureDisposition(error) {
+            case .cancelled:
+                sessionLoadStates[projectID] = fallbackSessionLoadState(for: projectID)
+            case .failed(let message):
+                sessionLoadStates[projectID] = .failed(message)
+            }
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -146,6 +146,62 @@ struct WorkspaceSessionLoadInvocationTokens {
     }
 }
 
+enum WorkspaceCatalogLoadState: Equatable {
+    case idle
+    case loading
+    case loaded
+    case failed(String)
+}
+
+enum WorkspaceCatalogLoadResult: Equatable {
+    case loaded
+    case cancelled
+    case failed(String)
+}
+
+struct WorkspaceCatalogRefreshScope: Equatable {
+    let hostScope: HostScope
+    let credentialsSuspended: Bool
+}
+
+/// Catalog 没有底层 single-flight；这里只隔离 View 调用的提交权，避免旧请求回写或把取消留成永久 loading。
+struct WorkspaceCatalogLoadCoordinator {
+    private(set) var state: WorkspaceCatalogLoadState = .idle
+    private var currentInvocationID: UUID?
+
+    @discardableResult
+    mutating func begin() -> UUID {
+        let invocationID = UUID()
+        currentInvocationID = invocationID
+        state = .loading
+        return invocationID
+    }
+
+    func isCurrent(_ invocationID: UUID) -> Bool {
+        currentInvocationID == invocationID
+    }
+
+    @discardableResult
+    mutating func complete(
+        _ invocationID: UUID,
+        result: WorkspaceCatalogLoadResult,
+        hasCachedProjects: Bool
+    ) -> Bool {
+        guard isCurrent(invocationID) else {
+            return false
+        }
+        switch result {
+        case .loaded:
+            state = .loaded
+        case .cancelled:
+            state = hasCachedProjects ? .loaded : .idle
+        case .failed(let message):
+            state = .failed(message)
+        }
+        return true
+    }
+}
+
 private struct WorkspaceGitInspectionTarget: Identifiable {
     let id: String
     let name: String
@@ -172,7 +228,7 @@ struct WorkspaceRootView: View {
     private let currentDate: () -> Date
 
     @State private var selectedWorkspaceID: String?
-    @State private var catalogState: CatalogState = .idle
+    @State private var catalogLoad = WorkspaceCatalogLoadCoordinator()
     @State private var sessionLoadStates: [String: WorkspaceSessionLoadState] = [:]
     @State private var sessionLoadInvocationTokens = WorkspaceSessionLoadInvocationTokens()
     @State private var isPresentingOpenWorkspace = false
@@ -202,6 +258,10 @@ struct WorkspaceRootView: View {
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
+        let catalogRefreshScope = WorkspaceCatalogRefreshScope(
+            hostScope: appStore.activeHostScope,
+            credentialsSuspended: appStore.isCredentialMemorySuspended
+        )
 
         Group {
             if embedsNavigationStack {
@@ -214,7 +274,11 @@ struct WorkspaceRootView: View {
                 navigationContent(tokens: tokens)
             }
         }
-        .task(id: appStore.activeHostScope) {
+        .task(id: catalogRefreshScope) {
+            // 后台会主动清空内存凭据；恢复完成发布 false 后，完整 scope 会确定性触发一次新刷新。
+            guard !catalogRefreshScope.credentialsSuspended else {
+                return
+            }
             migrateLegacyWorkspaceAppearance()
             synchronizeSelection()
             // 每次进入工作区都做轻量目录同步，同时执行旧版自动候选数据清理；
@@ -247,9 +311,6 @@ struct WorkspaceRootView: View {
         }
         .onChange(of: sessionStore.sidebarProjects.map(\.id)) { _, _ in
             synchronizeSelection()
-            if !sessionStore.sidebarProjects.isEmpty {
-                catalogState = .loaded
-            }
         }
         .sheet(isPresented: $isPresentingOpenWorkspace) {
             OpenWorkspaceSheet { workspaceID in
@@ -320,7 +381,7 @@ struct WorkspaceRootView: View {
     @ViewBuilder
     private func workspaceBrowser(tokens: ThemeTokens) -> some View {
         if sessionStore.sidebarProjects.isEmpty {
-            if catalogState == .loading {
+            if catalogLoad.state == .loading {
                 workspaceLoadingState(tokens: tokens)
             } else {
                 workspaceEmptyState(tokens: tokens)
@@ -366,7 +427,7 @@ struct WorkspaceRootView: View {
 
     private func workspaceEmptyState(tokens: ThemeTokens) -> some View {
         let isFailure: Bool
-        if case .failed = catalogState {
+        if case .failed = catalogLoad.state {
             isFailure = true
         } else {
             isFailure = false
@@ -443,7 +504,7 @@ struct WorkspaceRootView: View {
             GeometryReader { geometry in
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(spacing: 12) {
-                        if catalogState == .loading && sessionStore.sidebarProjects.isEmpty {
+                        if catalogLoad.state == .loading && sessionStore.sidebarProjects.isEmpty {
                             ForEach(0..<4, id: \.self) { index in
                                 WorkspaceLibraryCard(
                                     project: AgentProject(id: "loading-\(index)", name: L10n.text("ui.loading_workspace"), path: "/Users/you/code/project"),
@@ -608,17 +669,17 @@ struct WorkspaceRootView: View {
     }
 
     private var emptyWorkspaceTitle: String {
-        if case .failed = catalogState { return L10n.text("ui.unable_to_load_workspace") }
+        if case .failed = catalogLoad.state { return L10n.text("ui.unable_to_load_workspace") }
         return L10n.text("ui.no_workspace_yet")
     }
 
     private var emptyWorkspaceSymbol: String {
-        if case .failed = catalogState { return "exclamationmark.triangle" }
+        if case .failed = catalogLoad.state { return "exclamationmark.triangle" }
         return "folder.badge.plus"
     }
 
     private var emptyWorkspaceMessage: String {
-        if case .failed(let message) = catalogState { return message }
+        if case .failed(let message) = catalogLoad.state { return message }
         return L10n.text("ui.once_the_directory_is_open_you_can_browse")
     }
 
@@ -652,21 +713,35 @@ struct WorkspaceRootView: View {
     }
 
     private func refreshCatalog(forceGitSummary: Bool = false) async {
-        catalogState = .loading
+        let invocationID = catalogLoad.begin()
         do {
             try await sessionStore.refreshWorkspaceCatalog()
-            guard !Task.isCancelled else {
+            guard catalogLoad.isCurrent(invocationID) else {
                 return
             }
-            catalogState = .loaded
+            guard !Task.isCancelled else {
+                catalogLoad.complete(
+                    invocationID,
+                    result: .cancelled,
+                    hasCachedProjects: !sessionStore.sidebarProjects.isEmpty
+                )
+                return
+            }
+            catalogLoad.complete(
+                invocationID,
+                result: .loaded,
+                hasCachedProjects: !sessionStore.sidebarProjects.isEmpty
+            )
             await sessionStore.refreshWorkspaceGitSummaries(
                 for: sessionStore.sidebarProjects,
                 force: forceGitSummary
             )
-        } catch is CancellationError {
-            return
         } catch {
-            catalogState = .failed(error.localizedDescription)
+            catalogLoad.complete(
+                invocationID,
+                result: isCancellationError(error) ? .cancelled : .failed(error.localizedDescription),
+                hasCachedProjects: !sessionStore.sidebarProjects.isEmpty
+            )
         }
     }
 
@@ -717,12 +792,6 @@ struct WorkspaceRootView: View {
         sessionStore.sessions(forProjectID: projectID).isEmpty ? .idle : .loaded
     }
 
-    private enum CatalogState: Equatable {
-        case idle
-        case loading
-        case loaded
-        case failed(String)
-    }
 }
 
 private enum WorkspaceSessionLoadState: Equatable {

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -1916,6 +1916,11 @@ extension SessionStore {
         error: Error,
         reportForeground: Bool = true
     ) async {
+        // 页面生命周期、凭据后台挂起和旧 host waiter 的取消都不是工作区故障；
+        // 这里必须先静默收口，不能二次 resolve 后把 Swift.CancellationError 写入全局错误。
+        guard !isCancellationError(error) else {
+            return
+        }
         if terminateConnectionIfCredentialsInvalid(error) {
             return
         }

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+enum WorkspaceOpenOutcome: Equatable {
+    /// 工作区选择已经提交；会话首屏由 WorkspaceRoot 的独立加载生命周期继续补齐。
+    case opened(workspaceID: String)
+    case cancelled
+    case failed(String)
+
+    var didOpen: Bool {
+        if case .opened = self {
+            return true
+        }
+        return false
+    }
+}
+
 // 启动恢复、项目选择与 Worktree 生命周期从稳定外观 API 中拆出。
 extension SessionStore {
     func bootstrap() async {
@@ -622,7 +636,13 @@ extension SessionStore {
     /// 只刷新工作区目录，不改变当前会话选择，也不重建 WebSocket。
     /// 工作区页浏览和手动刷新必须与会话运行态隔离，避免用户查看目录时打断长任务。
     func refreshWorkspaceCatalog() async throws {
-        let fetchedProjects = try await clientFactory().projects()
+        let hostScope = appStore.activeHostScope
+        let client = try clientFactory()
+        let fetchedProjects = try await client.projects()
+        // projects 属于远端主机数据；旧 host 或已取消的 View 任务不得在 await 后写入当前 Store。
+        guard !Task.isCancelled, appStore.activeHostScope == hostScope else {
+            throw CancellationError()
+        }
         setProjectsIfChanged(fetchedProjects)
 
         // projects() 是后端可选目录，不等于用户已打开的工作区。旧实现把所有候选目录
@@ -696,17 +716,23 @@ extension SessionStore {
     }
 
     @discardableResult
-    func openWorkspace(path: String) async -> Bool {
+    func openWorkspaceOutcome(path: String) async -> WorkspaceOpenOutcome {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            setErrorMessage(L10n.text("ui.please_enter_the_directory_path_in_the_development"))
-            return false
+            let message = L10n.text("ui.please_enter_the_directory_path_in_the_development")
+            setErrorMessage(message)
+            return .failed(message)
         }
         let openIntent = reserveSelectionIntent()
         do {
             // 走 clientFactory（与会话请求同一个注入点）而不是 appStore.client()，
             // 让 resolve 和后续会话加载共用一条可测试链路。
             let resolvedWorkspace = try await clientFactory().resolveWorkspace(path: trimmed)
+            // resolve 之后的 remember 会写入当前 Profile；必须先确认旧意图仍持有提交权，
+            // 否则切主机或新导航会把上一台 Mac 的工作区持久化到新作用域。
+            guard !Task.isCancelled, isSelectionLeaseCurrent(openIntent) else {
+                return .cancelled
+            }
             // resolve 的返回路径是 agentd realpath；同时带上用户输入路径，才能把旧版保存的
             // 符号链接路径安全迁移到同一 canonical workspace，而不猜测其他同名目录。
             let workspace = rememberWorkspace(
@@ -715,28 +741,35 @@ extension SessionStore {
             )
             clearWorkspaceUnavailable(workspace.id)
             insertExpandedProjectID(workspace.id)
-            let selectionLease = commitSelection(
+            guard let selectionLease = commitSelection(
                 projectID: workspace.id,
                 sessionID: nil,
                 reason: .invalidation,
                 ifCurrent: openIntent
-            )
-            if selectionLease != nil {
-                setErrorMessage(nil)
-                disconnectWebSocket()
+            ) else {
+                return .cancelled
             }
+            setErrorMessage(nil)
+            disconnectWebSocket()
             await refreshSessions(
                 forProjectID: workspace.id,
                 activatesProject: false,
                 foregroundLease: selectionLease
             )
-            return true
+            return .opened(workspaceID: workspace.id)
         } catch {
-            if isSelectionLeaseCurrent(openIntent) {
-                setErrorMessage(error.localizedDescription)
+            guard !isCancellationError(error), isSelectionLeaseCurrent(openIntent) else {
+                return .cancelled
             }
-            return false
+            let message = error.localizedDescription
+            setErrorMessage(message)
+            return .failed(message)
         }
+    }
+
+    @discardableResult
+    func openWorkspace(path: String) async -> Bool {
+        await openWorkspaceOutcome(path: path).didOpen
     }
 
     @discardableResult

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -414,6 +414,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     private var requestedWorkspaceIDsStorage: [String] = []
 
     let projectsResult: [AgentProject]
+    let projectsHandler: (() async throws -> [AgentProject])?
     let sessionsResult: [AgentSession]
     let projectSessions: [String: [AgentSession]]
     let workspaceSessions: [String: [AgentSession]]
@@ -432,6 +433,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     let workspaceSessionsError: [String: Error]
     let capabilityResults: [String: Result<CapabilityListResponse, Error>]
     let resolveResults: [String: Result<AgentWorkspace, Error>]
+    let resolveWorkspaceHandler: ((String) async throws -> AgentWorkspace)?
     let worktreeCreateResults: [String: Result<WorktreeCreateResponse, Error>]
     let worktreeBranchResults: [String: Result<WorktreeBranchListResponse, Error>]
     let worktreeListResult: Result<[WorktreeListItem], Error>?
@@ -520,6 +522,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     init(
         projects: [AgentProject],
         sessions: [AgentSession],
+        projectsHandler: (() async throws -> [AgentProject])? = nil,
         projectSessions: [String: [AgentSession]] = [:],
         workspaceSessions: [String: [AgentSession]] = [:],
         projectPages: [String: SessionsPage] = [:],
@@ -537,6 +540,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         workspaceSessionsError: [String: Error] = [:],
         capabilityResults: [String: Result<CapabilityListResponse, Error>] = [:],
         resolveResults: [String: Result<AgentWorkspace, Error>] = [:],
+        resolveWorkspaceHandler: ((String) async throws -> AgentWorkspace)? = nil,
         worktreeCreateResults: [String: Result<WorktreeCreateResponse, Error>] = [:],
         worktreeBranchResults: [String: Result<WorktreeBranchListResponse, Error>] = [:],
         worktreeListResult: Result<[WorktreeListItem], Error>? = nil,
@@ -569,6 +573,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         externalActivityResponses: [ExternalActivityResponse?] = []
     ) {
         self.projectsResult = projects
+        self.projectsHandler = projectsHandler
         self.sessionsResult = sessions
         self.projectSessions = projectSessions
         self.workspaceSessions = workspaceSessions
@@ -590,6 +595,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         self.workspaceSessionsError = workspaceSessionsError
         self.capabilityResults = capabilityResults
         self.resolveResults = resolveResults
+        self.resolveWorkspaceHandler = resolveWorkspaceHandler
         self.worktreeCreateResults = worktreeCreateResults
         self.worktreeBranchResults = worktreeBranchResults
         self.worktreeListResult = worktreeListResult
@@ -623,7 +629,10 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     }
 
     func projects() async throws -> [AgentProject] {
-        projectsResult
+        if let projectsHandler {
+            return try await projectsHandler()
+        }
+        return projectsResult
     }
 
     func externalActivities() async throws -> ExternalActivityResponse? {
@@ -675,6 +684,9 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
 
     func resolveWorkspace(path: String) async throws -> AgentWorkspace {
         requestedResolvePaths.append(path)
+        if let resolveWorkspaceHandler {
+            return try await resolveWorkspaceHandler(path)
+        }
         switch resolveResults[path] {
         case .success(let workspace):
             return workspace

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
@@ -3,6 +3,172 @@ import XCTest
 
 @MainActor
 extension ConversationDataFlowTests {
+    func testWorkspaceCatalogCoordinatorRollsCurrentCancellationBackWithoutLeavingLoading() {
+        var coordinator = WorkspaceCatalogLoadCoordinator()
+
+        let emptyInvocation = coordinator.begin()
+        XCTAssertEqual(coordinator.state, .loading)
+        XCTAssertTrue(coordinator.complete(emptyInvocation, result: .cancelled, hasCachedProjects: false))
+        XCTAssertEqual(coordinator.state, .idle)
+
+        let cachedInvocation = coordinator.begin()
+        XCTAssertTrue(coordinator.complete(cachedInvocation, result: .cancelled, hasCachedProjects: true))
+        XCTAssertEqual(coordinator.state, .loaded)
+    }
+
+    func testWorkspaceCatalogCoordinatorRejectsOldFailureAndCancellationAfterNewInvocation() {
+        var coordinator = WorkspaceCatalogLoadCoordinator()
+        let first = coordinator.begin()
+        let latest = coordinator.begin()
+
+        XCTAssertFalse(coordinator.complete(first, result: .cancelled, hasCachedProjects: false))
+        XCTAssertEqual(coordinator.state, .loading, "旧取消不能替最新 invocation 回退状态")
+        XCTAssertTrue(coordinator.complete(latest, result: .loaded, hasCachedProjects: true))
+        XCTAssertFalse(coordinator.complete(first, result: .failed("旧请求失败"), hasCachedProjects: false))
+        XCTAssertEqual(coordinator.state, .loaded, "旧失败不能覆盖最新成功")
+    }
+
+    func testWorkspaceCatalogRefreshScopeTracksCredentialSuspensionWithoutChangingHost() {
+        let hostScope = AppStore().activeHostScope
+
+        XCTAssertNotEqual(
+            WorkspaceCatalogRefreshScope(hostScope: hostScope, credentialsSuspended: false),
+            WorkspaceCatalogRefreshScope(hostScope: hostScope, credentialsSuspended: true)
+        )
+    }
+
+    func testCancelledWorkspaceCatalogRequestCannotCommitLateProjects() async {
+        let staleProject = makeProject(id: "stale-catalog-project")
+        let gate = WorkspaceProjectsGate()
+        let client = MockSessionStoreClient(
+            projects: [],
+            sessions: [],
+            projectsHandler: { await gate.projects() }
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        let refresh = Task { @MainActor in
+            try await store.refreshWorkspaceCatalog()
+        }
+        await gate.waitUntilStarted()
+        refresh.cancel()
+        await gate.succeed(with: [staleProject])
+
+        do {
+            try await refresh.value
+            XCTFail("已取消的 catalog 调用应拒绝提交")
+        } catch {
+            XCTAssertTrue(isCancellationError(error))
+        }
+        XCTAssertTrue(store.projects.isEmpty)
+        XCTAssertTrue(store.sidebarProjects.isEmpty)
+    }
+
+    func testWorkspaceCancellationClassifierDoesNotHideRealNetworkFailures() {
+        XCTAssertTrue(isCancellationError(CancellationError()))
+        XCTAssertTrue(isCancellationError(URLError(.cancelled)))
+        XCTAssertFalse(isCancellationError(URLError(.timedOut)))
+        XCTAssertFalse(isCancellationError(URLError(.notConnectedToInternet)))
+        XCTAssertFalse(isCancellationError(AgentAPIError.server(status: 500, message: "server failed")))
+    }
+
+    func testOpenWorkspaceCancellationReturnsNeutralOutcomeWithoutPublishingError() async {
+        let path = "/Users/me/cancelled-workspace"
+        for error in [CancellationError(), URLError(.cancelled)] as [Error] {
+            let client = MockSessionStoreClient(
+                projects: [],
+                sessions: [],
+                resolveResults: [path: .failure(error)]
+            )
+            let store = SessionStore(
+                appStore: AppStore(),
+                conversationStore: ConversationStore(),
+                logStore: LogStore(),
+                clientFactory: { client }
+            )
+
+            let outcome = await store.openWorkspaceOutcome(path: path)
+            XCTAssertEqual(outcome, .cancelled)
+            XCTAssertNil(store.errorMessage)
+            XCTAssertTrue(store.sidebarProjects.isEmpty)
+        }
+    }
+
+    func testOpenWorkspaceRealFailureRemainsUserVisible() async {
+        let path = "/Users/me/forbidden-workspace"
+        let client = MockSessionStoreClient(
+            projects: [],
+            sessions: [],
+            resolveResults: [path: .failure(AgentAPIError.server(status: 403, message: "forbidden"))]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        guard case .failed(let message) = await store.openWorkspaceOutcome(path: path) else {
+            return XCTFail("403 必须保持为可展示失败")
+        }
+        XCTAssertTrue(message.contains("403"))
+        XCTAssertEqual(store.errorMessage, message)
+    }
+
+    func testWorkspaceLoadCancellationSkipsAvailabilityProbeAndGlobalErrorMutation() async {
+        let workspace = AgentWorkspace(project: makeProject(id: "workspace-cancelled-load"))
+        let client = MockSessionStoreClient(
+            projects: [],
+            sessions: [],
+            resolveResults: [workspace.path: .success(workspace)]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        await store.handleWorkspaceLoadFailure(workspace: workspace, error: CancellationError())
+
+        XCTAssertTrue(client.requestedResolvePaths.isEmpty, "取消不应再发 availability probe")
+        XCTAssertNil(store.errorMessage)
+    }
+
+    func testOpenWorkspaceLosingSelectionIntentBeforeResolveReturnsCannotPersistStaleWorkspace() async {
+        let project = makeProject(id: "workspace-stale-open")
+        let workspace = AgentWorkspace(project: project)
+        let gate = WorkspaceResolveGate()
+        let client = MockSessionStoreClient(
+            projects: [],
+            sessions: [],
+            resolveWorkspaceHandler: { _ in try await gate.resolve() }
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        let opening = Task { @MainActor in
+            await store.openWorkspaceOutcome(path: workspace.path)
+        }
+        await gate.waitUntilStarted()
+        store.setSelectedProjectID("newer-selection")
+        await gate.succeed(with: workspace)
+
+        let outcome = await opening.value
+        XCTAssertEqual(outcome, .cancelled)
+        XCTAssertTrue(store.sidebarProjects.isEmpty, "失去 ownership 的 resolve 结果不能写入最近工作区")
+        XCTAssertEqual(store.selectedProjectID, "newer-selection")
+    }
+
     func testWorkspaceSessionLoadInvocationTokensKeepOnlyLatestABAReturnEligible() {
         var tokens = WorkspaceSessionLoadInvocationTokens()
         let firstA = tokens.begin(for: "workspace-a")
@@ -130,5 +296,61 @@ extension ConversationDataFlowTests {
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("Claude workspace list failed"))
         }
+    }
+}
+
+private actor WorkspaceResolveGate {
+    private var continuation: CheckedContinuation<AgentWorkspace, Error>?
+    private var didStart = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func resolve() async throws -> AgentWorkspace {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            didStart = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !didStart else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func succeed(with workspace: AgentWorkspace) {
+        continuation?.resume(returning: workspace)
+        continuation = nil
+    }
+}
+
+private actor WorkspaceProjectsGate {
+    private var continuation: CheckedContinuation<[AgentProject], Never>?
+    private var didStart = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func projects() async -> [AgentProject] {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            didStart = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !didStart else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func succeed(with projects: [AgentProject]) {
+        continuation?.resume(returning: projects)
+        continuation = nil
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
@@ -77,6 +77,20 @@ extension ConversationDataFlowTests {
         XCTAssertFalse(isCancellationError(AgentAPIError.server(status: 500, message: "server failed")))
     }
 
+    func testWorkspaceSessionLoadFailureDispositionUsesFallbackOnlyForExplicitCancellation() {
+        XCTAssertEqual(
+            workspaceSessionLoadFailureDisposition(URLError(.cancelled)),
+            .cancelled
+        )
+
+        let timeout = URLError(.timedOut)
+        XCTAssertEqual(
+            workspaceSessionLoadFailureDisposition(timeout),
+            .failed(timeout.localizedDescription),
+            "超时仍必须进入可重试的真实失败态"
+        )
+    }
+
     func testOpenWorkspaceCancellationReturnsNeutralOutcomeWithoutPublishingError() async {
         let path = "/Users/me/cancelled-workspace"
         for error in [CancellationError(), URLError(.cancelled)] as [Error] {


### PR DESCRIPTION
## 目标

修复 iPad 工作区在前后台凭据挂起、页面切换或快速重复操作时永久显示骨架，并阻止 Swift.CancellationError 泄露到用户界面。

## 实现

- catalog 加载使用 invocation ownership，旧请求不能覆盖最新状态；取消回退到 loaded 或 idle。
- task identity 同时包含 host scope 和凭据挂起状态，前台恢复后确定性自愈刷新。
- 统一识别 CancellationError 与 URLError.cancelled，超时、断网和 HTTP 错误仍保持可见。
- 打开目录使用结构化 outcome，并在持久化前校验 open intent，取消不污染全局错误。
- browse、preview 与 shared workspace failure handler 静默收口生命周期取消。

## 验证

- build-for-testing：通过。
- MIM-79 定向回归：9/9 通过。
- MIM-38 single-flight 回归：3/3 通过。
- 固定 iPad Pro 13-inch (M5) Simulator 构建并运行成功。
- 运行态连续 3 次进入工作区均落到明确空态，无永久骨架。
- 无凭据时打开输入路径保留 Sheet，未显示 Swift.CancellationError，运行日志亦无该错误。
- check-source-size、check-public-repo-safety、git diff --check：通过。
- 完整套件执行 1046 项；剩余 23 个失败为 origin/main 可复现的 Xcode 27 beta 基线路径规范化和视觉快照波动，已用同设备基线对照确认。
- ChatGPT Pro 合并前 review：Revised Review Decision: PASS；Blocker/High 为 0。

Linear: MIM-79