### PR TITLE
MIM-73 Add Inspector presentation source

### DIFF
--- a/docs/design/mim-73-presentation-source.md
+++ b/docs/design/mim-73-presentation-source.md
@@ -44,13 +44,13 @@
 
 ## 实现
 
-ChatGPT Pro 实施前门禁结论为 `GO`（Blocker 0 / High 0 / Medium 3）。本轮先只完成 New Session Prototype Gate；Inspector 保留在 MIM-73 内作为第二阶段，但不与原型混入同一 PR：
+ChatGPT Pro 实施前门禁结论为 `GO`（Blocker 0 / High 0 / Medium 3）。New Session Prototype Gate 已通过 PR #119 合并到 `main`（merge commit `91d8e9b3`）；Inspector 继续使用独立分支完成第二阶段，避免把原型与扩展实现混在同一审查批次：
 
 1. 建立 source kind / presentation state 和单一 Namespace。
 2. 为会话列表 toolbar 与 iPad sidebar 两个入口绑定不同 source ID。
 3. 目标 `NewSessionSheet` 只在 source 存在且未启用 Reduce Motion 时使用 system zoom。
 4. 在 iPhone 17 Pro、iPhone 17e、iPad Pro 13-inch (M5) 和窄窗口验证 source identity、关闭返回、普通 fallback 与 Reduce Motion。
-5. Prototype 通过后才把同一模型扩展到 sheet 形态的 Inspector；attached inspector 和程序化路径保持原行为。
+5. Prototype 通过后把同一模型扩展到 sheet 形态的 Inspector；attached inspector 和程序化路径保持原行为。
 
 Prototype Gate 的状态职责进一步收敛为：source 是一次 Presentation identity 的组成部分，不是按钮级 UI flag；Reduce Motion 由展示入口读取并锁定到本次 Presentation，避免设置在表单打开时变化导致 SwiftUI 分支重建和本地状态丢失。关闭后必须清空整次 Presentation，下一次打开重新读取设置，并验证 `toolbar -> dismiss -> sidebar` 与反向顺序均不会复用旧 source。
 
@@ -65,6 +65,29 @@ Prototype Gate 的状态职责进一步收敛为：source 是一次 Presentation
 实施前评审记录：[MIM-73 ChatGPT Pro 会话](https://chatgpt.com/c/6a6e6fb1-afa8-83ea-b56d-e6e9e60b9968)。
 
 同一会话的 Prototype 合并前终审结论为 `GO`（Blocker 0 / High 0 / Medium 0 / Low 2，合并前必须修改项：无）。终审明确接受“打开时锁定 Reduce Motion 转场、下一次打开应用新值”的取舍，认为它比展示期间动态切换 View 结构更适合当前含本地表单状态的架构。
+
+### Inspector 第二阶段
+
+Inspector 实施前继续复用同一 ChatGPT Pro 会话，门禁结论为 `GO（有条件）`（Blocker 0 / High 0 / Medium 3）：
+
+1. `showingInspector` 继续是展示真相；新状态只保存一次 Presentation 的 host、可选 source 与锁定后的 transition。
+2. 只有 860–1179pt regular 宽度下、独立 `sessionDetail.inspector` 工具栏按钮的直接点击可以写入 `sessionToolbarInspector`。
+3. Compact 更多菜单、attached `.inspector`、布局恢复和子 Agent 程序化打开全部 fail closed，使用普通系统 Presentation。
+4. medium / attached host 变化立即失效旧 context，禁止把 zoom source 跨 host 迁移；Sheet 正常关闭则保留 context 到 `onDismiss`，让退出动画回到原 source。
+5. `WorkbenchChrome` 只消费 Shell 锁定的 context，不自行读取 Reduce Motion 或推导 eligibility，避免转场状态反向拥有 Inspector 业务状态。
+
+最终实现增加独立的 `InspectorPresentationState`，并把 source 标识只挂在中等宽度的独立工具栏项上。Inspector 内容增加 `sessionInspector.content` 可访问标识，便于设备级断言。Sheet 真正 dismiss 后只清理 transition context；用户明确点击“完成”或工具栏关闭时才清理相关子 Agent 导航，布局迁移关闭 Sheet 时保留关系，避免 compact / attached host 丢失同一子 Agent。
+
+### Inspector 验收证据
+
+- 最终定向回归 18/18 通过：`NewSessionPresentationSourceTests` 15/15、侧栏导航快照 1/1、1032pt / 1180pt 布局边界 2/2，覆盖 medium zoom、compact / attached / 程序化 fallback、Namespace 缺失、Reduce Motion 锁定、重入拒绝、dismiss 清理、连续来源序列和 host 变化失效。
+- iPad Pro 13-inch (M5) 1032pt：独立详情按钮沿自身源点 zoom 展开并返回；录屏 `/tmp/mim73-inspector-medium.mp4`。来源未误匹配刷新或更多按钮。
+- Reduce Motion：设置开启时同一入口改为普通 Sheet；录屏 `/tmp/mim73-inspector-reduce-motion.mp4`。单元测试同时验证当前 Presentation 锁定、下一次打开才读取新设置。
+- iPad 旋转 UI 回归：专用 `MimiRemotePhysicalUITests` 1/1 通过；Inspector 在 portrait → landscape → portrait 往返中保持展示，关闭后无残留。结果位于 `Test-MimiRemotePhysicalUITests-2026.08.02_07-54-17-+0800.xcresult`。
+- iPhone 17 Pro 与 iPhone 17e：各自使用独立 DerivedData 完成 Debug 构建；`… → 显示详情` 均展示带系统表单控制柄的普通大 Sheet，关闭后 `sessionInspector.content` 消失，小屏控件可用。
+- 1180pt attached 边界：`ResponsiveLayoutTests` 与 Inspector host 状态测试覆盖 `.inspector` 选择、无 zoom 和跨 host 清理。当前 Xcode 27 beta 远程模拟器在旋转后仍保持 1032pt 自由窗口，无法诚实形成 ≥1180pt 运行窗口，因此不把本轮旋转录屏误记为 attached 运行态证据。
+- 独立只读审查初次结论为 Blocker 0 / High 0 / Medium 1 / Low 1。修正 stale 子 Agent 后的复审继续发现一个 High：通用 `onDismiss` 清业务关系会误伤布局迁移。最终实现把用户关闭与 host 迁移拆开，复审结论为 `GO`（Blocker 0 / High 0 / Medium 0），文档 Low 同步关闭。
+- ChatGPT Pro 初次终审未识别上述迁移风险；收到独立复审证据与修正版源码包后纠正结论。最终纠错终审为 `GO`（Blocker 0 / High 0 / Medium 0 / Low 1，必须修改项：无），确认 `presentation dismiss ≠ business context dismiss` 的职责边界。Low 仅提醒未来若改变 interactive dismiss 语义需重新评估；当前范围无需修改。终审同时接受 1180pt 运行态缺口为已记录的剩余风险，不阻止本阶段合并。
 
 ## 风险与优化
 

--- a/ios/MimiRemote/Sources/Features/Inspector/SessionContextSidebarView.swift
+++ b/ios/MimiRemote/Sources/Features/Inspector/SessionContextSidebarView.swift
@@ -60,6 +60,7 @@ struct SessionContextSidebarView: View {
             }
         }
         .background(tokens.sidebarBackground)
+        .accessibilityIdentifier("sessionInspector.content")
         .sheet(item: $goalEditor) { draft in
             ThreadGoalEditorSheet(draft: draft)
         }

--- a/ios/MimiRemote/Sources/Features/Shell/NewSessionPresentationSource.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/NewSessionPresentationSource.swift
@@ -92,3 +92,85 @@ struct WorkbenchSheetPresentationState: Equatable {
         presentation = nil
     }
 }
+
+/// Inspector 与 New Session 使用不同的空间来源，避免两个展示生命周期互相污染。
+enum InspectorPresentationSource: String, Hashable {
+    case sessionToolbarInspector
+
+    var transitionSourceID: String { rawValue }
+}
+
+/// Inspector 的入口宿主。只有 regular/medium 布局下持续可见的工具栏按钮能成为 zoom source。
+enum InspectorPresentationHost: Hashable {
+    case compactSheet
+    case mediumSheet
+    case attached
+}
+
+enum InspectorPresentationTransitionPolicy: Hashable {
+    case systemSheet
+    case zoom(sourceID: String)
+}
+
+/// 仅描述本次 Inspector 展示的动画身份，不持有 Inspector 内部选择或业务状态。
+struct InspectorPresentationContext: Hashable {
+    let host: InspectorPresentationHost
+    let source: InspectorPresentationSource?
+    let transition: InspectorPresentationTransitionPolicy
+
+    init(
+        host: InspectorPresentationHost,
+        source: InspectorPresentationSource? = nil,
+        hasNamespace: Bool = false,
+        reduceMotion: Bool = false
+    ) {
+        self.host = host
+
+        let resolvedSource: InspectorPresentationSource? = if host == .mediumSheet,
+                                                               source == .sessionToolbarInspector,
+                                                               hasNamespace {
+            source
+        } else {
+            nil
+        }
+        self.source = resolvedSource
+
+        if !reduceMotion, let resolvedSource {
+            transition = .zoom(sourceID: resolvedSource.transitionSourceID)
+        } else {
+            transition = .systemSheet
+        }
+    }
+
+}
+
+/// `showingInspector` 仍由界面层负责；这里仅锁定与其同步的动画上下文。
+struct InspectorPresentationState: Equatable {
+    private(set) var context: InspectorPresentationContext?
+
+    mutating func present(
+        on host: InspectorPresentationHost,
+        source: InspectorPresentationSource? = nil,
+        hasNamespace: Bool = false,
+        reduceMotion: Bool = false
+    ) {
+        // 展示期间拒绝重入，避免另一个入口替换返回锚点或动态辅助功能改变转场。
+        guard context == nil else { return }
+        context = InspectorPresentationContext(
+            host: host,
+            source: source,
+            hasNamespace: hasNamespace,
+            reduceMotion: reduceMotion
+        )
+    }
+
+    mutating func dismiss() {
+        context = nil
+    }
+
+    mutating func layoutHostDidChange(to host: InspectorPresentationHost) {
+        guard context?.host != host else { return }
+        // Sheet 与 attached Inspector 是不同 host；旧 source/zoom 不得跨容器延续。
+        context = nil
+    }
+}

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -102,6 +102,7 @@ struct UnifiedWorkbenchShell: View {
     )
     @State private var didRestoreFloatingSidebarVisibility = false
     @State private var sheetPresentationState = WorkbenchSheetPresentationState()
+    @State private var inspectorPresentationState = InspectorPresentationState()
     @State private var sessionActionPresentation: SessionActionPresentation?
     @State private var notificationVisibilitySceneID = UUID()
     @State private var navigationBindingScheduler = WorkbenchNavigationBindingScheduler()
@@ -1036,7 +1037,7 @@ struct UnifiedWorkbenchShell: View {
                         .disabled(sessionStore.isRefreshingSelectedSession || sessionStore.isLoading)
 
                         Button {
-                            toggleInspector()
+                            toggleInspector(layout: layout)
                         } label: {
                             Label(
                                 showingInspector ? L10n.text("ui.hide_details") : L10n.text("ui.show_details"),
@@ -1078,16 +1079,7 @@ struct UnifiedWorkbenchShell: View {
                 }
                 // 宽屏保留两个独立动作；手机端已经收进单一更多菜单。
                 ToolbarSpacer(.fixed, placement: .topBarTrailing)
-                ToolbarItem(placement: .topBarTrailing) {
-                    workbenchToolbarIconButton(
-                        systemImage: "sidebar.right",
-                        accessibilityLabel: showingInspector ? L10n.text("ui.hide_details") : L10n.text("ui.show_details"),
-                        tokens: tokens,
-                        isActive: showingInspector
-                    ) {
-                        toggleInspector()
-                    }
-                }
+                inspectorToolbarItem(layout: layout, tokens: tokens)
             }
         }
         .background(tokens.background.ignoresSafeArea())
@@ -1103,6 +1095,8 @@ struct UnifiedWorkbenchShell: View {
         .sessionInspectorPresentation(
             isPresented: $showingInspector,
             layout: layout,
+            transitionContext: inspectorPresentationState.context,
+            presentationNamespace: presentationNamespace,
             relatedSubagent: $selectedRelatedSubagent,
             parentSessionID: $relatedSubagentParentID,
             onOpenSubagent: { subagent in
@@ -1110,6 +1104,15 @@ struct UnifiedWorkbenchShell: View {
             },
             onCloseRelatedSubagent: {
                 closeRelatedSubagent(keepInspectorVisible: true)
+            },
+            onRequestDismiss: {
+                // 只有用户明确结束当前 Inspector 时才清理子 Agent 导航。
+                // 布局迁移也会关闭 Sheet，但必须保留关系以迁移到 compact/attached host。
+                closeRelatedSubagent(keepInspectorVisible: false)
+            },
+            onDismiss: {
+                // Sheet 的返回动画完成后再清来源，保证 zoom 能回到原按钮。
+                inspectorPresentationState.dismiss()
             }
         )
     }
@@ -1226,6 +1229,9 @@ struct UnifiedWorkbenchShell: View {
         usesCompactNavigation: Bool,
         layout: WorkbenchLayout
     ) {
+        inspectorPresentationState.layoutHostDidChange(
+            to: inspectorPresentationHost(for: layout)
+        )
         if usesCompactNavigation {
             if let relation = selectedRelatedSubagent,
                let parentID = relatedSubagentParentID {
@@ -1248,6 +1254,7 @@ struct UnifiedWorkbenchShell: View {
         }
 
         if selectedRelatedSubagent != nil {
+            prepareInspectorPresentation(layout: layout)
             showingInspector = true
         }
 
@@ -1259,15 +1266,28 @@ struct UnifiedWorkbenchShell: View {
     }
 
     private func handleRelatedPresentationChange(layout: WorkbenchLayout) {
+        inspectorPresentationState.layoutHostDidChange(
+            to: inspectorPresentationHost(for: layout)
+        )
         guard selectedRelatedSubagent != nil, !layout.usesCompactNavigation else { return }
+        prepareInspectorPresentation(layout: layout)
         showingInspector = true
     }
 
-    private func toggleInspector() {
+    private func toggleInspector(
+        layout: WorkbenchLayout,
+        source: InspectorPresentationSource? = nil
+    ) {
         if showingInspector {
             closeRelatedSubagent(keepInspectorVisible: false)
             showingInspector = false
+            if layout.usesAttachedInspector {
+                // Attached host 没有 Sheet onDismiss，且从未使用 zoom，可同步结束动画上下文。
+                inspectorPresentationState.dismiss()
+            }
         } else {
+            // SwiftUI 可能在 Bool 写入的同一事务创建 Sheet；来源必须先锁定。
+            prepareInspectorPresentation(layout: layout, source: source)
             showingInspector = true
         }
     }
@@ -1292,6 +1312,7 @@ struct UnifiedWorkbenchShell: View {
         } else {
             // 宽屏替换附着检查器；中等宽度复用当前系统 sheet 并在其中 push，
             // 两种形态都保留父会话上下文。
+            prepareInspectorPresentation(layout: layout)
             showingInspector = true
         }
     }
@@ -1305,6 +1326,27 @@ struct UnifiedWorkbenchShell: View {
         if keepInspectorVisible {
             showingInspector = true
         }
+    }
+
+    private func inspectorPresentationHost(
+        for layout: WorkbenchLayout
+    ) -> InspectorPresentationHost {
+        if layout.usesCompactNavigation {
+            return .compactSheet
+        }
+        return layout.usesAttachedInspector ? .attached : .mediumSheet
+    }
+
+    private func prepareInspectorPresentation(
+        layout: WorkbenchLayout,
+        source: InspectorPresentationSource? = nil
+    ) {
+        inspectorPresentationState.present(
+            on: inspectorPresentationHost(for: layout),
+            source: source,
+            hasNamespace: true,
+            reduceMotion: reduceMotion
+        )
     }
 
     private func handleSelectionCommit(
@@ -1352,6 +1394,55 @@ struct UnifiedWorkbenchShell: View {
         case nil:
             break
         }
+    }
+
+    @ToolbarContentBuilder
+    private func inspectorToolbarItem(
+        layout: WorkbenchLayout,
+        tokens: ThemeTokens
+    ) -> some ToolbarContent {
+        if layout.usesSheetInspectorNavigation {
+            ToolbarItem(placement: .topBarTrailing) {
+                inspectorToolbarButton(
+                    layout: layout,
+                    tokens: tokens,
+                    source: .sessionToolbarInspector
+                )
+            }
+            // 只有中等宽度的独立按钮是稳定锚点；attached Inspector 不参与 Sheet zoom。
+            .matchedTransitionSource(
+                id: InspectorPresentationSource
+                    .sessionToolbarInspector
+                    .transitionSourceID,
+                in: presentationNamespace
+            )
+        } else {
+            ToolbarItem(placement: .topBarTrailing) {
+                inspectorToolbarButton(
+                    layout: layout,
+                    tokens: tokens,
+                    source: nil
+                )
+            }
+        }
+    }
+
+    private func inspectorToolbarButton(
+        layout: WorkbenchLayout,
+        tokens: ThemeTokens,
+        source: InspectorPresentationSource?
+    ) -> some View {
+        workbenchToolbarIconButton(
+            systemImage: "sidebar.right",
+            accessibilityLabel: showingInspector
+                ? L10n.text("ui.hide_details")
+                : L10n.text("ui.show_details"),
+            tokens: tokens,
+            isActive: showingInspector
+        ) {
+            toggleInspector(layout: layout, source: source)
+        }
+        .accessibilityIdentifier("sessionDetail.inspector")
     }
 
     /// 顶栏交给系统工具栏材质和命中区域处理；这里只表达图标与激活状态，避免自绘圆形再叠一层系统玻璃。

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -716,19 +716,27 @@ extension View {
     func sessionInspectorPresentation(
         isPresented: Binding<Bool>,
         layout: WorkbenchLayout,
+        transitionContext: InspectorPresentationContext?,
+        presentationNamespace: Namespace.ID,
         relatedSubagent: Binding<SessionContextSubagent?>,
         parentSessionID: Binding<SessionID?>,
         onOpenSubagent: @escaping (SessionContextSubagent) -> Void,
-        onCloseRelatedSubagent: @escaping () -> Void
+        onCloseRelatedSubagent: @escaping () -> Void,
+        onRequestDismiss: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
     ) -> some View {
         modifier(
             SessionInspectorPresentation(
                 isPresented: isPresented,
                 layout: layout,
+                transitionContext: transitionContext,
+                presentationNamespace: presentationNamespace,
                 relatedSubagent: relatedSubagent,
                 parentSessionID: parentSessionID,
                 onOpenSubagent: onOpenSubagent,
-                onCloseRelatedSubagent: onCloseRelatedSubagent
+                onCloseRelatedSubagent: onCloseRelatedSubagent,
+                onRequestDismiss: onRequestDismiss,
+                onDismiss: onDismiss
             )
         )
     }
@@ -738,10 +746,14 @@ struct SessionInspectorPresentation: ViewModifier {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding var isPresented: Bool
     let layout: WorkbenchLayout
+    let transitionContext: InspectorPresentationContext?
+    let presentationNamespace: Namespace.ID
     @Binding var relatedSubagent: SessionContextSubagent?
     @Binding var parentSessionID: SessionID?
     let onOpenSubagent: (SessionContextSubagent) -> Void
     let onCloseRelatedSubagent: () -> Void
+    let onRequestDismiss: () -> Void
+    let onDismiss: () -> Void
 
     @ViewBuilder
     func body(content: Content) -> some View {
@@ -770,51 +782,69 @@ struct SessionInspectorPresentation: ViewModifier {
                 )
             }
         } else {
-            content.sheet(isPresented: $isPresented) {
-                NavigationStack {
-                    SessionInspectorView()
-                        .environment(
-                            \.openSubagentSession,
-                            OpenSubagentSessionAction(handler: onOpenSubagent)
-                        )
-                        .navigationDestination(
-                            isPresented: Binding(
-                                get: {
-                                    layout.usesSheetInspectorNavigation
-                                        && relatedSubagent != nil
-                                        && parentSessionID != nil
-                                },
-                                set: { presented in
-                                    if !presented, layout.usesSheetInspectorNavigation {
-                                        onCloseRelatedSubagent()
-                                    }
-                                }
-                            )
-                        ) {
-                            if let relatedSubagent, let parentSessionID {
-                                RelatedSessionConversationView(
-                                    relation: relatedSubagent,
-                                    parentSessionID: parentSessionID,
-                                    showsCloseButton: false,
-                                    onClose: {}
-                                )
-                            }
-                        }
-                }
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button(L10n.text("ui.complete")) {
-                            isPresented = false
-                        }
-                    }
-                }
-                .interactiveDismissDisabled(
-                    layout.usesSheetInspectorNavigation && relatedSubagent != nil
-                )
-                .presentationDetents(horizontalSizeClass == .compact ? [.large] : [.medium, .large])
-                .presentationDragIndicator(.visible)
+            content.sheet(isPresented: $isPresented, onDismiss: onDismiss) {
+                transitionedInspectorSheet
             }
         }
+    }
+
+    @ViewBuilder
+    private var transitionedInspectorSheet: some View {
+        // Context 在打开前锁定；展示期间不重新读取布局或 Reduce Motion 来切换 View 结构。
+        switch transitionContext?.transition ?? .systemSheet {
+        case .systemSheet:
+            inspectorSheet
+        case .zoom(let sourceID):
+            inspectorSheet.navigationTransition(
+                .zoom(sourceID: sourceID, in: presentationNamespace)
+            )
+        }
+    }
+
+    private var inspectorSheet: some View {
+        NavigationStack {
+            SessionInspectorView()
+                .environment(
+                    \.openSubagentSession,
+                    OpenSubagentSessionAction(handler: onOpenSubagent)
+                )
+                .navigationDestination(
+                    isPresented: Binding(
+                        get: {
+                            layout.usesSheetInspectorNavigation
+                                && relatedSubagent != nil
+                                && parentSessionID != nil
+                        },
+                        set: { presented in
+                            if !presented, layout.usesSheetInspectorNavigation {
+                                onCloseRelatedSubagent()
+                            }
+                        }
+                    )
+                ) {
+                    if let relatedSubagent, let parentSessionID {
+                        RelatedSessionConversationView(
+                            relation: relatedSubagent,
+                            parentSessionID: parentSessionID,
+                            showsCloseButton: false,
+                            onClose: {}
+                        )
+                    }
+                }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(L10n.text("ui.complete")) {
+                    onRequestDismiss()
+                    isPresented = false
+                }
+            }
+        }
+        .interactiveDismissDisabled(
+            layout.usesSheetInspectorNavigation && relatedSubagent != nil
+        )
+        .presentationDetents(horizontalSizeClass == .compact ? [.large] : [.medium, .large])
+        .presentationDragIndicator(.visible)
     }
 }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/NewSessionPresentationSourceTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/NewSessionPresentationSourceTests.swift
@@ -119,4 +119,171 @@ final class NewSessionPresentationSourceTests: XCTestCase {
         state.present(.newSession, source: .sessionsToolbarNewSession)
         XCTAssertEqual(state.presentation?.source, .sessionsToolbarNewSession)
     }
+
+    func testInspectorMediumToolbarWithNamespaceUsesZoom() {
+        var state = InspectorPresentationState()
+
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true
+        )
+
+        XCTAssertEqual(state.context?.host, .mediumSheet)
+        XCTAssertEqual(state.context?.source, .sessionToolbarInspector)
+        XCTAssertEqual(
+            state.context?.transition,
+            .zoom(
+                sourceID: InspectorPresentationSource
+                    .sessionToolbarInspector
+                    .transitionSourceID
+            )
+        )
+    }
+
+    func testInspectorFallbackHostsAndMissingNamespaceUseSystemSheet() {
+        for host in [
+            InspectorPresentationHost.compactSheet,
+            .attached,
+        ] {
+            var state = InspectorPresentationState()
+            state.present(
+                on: host,
+                source: .sessionToolbarInspector,
+                hasNamespace: true
+            )
+
+            XCTAssertNil(state.context?.source, "Unexpected source for \(host)")
+            XCTAssertEqual(state.context?.transition, .systemSheet)
+        }
+
+        var missingNamespaceState = InspectorPresentationState()
+        missingNamespaceState.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: false
+        )
+        XCTAssertNil(missingNamespaceState.context?.source)
+        XCTAssertEqual(missingNamespaceState.context?.transition, .systemSheet)
+
+        var programmaticState = InspectorPresentationState()
+        programmaticState.present(on: .mediumSheet)
+        XCTAssertNil(programmaticState.context?.source)
+        XCTAssertEqual(programmaticState.context?.transition, .systemSheet)
+    }
+
+    func testInspectorReduceMotionIsLockedForCurrentPresentation() {
+        var state = InspectorPresentationState()
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true,
+            reduceMotion: true
+        )
+
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true,
+            reduceMotion: false
+        )
+        XCTAssertEqual(state.context?.source, .sessionToolbarInspector)
+        XCTAssertEqual(state.context?.transition, .systemSheet)
+
+        state.dismiss()
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true,
+            reduceMotion: false
+        )
+        XCTAssertEqual(
+            state.context?.transition,
+            .zoom(
+                sourceID: InspectorPresentationSource
+                    .sessionToolbarInspector
+                    .transitionSourceID
+            )
+        )
+    }
+
+    func testInspectorActivePresentationRejectsReentryReplacement() {
+        var state = InspectorPresentationState()
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true
+        )
+
+        state.present(on: .mediumSheet, reduceMotion: true)
+
+        XCTAssertEqual(state.context?.host, .mediumSheet)
+        XCTAssertEqual(state.context?.source, .sessionToolbarInspector)
+        XCTAssertEqual(
+            state.context?.transition,
+            .zoom(
+                sourceID: InspectorPresentationSource
+                    .sessionToolbarInspector
+                    .transitionSourceID
+            )
+        )
+    }
+
+    func testInspectorDismissClearsContext() {
+        var state = InspectorPresentationState()
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true
+        )
+
+        state.dismiss()
+
+        XCTAssertNil(state.context)
+    }
+
+    func testInspectorToolbarFallbackToolbarSequenceDoesNotLeakSource() {
+        var state = InspectorPresentationState()
+
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true
+        )
+        XCTAssertEqual(state.context?.source, .sessionToolbarInspector)
+        state.dismiss()
+
+        state.present(on: .mediumSheet)
+        XCTAssertNil(state.context?.source)
+        XCTAssertEqual(state.context?.transition, .systemSheet)
+        state.dismiss()
+
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true
+        )
+        XCTAssertEqual(state.context?.source, .sessionToolbarInspector)
+        XCTAssertEqual(
+            state.context?.transition,
+            .zoom(
+                sourceID: InspectorPresentationSource
+                    .sessionToolbarInspector
+                    .transitionSourceID
+            )
+        )
+    }
+
+    func testInspectorLayoutHostChangeClearsOldTransitionContext() {
+        var state = InspectorPresentationState()
+        state.present(
+            on: .mediumSheet,
+            source: .sessionToolbarInspector,
+            hasNamespace: true
+        )
+
+        state.layoutHostDidChange(to: .attached)
+
+        XCTAssertNil(state.context)
+    }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -185,6 +185,33 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         }
     }
 
+    func testInspectorPresentationSurvivesIPadRotation() throws {
+        try XCTSkipUnless(
+            UIDevice.current.userInterfaceIdiom == .pad,
+            "Inspector 的 sheet / attached 切换只在 iPad 验收。"
+        )
+        rotate(to: .portrait)
+        try openComposerIfNeeded()
+
+        let inspectorButton = app.descendant(identifier: "sessionDetail.inspector")
+        XCTAssertTrue(inspectorButton.waitForExistence(timeout: 10), "中等宽度应展示独立 Inspector 入口")
+        inspectorButton.tap()
+
+        let inspectorContent = app.descendant(identifier: "sessionInspector.content")
+        XCTAssertTrue(inspectorContent.waitForExistence(timeout: 10), "竖屏中等宽度应打开 Inspector Sheet")
+
+        rotate(to: .landscapeLeft)
+        XCTAssertTrue(inspectorContent.waitForExistence(timeout: 10), "旋转后 Inspector 内容不应丢失")
+
+        rotate(to: .portrait)
+        XCTAssertTrue(inspectorContent.waitForExistence(timeout: 10), "返回中等宽度后 Inspector 应保持展示")
+
+        let closeButton = app.descendant(identifier: "sessionDetail.inspector")
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 5), "Inspector 展示期间应保留同一工具栏入口")
+        closeButton.tap()
+        XCTAssertTrue(inspectorContent.waitForNonExistence(timeout: 10), "关闭后不应残留 Sheet 或 attached Inspector")
+    }
+
     func testWideIPadFloatingSidebarDragDoesNotStealSessionRowGestures() throws {
         try XCTSkipUnless(
             UIDevice.current.userInterfaceIdiom == .pad,


### PR DESCRIPTION
## 目标

完成 MIM-73 Inspector 第二阶段：只让 860–1179pt regular 布局下稳定可见的详情工具栏按钮使用 SwiftUI source zoom，其余 compact 菜单、attached Inspector 和程序化路径保持系统 Presentation。

## 实现

- 新增独立的 `InspectorPresentationState`，锁定单次展示的 host、source 与 Reduce Motion 策略。
- 仅 `sessionDetail.inspector` 中等宽度工具栏入口注册 `matchedTransitionSource`。
- Sheet 只消费锁定后的 transition context；attached Inspector 不消费 zoom source。
- host 变化时清理旧 transition context，拒绝展示期间的来源重入。
- 区分用户主动关闭与布局迁移：用户“完成”清理相关子 Agent，通用 `onDismiss` 只清 Presentation context，避免迁移到 compact/attached 时丢失同一子 Agent。
- 增加 Inspector 内容/按钮的稳定可访问标识、状态单测、iPad 旋转 UI 回归和中文设计记录。

## 验证

- 定向回归 18/18：15 个 Presentation state tests、1 个导航快照、2 个 1032/1180pt 布局边界测试。
- iPad 1032pt：正常动效沿详情按钮 zoom；Reduce Motion 为普通 Sheet。
- iPad 旋转 UI 回归 1/1：portrait → landscape → portrait 保持展示，关闭后无残留。
- iPhone 17 Pro / 17e：Debug 构建成功，更多菜单打开普通大 Sheet并可关闭。
- 独立复审最终 GO：Blocker 0 / High 0 / Medium 0。
- ChatGPT Pro 纠错终审最终 GO：Blocker 0 / High 0 / Medium 0，must-fix none。
- `git diff --check` 通过。

## 已知剩余风险

当前 Xcode 27 beta 远程 iPad 旋转后仍保持 1032pt 自由窗口，未形成真实 ≥1180pt attached 运行窗口。attached host、无 zoom 和跨 host 清理已由生产代码审查、布局边界测试与状态测试覆盖；该运行态缺口已由独立审查与 Pro 接受为非合并阻断风险。

Linear: MIM-73
