### PR TITLE
MIM-11 为主机平台图标增加品牌配色

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
@@ -405,7 +405,7 @@ private struct Windows11Mark: View {
 }
 
 /// 在现有可缩放 Tux 轮廓内叠加经典黑白、橙黄配色。
-/// 所有色块最终再经过轮廓遮罩，缩小到工具栏尺寸时也不会越界或污染状态圆点。
+/// 彩色色块保持在透明负空间内，整体裁到统一视觉盒，避免缩小时污染状态圆点。
 private struct LinuxTuxMark: View {
     @Environment(\.colorScheme) private var colorScheme
 
@@ -418,7 +418,13 @@ private struct LinuxTuxMark: View {
 
     var body: some View {
         ZStack {
-            Color(red: 0.08, green: 0.09, blue: 0.10)
+            // 原 SVG 的眼睛、肚皮和脚掌本身就是透明负空间，不能再把它当最终遮罩。
+            // 先绘制黑色模板，再把经典配色填回这些区域，深色背景下才不会被透穿。
+            Image("LinuxTux")
+                .resizable()
+                .renderingMode(.template)
+                .scaledToFit()
+                .foregroundStyle(Color(red: 0.08, green: 0.09, blue: 0.10))
 
             Ellipse()
                 .fill(Color(red: 0.95, green: 0.95, blue: 0.92))
@@ -437,12 +443,7 @@ private struct LinuxTuxMark: View {
             foot(xOffset: width * 0.20)
         }
         .frame(width: width, height: size)
-        .mask {
-            Image("LinuxTux")
-                .resizable()
-                .renderingMode(.template)
-                .scaledToFit()
-        }
+        .clipped()
         .shadow(color: outline, radius: max(0.45, size / 24))
     }
 

--- a/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
@@ -313,7 +313,7 @@ struct HostSwitcherMenu: View {
 }
 
 /// 三个平台图标保持相同的视觉盒，连接状态由调用方独立表达。
-/// Windows 使用 Windows 11 的正视四格造型；Linux 使用模板渲染的经典 Tux 矢量图。
+/// 品牌平台使用自己的固定色，只有未知平台继续继承调用方的前景色。
 struct HostPlatformGlyph: View {
     let kind: HostPlatformIconKind
     let size: CGFloat
@@ -327,18 +327,12 @@ struct HostPlatformGlyph: View {
     private var glyph: some View {
         switch kind {
         case .apple:
-            Image(systemName: "apple.logo")
-                .font(.system(size: size * 8 / 9, weight: size < 14 ? .medium : .semibold))
-                .symbolRenderingMode(.hierarchical)
+            AppleRainbowMark(size: size * 8 / 9)
         case .windows11:
             Windows11Mark(spacing: size / 12)
                 .frame(width: size * 5 / 6, height: size * 5 / 6)
         case .linuxTux:
-            Image("LinuxTux")
-                .resizable()
-                .renderingMode(.template)
-                .scaledToFit()
-                .frame(width: size * 17 / 18, height: size)
+            LinuxTuxMark(size: size)
         case .genericComputer:
             Image(systemName: "desktopcomputer")
                 .font(.system(size: size * 8 / 9, weight: size < 14 ? .medium : .semibold))
@@ -352,19 +346,135 @@ struct HostPlatformGlyph: View {
     }
 }
 
+/// 1977 彩虹苹果从上到下依次为绿、黄、橙、红、紫、蓝。
+/// 直接用系统 Apple 轮廓做遮罩，既保留经典咬口，也无需维护另一份轮廓资源。
+private struct AppleRainbowMark: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let size: CGFloat
+
+    private let colors: [Color] = [
+        Color(red: 0.38, green: 0.73, blue: 0.27),
+        Color(red: 0.99, green: 0.72, blue: 0.15),
+        Color(red: 0.96, green: 0.51, blue: 0.12),
+        Color(red: 0.88, green: 0.23, blue: 0.24),
+        Color(red: 0.59, green: 0.24, blue: 0.59),
+        Color(red: 0.00, green: 0.62, blue: 0.86)
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(colors.indices, id: \.self) { index in
+                colors[index]
+            }
+        }
+        .frame(width: size, height: size)
+        .mask {
+            Image(systemName: "apple.logo")
+                .resizable()
+                .scaledToFit()
+        }
+        // 黄色条在浅色背景、黑色轮廓在深色背景都需要一层极轻的边缘分离。
+        .shadow(
+            color: colorScheme == .dark ? .white.opacity(0.24) : .black.opacity(0.18),
+            radius: max(0.35, size / 36)
+        )
+    }
+}
+
 private struct Windows11Mark: View {
     let spacing: CGFloat
 
     var body: some View {
         VStack(spacing: spacing) {
             HStack(spacing: spacing) {
-                Rectangle()
-                Rectangle()
+                tile
+                tile
             }
             HStack(spacing: spacing) {
-                Rectangle()
-                Rectangle()
+                tile
+                tile
             }
         }
+    }
+
+    private var tile: some View {
+        Rectangle()
+            .fill(Color(red: 0.00, green: 0.47, blue: 0.83))
+    }
+}
+
+/// 在现有可缩放 Tux 轮廓内叠加经典黑白、橙黄配色。
+/// 所有色块最终再经过轮廓遮罩，缩小到工具栏尺寸时也不会越界或污染状态圆点。
+private struct LinuxTuxMark: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let size: CGFloat
+
+    private var width: CGFloat { size * 17 / 18 }
+    private var outline: Color {
+        colorScheme == .dark ? .white.opacity(0.34) : .black.opacity(0.12)
+    }
+
+    var body: some View {
+        ZStack {
+            Color(red: 0.08, green: 0.09, blue: 0.10)
+
+            Ellipse()
+                .fill(Color(red: 0.95, green: 0.95, blue: 0.92))
+                .frame(width: width * 0.58, height: size * 0.55)
+                .offset(y: size * 0.14)
+
+            eye(xOffset: -width * 0.09)
+            eye(xOffset: width * 0.09)
+
+            TuxBeakShape()
+                .fill(Color(red: 0.98, green: 0.66, blue: 0.08))
+                .frame(width: width * 0.28, height: size * 0.14)
+                .offset(y: -size * 0.13)
+
+            foot(xOffset: -width * 0.20)
+            foot(xOffset: width * 0.20)
+        }
+        .frame(width: width, height: size)
+        .mask {
+            Image("LinuxTux")
+                .resizable()
+                .renderingMode(.template)
+                .scaledToFit()
+        }
+        .shadow(color: outline, radius: max(0.45, size / 24))
+    }
+
+    private func eye(xOffset: CGFloat) -> some View {
+        ZStack {
+            Ellipse()
+                .fill(Color.white)
+                .frame(width: width * 0.19, height: size * 0.22)
+            Circle()
+                .fill(Color.black)
+                .frame(width: max(1, width * 0.065), height: max(1, width * 0.065))
+                .offset(y: size * 0.015)
+        }
+        .offset(x: xOffset, y: -size * 0.28)
+    }
+
+    private func foot(xOffset: CGFloat) -> some View {
+        Ellipse()
+            .fill(Color(red: 0.96, green: 0.57, blue: 0.06))
+            .frame(width: width * 0.44, height: size * 0.18)
+            .offset(x: xOffset, y: size * 0.43)
+    }
+}
+
+private struct TuxBeakShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
+        path.closeSubpath()
+        return path
     }
 }


### PR DESCRIPTION
## 变更内容

- Apple / macOS 主机使用 1977 六色彩虹 Apple 图标
- Windows 主机使用蓝色 Windows 11 四窗格图标
- Linux 主机使用经典黑白橙黄 Tux 图标
- 未知平台继续使用通用电脑图标，连接状态颜色保持独立

## 用户影响

“Mac 连接”、侧栏和主机切换入口的平台辨识度更高，浅色与深色模式下均可清晰区分。

## 验证

- `bash ./scripts/ios-dev.sh build` 通过
- iPad Pro 13-inch (M5) Simulator 浅色/深色运行态验收通过
- macOS / Windows / Linux 三种平台无障碍标签检查通过
- 测试主体执行 1133 项；23 项失败为现有路径断言及快照基线漂移，未涉及本次修改文件

Linear: MIM-11
