### PR TITLE
MIM-24 Isolate subagent sessions from top-level lists

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		B5BB3BBE3B50E66A5C6A081F /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 135E8C33C50F8EF2A9F9D9F1 /* Markdown */; };
 		B7F45B51F9933CD5BED26A48 /* testComposerStatusTrayIPadMiniLandscapeDetailWidth.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 495CF4F9BDB35ED685F879F7 /* testComposerStatusTrayIPadMiniLandscapeDetailWidth.1.png */; };
 		B7FA427B42C52F695B6DDD28 /* CodexAppServerEventProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0764989DE2B4FAEF1543FF5 /* CodexAppServerEventProjection.swift */; };
+		C02400000000000000000002 /* CodexAppServerThreadOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02400000000000000000001 /* CodexAppServerThreadOwnership.swift */; };
 		B94659A58D5F94B552D90D4F /* ComposerRequestCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41787BD804E7C9AD16448E38 /* ComposerRequestCards.swift */; };
 		BC8B20DA0FE42207D5D2CA8C /* ComposerTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E9EA7D6A93EB6697C0B874 /* ComposerTextEditor.swift */; };
 		BDDBF10C9208B7AB95535A57 /* LogStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E1C34623582EDA99D6B917 /* LogStoreTests.swift */; };
@@ -427,6 +428,7 @@
 		BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerTransport.swift; sourceTree = "<group>"; };
 		C01D29CF13ECEA0EBF33BF7C /* HostSwitcherMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostSwitcherMenu.swift; sourceTree = "<group>"; };
 		C0764989DE2B4FAEF1543FF5 /* CodexAppServerEventProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerEventProjection.swift; sourceTree = "<group>"; };
+		C02400000000000000000001 /* CodexAppServerThreadOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerThreadOwnership.swift; sourceTree = "<group>"; };
 		C1DC105E6D153719C86CBB30 /* ConversationMessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageBubble.swift; sourceTree = "<group>"; };
 		C2E9BE6E1D3AD3BE0B2C111B /* ConversationLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLayout.swift; sourceTree = "<group>"; };
 		C37E5D5C19C4592F82C8F319 /* testCommentaryAndTrailingProcessRendering.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCommentaryAndTrailingProcessRendering.1.png; sourceTree = "<group>"; };
@@ -697,6 +699,7 @@
 			children = (
 				3CF761429383D479BD96FC52 /* AgentAPIClient.swift */,
 				C0764989DE2B4FAEF1543FF5 /* CodexAppServerEventProjection.swift */,
+				C02400000000000000000001 /* CodexAppServerThreadOwnership.swift */,
 				A7F06515CE242219649D0218 /* CodexAppServerInteractionLifecycle.swift */,
 				469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */,
 				D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */,
@@ -1266,6 +1269,7 @@
 				76DD6A7B8D4D93D4385A615D /* AssistantTextNormalizer.swift in Sources */,
 				0BDBB13C211DA0019F3B8E9E /* CameraAttachmentViews.swift in Sources */,
 				B7FA427B42C52F695B6DDD28 /* CodexAppServerEventProjection.swift in Sources */,
+				C02400000000000000000002 /* CodexAppServerThreadOwnership.swift in Sources */,
 				0DC788182243F2C8A136A742 /* CodexAppServerInteractionLifecycle.swift in Sources */,
 				FAD77559CF6FDCD943849D7C /* CodexAppServerSessionClients.swift in Sources */,
 				5344C41233BA0E47A0C29FDA /* CodexAppServerSessionRuntime.swift in Sources */,

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -534,6 +534,7 @@ extension CodexAppServerSessionRuntime {
             ?? rateLimitSummary(fromSnapshot: thread["rate_limit"]?.objectValue)
             ?? cached?.rateLimit
             ?? accountRateLimit
+        let ownership = threadOwnership(from: thread, cached: cached)
         let context = sessionContext(
             from: thread,
             sessionID: id,
@@ -541,7 +542,10 @@ extension CodexAppServerSessionRuntime {
             status: effectiveStatus,
             statusValue: forceRunning ? nil : thread["status"],
             project: project ?? fallbackProject,
-            goal: goal
+            goal: goal,
+            createdAt: ownership.createdAt,
+            parentThreadID: ownership.parentThreadID,
+            isSubagent: ownership.isSubagent
         )
         return AgentSession(
             id: id,
@@ -553,7 +557,7 @@ extension CodexAppServerSessionRuntime {
             source: runtimeProvider,
             runtimeProvider: runtimeProvider,
             resumeID: id,
-            createdAt: date(from: thread["createdAt"]),
+            createdAt: ownership.createdAt,
             updatedAt: date(from: thread["updatedAt"]),
             recencyAt: date(from: thread["recencyAt"]),
             preview: preview,
@@ -564,30 +568,13 @@ extension CodexAppServerSessionRuntime {
             rateLimit: rateLimit,
             goal: goal,
             appServerSessionID: nonEmpty(thread["sessionId"]?.stringValue),
-            parentThreadID: nonEmpty(thread["parentThreadId"]?.stringValue),
+            parentThreadID: ownership.parentThreadID,
+            isSubagent: ownership.isSubagent,
             agentNickname: nonEmpty(thread["agentNickname"]?.stringValue),
             agentRole: nonEmpty(thread["agentRole"]?.stringValue),
             canAcceptDirectInput: thread["canAcceptDirectInput"]?.boolValue,
             context: context
         )
-    }
-
-    func gatewayAnnotatedProject(
-        from thread: [String: CodexAppServerJSONValue],
-        projects: [AgentProject]
-    ) -> AgentProject? {
-        guard let annotation = thread["mimiRemote"]?.objectValue,
-              annotation["discovery"]?.stringValue == "global",
-              let projectID = nonEmpty(annotation["projectId"]?.stringValue),
-              let projectPath = nonEmpty(annotation["projectPath"]?.stringValue)
-        else {
-            return nil
-        }
-        // agentd 已做 repo identity 裁剪；iOS 再与当前 config.projects 交叉验证，
-        // 避免陈旧连接或协议混用把会话投影到不存在的项目。
-        return projects.first {
-            $0.id == projectID && $0.path == projectPath
-        }
     }
 
     func sessionContext(
@@ -597,12 +584,18 @@ extension CodexAppServerSessionRuntime {
         status: String,
         statusValue: CodexAppServerJSONValue?,
         project: AgentProject?,
-        goal: ThreadGoal?
+        goal: ThreadGoal?,
+        createdAt: Date?,
+        parentThreadID: String?,
+        isSubagent: Bool?
     ) -> SessionContextSnapshot {
         let threadID = thread["id"]?.stringValue ?? sessionID
         return SessionContextSnapshot(
             sessionID: sessionID,
             threadID: threadID,
+            createdAt: createdAt,
+            parentThreadID: parentThreadID,
+            isSubagent: isSubagent,
             status: contextStatus(from: statusValue, fallbackStatus: status),
             environment: SessionContextEnvironment(
                 id: "local",
@@ -986,10 +979,16 @@ extension CodexAppServerSessionRuntime {
         if let label = sourceLabel(from: thread["source"]) {
             sources.append(SessionContextSource(id: "session_source", kind: "session", label: label, subtitle: L10n.text("ui.original_source")))
         }
-        if let threadSource = nonEmpty(thread["threadSource"]?.stringValue) {
+        if let threadSource = nonEmpty(
+            thread["threadSource"]?.stringValue,
+            thread["thread_source"]?.stringValue
+        ) {
             sources.append(SessionContextSource(id: "thread_source", kind: "thread", label: threadSource, subtitle: L10n.text("ui.thread_source")))
         }
-        if let forkedFrom = nonEmpty(thread["forkedFromId"]?.stringValue) {
+        if let forkedFrom = nonEmpty(
+            thread["forkedFromId"]?.stringValue,
+            thread["forked_from_id"]?.stringValue
+        ) {
             sources.append(SessionContextSource(id: "forked_from", kind: "fork", label: String(forkedFrom.prefix(32)), subtitle: L10n.text("ui.fork_source")))
         }
         if sources.isEmpty, let project {
@@ -1008,8 +1007,13 @@ extension CodexAppServerSessionRuntime {
         if let custom = nonEmpty(object["custom"]?.stringValue) {
             return custom
         }
-        if let subAgent = nonEmpty(object["subAgent"]?.stringValue) {
-            return "subAgent \(subAgent)"
+        if let entry = object.first(where: { $0.key.lowercased() == "subagent" }) {
+            if let subAgent = nonEmpty(entry.value.stringValue) {
+                return "subAgent \(subAgent)"
+            }
+            if entry.value.objectValue != nil || entry.value.boolValue == true {
+                return "subAgent"
+            }
         }
         return nil
     }
@@ -1020,7 +1024,10 @@ extension CodexAppServerSessionRuntime {
     ) -> [SessionContextSubagent] {
         var subagents: [SessionContextSubagent] = []
         var seenThreadIDs = Set<String>()
-        if let parentThreadID = nonEmpty(thread["parentThreadId"]?.stringValue) {
+        if let parentThreadID = nonEmpty(
+            thread["parentThreadId"]?.stringValue,
+            thread["parent_thread_id"]?.stringValue
+        ) {
             if let childThreadID = nonEmpty(thread["id"]?.stringValue) {
                 subagents.append(
                     SessionContextSubagent(

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1035,10 +1035,15 @@ actor CodexAppServerSessionRuntime {
         )
         let object = result?.objectValue ?? [:]
         let rawTurns = object["data"]?.arrayValue?.compactMap(\.objectValue) ?? []
+        let rawChronologicalTurns = Array(rawTurns.reversed())
         let chronologicalTurns = childOwnedHistoryTurns(
             in: thread,
-            turns: Array(rawTurns.reversed())
+            turns: rawChronologicalTurns
         )
+        // desc 分页一旦碰到 child 创建前的父 Turn（或无时间戳的继承 rollout），
+        // 后续 cursor 只会继续向更早的父前缀移动。此时必须本地关闭分页，不能把过滤后的
+        // 空页配上上游 nextCursor 再交给 UI。
+        let reachedInheritedBoundary = chronologicalTurns.count < rawChronologicalTurns.count
         // iPad 在 turn 结束后才恢复连接时，会错过实时 turn/completed，但分页历史已经能看到
         // 对应 turn 的终态。这里用最新一页的权威 turn 结果补回完成事件，避免消息已显示完成，
         // runtime 仍保留陈旧 activeTurnID，进而让后续输入永久卡在本地队列。
@@ -1069,7 +1074,8 @@ actor CodexAppServerSessionRuntime {
                 turnID: recoveredTerminalTurn.turnID
             )
         }
-        let nextCursor = firstString(in: object, keys: ["nextCursor", "next_cursor"])
+        let upstreamNextCursor = firstString(in: object, keys: ["nextCursor", "next_cursor"])
+        let nextCursor = reachedInheritedBoundary ? nil : upstreamNextCursor
         return HistoryMessagesPage(
             messages: messages,
             previousCursor: nextCursor.map(Self.encodeThreadTurnsCursor),
@@ -1171,8 +1177,9 @@ actor CodexAppServerSessionRuntime {
     }
 
     /// Codex 子 Agent 的 Thread 会带上 spawn/fork 时继承的父 Turn，供模型建立上下文。
-    /// 这段前缀不属于子 Agent 自己的执行历史；只有父子身份和时间边界都明确时才裁剪，
-    /// 任何字段缺失或秒级时间戳相等都 fail-open，避免误删普通会话和真实子 Turn。
+    /// 这段前缀不属于子 Agent 自己的执行历史；只有 child 身份和创建时间都明确时才裁剪。
+    /// 已确认 child 后，无 startedAt 的 synthetic rollout 无法证明归 child 所有，按隔离优先丢弃；
+    /// 普通 fork、身份/创建时间缺失仍 fail-open，同秒创建的第一个真实 child Turn 继续保留。
     func childOwnedHistoryTurns(
         in thread: [String: CodexAppServerJSONValue],
         turns: [[String: CodexAppServerJSONValue]]
@@ -1181,17 +1188,8 @@ actor CodexAppServerSessionRuntime {
             thread["parentThreadId"]?.stringValue,
             thread["parent_thread_id"]?.stringValue
         ) != nil
-        let threadSource = nonEmpty(
-            thread["threadSource"]?.stringValue,
-            thread["thread_source"]?.stringValue
-        )?.lowercased()
-        let source = thread["source"]?.objectValue
-        let hasSubagentSource = threadSource?.hasPrefix("subagent") == true
-            || source?["subAgent"]?.objectValue != nil
-            || source?["subagent"]?.objectValue != nil
-            || nonEmpty(source?["subAgent"]?.stringValue, source?["subagent"]?.stringValue) != nil
 
-        guard hasParentThread || hasSubagentSource,
+        guard hasParentThread || hasSubagentSource(in: thread),
               let threadCreatedAt = firstDate(in: thread, keys: ["createdAt", "created_at"])
         else {
             return turns
@@ -1199,7 +1197,7 @@ actor CodexAppServerSessionRuntime {
 
         return turns.filter { turn in
             guard let turnStartedAt = firstDate(in: turn, keys: ["startedAt", "started_at"]) else {
-                return true
+                return false
             }
             return turnStartedAt >= threadCreatedAt
         }
@@ -1221,8 +1219,9 @@ actor CodexAppServerSessionRuntime {
                 "createdAt": cached.createdAt.map { .double($0.timeIntervalSince1970) } ?? .null,
                 "updatedAt": cached.updatedAt.map { .double($0.timeIntervalSince1970) } ?? .null,
                 // prepareRelatedSession 会先 thread/read，再走 turns/list；缓存壳层必须保留
-                // 父子身份，否则分页历史会因缺 metadata 而错误 fail-open。
-                "parentThreadId": cached.parentThreadID.map { .string($0) } ?? .null
+                // parent 与 source-only subAgent 身份，否则分页历史会因缺 metadata 而错误 fail-open。
+                "parentThreadId": cached.parentThreadID.map { .string($0) } ?? .null,
+                "threadSource": cached.isSubagentThread ? .string("subagent") : .null
             ]
         }
         let project = projects.first

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerThreadOwnership.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerThreadOwnership.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+extension CodexAppServerSessionRuntime {
+    func gatewayAnnotatedProject(
+        from thread: [String: CodexAppServerJSONValue],
+        projects: [AgentProject]
+    ) -> AgentProject? {
+        guard let annotation = thread["mimiRemote"]?.objectValue,
+              annotation["discovery"]?.stringValue == "global",
+              let projectID = nonEmpty(annotation["projectId"]?.stringValue),
+              let projectPath = nonEmpty(annotation["projectPath"]?.stringValue)
+        else {
+            return nil
+        }
+        // agentd 已做 repo identity 裁剪；iOS 再与当前 config.projects 交叉验证，
+        // 避免陈旧连接或协议混用把会话投影到不存在的项目。
+        return projects.first {
+            $0.id == projectID && $0.path == projectPath
+        }
+    }
+
+    /// ownership 只来自结构父子字段或明确的 subAgent source。
+    /// `forkedFromId` 是普通 fork 的来源信息，不能参与顶层可见性或历史隔离判断。
+    func threadOwnership(
+        from thread: [String: CodexAppServerJSONValue],
+        cached: AgentSession?
+    ) -> (createdAt: Date?, parentThreadID: String?, isSubagent: Bool?) {
+        let createdAt = cached?.createdAt
+            ?? firstDate(in: thread, keys: ["createdAt", "created_at"])
+        let parentThreadID = nonEmpty(
+            cached?.parentThreadID,
+            thread["parentThreadId"]?.stringValue,
+            thread["parent_thread_id"]?.stringValue
+        )
+        let hasSubagentIdentity = parentThreadID != nil
+            || cached?.isSubagent == true
+            || hasSubagentSource(in: thread)
+        return (
+            createdAt: createdAt,
+            parentThreadID: parentThreadID,
+            isSubagent: hasSubagentIdentity ? true : cached?.isSubagent
+        )
+    }
+
+    func hasSubagentSource(in thread: [String: CodexAppServerJSONValue]) -> Bool {
+        let threadSource = nonEmpty(
+            thread["threadSource"]?.stringValue,
+            thread["thread_source"]?.stringValue
+        )?.lowercased()
+        if threadSource?.hasPrefix("subagent") == true {
+            return true
+        }
+        if nonEmpty(thread["source"]?.stringValue)?.lowercased().hasPrefix("subagent") == true {
+            return true
+        }
+        guard let source = thread["source"]?.objectValue else {
+            return false
+        }
+        return source.contains { key, value in
+            guard key.lowercased() == "subagent" else { return false }
+            return value.objectValue != nil
+                || nonEmpty(value.stringValue) != nil
+                || value.boolValue == true
+        }
+    }
+}

--- a/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
@@ -90,7 +90,7 @@ struct AgentSession: Identifiable, Codable, Hashable {
     let source: String
     let runtimeProvider: String?
     let resumeID: String?
-    let createdAt: Date?
+    var createdAt: Date?
     var updatedAt: Date?
     var recencyAt: Date?
     var preview: String?
@@ -104,6 +104,8 @@ struct AgentSession: Identifiable, Codable, Hashable {
     var goal: ThreadGoal?
     var appServerSessionID: String?
     var parentThreadID: String?
+    /// `parentThreadID` 缺失时仍可能是 source-only 子 Agent；nil 表示旧协议未提供身份结论。
+    var isSubagent: Bool?
     var agentNickname: String?
     var agentRole: String?
     var canAcceptDirectInput: Bool?
@@ -134,7 +136,16 @@ struct AgentSession: Identifiable, Codable, Hashable {
     /// 旧 App Server 的普通顶层 thread 没有 capability 字段，继续沿用既有可写行为；
     /// 子会话缺字段则 fail-closed，避免把协议未知误当成可直接输入。
     var allowsDirectInput: Bool {
-        canAcceptDirectInput ?? (parentThreadID == nil)
+        canAcceptDirectInput ?? !isSubagentThread
+    }
+
+    /// 父子关系或明确的 subAgent source 任一成立，都按结构子任务处理。
+    /// `forkedFromId` 不进入模型，普通 fork 因此不会被误判为子 Agent。
+    var isSubagentThread: Bool {
+        parentThreadID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            || context?.parentThreadID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            || isSubagent == true
+            || context?.isSubagent == true
     }
 
     var displayStatusText: String {
@@ -165,6 +176,7 @@ struct AgentSession: Identifiable, Codable, Hashable {
         goal: ThreadGoal? = nil,
         appServerSessionID: String? = nil,
         parentThreadID: String? = nil,
+        isSubagent: Bool? = nil,
         agentNickname: String? = nil,
         agentRole: String? = nil,
         canAcceptDirectInput: Bool? = nil,
@@ -180,7 +192,7 @@ struct AgentSession: Identifiable, Codable, Hashable {
         let normalizedRuntimeProvider = runtimeProvider?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.runtimeProvider = normalizedRuntimeProvider?.isEmpty == false ? normalizedRuntimeProvider : nil
         self.resumeID = resumeID
-        self.createdAt = createdAt
+        self.createdAt = createdAt ?? context?.createdAt
         self.updatedAt = updatedAt
         self.recencyAt = recencyAt
         self.preview = preview
@@ -195,7 +207,18 @@ struct AgentSession: Identifiable, Codable, Hashable {
         self.pendingUserInput = status == "waiting_for_input" ? pendingUserInput : nil
         self.goal = goal ?? context?.goal
         self.appServerSessionID = appServerSessionID
-        self.parentThreadID = parentThreadID
+        let normalizedParentThreadID = parentThreadID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedContextParentThreadID = context?.parentThreadID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        self.parentThreadID = normalizedParentThreadID?.isEmpty == false
+            ? normalizedParentThreadID
+            : (normalizedContextParentThreadID?.isEmpty == false ? normalizedContextParentThreadID : nil)
+        if isSubagent == true || context?.isSubagent == true || self.parentThreadID != nil {
+            self.isSubagent = true
+        } else {
+            self.isSubagent = isSubagent ?? context?.isSubagent
+        }
         self.agentNickname = agentNickname
         self.agentRole = agentRole
         self.canAcceptDirectInput = canAcceptDirectInput
@@ -254,6 +277,7 @@ struct AgentSession: Identifiable, Codable, Hashable {
         case goal
         case appServerSessionID = "app_server_session_id"
         case parentThreadID = "parent_thread_id"
+        case isSubagent = "is_subagent"
         case agentNickname = "agent_nickname"
         case agentRole = "agent_role"
         case canAcceptDirectInput = "can_accept_direct_input"

--- a/ios/MimiRemote/Sources/Core/Models/SessionContextModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionContextModels.swift
@@ -3,6 +3,10 @@ import Foundation
 struct SessionContextSnapshot: Codable, Hashable {
     var sessionID: SessionID?
     var threadID: String?
+    var createdAt: Date?
+    var parentThreadID: String?
+    /// Optional 保留“旧协议未知”与“明确不是子 Agent”的差异，并兼容旧持久化 JSON。
+    var isSubagent: Bool?
     var status: SessionContextStatus?
     var environment: SessionContextEnvironment?
     var git: SessionContextGitInfo?
@@ -15,6 +19,9 @@ struct SessionContextSnapshot: Codable, Hashable {
     enum CodingKeys: String, CodingKey {
         case sessionID = "session_id"
         case threadID = "thread_id"
+        case createdAt = "created_at"
+        case parentThreadID = "parent_thread_id"
+        case isSubagent = "is_subagent"
         case status
         case environment
         case git
@@ -28,6 +35,9 @@ struct SessionContextSnapshot: Codable, Hashable {
     init(
         sessionID: SessionID? = nil,
         threadID: String? = nil,
+        createdAt: Date? = nil,
+        parentThreadID: String? = nil,
+        isSubagent: Bool? = nil,
         status: SessionContextStatus? = nil,
         environment: SessionContextEnvironment? = nil,
         git: SessionContextGitInfo? = nil,
@@ -39,6 +49,9 @@ struct SessionContextSnapshot: Codable, Hashable {
     ) {
         self.sessionID = sessionID
         self.threadID = threadID
+        self.createdAt = createdAt
+        self.parentThreadID = parentThreadID
+        self.isSubagent = isSubagent
         self.status = status
         self.environment = environment
         self.git = git
@@ -53,6 +66,9 @@ struct SessionContextSnapshot: Codable, Hashable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.sessionID = try container.decodeIfPresent(SessionID.self, forKey: .sessionID)
         self.threadID = try container.decodeIfPresent(String.self, forKey: .threadID)
+        self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        self.parentThreadID = try container.decodeIfPresent(String.self, forKey: .parentThreadID)
+        self.isSubagent = try container.decodeIfPresent(Bool.self, forKey: .isSubagent)
         self.status = try container.decodeIfPresent(SessionContextStatus.self, forKey: .status)
         self.environment = try container.decodeIfPresent(SessionContextEnvironment.self, forKey: .environment)
         self.git = try container.decodeIfPresent(SessionContextGitInfo.self, forKey: .git)

--- a/ios/MimiRemote/Sources/State/SessionContextStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionContextStore.swift
@@ -49,12 +49,23 @@ final class SessionContextStore: ObservableObject {
             if context.goal == nil {
                 context.goal = session.goal
             }
+            // list/read 的 ownership 字段比增量 context 事件完整；这里只补空值并让 child 身份单调为真。
+            context.createdAt = context.createdAt ?? session.createdAt
+            context.parentThreadID = Self.nonEmpty(context.parentThreadID, session.parentThreadID)
+            context.isSubagent = Self.mergedSubagentFlag(
+                base: context.isSubagent,
+                update: session.isSubagent,
+                hasParent: context.parentThreadID != nil
+            )
             upsert(context, fallbackSessionID: session.id)
             return
         }
         let context = SessionContextSnapshot(
             sessionID: session.id,
             threadID: session.resumeID,
+            createdAt: session.createdAt,
+            parentThreadID: session.parentThreadID,
+            isSubagent: session.isSubagentThread ? true : session.isSubagent,
             status: SessionContextStatus(type: Self.statusType(from: session.status)),
             environment: SessionContextEnvironment(
                 id: "local",
@@ -153,10 +164,24 @@ final class SessionContextStore: ObservableObject {
         guard var base else {
             var next = update
             next.tasks = Array(update.tasks.prefix(maxTasks))
+            next.parentThreadID = nonEmpty(next.parentThreadID, nil)
+            next.isSubagent = mergedSubagentFlag(
+                base: nil,
+                update: next.isSubagent,
+                hasParent: next.parentThreadID != nil
+            )
             return next
         }
         base.sessionID = update.sessionID ?? base.sessionID
         base.threadID = update.threadID ?? base.threadID
+        // ownership 是线程身份，不是瞬时状态。稀疏 status/task 更新不得把已知 child 降级成 root。
+        base.createdAt = base.createdAt ?? update.createdAt
+        base.parentThreadID = nonEmpty(base.parentThreadID, update.parentThreadID)
+        base.isSubagent = mergedSubagentFlag(
+            base: base.isSubagent,
+            update: update.isSubagent,
+            hasParent: base.parentThreadID != nil
+        )
         base.status = update.status ?? base.status
         base.environment = mergeEnvironment(base.environment, update.environment)
         base.git = update.git ?? base.git
@@ -285,5 +310,16 @@ final class SessionContextStore: ObservableObject {
             return fallback
         }
         return preferred
+    }
+
+    private static func mergedSubagentFlag(
+        base: Bool?,
+        update: Bool?,
+        hasParent: Bool
+    ) -> Bool? {
+        if hasParent || base == true || update == true {
+            return true
+        }
+        return update ?? base
     }
 }

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -1645,7 +1645,10 @@ extension SessionStore {
         recordRunningSessionsMissingFromFreshPage(freshIDs: freshIDs, projectID: projectID)
         var result = pageSessionsPreservingSelection(fresh, projectID: projectID)
         var knownIDs = Set(result.map(\.id))
-        let projectedSessions = sessions(forProjectID: projectID).filter { session in
+        // 生命周期合并必须读取 canonical sessions；`sessions(forProjectID:)` 是顶层展示投影，
+        // 已按 MIM-24 排除 child，不能用来决定 canonical 数据是否保留。
+        let canonicalProjectSessions = canonicalSessions(forProjectID: projectID)
+        let projectedSessions = canonicalProjectSessions.filter { session in
             guard recentActivityProjectionBySessionID[session.id] != nil,
                   shouldRetainSessionMissingFromFreshPage(session),
                   !knownIDs.contains(session.id) else {
@@ -1656,7 +1659,7 @@ extension SessionStore {
         }
         // 新建/发送后的列表请求可能命中旧缓存或旧的 single-flight 响应；服务端列表确认前不能删掉本地最近项。
         result.append(contentsOf: projectedSessions)
-        let knownRunningSessions = sessions(forProjectID: projectID).filter { session in
+        let knownRunningSessions = canonicalProjectSessions.filter { session in
             guard session.isRunning,
                   shouldRetainSessionMissingFromFreshPage(session),
                   !knownIDs.contains(session.id) else {
@@ -1669,7 +1672,20 @@ extension SessionStore {
         // thread/read 校准。读取也失败时最多保留 3 个刷新周期，不能形成永久幽灵运行态。
         result.append(contentsOf: knownRunningSessions)
 
-        let controlledGlobalSessions = sessions(forProjectID: projectID).filter { session in
+        let knownChildSessions = canonicalProjectSessions.filter { session in
+            guard session.isSubagentThread,
+                  shouldRetainSessionMissingFromFreshPage(session),
+                  !knownIDs.contains(session.id) else {
+                return false
+            }
+            knownIDs.insert(session.id)
+            return true
+        }
+        // workspace thread/list 可能不返回已通过父上下文进入的 child。顶层展示继续隐藏它，
+        // 但刷新不能删除父子导航、历史与次级观察仍依赖的 canonical 记录。
+        result.append(contentsOf: knownChildSessions)
+
+        let controlledGlobalSessions = canonicalProjectSessions.filter { session in
             guard controlledGlobalSessionIDs.contains(session.id),
                   shouldRetainSessionMissingFromFreshPage(session),
                   !knownIDs.contains(session.id) else {
@@ -1688,7 +1704,7 @@ extension SessionStore {
             return result
         }
 
-        let olderLoadedSessions = sessions(forProjectID: projectID).filter { session in
+        let olderLoadedSessions = canonicalProjectSessions.filter { session in
             guard shouldRetainSessionMissingFromFreshPage(session),
                   !knownIDs.contains(session.id) else {
                 return false
@@ -1706,7 +1722,7 @@ extension SessionStore {
     }
 
     func recordRunningSessionsMissingFromFreshPage(freshIDs: Set<SessionID>, projectID: String) {
-        let runningSessions = sessions(forProjectID: projectID).filter(\.isRunning)
+        let runningSessions = canonicalSessions(forProjectID: projectID).filter(\.isRunning)
         let runningIDs = Set(runningSessions.map(\.id))
 
         // 当前页重新出现、或实时事件已把它改成终态时，连续缺失计数立即失效。
@@ -1734,6 +1750,10 @@ extension SessionStore {
                 scheduleMissingRunningSessionReconciliation(session)
             }
         }
+    }
+
+    func canonicalSessions(forProjectID projectID: String) -> [AgentSession] {
+        sessions.filter { $0.projectID == projectID }
     }
 
     func shouldRetainSessionMissingFromFreshPage(_ session: AgentSession) -> Bool {
@@ -1810,6 +1830,7 @@ extension SessionStore {
             goal: item.goal,
             appServerSessionID: item.appServerSessionID,
             parentThreadID: item.parentThreadID,
+            isSubagent: item.isSubagent,
             agentNickname: item.agentNickname,
             agentRole: item.agentRole,
             canAcceptDirectInput: item.canAcceptDirectInput,
@@ -2550,7 +2571,10 @@ extension SessionStore {
             return base
         }
         let remote = remoteSessionSearchResults.filter { session in
-            projectID == nil || session.projectID == projectID
+            // 远端搜索结果不会经过 canonical sessions 的列表索引；必须在合并投影时
+            // 再走一次统一谓词，避免 child Thread 通过搜索重新出现在顶层列表。
+            isListableSession(session)
+                && (projectID == nil || session.projectID == projectID)
         }
         guard !remote.isEmpty else {
             return base
@@ -2589,23 +2613,21 @@ extension SessionStore {
     }
 
     func isListableSession(_ session: AgentSession) -> Bool {
-        !archivedSessionIDs.contains(session.id) || session.id == selectedSessionID || session.isRunning
+        // canonical sessions 仍保留 child，供父子导航、历史和实时观察使用；
+        // 只有顶层 presentation 排除 child，避免同一父会话的派生 Thread 被平铺成重复会话。
+        !session.isSubagentThread
+            && (!archivedSessionIDs.contains(session.id) || session.id == selectedSessionID || session.isRunning)
     }
 
     /// 只用于根侧栏的有界展示优先级，不参与授权、父子关系或输入权限判断。
     /// `<codex_delegation>` 是 Codex Desktop 独立派生 Thread 的兼容提示；必须同时满足
     /// agentd 受控全局授权、Codex runtime 与协议只读，不能单凭用户可伪造的 preview 提权。
     func isControlledGlobalDerivedReadOnlySession(_ session: AgentSession) -> Bool {
-        guard controlledGlobalSessionIDs.contains(session.id),
+        guard !session.isSubagentThread,
+              controlledGlobalSessionIDs.contains(session.id),
               Self.normalizedRuntimeProvider(session.runtimeProvider ?? session.source) == "codex",
               !session.allowsDirectInput else {
             return false
-        }
-
-        if let parentThreadID = session.parentThreadID?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !parentThreadID.isEmpty {
-            return true
         }
 
         let preview = session.preview?

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -1586,13 +1586,39 @@ extension SessionStore {
     }
 
     func sessionPreparedForStorage(_ incoming: AgentSession) -> AgentSession {
+        let ownershipPreserved = sessionPreservingSubagentOwnership(incoming)
         let preserved = sessionPreservingLocalCompletedGoal(
-            sessionPreservingLocalCompletedStatus(sessionPreservingActiveApproval(incoming))
+            sessionPreservingLocalCompletedStatus(sessionPreservingActiveApproval(ownershipPreserved))
         )
         let previewProjected = sessionApplyingListProjection(preserved)
         let monotonicRecency = sessionPreservingRecencyFloor(previewProjected)
         let recentProjected = sessionApplyingRecentActivityProjection(monotonicRecency)
         return sessionApplyingExternalActivity(recentProjected)
+    }
+
+    /// 子 Agent ownership 和创建时间属于线程身份，而非一次列表响应的瞬时字段。
+    /// REST / DataFlow 的稀疏同 ID 更新也必须单调保留，避免刷新后 child 被重新平铺为 root，
+    /// 或历史过滤因为 createdAt 丢失而放回父会话前缀。
+    func sessionPreservingSubagentOwnership(_ incoming: AgentSession) -> AgentSession {
+        guard let existing = sessionsByID[incoming.id] else {
+            return incoming
+        }
+        var result = incoming
+        result.createdAt = result.createdAt ?? existing.createdAt ?? existing.context?.createdAt
+
+        let incomingParent = result.parentThreadID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if incomingParent?.isEmpty != false {
+            let existingParent = existing.parentThreadID?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            result.parentThreadID = existingParent?.isEmpty == false
+                ? existingParent
+                : existing.context?.parentThreadID
+        }
+        if existing.isSubagentThread || result.isSubagentThread {
+            result.isSubagent = true
+        }
+        return result
     }
 
     func sessionApplyingExternalActivity(_ incoming: AgentSession) -> AgentSession {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -605,11 +605,15 @@ final class CodexAppServerProtocolTests: XCTestCase {
 
         XCTAssertEqual(session.projectID, project.id)
         XCTAssertEqual(session.parentThreadID, "parent-thread")
+        XCTAssertEqual(session.isSubagent, true)
+        XCTAssertTrue(session.isSubagentThread)
         XCTAssertEqual(session.appServerSessionID, "session-child")
         XCTAssertEqual(session.agentNickname, "Euler")
         XCTAssertEqual(session.agentRole, "worker")
         XCTAssertEqual(session.canAcceptDirectInput, false)
         XCTAssertFalse(session.allowsDirectInput)
+        XCTAssertEqual(session.context?.parentThreadID, "parent-thread")
+        XCTAssertEqual(session.context?.isSubagent, true)
         XCTAssertEqual(session.context?.subagents.first?.id, "child-thread")
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -7,6 +7,123 @@ import UIKit
 
 @MainActor
 extension ConversationDataFlowTests {
+    func testTopLevelSessionProjectionsHideChildrenButKeepCanonicalRootsAndForks() {
+        let project = makeProject(id: "proj_top_level_child_filter")
+        let parent = makeSession(
+            id: "thread-parent",
+            projectID: project.id,
+            title: "Parent root",
+            status: "history",
+            source: "codex"
+        )
+        var structuralChild = makeSession(
+            id: "thread-child-structural",
+            projectID: project.id,
+            title: "Structural child",
+            status: "history",
+            source: "codex"
+        )
+        structuralChild.parentThreadID = parent.id
+        structuralChild.canAcceptDirectInput = false
+        var runningChild = makeSession(
+            id: "thread-child-running",
+            projectID: project.id,
+            title: "Running child",
+            status: "running",
+            source: "codex"
+        )
+        runningChild.parentThreadID = parent.id
+        runningChild.canAcceptDirectInput = false
+        var sourceOnlyChild = makeSession(
+            id: "thread-child-source-only",
+            projectID: project.id,
+            title: "Source-only child",
+            status: "history",
+            source: "codex"
+        )
+        sourceOnlyChild.isSubagent = true
+        sourceOnlyChild.canAcceptDirectInput = false
+        let ordinaryFork = makeSession(
+            id: "thread-ordinary-fork",
+            projectID: project.id,
+            title: "Ordinary fork root",
+            status: "running",
+            source: "codex"
+        )
+        var externalReadOnlyRoot = makeSession(
+            id: "thread-external-read-only-root",
+            projectID: project.id,
+            title: "External read-only root",
+            status: "history",
+            source: "codex"
+        )
+        externalReadOnlyRoot.canAcceptDirectInput = false
+
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
+        )
+        store.projects = [project]
+        store.recentWorkspaces = [AgentWorkspace(project: project)]
+        store.sessions = [
+            parent,
+            structuralChild,
+            runningChild,
+            sourceOnlyChild,
+            ordinaryFork,
+            externalReadOnlyRoot,
+        ]
+
+        let childIDs = Set([structuralChild.id, runningChild.id, sourceOnlyChild.id])
+        let topLevelProjections = [
+            store.sessionLibrarySessions,
+            store.recentSessions,
+            store.activeSessions,
+            store.recentHistorySessions,
+            store.filteredSessions,
+            store.sessions(forProjectID: project.id),
+            store.visibleSessions(forProjectID: project.id),
+            store.sessionListSnapshot(forProjectID: project.id).visibleSessions,
+        ]
+
+        XCTAssertTrue(childIDs.isSubset(of: Set(store.sessionsByID.keys)), "child 必须留在 canonical store 供父子导航读取")
+        for projection in topLevelProjections {
+            XCTAssertTrue(childIDs.isDisjoint(with: Set(projection.map(\.id))))
+        }
+        XCTAssertTrue(store.activeSessions.contains { $0.id == ordinaryFork.id }, "普通 fork 仍是可独立打开的 root")
+        XCTAssertTrue(store.sessionLibrarySessions.contains { $0.id == externalReadOnlyRoot.id }, "只读能力不能被误当成 child 身份")
+        XCTAssertTrue(store.sessions(forProjectID: project.id).contains { $0.id == parent.id })
+
+        store.sessionSearchQuery = "remote child needle"
+        var remoteChild = sourceOnlyChild
+        remoteChild.title = "Remote child needle"
+        store.remoteSessionSearchResults = [remoteChild]
+        store.remoteSessionSearchSnippetByID[remoteChild.id] = "remote child needle"
+
+        XCTAssertTrue(store.sessionLibrarySessions.isEmpty)
+        XCTAssertTrue(store.filteredSessions.isEmpty)
+        XCTAssertTrue(store.filteredSessionSidebarProjects.isEmpty)
+        XCTAssertTrue(store.sessionListSnapshot(forProjectID: project.id).visibleSessions.isEmpty)
+
+        var remoteRoot = makeSession(
+            id: "thread-remote-read-only-root",
+            projectID: project.id,
+            title: "Remote child needle root",
+            status: "history",
+            source: "codex"
+        )
+        remoteRoot.canAcceptDirectInput = false
+        store.remoteSessionSearchResults = [remoteChild, remoteRoot]
+        store.remoteSessionSearchSnippetByID[remoteRoot.id] = "remote child needle"
+
+        XCTAssertEqual(store.sessionLibrarySessions.map(\.id), [remoteRoot.id])
+        XCTAssertEqual(store.filteredSessions.map(\.id), [remoteRoot.id])
+        XCTAssertEqual(store.filteredSessionSidebarProjects.map(\.id), [project.id])
+        XCTAssertEqual(store.sessionListSnapshot(forProjectID: project.id).visibleSessions.map(\.id), [remoteRoot.id])
+    }
+
     func testRefreshWithoutRecentWorkspacesDoesNotLoadSessions() async {
         let project = makeProject(id: "proj_no_recent")
         let history = makeSession(id: "codex_history", projectID: project.id, title: "历史", status: "history", source: "codex", resumeID: "history")
@@ -161,10 +278,11 @@ extension ConversationDataFlowTests {
         await store.refreshSessionLibraryIndex(authoritative: true)
 
         let initialVisibleIDs = store.recentHistorySessions.map(\.id)
-        XCTAssertEqual(initialVisibleIDs.count, 9, "普通前 8 与重复的派生前 3 去重后应保持有界")
+        XCTAssertEqual(initialVisibleIDs.count, 10, "structural child 隐藏后，普通前 8 加最多 3 条 root 派生补充仍应保持有界")
         XCTAssertEqual(Set(initialVisibleIDs).count, initialVisibleIDs.count)
-        XCTAssertTrue(initialVisibleIDs.contains(targetDelegation.id), "全局第 14、派生第 3 的 MIM-56 应进入默认侧栏")
-        XCTAssertFalse(initialVisibleIDs.contains(fourthDelegation.id), "派生补充集不得突破 3 条上限")
+        XCTAssertFalse(initialVisibleIDs.contains(newestStructuralChild.id), "有 parentThreadID 的 child 不能占顶层补充名额")
+        XCTAssertTrue(initialVisibleIDs.contains(targetDelegation.id), "无 parent/source-only 标记的只读 root 仍可进入默认侧栏")
+        XCTAssertTrue(initialVisibleIDs.contains(fourthDelegation.id), "structural child 隐藏后第三条 root 补充应保持可见")
         XCTAssertTrue(
             store.visibleSessions(forProjectID: project.id).contains { $0.id == targetDelegation.id },
             "展开当前目录时也应在普通预览之外看到派生第 3 条"
@@ -174,7 +292,7 @@ extension ConversationDataFlowTests {
                 $0.id == targetDelegation.id
             }
         )
-        XCTAssertFalse(
+        XCTAssertTrue(
             store.visibleSessions(forProjectID: project.id).contains { $0.id == fourthDelegation.id }
         )
 
@@ -325,7 +443,7 @@ extension ConversationDataFlowTests {
 
         await store.refreshSessionLibraryIndex(authoritative: true)
 
-        XCTAssertTrue(store.recentHistorySessions.contains { $0.id == structuralChild.id })
+        XCTAssertFalse(store.recentHistorySessions.contains { $0.id == structuralChild.id })
         XCTAssertTrue(store.recentHistorySessions.contains { $0.id == envelopeChild.id })
         XCTAssertFalse(store.recentHistorySessions.contains { $0.id == writableEnvelope.id })
         XCTAssertFalse(store.recentHistorySessions.contains { $0.id == claudeEnvelope.id })

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SubagentHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SubagentHistoryTests.swift
@@ -33,11 +33,11 @@ extension ConversationDataFlowTests {
 
         XCTAssertEqual(
             filtered.compactMap { $0["id"]?.stringValue },
-            ["same-second-turn", "missing-time-turn", "child-turn"]
+            ["same-second-turn", "child-turn"]
         )
         XCTAssertEqual(
             sourceOnlyFiltered.compactMap { $0["id"]?.stringValue },
-            ["same-second-turn", "missing-time-turn", "child-turn"]
+            ["same-second-turn", "child-turn"]
         )
     }
 
@@ -46,8 +46,9 @@ extension ConversationDataFlowTests {
             endpoint: "http://127.0.0.1:8787",
             token: "test"
         )
-        let preCreationTurn: [[String: CodexAppServerJSONValue]] = [
+        let preCreationTurns: [[String: CodexAppServerJSONValue]] = [
             ["id": .string("pre-creation-turn"), "startedAt": .int(100)],
+            ["id": .string("missing-time-turn")],
         ]
         let ordinaryFork: [String: CodexAppServerJSONValue] = [
             "id": .string("ordinary-fork"),
@@ -64,15 +65,21 @@ extension ConversationDataFlowTests {
 
         let ordinaryForkResult = await runtime.childOwnedHistoryTurns(
             in: ordinaryFork,
-            turns: preCreationTurn
+            turns: preCreationTurns
         )
         let missingMetadataResult = await runtime.childOwnedHistoryTurns(
             in: childWithoutCreatedAt,
-            turns: preCreationTurn
+            turns: preCreationTurns
         )
 
-        XCTAssertEqual(ordinaryForkResult.compactMap { $0["id"]?.stringValue }, ["pre-creation-turn"])
-        XCTAssertEqual(missingMetadataResult.compactMap { $0["id"]?.stringValue }, ["pre-creation-turn"])
+        XCTAssertEqual(
+            ordinaryForkResult.compactMap { $0["id"]?.stringValue },
+            ["pre-creation-turn", "missing-time-turn"]
+        )
+        XCTAssertEqual(
+            missingMetadataResult.compactMap { $0["id"]?.stringValue },
+            ["pre-creation-turn", "missing-time-turn"]
+        )
     }
 
     func testFullThreadReadHidesInheritedSubagentPrefix() async throws {
@@ -110,7 +117,7 @@ extension ConversationDataFlowTests {
         XCTAssertFalse(page.context?.tasks.contains { $0.id == "parent-command" } == true)
     }
 
-    func testPagedTurnHistoryUsesCachedParentMetadataToHideInheritedPrefix() async throws {
+    func testPagedTurnHistoryUsesCachedSourceOnlyChildMetadataAndClosesInheritedCursor() async throws {
         let project = AgentProject(id: "subagent-paged", name: "Subagent Paged", path: "/tmp/subagent-paged")
         let transport = FakeCodexAppServerTransport()
         let allowedMethods = [
@@ -143,7 +150,7 @@ extension ConversationDataFlowTests {
         transportResponse(
             transport,
             id: metadataRead.id,
-            result: #"{"thread":{"id":"child-thread","sessionId":"child-thread","parentThreadId":"parent-thread","forkedFromId":"parent-thread","preview":"child","ephemeral":false,"modelProvider":"openai","createdAt":200,"updatedAt":220,"status":{"type":"idle"},"path":null,"cwd":"/tmp/subagent-paged","cliVersion":"0.0.0","source":{"subAgent":{"thread_spawn":{}}},"threadSource":"subagent","agentNickname":"Curie","name":null,"turns":[]}}"#
+            result: #"{"thread":{"id":"child-thread","sessionId":"child-thread","preview":"child","ephemeral":false,"modelProvider":"openai","createdAt":200,"updatedAt":220,"status":{"type":"idle"},"path":null,"cwd":"/tmp/subagent-paged","cliVersion":"0.0.0","source":{"subAgent":{"thread_spawn":{}}},"agentNickname":"Curie","name":null,"turns":[]}}"#
         )
         _ = try await hydrateTask.value
 
@@ -159,14 +166,106 @@ extension ConversationDataFlowTests {
         transportResponse(
             transport,
             id: turnsRequest.id,
-            result: #"{"data":[{"id":"child-turn","startedAt":201,"completedAt":220,"status":"completed","items":[{"type":"agentMessage","id":"child-result","text":"child result","phase":"final_answer"}]},{"id":"inherited-turn","startedAt":100,"status":"interrupted","items":[{"type":"userMessage","id":"parent-user","content":[{"type":"text","text":"parent request"}]},{"type":"agentMessage","id":"parent-commentary","text":"parent commentary","phase":"commentary"}]}],"nextCursor":null}"#
+            result: #"{"data":[{"id":"child-turn","startedAt":201,"completedAt":220,"status":"completed","items":[{"type":"agentMessage","id":"child-result","text":"child result","phase":"final_answer"}]},{"id":"synthetic-parent-rollout","status":"completed","items":[{"type":"agentMessage","id":"synthetic-parent-result","text":"synthetic parent result","phase":"final_answer"}]},{"id":"inherited-turn","startedAt":100,"status":"interrupted","items":[{"type":"userMessage","id":"parent-user","content":[{"type":"text","text":"parent request"}]},{"type":"agentMessage","id":"parent-commentary","text":"parent commentary","phase":"commentary"}]}],"nextCursor":"older-parent-prefix"}"#
         )
 
         let page = try await pageTask.value
         let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
 
         XCTAssertEqual(page.messages.map(\.content), ["child result"])
+        XCTAssertNil(page.previousCursor)
+        XCTAssertFalse(page.hasMoreBefore)
         XCTAssertEqual(requests.filter { $0.method == "thread/read" }.count, 1)
         XCTAssertEqual(requests.filter { $0.method == "thread/turns/list" }.count, 1)
+
+        // 人工直达一个更老 cursor，覆盖真实数据里“整页都是继承 synthetic rollout”的边界；
+        // 即使上游继续给 nextCursor，返回给 Store 的 cursor/hasMore/notice 也必须一致关闭。
+        let sentBeforeInheritedOnlyPage = await transport.sentMessages().count
+        let inheritedOnlyTask = Task {
+            try await runtime.messagesPage(
+                sessionID: "child-thread",
+                before: CodexAppServerSessionRuntime.encodeThreadTurnsCursor("forced-parent-page"),
+                limit: 50,
+                loadMode: .economy
+            )
+        }
+        let inheritedOnlyRequest = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/turns/list",
+            after: sentBeforeInheritedOnlyPage
+        )
+        XCTAssertEqual(inheritedOnlyRequest.params?.objectValue?["cursor"]?.stringValue, "forced-parent-page")
+        transportResponse(
+            transport,
+            id: inheritedOnlyRequest.id,
+            result: #"{"data":[{"id":"synthetic-parent-only","status":"completed","items":[{"type":"agentMessage","id":"synthetic-parent-only-result","text":"parent only","phase":"final_answer"}]},{"id":"older-parent-only","startedAt":50,"status":"completed","items":[{"type":"agentMessage","id":"older-parent-only-result","text":"older parent only","phase":"final_answer"}]}],"nextCursor":"even-older-parent"}"#
+        )
+
+        let inheritedOnlyPage = try await inheritedOnlyTask.value
+        XCTAssertTrue(inheritedOnlyPage.messages.isEmpty)
+        XCTAssertNil(inheritedOnlyPage.previousCursor)
+        XCTAssertFalse(inheritedOnlyPage.hasMoreBefore)
+        XCTAssertNil(inheritedOnlyPage.notice)
+    }
+
+    func testOrdinaryForkPagedHistoryKeepsPreCreationTurnsAndCursor() async throws {
+        let project = AgentProject(id: "ordinary-fork-paged", name: "Ordinary Fork", path: "/tmp/ordinary-fork-paged")
+        let transport = FakeCodexAppServerTransport()
+        let allowedMethods = [
+            "initialize",
+            "initialized",
+            "thread/read",
+            "thread/turns/list",
+        ]
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(project: project, allowedMethods: allowedMethods)
+            }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+
+        let hydrateTask = Task {
+            try await client.session(id: "ordinary-fork", afterSeq: nil)
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#
+        )
+        let metadataRead = try await waitForFakeAppServerRequest(transport, method: "thread/read")
+        transportResponse(
+            transport,
+            id: metadataRead.id,
+            result: #"{"thread":{"id":"ordinary-fork","sessionId":"ordinary-fork","forkedFromId":"root-thread","preview":"fork","ephemeral":false,"modelProvider":"openai","createdAt":200,"updatedAt":220,"status":{"type":"idle"},"path":null,"cwd":"/tmp/ordinary-fork-paged","cliVersion":"0.0.0","source":{"custom":"vscode"},"threadSource":"user","name":"Ordinary fork","turns":[]}}"#
+        )
+        _ = try await hydrateTask.value
+
+        let sentBeforePage = await transport.sentMessages().count
+        let pageTask = Task {
+            try await client.messagesPage(sessionID: "ordinary-fork", before: nil, limit: 50)
+        }
+        let turnsRequest = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/turns/list",
+            after: sentBeforePage
+        )
+        transportResponse(
+            transport,
+            id: turnsRequest.id,
+            result: #"{"data":[{"id":"missing-time-turn","status":"completed","items":[{"type":"agentMessage","id":"missing-time-result","text":"missing time root result","phase":"final_answer"}]},{"id":"pre-creation-turn","startedAt":100,"completedAt":110,"status":"completed","items":[{"type":"agentMessage","id":"pre-creation-result","text":"pre-creation root result","phase":"final_answer"}]}],"nextCursor":"ordinary-older"}"#
+        )
+
+        let page = try await pageTask.value
+
+        XCTAssertEqual(
+            Set(page.messages.map(\.content)),
+            Set(["missing time root result", "pre-creation root result"])
+        )
+        XCTAssertNotNil(page.previousCursor)
+        XCTAssertTrue(page.hasMoreBefore)
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SubagentSessionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SubagentSessionTests.swift
@@ -95,10 +95,293 @@ extension CodexAppServerProtocolTests {
         XCTAssertEqual(subagents[0].canAcceptDirectInput, false)
         XCTAssertEqual(subagents[1].canAcceptDirectInput, true)
     }
+
+    func testThreadProjectionRecognizesSourceOnlySubagentAndSnakeCaseOwnership() async throws {
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "test"
+        )
+        let createdAt = Date(timeIntervalSince1970: 1_780_490_200)
+        let sourceOnlyThread: [String: CodexAppServerJSONValue] = [
+            "id": .string("source-only-child"),
+            "cwd": .string("/tmp/source-only-child"),
+            "status": .object(["type": .string("idle")]),
+            "created_at": .double(createdAt.timeIntervalSince1970),
+            "source": .object(["subAgent": .object(["thread_spawn": .object([:])])]),
+        ]
+
+        let sourceOnly = try await runtime.agentSession(
+            from: sourceOnlyThread,
+            projects: [],
+            fallbackProject: nil
+        )
+
+        XCTAssertNil(sourceOnly.parentThreadID)
+        XCTAssertEqual(sourceOnly.isSubagent, true)
+        XCTAssertTrue(sourceOnly.isSubagentThread)
+        XCTAssertFalse(sourceOnly.allowsDirectInput, "source-only 子 Agent 缺 capability 时必须 fail-closed")
+        XCTAssertEqual(sourceOnly.createdAt, createdAt)
+        XCTAssertEqual(sourceOnly.context?.createdAt, createdAt)
+        XCTAssertNil(sourceOnly.context?.parentThreadID)
+        XCTAssertEqual(sourceOnly.context?.isSubagent, true)
+
+        let snakeCaseParent = try await runtime.agentSession(
+            from: [
+                "id": .string("snake-case-child"),
+                "cwd": .string("/tmp/snake-case-child"),
+                "status": .object(["type": .string("idle")]),
+                "parent_thread_id": .string("snake-case-parent"),
+                "thread_source": .string("SubAgent/worker"),
+            ],
+            projects: [],
+            fallbackProject: nil
+        )
+        XCTAssertEqual(snakeCaseParent.parentThreadID, "snake-case-parent")
+        XCTAssertTrue(snakeCaseParent.isSubagentThread)
+        XCTAssertEqual(snakeCaseParent.context?.parentThreadID, "snake-case-parent")
+        XCTAssertEqual(snakeCaseParent.context?.subagents.first?.parentThreadID, "snake-case-parent")
+    }
+
+    func testThreadProjectionNeverTreatsOrdinaryForkAsSubagent() async throws {
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "test"
+        )
+        let session = try await runtime.agentSession(
+            from: [
+                "id": .string("ordinary-fork"),
+                "cwd": .string("/tmp/ordinary-fork"),
+                "status": .object(["type": .string("idle")]),
+                "forkedFromId": .string("root-thread"),
+                "threadSource": .string("user"),
+                "source": .string("vscode"),
+            ],
+            projects: [],
+            fallbackProject: nil
+        )
+
+        XCTAssertNil(session.parentThreadID)
+        XCTAssertNotEqual(session.isSubagent, true)
+        XCTAssertFalse(session.isSubagentThread)
+        XCTAssertTrue(session.allowsDirectInput)
+        XCTAssertEqual(session.context?.sources.first(where: { $0.kind == "fork" })?.label, "root-thread")
+    }
+
+    func testSparseThreadProjectionDoesNotDowngradeCachedSubagentOwnership() async throws {
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "test"
+        )
+        let createdAt = Date(timeIntervalSince1970: 1_780_490_300)
+        await runtime.handle(CodexAppServerNotification(
+            method: "thread/started",
+            params: .object([
+                "thread": .object([
+                    "id": .string("sticky-source-child"),
+                    "cwd": .string("/tmp/sticky-source-child"),
+                    "status": .object(["type": .string("active")]),
+                    "createdAt": .double(createdAt.timeIntervalSince1970),
+                    "source": .string("subAgent"),
+                ]),
+            ])
+        ))
+
+        let sparse = try await runtime.agentSession(
+            from: [
+                "id": .string("sticky-source-child"),
+                "cwd": .string("/tmp/sticky-source-child"),
+                "status": .object(["type": .string("idle")]),
+            ],
+            projects: [],
+            fallbackProject: nil
+        )
+
+        XCTAssertEqual(sparse.createdAt, createdAt)
+        XCTAssertEqual(sparse.isSubagent, true)
+        XCTAssertTrue(sparse.isSubagentThread)
+        XCTAssertEqual(sparse.context?.createdAt, createdAt)
+        XCTAssertEqual(sparse.context?.isSubagent, true)
+    }
 }
 
 @MainActor
 extension ConversationDataFlowTests {
+    func testAgentSessionOwnershipCodableRemainsBackwardCompatible() throws {
+        let legacyJSON = #"{"id":"legacy","project_id":"repo","project":"Repo","dir":"/tmp/repo","title":"Legacy","status":"history","source":"codex"}"#
+        let legacy = try JSONDecoder().decode(AgentSession.self, from: Data(legacyJSON.utf8))
+
+        XCTAssertNil(legacy.isSubagent)
+        XCTAssertFalse(legacy.isSubagentThread)
+        XCTAssertTrue(legacy.allowsDirectInput)
+
+        let child = AgentSession(
+            id: "source-child",
+            projectID: "repo",
+            project: "Repo",
+            dir: "/tmp/repo",
+            title: "Child",
+            status: "history",
+            source: "codex",
+            resumeID: "source-child",
+            createdAt: Date(timeIntervalSince1970: 123),
+            updatedAt: nil,
+            isSubagent: true
+        )
+        let roundTrip = try JSONDecoder().decode(
+            AgentSession.self,
+            from: JSONEncoder().encode(child)
+        )
+        XCTAssertEqual(roundTrip.isSubagent, true)
+        XCTAssertTrue(roundTrip.isSubagentThread)
+        XCTAssertFalse(roundTrip.allowsDirectInput)
+    }
+
+    func testDataFlowSessionRowRestoresOwnershipFromContext() throws {
+        let rowJSON = #"{"id":"row-child","project_id":"repo","project_name":"Repo","project_path":"/tmp/repo","title":"Row child","status":"history","source":"codex","context":{"session_id":"row-child","created_at":789,"parent_thread_id":"row-parent","is_subagent":true}}"#
+        let row = try JSONDecoder().decode(DataFlowSessionRow.self, from: Data(rowJSON.utf8))
+        let session = AgentSession(row: row)
+
+        XCTAssertEqual(session.createdAt, Date(timeIntervalSinceReferenceDate: 789))
+        XCTAssertEqual(session.parentThreadID, "row-parent")
+        XCTAssertEqual(session.isSubagent, true)
+        XCTAssertTrue(session.isSubagentThread)
+        XCTAssertFalse(session.allowsDirectInput)
+    }
+
+    func testSessionStoreSparseMergePreservesKnownSubagentOwnership() {
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
+        )
+        let createdAt = Date(timeIntervalSince1970: 1_234)
+        let knownChild = AgentSession(
+            id: "sticky-store-child",
+            projectID: "repo",
+            project: "Repo",
+            dir: "/tmp/repo",
+            title: "Known child",
+            status: "running",
+            source: "codex",
+            resumeID: "sticky-store-child",
+            createdAt: createdAt,
+            updatedAt: nil,
+            parentThreadID: "sticky-store-parent",
+            isSubagent: true
+        )
+        store.sessions = [knownChild]
+
+        let sparse = AgentSession(
+            id: knownChild.id,
+            projectID: knownChild.projectID,
+            project: knownChild.project,
+            dir: knownChild.dir,
+            title: knownChild.title,
+            status: "history",
+            source: knownChild.source,
+            resumeID: knownChild.resumeID,
+            createdAt: nil,
+            updatedAt: Date()
+        )
+        store.mergeSessionPage([sparse])
+
+        let merged = store.sessionsByID[knownChild.id]
+        XCTAssertEqual(merged?.createdAt, createdAt)
+        XCTAssertEqual(merged?.parentThreadID, "sticky-store-parent")
+        XCTAssertEqual(merged?.isSubagent, true)
+        XCTAssertTrue(merged?.isSubagentThread == true)
+    }
+
+    func testWorkspaceFirstPageRefreshKeepsChildCanonicalButHiddenFromTopLevel() {
+        let project = makeProject(id: "proj-child-refresh")
+        let parent = makeSession(
+            id: "refresh-parent",
+            projectID: project.id,
+            title: "Parent",
+            status: "history",
+            source: "codex"
+        )
+        var child = makeSession(
+            id: "refresh-child",
+            projectID: project.id,
+            title: "Child",
+            status: "history",
+            source: "codex"
+        )
+        child.parentThreadID = parent.id
+        child.isSubagent = true
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [project], sessions: [parent]) }
+        )
+        store.projects = [project]
+        store.sessions = [parent, child]
+
+        let refreshedPage = store.pageSessionsPreservingLoadedWindow(
+            [parent],
+            projectID: project.id
+        )
+        store.replaceSessionsIfChanged(with: refreshedPage, projectID: project.id)
+
+        XCTAssertNotNil(store.sessionsByID[child.id], "顶层首屏缺少 child 时不能删除 canonical 父子关系")
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), [parent.id])
+        XCTAssertEqual(store.sessionLibrarySessions.map(\.id), [parent.id])
+    }
+
+    func testSessionContextOwnershipSurvivesSparseUpdatesAndCodableRoundTrip() throws {
+        let store = SessionContextStore()
+        let createdAt = Date(timeIntervalSince1970: 456)
+        let child = AgentSession(
+            id: "sticky-child",
+            projectID: "repo",
+            project: "Repo",
+            dir: "/tmp/repo",
+            title: "Child",
+            status: "running",
+            source: "codex",
+            resumeID: "sticky-child",
+            createdAt: createdAt,
+            updatedAt: nil,
+            parentThreadID: "parent-thread",
+            isSubagent: true
+        )
+
+        store.upsert(from: child)
+        store.upsert(
+            SessionContextSnapshot(
+                sessionID: child.id,
+                status: SessionContextStatus(type: "idle"),
+                updatedAt: Date()
+            ),
+            fallbackSessionID: child.id
+        )
+
+        let merged = try XCTUnwrap(store.context(for: child.id))
+        XCTAssertEqual(merged.createdAt, createdAt)
+        XCTAssertEqual(merged.parentThreadID, "parent-thread")
+        XCTAssertEqual(merged.isSubagent, true)
+
+        let roundTrip = try JSONDecoder().decode(
+            SessionContextSnapshot.self,
+            from: JSONEncoder().encode(merged)
+        )
+        XCTAssertEqual(roundTrip.createdAt, createdAt)
+        XCTAssertEqual(roundTrip.parentThreadID, "parent-thread")
+        XCTAssertEqual(roundTrip.isSubagent, true)
+
+        let legacyContextJSON = #"{"session_id":"legacy-context","tasks":[],"sources":[],"subagents":[]}"#
+        let legacy = try JSONDecoder().decode(
+            SessionContextSnapshot.self,
+            from: Data(legacyContextJSON.utf8)
+        )
+        XCTAssertNil(legacy.createdAt)
+        XCTAssertNil(legacy.parentThreadID)
+        XCTAssertNil(legacy.isSubagent)
+    }
+
     func testSessionContextStoreMergesUpdatesAndAttachesSubagents() {
         let store = SessionContextStore()
         store.upsert(


### PR DESCRIPTION
## 目标

稳定识别 Codex 子 Agent 会话：顶层列表与远程搜索不再混入子会话，同时父会话仍可进入子会话并正确分页查看历史。

## 根因

- 子会话 ownership 元数据在协议投影、持久化和稀疏刷新中会丢失。
- 顶层展示直接消费 canonical session 集合，导致子会话泄漏。
- 子会话历史会保留创建前继承消息或无 startedAt 的合成 turn，并继续暴露无效游标。
- workspace 首屏刷新曾从展示过滤后的集合维护生命周期，可能误删 canonical 子会话。

## 实现

- 持久化并单调合并 parentThreadID / isSubagent / createdAt，兼容 camelCase、snake_case 与 source.subAgent。
- 顶层列表和远程搜索统一隐藏子会话；canonical store 保留子会话，供父会话导航和历史读取。
- 子会话历史按创建边界裁剪继承 turn，并在到达边界后关闭游标；普通 fork 保持原行为。
- workspace refresh 改用 canonical session 做生命周期维护，避免 presentation filter 误删子会话。

## 验证

- MIM-24 精确回归：17/17 通过。
- CodexAppServerProtocolTests：76 项通过，3 项仅因环境条件跳过，0 失败。
- 多 runtime 分页：5/5 通过。
- workspace canonical retention 与运行生命周期补充回归：7/7 通过。
- swiftc -parse、git diff --check、pbxproj plutil、source-size、本地化、网络安全、Privacy Manifest 检查均通过。
- 两轮独立子 Agent 审查通过；审查发现并修复 workspace refresh 误删 canonical child 的 P1，复审无 P0-P3。

## 待发布验证

合并后随下一版 TestFlight 在真机确认：iPhone 顶层会话列表不展示子会话；从父会话进入子会话及向上分页历史正常。固定 iPad 模拟器回归已通过。