### PR TITLE
MIM-69 统一高频交互反馈与降级规则

### DIFF
--- a/docs/design/mim-69-interaction-feedback.md
+++ b/docs/design/mim-69-interaction-feedback.md
@@ -1,0 +1,31 @@
+# MIM-69 统一交互反馈规则
+
+## 目标
+
+为高频触控、状态变化、面板呈现和手势落位提供最小语义入口，让新功能复用一致反馈，并完整支持 Reduce Motion。
+
+## 方案
+
+| 语义 | 普通模式 | Reduce Motion 等价反馈 |
+| --- | --- | --- |
+| `press` | 即时轻微缩放与透明度变化，临界阻尼回弹 | 仅短透明度变化，不缩放 |
+| `stateTransition` | 临界阻尼状态过渡 | 短淡变，不做空间移动 |
+| `presentation` | 面板沿来源方向呈现，可轻微自然回弹 | 仅淡入淡出，不做大范围位移 |
+| `gestureSettling` | 继承手势结果并自然落位 | 直接到达最终位置，仅保留短淡变 |
+
+统一入口为 `MimiMotion` 与 `MimiPressButtonStyle`。调用方在 Reduce Motion 下除了选择 fallback 曲线，还必须读取 `allowsScale` / `allowsSpatialMotion`，避免只换曲线却继续执行缩放或大范围位移。
+
+## 实现
+
+- Press 由 `ButtonStyle.Configuration.isPressed` 在触点按下时立即响应。
+- Press 样式只拥有 pressed；Focus 使用 SwiftUI 原生 FocusState/focus effect，Hover 使用 `hoverEffect`。
+- 视觉优先级为 `pressed > focused > hovered > resting`。Hover 只是指针增强，不得承载唯一信息或唯一入口。
+- Haptic 只允许在 `commit`、`completion`、`failure`、`snap` 离散节点调用一次。持续的 preparing/loading/running 状态不得循环触发。
+- `prepare` 只负责预热，`fire` 只负责发出一次反馈；两者不隐式串联。
+- 每个业务节点由调用方拥有去重责任；基础层不使用时间窗口做全局去重，避免误伤合法连续操作。
+
+## 风险与优化
+
+- 本 Issue 不迁移全仓历史动画；后续功能应直接使用语义入口，历史参数按真实需求逐步收敛。
+- `gestureSettling` 的 velocity handoff 与目标投影属于具体手势实现，不能被固定 token 代替。
+- Haptic 必须在真机上做最终体感验证；Simulator 与单元测试只能验证事件映射和调用边界。

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -206,6 +206,8 @@
 		F08F39B329A077D24D08FECF /* testWorkspaceOpenCurrentDirectoryButton.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 0AEF1C233E236BA44225FA2F /* testWorkspaceOpenCurrentDirectoryButton.1.png */; };
 		F0ABEBFE125D238054D75506 /* DoctorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C5A70C7B1570DFCB3F7CF1 /* DoctorView.swift */; };
 		F0DC6138A242D45D79253F8B /* HostWarmSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053D35545CB6F6F836EAADBA /* HostWarmSnapshotTests.swift */; };
+		F16900000000000000000001 /* MimiInteractionFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16900000000000000000002 /* MimiInteractionFeedback.swift */; };
+		F16900000000000000000004 /* MimiInteractionFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16900000000000000000005 /* MimiInteractionFeedbackTests.swift */; };
 		F1BFCDBADE221F598CA62933 /* testExpandedWorkGroupRendering.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 7587EB164AF1902FAD735D90 /* testExpandedWorkGroupRendering.1.png */; };
 		F38D8C9DDF3FCC6EBBE20885 /* SessionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9975BE3B6F00A870817B17 /* SessionIndexStore.swift */; };
 		F3ABBC8502D690C76985F756 /* AgentAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF761429383D479BD96FC52 /* AgentAPIClient.swift */; };
@@ -354,6 +356,8 @@
 		7A4E57C95034C12853D10303 /* MediaWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaWorker.swift; sourceTree = "<group>"; };
 		7D29856557B35AE9C7C9B5EA /* QRCodeScannerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeScannerSheet.swift; sourceTree = "<group>"; };
 		80C5A70C7B1570DFCB3F7CF1 /* DoctorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoctorView.swift; sourceTree = "<group>"; };
+		F16900000000000000000002 /* MimiInteractionFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiInteractionFeedback.swift; sourceTree = "<group>"; };
+		F16900000000000000000005 /* MimiInteractionFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiInteractionFeedbackTests.swift; sourceTree = "<group>"; };
 		80D89DB26E0A1CA68C63E07D /* FileUploadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadStore.swift; sourceTree = "<group>"; };
 		80F8AA2ABA18C212AEAA34E1 /* HostStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStatusStore.swift; sourceTree = "<group>"; };
 		81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationConnectionRecoveryTests.swift; sourceTree = "<group>"; };
@@ -601,6 +605,7 @@
 				053D35545CB6F6F836EAADBA /* HostWarmSnapshotTests.swift */,
 				8AA53A2531C62C2974077C88 /* LocalizationTests.swift */,
 				A0E1C34623582EDA99D6B917 /* LogStoreTests.swift */,
+				F16900000000000000000005 /* MimiInteractionFeedbackTests.swift */,
 				24B74985F9E77EEE70BC1856 /* MarkdownRenderingTests.swift */,
 				8EABFF317C695883ECE910D0 /* PairingLinkTests.swift */,
 				EF8E25B79CBECB1CB0EDBD5B /* ProtocolContractTests.swift */,
@@ -833,6 +838,14 @@
 			path = Localization;
 			sourceTree = "<group>";
 		};
+		F16900000000000000000003 /* Interaction */ = {
+			isa = PBXGroup;
+			children = (
+				F16900000000000000000002 /* MimiInteractionFeedback.swift */,
+			);
+			path = Interaction;
+			sourceTree = "<group>";
+		};
 		BC50ED3CCF73CFBFDF3C6171 = {
 			isa = PBXGroup;
 			children = (
@@ -861,6 +874,7 @@
 			children = (
 				D28C291AC46CF73586F8764A /* AppExternalLinks.swift */,
 				5BB12206C8D32201707AA176 /* API */,
+				F16900000000000000000003 /* Interaction */,
 				9DD779B181654D6C7D59AEE9 /* Localization */,
 				07A81BF8D51C2B90E153B254 /* Media */,
 				16A54848C6A9B1324C77E712 /* Models */,
@@ -1178,6 +1192,7 @@
 				F0DC6138A242D45D79253F8B /* HostWarmSnapshotTests.swift in Sources */,
 				E4A6ECBFD5B621FB6A30299A /* LocalizationTests.swift in Sources */,
 				BDDBF10C9208B7AB95535A57 /* LogStoreTests.swift in Sources */,
+				F16900000000000000000004 /* MimiInteractionFeedbackTests.swift in Sources */,
 				4DDCF6949E6DDCC9ABEBE709 /* MarkdownRenderingTests.swift in Sources */,
 				89DCEF26CCF404A369DFDE80 /* PairingLinkTests.swift in Sources */,
 				E321385031CD0951AABBF21C /* ProtocolContractTests.swift in Sources */,
@@ -1268,6 +1283,7 @@
 				CA5DCE5FDDA7F1DE9C0C64F7 /* MarkdownParser.swift in Sources */,
 				0FCA7C8C42E283AD24681BA0 /* MarkdownStyle.swift in Sources */,
 				410ECA3E93AE577686A636C0 /* MediaWorker.swift in Sources */,
+				F16900000000000000000001 /* MimiInteractionFeedback.swift in Sources */,
 				3B0E963BB2856F7CDD36EB67 /* MessageStore.swift in Sources */,
 				E158B34D71964DBF782D1DDF /* MimiRemoteApp.swift in Sources */,
 				41B2009F6B92E4B407CFDB72 /* ModelReasoningGridPicker.swift in Sources */,

--- a/ios/MimiRemote/Sources/Core/Interaction/MimiInteractionFeedback.swift
+++ b/ios/MimiRemote/Sources/Core/Interaction/MimiInteractionFeedback.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+import UIKit
+
+/// Mimi 的交互动效只按用户意图命名，页面不得再复制一组无语义的 spring 参数。
+enum MimiMotion: CaseIterable {
+    case press
+    case stateTransition
+    case presentation
+    case gestureSettling
+
+    struct Resolution: Equatable {
+        let curve: Curve
+        let allowsScale: Bool
+        let allowsSpatialMotion: Bool
+
+        var animation: Animation {
+            curve.animation
+        }
+    }
+
+    enum Curve: Equatable {
+        case easeOut(duration: Double)
+        case spring(response: Double, dampingFraction: Double, blendDuration: Double)
+
+        var animation: Animation {
+            switch self {
+            case .easeOut(let duration):
+                return .easeOut(duration: duration)
+            case .spring(let response, let dampingFraction, let blendDuration):
+                return .spring(
+                    response: response,
+                    dampingFraction: dampingFraction,
+                    blendDuration: blendDuration
+                )
+            }
+        }
+    }
+
+    func resolve(reduceMotion: Bool) -> Resolution {
+        if reduceMotion {
+            // Reduce Motion 仍保留短淡变反馈，但不允许非必要缩放或大范围空间移动。
+            switch self {
+            case .press:
+                return Resolution(
+                    curve: .easeOut(duration: 0.08),
+                    allowsScale: false,
+                    allowsSpatialMotion: false
+                )
+            case .stateTransition, .gestureSettling:
+                return Resolution(
+                    curve: .easeOut(duration: 0.12),
+                    allowsScale: false,
+                    allowsSpatialMotion: false
+                )
+            case .presentation:
+                return Resolution(
+                    curve: .easeOut(duration: 0.16),
+                    allowsScale: false,
+                    allowsSpatialMotion: false
+                )
+            }
+        }
+
+        switch self {
+        case .press:
+            return Resolution(
+                curve: .spring(response: 0.22, dampingFraction: 1, blendDuration: 0),
+                allowsScale: true,
+                allowsSpatialMotion: false
+            )
+        case .stateTransition:
+            return Resolution(
+                curve: .spring(response: 0.34, dampingFraction: 1, blendDuration: 0.08),
+                allowsScale: false,
+                allowsSpatialMotion: true
+            )
+        case .presentation:
+            return Resolution(
+                curve: .spring(response: 0.38, dampingFraction: 0.86, blendDuration: 0),
+                allowsScale: false,
+                allowsSpatialMotion: true
+            )
+        case .gestureSettling:
+            return Resolution(
+                curve: .spring(response: 0.28, dampingFraction: 0.82, blendDuration: 0),
+                allowsScale: false,
+                allowsSpatialMotion: true
+            )
+        }
+    }
+
+    func animation(reduceMotion: Bool) -> Animation {
+        resolve(reduceMotion: reduceMotion).animation
+    }
+}
+
+/// 高频触控面的统一即时按压反馈。
+///
+/// 本样式只拥有 pressed 状态。Focus 继续由 FocusState/系统 focus effect 表达，Hover 继续使用
+/// hoverEffect，避免自建状态机与系统输入竞争；视觉优先级固定为 pressed > focused > hovered > resting。
+struct MimiPressButtonStyle: ButtonStyle {
+    let reduceMotion: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        let motion = MimiMotion.press.resolve(reduceMotion: reduceMotion)
+
+        configuration.label
+            .scaleEffect(configuration.isPressed && motion.allowsScale ? 0.985 : 1)
+            .opacity(configuration.isPressed ? 0.84 : 1)
+            .animation(motion.animation, value: configuration.isPressed)
+    }
+}
+
+/// Haptic 只描述一次用户可感知的离散节点，不表示 loading、running 等持续状态。
+enum MimiHapticEvent: CaseIterable {
+    case commit
+    case completion
+    case failure
+    case snap
+
+    var pattern: MimiHapticPattern {
+        switch self {
+        case .commit:
+            return .impactMedium
+        case .completion:
+            return .notificationSuccess
+        case .failure:
+            return .notificationError
+        case .snap:
+            return .selection
+        }
+    }
+}
+
+enum MimiHapticPattern: Hashable {
+    case impactMedium
+    case notificationSuccess
+    case notificationError
+    case selection
+}
+
+@MainActor
+enum MimiHaptics {
+    private static let commitGenerator = UIImpactFeedbackGenerator(style: .medium)
+    private static let completionGenerator = UINotificationFeedbackGenerator()
+    private static let failureGenerator = UINotificationFeedbackGenerator()
+    private static let snapGenerator = UISelectionFeedbackGenerator()
+
+    static func prepare(_ event: MimiHapticEvent) {
+        switch event.pattern {
+        case .impactMedium:
+            commitGenerator.prepare()
+        case .notificationSuccess:
+            completionGenerator.prepare()
+        case .notificationError:
+            failureGenerator.prepare()
+        case .selection:
+            snapGenerator.prepare()
+        }
+    }
+
+    static func fire(_ event: MimiHapticEvent) {
+        // 一次调用只允许一个 generator 发出一次反馈；事件去重由拥有业务节点的调用方负责。
+        switch event.pattern {
+        case .impactMedium:
+            commitGenerator.impactOccurred()
+        case .notificationSuccess:
+            completionGenerator.notificationOccurred(.success)
+        case .notificationError:
+            failureGenerator.notificationOccurred(.error)
+        case .selection:
+            snapGenerator.selectionChanged()
+        }
+    }
+}

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerAttachmentViews.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerAttachmentViews.swift
@@ -557,7 +557,7 @@ struct AddContentPanel: View {
                         .frame(width: 44, height: 44)
                         .background(tokens.selectionFill, in: Circle())
                 }
-                .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+                .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
                 .accessibilityLabel(L10n.text("ui.return_to_add_content"))
             } else {
                 Image(systemName: "plus")
@@ -588,7 +588,7 @@ struct AddContentPanel: View {
                     .frame(width: 44, height: 44)
                     .background(tokens.selectionFill.opacity(0.72), in: Circle())
             }
-            .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
             .accessibilityLabel(L10n.text("ui.close_adding_content"))
         }
     }
@@ -786,7 +786,7 @@ struct AddContentPanel: View {
             }
             .contentShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(title)
         .accessibilityHint(subtitle)
         .accessibilityIdentifier(accessibilityIdentifier)
@@ -828,7 +828,7 @@ struct AddContentPanel: View {
             .frame(maxWidth: .infinity, minHeight: 56)
             .contentShape(Rectangle())
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier(accessibilityIdentifier)
@@ -873,7 +873,7 @@ struct AddContentPanel: View {
             .frame(maxWidth: .infinity, minHeight: 64)
             .contentShape(Rectangle())
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier(accessibilityIdentifier)
@@ -921,7 +921,7 @@ struct AddContentPanel: View {
                                 .background(tokens.elevatedSurface, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
                                 .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                             }
-                            .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+                            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
                             .disabled(!plugin.enabled)
                             .opacity(plugin.enabled ? 1 : 0.58)
                         }
@@ -974,7 +974,7 @@ struct AddContentPanel: View {
                         )
                         .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     }
-                    .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+                    .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
                     .accessibilityHint(mode.detail)
                 }
             }
@@ -1008,7 +1008,7 @@ struct AddContentPanel: View {
                         .background(tokens.elevatedSurface, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
                         .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     }
-                    .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+                    .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
                 }
             }
         }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -109,20 +109,25 @@ struct CompactComposerLeadingControlsShell: View {
 extension ComposerView {
     @ViewBuilder
     var addContentButton: some View {
-        Button {
-            showsAddContentPanel.toggle()
-        } label: {
-            composerToolbarControlLabel(
-                title: nil,
-                systemImage: "plus",
-                accessibilityLabel: L10n.text("ui.add_content")
-            )
+        ZStack {
+            Button {
+                showsAddContentPanel.toggle()
+            } label: {
+                composerToolbarControlLabel(
+                    title: nil,
+                    systemImage: "plus",
+                    accessibilityLabel: L10n.text("ui.add_content")
+                )
+            }
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
+            .accessibilityLabel(L10n.text("ui.add_content"))
+            .accessibilityIdentifier("composer.addContent")
+            .help(L10n.text("ui.add_an_image_plugin_skill_or_shortcut_phrase"))
+            .disabled(isRequestingCameraAuthorization)
         }
-        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
-        .accessibilityLabel(L10n.text("ui.add_content"))
-        .accessibilityIdentifier("composer.addContent")
-        .help(L10n.text("ui.add_an_image_plugin_skill_or_shortcut_phrase"))
-        .disabled(isRequestingCameraAuthorization)
+        // Popover 必须挂在不会参与按压缩放的固定锚点上；否则系统可能在 spring
+        // 回弹途中读取 source rect，让箭头与“+”入口出现瞬时偏移。
+        .frame(width: 44, height: 44)
         .popover(isPresented: $showsAddContentPanel, arrowEdge: .bottom) {
             AddContentPanel(
                 skillShortcuts: enabledSkillShortcuts,

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -118,7 +118,7 @@ extension ComposerView {
                 accessibilityLabel: L10n.text("ui.add_content")
             )
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.add_content"))
         .accessibilityIdentifier("composer.addContent")
         .help(L10n.text("ui.add_an_image_plugin_skill_or_shortcut_phrase"))
@@ -600,7 +600,7 @@ extension ComposerView {
             )
             .contentShape(RoundedRectangle(cornerRadius: showLabels ? 12 : 22, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .keyboardShortcut(.return, modifiers: .command)
         .disabled(!enabled)
         .accessibilityLabel(isGoalMode ? L10n.text("ui.send_target_task") : (composerState.voiceDraftNeedsReview ? L10n.text("ui.confirm_sending_voice_draft") : L10n.text("ui.send")))
@@ -625,7 +625,7 @@ extension ComposerView {
             .frame(width: 44, height: 44)
             .contentShape(Circle())
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(!canInterruptSelectedSession)
         .opacity(canInterruptSelectedSession ? 1 : 0.52)
         .accessibilityLabel(L10n.text("ui.stop_current_reply"))

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerRequestCards.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerRequestCards.swift
@@ -239,7 +239,7 @@ struct PendingApprovalActionCard: View {
                 .frame(maxWidth: .infinity, minHeight: 52)
                 .contentShape(Rectangle())
             }
-            .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
             .accessibilityIdentifier("approval.details")
             .accessibilityHint(L10n.text(isDetailsExpanded ? "ui.hide_details" : "ui.show_details"))
 
@@ -328,7 +328,7 @@ struct PendingApprovalActionCard: View {
                 .background(tokens.accentSoft, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
                 .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
-            .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
             .disabled(isSendingDecision || !approval.hasDecisionContext)
             .accessibilityIdentifier("approval.alwaysAllow")
             .accessibilityHint(L10n.text("ui.after_confirmation_write_the_precise_rules_suggested_by"))
@@ -382,7 +382,7 @@ struct PendingApprovalActionCard: View {
                 .background(tokens.accentSoft, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
                 .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(isSendingDecision || !approval.hasDecisionContext)
         .accessibilityIdentifier(identifier)
         .accessibilityHint(L10n.text("ui.codex_saves_this_choice_on_the_mac"))
@@ -403,7 +403,7 @@ struct PendingApprovalActionCard: View {
                 }
                 .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(isSendingDecision)
         .accessibilityIdentifier("approval.reject")
         .accessibilityLabel(L10n.text("ui.deny_approval"))
@@ -428,7 +428,7 @@ struct PendingApprovalActionCard: View {
                 )
                 .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(!isEnabled)
         .accessibilityIdentifier("approval.approveOnce")
         .accessibilityLabel(L10n.text("ui.approval_36f0d72e"))
@@ -689,7 +689,7 @@ struct PendingUserInputResumeButton: View {
                 borderColor: tokens.accent.opacity(colorScheme == .dark ? 0.38 : 0.28)
             )
         )
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(isSubmitting)
         .accessibilityLabel(L10n.text("ui.continue_filling_supplementary_information"))
         .accessibilityValue(request.title)

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
@@ -629,7 +629,7 @@ struct ComposerStatusTray: View {
                 .font(themeStore.uiFont(size: 13, weight: .semibold))
                 .frame(width: 44, height: 44)
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .foregroundStyle(isRefreshDisabled ? themeStore.tokens(for: colorScheme).tertiaryText : tint)
         .disabled(isRefreshDisabled)
         .help(L10n.text("ui.refresh_codex_usage"))
@@ -658,7 +658,7 @@ struct ComposerStatusTray: View {
                 )
                 .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(isDisabled)
         .help(title)
         .accessibilityLabel(title)

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -77,9 +77,7 @@ struct ComposerView: View {
     static let maximumImageAttachmentCount = 8
 
     var composerMotionAnimation: Animation {
-        reduceMotion
-            ? .easeOut(duration: 0.12)
-            : .spring(response: 0.34, dampingFraction: 1, blendDuration: 0.08)
+        MimiMotion.stateTransition.animation(reduceMotion: reduceMotion)
     }
 
     var body: some View {
@@ -934,7 +932,7 @@ struct ComposerView: View {
             .frame(maxWidth: .infinity, minHeight: 44)
             .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.expand_input_box"))
         .accessibilityValue(collapsedPhoneComposerText)
         .accessibilityIdentifier("composer.expand")
@@ -1274,7 +1272,7 @@ struct ComposerView: View {
                 accessibilityLabel: L10n.text("ui.session_options")
             )
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.session_options"))
         .accessibilityValue(composerOptionsAccessibilityValue)
         .accessibilityHint(L10n.text("ui.adjust_build_settings_and_sending_mode"))
@@ -1366,7 +1364,7 @@ struct ComposerView: View {
                 accessibilityLabel: L10n.text("ui.select_skill")
             )
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.select_skill"))
         .accessibilityValue(selectedSkillPaths.isEmpty ? L10n.text("ui.not_selected") : L10n.plural("ui.skills_selected_count", count: selectedSkillPaths.count))
         .accessibilityIdentifier("composer.skill")
@@ -1525,7 +1523,7 @@ struct ComposerView: View {
                 )
                 .contentShape(RoundedRectangle(cornerRadius: usesCompactComposerMetrics ? 22 : 12, style: .continuous))
             }
-            .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
             .help(isGuidedSelected ? L10n.text("ui.immediately_change_the_reply_currently_being_generated") : L10n.text("ui.save_it_in_this_device_first_and_automatically"))
             .accessibilityLabel(L10n.text("ui.append_mode_on_the_fly"))
             .accessibilityValue(isGuidedSelected ? L10n.text("ui.lead_current_reply") : L10n.text("ui.queue_for_next_round"))
@@ -1630,7 +1628,7 @@ struct ComposerView: View {
             )
             .contentTransition(.opacity)
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.switch_model_and_inference_strength"))
         .accessibilityValue(modelShortcutAccessibilityValue(for: modelPickerTriggerTitle))
         .accessibilityHint(L10n.text("ui.select_the_model_to_use_in_the_next"))
@@ -1804,7 +1802,7 @@ struct ComposerView: View {
                 accessibilityLabel: L10n.text("ui.permission_mode")
             )
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.permission_mode"))
         .accessibilityValue(permissionTitle)
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -1,5 +1,4 @@
 import AVFoundation
-import AudioToolbox
 import SwiftUI
 import UIKit
 
@@ -124,27 +123,12 @@ struct VoiceMicButton: View {
             )
             .contentShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         // 准备音频会话可能耗时，必须允许用户再次点击取消；否则准备卡住时按钮会永久无响应。
         .disabled(!state.isEnabled)
         .accessibilityLabel(state.accessibilityTitle)
         .accessibilityValue(state.accessibilityValue)
         .accessibilityHint(state.accessibilityHint(usesRealtimeTranscription: usesRealtimeTranscription))
-    }
-}
-
-struct ComposerPressButtonStyle: ButtonStyle {
-    let reduceMotion: Bool
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            // 玻璃键帽用很短的缩放和明度变化确认按压；降低动态效果时只保留明度反馈。
-            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.985 : 1)
-            .opacity(configuration.isPressed ? 0.82 : 1)
-            .animation(
-                .easeOut(duration: reduceMotion ? 0 : 0.08),
-                value: configuration.isPressed
-            )
     }
 }
 
@@ -296,27 +280,6 @@ final class VoiceLevelMeter: ObservableObject {
     func reset() {
         samples = Array(repeating: 0, count: VoiceLevelMeter.barCount)
         previousLevel = 0
-    }
-}
-
-@MainActor
-enum VoiceHaptics {
-    private static let recordingStartGenerator = UIImpactFeedbackGenerator(style: .heavy)
-    private static let recordingReadyGenerator = UINotificationFeedbackGenerator()
-
-    static func prepareRecordingStarted() {
-        recordingStartGenerator.prepare()
-        recordingReadyGenerator.prepare()
-    }
-
-    static func recordingStarted() {
-        // 语音输入的唯一震动锚点：只有录音器已经开始采样后才震动。
-        // 用户感受到这次反馈，就可以立即开口。
-        recordingStartGenerator.impactOccurred(intensity: 1.0)
-        recordingReadyGenerator.notificationOccurred(.success)
-        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
-        recordingStartGenerator.prepare()
-        recordingReadyGenerator.prepare()
     }
 }
 
@@ -666,7 +629,7 @@ final class VoiceInputController: NSObject, ObservableObject {
         }
 
         isPreparing = true
-        VoiceHaptics.prepareRecordingStarted()
+        MimiHaptics.prepare(.commit)
 
         let pendingAudioSessionCleanup = audioSessionCleanupTask
         Task {
@@ -715,7 +678,7 @@ final class VoiceInputController: NSObject, ObservableObject {
         noticeMessage = nil
 
         isPreparing = true
-        VoiceHaptics.prepareRecordingStarted()
+        MimiHaptics.prepare(.commit)
         let session = AppleSpeechTranscriptionSession(audioSessionCoordinator: audioSessionCoordinator)
         appleSession = session
         let pendingAudioSessionCleanup = audioSessionCleanupTask
@@ -780,7 +743,8 @@ final class VoiceInputController: NSObject, ObservableObject {
                 isPreparing = false
                 isRecording = true
                 levelMeter.prepareForRecording()
-                VoiceHaptics.recordingStarted()
+                // 录音器真正开始采样后只发出一次 commit；准备和持续录音状态不重复触发。
+                MimiHaptics.fire(.commit)
             } catch is CancellationError {
                 await session.cancel()
                 if startRequestID == requestID {
@@ -912,7 +876,7 @@ final class VoiceInputController: NSObject, ObservableObject {
         Task {
             try? await audioSessionCoordinator.prewarm()
         }
-        VoiceHaptics.prepareRecordingStarted()
+        MimiHaptics.prepare(.commit)
     }
 
     private func startRecording(requestID: UUID) async throws {
@@ -944,7 +908,8 @@ final class VoiceInputController: NSObject, ObservableObject {
             levelMeter.prepareForRecording()
             isPreparing = false
             isRecording = true
-            VoiceHaptics.recordingStarted()
+            // 录音器真正开始采样后只发出一次 commit；准备和持续录音状态不重复触发。
+            MimiHaptics.fire(.commit)
             startMetering()
         } catch {
             await audioSessionCoordinator.deactivate(activation)

--- a/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
@@ -488,7 +488,7 @@ private struct ModelReasoningPickerHeader: View {
             .contentShape(Rectangle())
         }
         .menuStyle(.button)
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.all_models"))
     }
 
@@ -534,7 +534,7 @@ private struct ModelReasoningPickerHeader: View {
             .contentShape(Rectangle())
         }
         .toggleStyle(.button)
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.quick_mode"))
         .accessibilityValue(isFastMode ? L10n.text("ui.already_turned_on") : L10n.text("ui.closed"))
         .accessibilityHint(L10n.text("ui.after_turning_it_on_the_priority_service_speed"))
@@ -773,7 +773,7 @@ private struct ModelReasoningStandardGrid<CornerContent: View>: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .contentShape(Rectangle())
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(!isAvailable)
         .hoverEffect(.highlight)
         .accessibilityLabel(
@@ -1049,7 +1049,7 @@ private struct ModelReasoningAccessiblePicker: View {
                 .frame(minHeight: 44)
                 .background(tokens.elevatedSurface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
-            .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
 
             ForEach(layout.efforts) { effort in
                 let isAvailable = activeOption.map {
@@ -1074,7 +1074,7 @@ private struct ModelReasoningAccessiblePicker: View {
                     .frame(minHeight: 44)
                     .background(tokens.elevatedSurface.opacity(0.72), in: RoundedRectangle(cornerRadius: 12))
                 }
-                .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+                .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
                 .disabled(!isAvailable)
                 .accessibilityLabel(
                     "\(activeOption.map { ModelReasoningGridCatalog.shortTitle(for: $0, kind: layout.kind) } ?? ""), "

--- a/ios/MimiRemote/Sources/Features/Conversation/SkillInterfaceViews.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/SkillInterfaceViews.swift
@@ -195,7 +195,7 @@ struct SkillSelectionContent: View {
                     .frame(width: 44, height: 44)
                     .background(tokens.selectionFill, in: Circle())
             }
-            .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
             .accessibilityLabel(L10n.text("ui.return_to_add_content"))
         } else {
             SkillIconView(
@@ -233,7 +233,7 @@ struct SkillSelectionContent: View {
             .frame(width: 44, height: 44)
             .background(tokens.selectionFill.opacity(0.72), in: Circle())
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .disabled(isRefreshing)
         .accessibilityLabel(L10n.text("ui.refresh_skill_list"))
     }
@@ -387,7 +387,7 @@ private struct SkillSelectionRow: View {
             .scaleEffect(isSelected && !reduceMotion ? 1.012 : 1)
             .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
-        .buttonStyle(ComposerPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .animation(reduceMotion ? .easeOut(duration: 0.12) : .spring(response: 0.32, dampingFraction: 0.86), value: isSelected)
         .accessibilityLabel(L10n.format("ui.skill_named", metadata.displayName))
         .accessibilityValue(isSelected ? L10n.text("ui.selected") : L10n.text("ui.not_selected"))

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -815,23 +815,6 @@ private enum WorkspaceSessionLoadState: Equatable {
     }
 }
 
-private struct WorkspaceActionPressButtonStyle: ButtonStyle {
-    let reduceMotion: Bool
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            // 按下反馈直接跟随触点；减少动态效果时仅改变透明度，避免不必要的缩放运动。
-            .scaleEffect(reduceMotion || !configuration.isPressed ? 1 : 0.985)
-            .opacity(configuration.isPressed ? 0.84 : 1)
-            .animation(
-                reduceMotion
-                    ? .easeOut(duration: 0.08)
-                    : .spring(response: 0.22, dampingFraction: 1),
-                value: configuration.isPressed
-            )
-    }
-}
-
 private struct WorkspaceLibraryCard: View {
     @EnvironmentObject private var themeStore: ThemeStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -864,7 +847,7 @@ private struct WorkspaceLibraryCard: View {
             Button(action: action) {
                 cardContent
             }
-            .buttonStyle(WorkspaceActionPressButtonStyle(reduceMotion: reduceMotion))
+            .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
             .accessibilityLabel(accessibilitySummary)
 
             Menu {
@@ -1306,7 +1289,7 @@ private struct WorkspaceCharacterPicker: View {
                             }
                         }
                     }
-                    .buttonStyle(WorkspaceActionPressButtonStyle(reduceMotion: reduceMotion))
+                    .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
                     .disabled(isUnavailable)
                     .opacity(isUnavailable ? 0.36 : 1)
                     .accessibilityIdentifier("workspace.character.\(character.id)")
@@ -1387,7 +1370,7 @@ private struct WorkspaceEmojiPicker: View {
                             }
                         }
                     }
-                    .buttonStyle(WorkspaceActionPressButtonStyle(reduceMotion: reduceMotion))
+                    .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
                     .disabled(isUnavailable)
                     .opacity(isUnavailable ? 0.36 : 1)
                     .accessibilityLabel(emoji)
@@ -1558,7 +1541,7 @@ private struct WorkspaceDetailView: View {
             .background(tokens.contentPanelBackground, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         }
-        .buttonStyle(WorkspaceActionPressButtonStyle(reduceMotion: reduceMotion))
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
     }
 
     @ViewBuilder

--- a/ios/MimiRemote/Tests/MimiRemoteTests/MimiInteractionFeedbackTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/MimiInteractionFeedbackTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import MimiRemote
+
+final class MimiInteractionFeedbackTests: XCTestCase {
+    func testEveryMotionTokenHasSpringAndReducedMotionFallback() {
+        for token in MimiMotion.allCases {
+            let normal = token.resolve(reduceMotion: false)
+            let reduced = token.resolve(reduceMotion: true)
+
+            guard case .spring = normal.curve else {
+                return XCTFail("\(token) 普通模式必须使用可中断的 spring")
+            }
+            guard case .easeOut = reduced.curve else {
+                return XCTFail("\(token) Reduce Motion 必须使用短淡变 fallback")
+            }
+            XCTAssertFalse(reduced.allowsScale)
+            XCTAssertFalse(reduced.allowsSpatialMotion)
+        }
+    }
+
+    func testPressOnlyAllowsScaleOutsideReducedMotion() {
+        XCTAssertTrue(MimiMotion.press.resolve(reduceMotion: false).allowsScale)
+        XCTAssertFalse(MimiMotion.press.resolve(reduceMotion: true).allowsScale)
+        XCTAssertFalse(MimiMotion.press.resolve(reduceMotion: false).allowsSpatialMotion)
+    }
+
+    func testMotionTokensKeepDistinctSemanticCurves() {
+        XCTAssertEqual(
+            MimiMotion.press.resolve(reduceMotion: false).curve,
+            .spring(response: 0.22, dampingFraction: 1, blendDuration: 0)
+        )
+        XCTAssertEqual(
+            MimiMotion.stateTransition.resolve(reduceMotion: false).curve,
+            .spring(response: 0.34, dampingFraction: 1, blendDuration: 0.08)
+        )
+        XCTAssertEqual(
+            MimiMotion.presentation.resolve(reduceMotion: true).curve,
+            .easeOut(duration: 0.16)
+        )
+        XCTAssertEqual(
+            MimiMotion.gestureSettling.resolve(reduceMotion: true).curve,
+            .easeOut(duration: 0.12)
+        )
+    }
+
+    func testHapticEventsMapToExactlyOneDistinctPattern() {
+        let patterns = MimiHapticEvent.allCases.map(\.pattern)
+
+        XCTAssertEqual(
+            patterns,
+            [.impactMedium, .notificationSuccess, .notificationError, .selection]
+        )
+        XCTAssertEqual(Set(patterns).count, MimiHapticEvent.allCases.count)
+    }
+}


### PR DESCRIPTION
## 目标

为高频交互建立统一、语义化且支持 Reduce Motion 的反馈基础，避免各页面继续复制不同的动画参数和触感实现。

## 改动

- 新增 MimiMotion，覆盖 press、stateTransition、presentation、gestureSettling，并提供 Reduce Motion 等价反馈与空间运动约束。
- 新增 MimiPressButtonStyle，统一 Composer 与 Workspace 高频按钮的按压反馈。
- 新增 MimiHapticEvent / MimiHaptics，一次业务节点只发出一次明确反馈；语音录制在真正开始采样后触发 commit。
- 补充交互规则文档与纯逻辑单元测试。

## 影响

- 普通模式保留现有轻微缩放和弹簧手感。
- Reduce Motion 下取消按压缩放和非必要空间运动，仅保留短淡变。
- 移除语音录制开始时叠加 impact、success notification 与系统振动的三重反馈。

## 验证

- MimiInteractionFeedbackTests：4/4 通过。
- ConversationDataFlowTests 语音录制状态回归：5/5 通过。
- bash ./scripts/ios-dev.sh build：固定 iPad Pro 13-inch (M5) Simulator，成功。
- git diff --check 与 Xcode project plutil 校验通过。
- ChatGPT Pro 实现审查：PASS；Blocker 0、High 0，唯一 Medium 建议已落实（fire 不再隐式 prepare）。

## Verify 阶段待确认

- 实体设备确认录音真正开始采样时只有一次 commit 触感，取消、准备中和持续录音不重复震动。
- 实体设备确认触感强度不过重；Simulator 无法替代此验收。

Linear: MIM-69
