### PR TITLE
MIM-85 Fix incomplete workspace session first page

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		E790247242197F065BB1F1DE /* ConversationDirectRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */; };
 		C05700000000000000000001 /* ConversationMultiRuntimePaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05700000000000000000002 /* ConversationMultiRuntimePaginationTests.swift */; };
 		C03800000000000000000001 /* WorkspaceSessionLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03800000000000000000002 /* WorkspaceSessionLoadingTests.swift */; };
+		C05900000000000000000001 /* WorkspaceSessionAuthoritativeContinuationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05900000000000000000002 /* WorkspaceSessionAuthoritativeContinuationTests.swift */; };
 		E7EE1A6D1A2A19F69E8F6513 /* testConversationBubbleAlignment.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 0FC920B8D7FE7F76E2C18FD7 /* testConversationBubbleAlignment.1.png */; };
 		E811D57414AC2415D22ADDF0 /* APIResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B02E274C8B9B137FF4ACB /* APIResponses.swift */; };
 		E8CF63B25946995924E1B888 /* InitialConnectionSettingsSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C75EB69B7DE1AAE7350B2C5 /* InitialConnectionSettingsSections.swift */; };
@@ -258,6 +259,7 @@
 		025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeTests.swift; sourceTree = "<group>"; };
 		C05700000000000000000002 /* ConversationMultiRuntimePaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMultiRuntimePaginationTests.swift; sourceTree = "<group>"; };
 		C03800000000000000000002 /* WorkspaceSessionLoadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionLoadingTests.swift; sourceTree = "<group>"; };
+		C05900000000000000000002 /* WorkspaceSessionAuthoritativeContinuationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionAuthoritativeContinuationTests.swift; sourceTree = "<group>"; };
 		02BA631A94730FC521FE15F6 /* AssistantTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantTextNormalizer.swift; sourceTree = "<group>"; };
 		033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationRuntimeFlowTests.swift; sourceTree = "<group>"; };
 		04740AD795D6AEEF87C98B35 /* ConversationMessageAccessories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageAccessories.swift; sourceTree = "<group>"; };
@@ -646,6 +648,7 @@
 				7348A6FCD28C7489CC7097AD /* ThemeStoreTests.swift */,
 				AB4A66767462028B863816B7 /* WorkspaceAppearanceStoreTests.swift */,
 				85879EDF3D64609C3C6BA873 /* WorkspaceGitSummaryTests.swift */,
+				C05900000000000000000002 /* WorkspaceSessionAuthoritativeContinuationTests.swift */,
 				C03800000000000000000002 /* WorkspaceSessionLoadingTests.swift */,
 				327AF69020E348B4AE9F7BBE /* WorkspaceVisualSnapshotTests.swift */,
 				7DD567ECF6024FEEF09274D5 /* __Snapshots__ */,
@@ -1245,6 +1248,7 @@
 				420F5F2A694B0E491DBD45B0 /* ThemeStoreTests.swift in Sources */,
 				A3621619C40A5F0CFB0C4F10 /* WorkspaceAppearanceStoreTests.swift in Sources */,
 				951475AE3120CB42A905E3B3 /* WorkspaceGitSummaryTests.swift in Sources */,
+				C05900000000000000000001 /* WorkspaceSessionAuthoritativeContinuationTests.swift in Sources */,
 				C03800000000000000000001 /* WorkspaceSessionLoadingTests.swift in Sources */,
 				626E053AFAE30F345EEFC01D /* WorkspaceVisualSnapshotTests.swift in Sources */,
 			);

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
@@ -339,8 +339,8 @@ final class AppServerRuntimeBundle {
     }
 }
 
-private struct RuntimeSessionsContinuation: Codable {
-    enum State: String, Codable {
+private struct RuntimeSessionsContinuation: Codable, Hashable {
+    enum State: String, Codable, Hashable {
         case notStarted
         case canContinue
         case exhausted
@@ -677,6 +677,26 @@ final class MultiRuntimeSessionAPIClient: SessionStoreAPIClient {
         var continuation: RuntimeSessionsContinuation
     }
 
+    private final class EmptyPageRefillBudget {
+        private(set) var remaining: Int
+
+        init(limit: Int) {
+            remaining = max(0, limit)
+        }
+
+        var isExhausted: Bool { remaining == 0 }
+
+        func consume() -> Bool {
+            guard remaining > 0 else { return false }
+            remaining -= 1
+            return true
+        }
+    }
+
+    /// 单次合并调用最多跨过 8 个空 continuation 页；更深历史交给返回的安全 cursor
+    /// 在下一次 Store 补页中继续，避免一个 RPC 独占 gateway。
+    private static let maximumEmptyPageRefillsPerRequest = 8
+
     private enum SessionListScope {
         case projectID(String?)
         case workspace(AgentWorkspace)
@@ -697,23 +717,28 @@ final class MultiRuntimeSessionAPIClient: SessionStoreAPIClient {
             sessions: SessionIndexStore.sortedSessions(decoded.claudeBuffer),
             continuation: decoded.claude
         )
+        let emptyPageRefillBudget = EmptyPageRefillBudget(
+            limit: Self.maximumEmptyPageRefillsPerRequest
+        )
 
-        codex = try await refilledCandidate(
+        codex = try await refilledCandidateSkippingEmptyPages(
             codex,
             runtime: bundle.codex,
             scope: scope,
             limit: limit,
             consistency: consistency,
-            available: true
+            available: true,
+            budget: emptyPageRefillBudget
         )
         let claudeAvailable = try await bundle.codex.channelAvailable(runtimeProvider: "claude")
-        claude = try await refilledCandidate(
+        claude = try await refilledCandidateSkippingEmptyPages(
             claude,
             runtime: bundle.claude,
             scope: scope,
             limit: limit,
             consistency: consistency,
-            available: claudeAvailable
+            available: claudeAvailable,
+            budget: emptyPageRefillBudget
         )
 
         // limit=nil 沿用旧语义：只返回本轮首次取得的候选窗口，不扫描完整历史。
@@ -723,26 +748,76 @@ final class MultiRuntimeSessionAPIClient: SessionStoreAPIClient {
         emitted.reserveCapacity(outputLimit)
 
         mergeLoop: while emitted.count < outputLimit {
-            // 某侧 buffer 用完但仍有 continuation 时，必须在输出另一侧更旧记录前补齐候选。
-            // 否则未知的下一条可能比另一侧当前 head 更新，形成跨页逆序。
-            if codex.sessions.isEmpty, !claude.sessions.isEmpty {
-                codex = try await refilledCandidate(
+            if !claudeAvailable,
+               claude.sessions.isEmpty,
+               claude.continuation.hasMore {
+                // channel 可能在两次“显示更多”之间临时下线。不能反复调用 no-op refill，
+                // 也不能越过未知的 Claude head 输出 Codex 旧记录；保留双方 buffer/cursor，
+                // 待下一次 channel 恢复后从同一 opaque cursor 安全继续。
+                break mergeLoop
+            }
+            if codex.sessions.isEmpty, claude.sessions.isEmpty {
+                guard codex.continuation.hasMore || claude.continuation.hasMore else {
+                    break mergeLoop
+                }
+                guard !emptyPageRefillBudget.isExhausted else {
+                    // continuation 留在 composite cursor，下一次 Store 补页可从原位置安全继续。
+                    break mergeLoop
+                }
+
+                // 两侧当前页都可能被上游过滤为空，但 cursor 仍指向更旧页。nil/nil 只表示
+                // “当前 buffer 为空”，不能冒充“两个 Runtime 都已耗尽”。
+                codex = try await refilledCandidateSkippingEmptyPages(
                     codex,
                     runtime: bundle.codex,
                     scope: scope,
                     limit: limit,
                     consistency: consistency,
-                    available: true
+                    available: true,
+                    budget: emptyPageRefillBudget
                 )
-            }
-            if claude.sessions.isEmpty, !codex.sessions.isEmpty {
-                claude = try await refilledCandidate(
+                claude = try await refilledCandidateSkippingEmptyPages(
                     claude,
                     runtime: bundle.claude,
                     scope: scope,
                     limit: limit,
                     consistency: consistency,
-                    available: claudeAvailable
+                    available: claudeAvailable,
+                    budget: emptyPageRefillBudget
+                )
+                continue mergeLoop
+            }
+
+            if emptyPageRefillBudget.isExhausted,
+               (codex.sessions.isEmpty && codex.continuation.hasMore
+                   || claude.sessions.isEmpty && claude.continuation.hasMore) {
+                // 另一侧的未知 head 仍可能更新；预算耗尽时保留当前 buffers/cursors，
+                // 不冒险输出另一侧更旧记录而破坏跨页全局顺序。
+                break mergeLoop
+            }
+
+            // 某侧 buffer 用完但仍有 continuation 时，必须在输出另一侧更旧记录前补齐候选。
+            // 否则未知的下一条可能比另一侧当前 head 更新，形成跨页逆序。
+            if codex.sessions.isEmpty, !claude.sessions.isEmpty {
+                codex = try await refilledCandidateSkippingEmptyPages(
+                    codex,
+                    runtime: bundle.codex,
+                    scope: scope,
+                    limit: limit,
+                    consistency: consistency,
+                    available: true,
+                    budget: emptyPageRefillBudget
+                )
+            }
+            if claude.sessions.isEmpty, !codex.sessions.isEmpty {
+                claude = try await refilledCandidateSkippingEmptyPages(
+                    claude,
+                    runtime: bundle.claude,
+                    scope: scope,
+                    limit: limit,
+                    consistency: consistency,
+                    available: claudeAvailable,
+                    budget: emptyPageRefillBudget
                 )
             }
 
@@ -771,6 +846,49 @@ final class MultiRuntimeSessionAPIClient: SessionStoreAPIClient {
         )
         let nextCursor = next.encodedIfNeeded()
         return SessionsPage(sessions: emitted, nextCursor: nextCursor, hasMore: nextCursor != nil)
+    }
+
+    private func refilledCandidateSkippingEmptyPages(
+        _ current: RuntimePage,
+        runtime: CodexAppServerSessionRuntime,
+        scope: SessionListScope,
+        limit: Int?,
+        consistency: SessionListConsistency,
+        available: Bool,
+        budget: EmptyPageRefillBudget
+    ) async throws -> RuntimePage {
+        guard available else { return current }
+
+        var candidate = current
+        var seenEmptyContinuations: Set<RuntimeSessionsContinuation> = []
+        while candidate.sessions.isEmpty {
+            switch candidate.continuation.state {
+            case .notStarted:
+                break
+            case .canContinue:
+                guard seenEmptyContinuations.insert(candidate.continuation).inserted else {
+                    // cursor 形成 A→B→A 之类的环时 fail closed，避免空页请求永久占用 gateway。
+                    candidate.continuation = .exhausted
+                    return candidate
+                }
+                guard budget.consume() else {
+                    // 不消费当前 continuation；调用方会把它原样编码回 composite cursor。
+                    return candidate
+                }
+            case .exhausted:
+                return candidate
+            }
+
+            candidate = try await refilledCandidate(
+                candidate,
+                runtime: runtime,
+                scope: scope,
+                limit: limit,
+                consistency: consistency,
+                available: available
+            )
+        }
+        return candidate
     }
 
     private func refilledCandidate(
@@ -815,9 +933,20 @@ final class MultiRuntimeSessionAPIClient: SessionStoreAPIClient {
                 consistency: consistency
             )
         }
+        let continuation = Self.continuation(after: page)
+        let progressedContinuation: RuntimeSessionsContinuation
+        if let cursor,
+           continuation.hasMore,
+           continuation.cursor == cursor {
+            // 同一 cursor 再次返回自身不可能推进分页；即使这一页带有数据，也必须在消费完
+            // 当前 buffer 后停止，避免下一轮重复请求、重复会话或空页死循环。
+            progressedContinuation = .exhausted
+        } else {
+            progressedContinuation = continuation
+        }
         return RuntimePage(
             sessions: SessionIndexStore.sortedSessions(page.sessions),
-            continuation: Self.continuation(after: page)
+            continuation: progressedContinuation
         )
     }
 

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -177,6 +177,7 @@ struct WorkspaceCatalogRefreshScope: Equatable {
 struct WorkspaceSessionRefreshScope: Equatable {
     let hostScope: HostScope
     let workspaceID: String?
+    let needsAuthoritativeFirstPage: Bool
 }
 
 /// Catalog 没有底层 single-flight；这里只隔离 View 调用的提交权，避免旧请求回写或把取消留成永久 loading。
@@ -279,7 +280,10 @@ struct WorkspaceRootView: View {
         )
         let sessionRefreshScope = WorkspaceSessionRefreshScope(
             hostScope: appStore.activeHostScope,
-            workspaceID: selectedWorkspaceID
+            workspaceID: selectedWorkspaceID,
+            needsAuthoritativeFirstPage: selectedWorkspaceID.map {
+                sessionStore.needsAuthoritativeWorkspaceSessionFirstPage(projectID: $0)
+            } ?? false
         )
 
         Group {
@@ -318,7 +322,7 @@ struct WorkspaceRootView: View {
         .task(id: sessionRefreshScope) {
             guard let selectedWorkspaceID = sessionRefreshScope.workspaceID else { return }
             // 稀疏缓存继续即时展示；只有 Store 记录了当前 HostScope 的 authoritative 首屏才可跳过请求。
-            guard sessionStore.needsAuthoritativeWorkspaceSessionFirstPage(projectID: selectedWorkspaceID) else {
+            guard sessionRefreshScope.needsAuthoritativeFirstPage else {
                 sessionLoadInvocationTokens.begin(for: selectedWorkspaceID)
                 sessionLoadStates[selectedWorkspaceID] = .loaded
                 return

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -776,7 +776,10 @@ struct WorkspaceRootView: View {
         let invocationID = sessionLoadInvocationTokens.begin(for: projectID)
         sessionLoadStates[projectID] = .loading
         do {
-            if onlyIfAuthoritativeFirstPageIsNeeded {
+            if onlyIfAuthoritativeFirstPageIsNeeded
+                || sessionStore.needsAuthoritativeWorkspaceSessionFirstPage(projectID: projectID) {
+                // 手动刷新若接手到前一轮 partial，也必须沿保存 cursor 完成整条权威窗口；
+                // 已完成窗口仍走下面的普通单次刷新，保留“主动拉最新”的语义。
                 try await sessionStore.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: projectID)
             } else {
                 try await sessionStore.refreshWorkspaceSessions(projectID: projectID)

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -415,6 +415,9 @@ final class SessionStore: ObservableObject {
     /// presentation 补页保持顺序且有界：最小批量避免 child 密集时退化成逐条 RPC，页数上限防止异常 cursor 请求风暴。
     static let minimumSessionPresentationFillPageLimit = 5
     static let maximumSessionPresentationFillPageCount = 12
+    /// 单批达到页数上限时从已提交 cursor 续跑；每 4 批主动让出执行权并短暂退避，避免高密度历史长期独占链路。
+    static let sessionPresentationFillBatchCountPerBurst = 4
+    static let sessionPresentationFillBurstBackoffNanoseconds: UInt64 = 250_000_000
     static let missingRunningSessionReadThreshold = 2
     static let maximumUnverifiedRunningSessionMisses = 3
     static let commandActionHistoryLimit = 10

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -352,7 +352,7 @@ final class SessionStore: ObservableObject {
     var sessionFirstPageWaiterCountByProjectID: [String: Int] = [:]
     var sessionListFirstPageInFlightByKey: [SessionListFirstPageRequestKey: SessionListFirstPageInFlight] = [:]
     var sessionListFirstPageCacheByKey: [SessionListFirstPageRequestKey: SessionListFirstPageCacheEntry] = [:]
-    var workspaceSessionFirstPageCompletionByKey: [WorkspaceSessionFirstPageKey: WorkspaceSessionFirstPageCompletion] = [:]
+    @Published var workspaceSessionFirstPageCompletionByKey: [WorkspaceSessionFirstPageKey: WorkspaceSessionFirstPageCompletion] = [:]
     var sessionListCooldownUntilByBudgetKey: [SessionListBudgetKey: Date] = [:]
     var sessionListReconciliationTasksByProjectID: [String: Task<Void, Never>] = [:]
     var gitRefreshTasksByPath: [String: Task<Void, Never>] = [:]
@@ -412,6 +412,9 @@ final class SessionStore: ObservableObject {
     // 首屏先拿较小窗口，避免为了预览历史会话而卡住整个工作台。
     static let initialSessionPageLimit = 20
     static let expandedSessionPageLimit = 20
+    /// presentation 补页保持顺序且有界：最小批量避免 child 密集时退化成逐条 RPC，页数上限防止异常 cursor 请求风暴。
+    static let minimumSessionPresentationFillPageLimit = 5
+    static let maximumSessionPresentationFillPageCount = 12
     static let missingRunningSessionReadThreshold = 2
     static let maximumUnverifiedRunningSessionMisses = 3
     static let commandActionHistoryLimit = 10

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -1449,8 +1449,11 @@ extension SessionStore {
         sessionListFirstPageCacheByKey = sessionListFirstPageCacheByKey.filter {
             replacements[$0.key.workspaceID] == nil
         }
-        workspaceSessionFirstPageCompletionByKey = workspaceSessionFirstPageCompletionByKey.filter {
+        let retainedWorkspaceCompletions = workspaceSessionFirstPageCompletionByKey.filter {
             replacements[$0.key.workspaceID] == nil
+        }
+        if retainedWorkspaceCompletions != workspaceSessionFirstPageCompletionByKey {
+            workspaceSessionFirstPageCompletionByKey = retainedWorkspaceCompletions
         }
 
         let workspacesByID = Dictionary(
@@ -1916,8 +1919,11 @@ extension SessionStore {
         sessionPageLoadingTokenByProjectID.removeValue(forKey: project.id)
         sessionFirstPageLoadingConsistencyByProjectID.removeValue(forKey: project.id)
         sessionFirstPageWaiterCountByProjectID.removeValue(forKey: project.id)
-        workspaceSessionFirstPageCompletionByKey = workspaceSessionFirstPageCompletionByKey.filter {
+        let retainedWorkspaceCompletions = workspaceSessionFirstPageCompletionByKey.filter {
             $0.key.workspaceID != project.id
+        }
+        if retainedWorkspaceCompletions != workspaceSessionFirstPageCompletionByKey {
+            workspaceSessionFirstPageCompletionByKey = retainedWorkspaceCompletions
         }
         clearSessionReminders(forProjectID: project.id)
         sessions = sessions.filter { $0.projectID != project.id }
@@ -2343,7 +2349,9 @@ extension SessionStore {
         sessionListFirstPageInFlightByKey.values.forEach { $0.task.cancel() }
         sessionListFirstPageInFlightByKey = [:]
         sessionListFirstPageCacheByKey = [:]
-        workspaceSessionFirstPageCompletionByKey = [:]
+        if !workspaceSessionFirstPageCompletionByKey.isEmpty {
+            workspaceSessionFirstPageCompletionByKey = [:]
+        }
         sessionListCooldownUntilByBudgetKey = [:]
         lastSessionLibraryIndexRefreshAt = nil
         sessionListReconciliationTasksByProjectID.values.forEach { $0.cancel() }

--- a/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
@@ -384,7 +384,7 @@ extension SessionStore {
         do {
             // 外部活动补拉也必须加入首屏 single-flight；否则它与工作区前台刷新重叠时，
             // 会并发启动两条 cursor 链并触发 gateway 的并发保护。
-            let page = try await sessionListFirstPage(
+            let result = try await sessionListFirstPage(
                 workspace: workspace,
                 limit: Self.initialSessionPageLimit,
                 reuseRecent: false,
@@ -393,16 +393,22 @@ extension SessionStore {
                 client: client,
                 hostScope: hostScope
             )
+            let page = result.page
             guard appStore.activeHostScope == hostScope,
                   !Task.isCancelled,
-                  isCurrentWorkspaceIdentity(workspace, hostScope: hostScope) else {
+                  isCurrentWorkspaceIdentity(workspace, hostScope: hostScope),
+                  authoritativeWorkspaceSessionFirstPageContinuationCursor(
+                    workspace: workspace,
+                    hostScope: hostScope
+                  ) == result.requestedCursor else {
                 return
             }
             mergeSessionPage(sessions(page.sessions, in: workspace))
             updateWorkspaceSessionFirstPageState(
                 workspace: workspace,
                 page: page,
-                consistency: .authoritative
+                consistency: .authoritative,
+                requestedCursor: result.requestedCursor
             )
             recordWorkspaceSessionFirstPageCompletion(
                 workspace: workspace,

--- a/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
@@ -382,11 +382,16 @@ extension SessionStore {
             return
         }
         do {
-            let page = try await client.sessionsPage(
+            // 外部活动补拉也必须加入首屏 single-flight；否则它与工作区前台刷新重叠时，
+            // 会并发启动两条 cursor 链并触发 gateway 的并发保护。
+            let page = try await sessionListFirstPage(
                 workspace: workspace,
-                cursor: nil,
                 limit: Self.initialSessionPageLimit,
-                consistency: .authoritative
+                reuseRecent: false,
+                consistency: .authoritative,
+                source: .externalActivity,
+                client: client,
+                hostScope: hostScope
             )
             guard appStore.activeHostScope == hostScope,
                   !Task.isCancelled,
@@ -401,6 +406,7 @@ extension SessionStore {
             )
             recordWorkspaceSessionFirstPageCompletion(
                 workspace: workspace,
+                page: page,
                 consistency: .authoritative
             )
             clearWorkspaceUnavailable(projectID)

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -1143,13 +1143,13 @@ extension SessionStore {
             guard let page = result.page,
                   isCurrentWorkspaceIdentity(result.workspace) else { continue }
             let pageSessions = sessions(page.sessions, in: result.workspace)
-            if shouldProtectAuthoritativeWorkspaceSessionFirstPage(
-                workspace: result.workspace,
-                incomingConsistency: consistency
-            ) {
-                // 会话库的弱页可能晚于前台精确页返回；只补新 ID，不能把精确字段覆盖回稀疏索引值。
-                mergeSessionPageAddingMissingOnly(pageSessions)
+            if consistency == .fastIndexed {
+                mergeFastIndexedSessionPagePreservingAuthoritativeFields(
+                    pageSessions,
+                    workspace: result.workspace
+                )
             } else {
+                // 新一轮权威刷新必须能修正旧权威数据；只有弱一致性页需要降级保护。
                 mergeSessionPage(pageSessions)
             }
             updateWorkspaceSessionFirstPageState(
@@ -1159,6 +1159,7 @@ extension SessionStore {
             )
             recordWorkspaceSessionFirstPageCompletion(
                 workspace: result.workspace,
+                page: page,
                 consistency: consistency
             )
             clearWorkspaceUnavailable(result.workspace.id)
@@ -1196,9 +1197,12 @@ extension SessionStore {
         guard let workspace = ensureWorkspaceForKnownProjectID(projectID) else {
             return nil
         }
-        return workspaceSessionFirstPageCompletionByKey[
+        guard let completion = workspaceSessionFirstPageCompletionByKey[
             workspaceSessionFirstPageKey(for: workspace)
-        ]?.consistency
+        ], completion.isPresentationWindowComplete else {
+            return nil
+        }
+        return completion.consistency
     }
 
     func needsAuthoritativeWorkspaceSessionFirstPage(projectID: String) -> Bool {
@@ -1207,21 +1211,69 @@ extension SessionStore {
 
     func recordWorkspaceSessionFirstPageCompletion(
         workspace: AgentWorkspace,
+        page: SessionsPage,
         consistency: SessionListConsistency
     ) {
         guard isCurrentWorkspaceIdentity(workspace) else { return }
         let hostScope = appStore.activeHostScope
         let key = workspaceSessionFirstPageKey(for: workspace, hostScope: hostScope)
-        if workspaceSessionFirstPageCompletionByKey[key]?.consistency == .authoritative,
+        if let existingCompletion = workspaceSessionFirstPageCompletionByKey[key],
+           existingCompletion.consistency == .authoritative,
            consistency == .fastIndexed {
+            invalidateAuthoritativeWorkspaceSessionPresentationCompletionIfNeeded(
+                workspace: workspace
+            )
             return
         }
-        // 旧 generation 的结论永远不能再次命中；在写入新结论时顺手裁掉，避免长时间切换主机后增长。
-        workspaceSessionFirstPageCompletionByKey = workspaceSessionFirstPageCompletionByKey.filter {
+        let presentationWindowComplete = isWorkspaceSessionPresentationWindowComplete(
+            workspace: workspace,
+            page: page,
+            limit: Self.initialSessionPageLimit
+        )
+        let existingCompletion = workspaceSessionFirstPageCompletionByKey[key]
+        let completion: WorkspaceSessionFirstPageCompletion
+        if let existingCompletion,
+           existingCompletion.consistency == consistency,
+           existingCompletion.isPresentationWindowComplete == presentationWindowComplete {
+            // completedAt 表示首次进入当前语义状态的时刻；相同结果不重写时间戳，
+            // 也避免 @Published 在重复轮询时制造无意义的整页刷新。
+            completion = existingCompletion
+        } else {
+            completion = WorkspaceSessionFirstPageCompletion(
+                consistency: consistency,
+                isPresentationWindowComplete: presentationWindowComplete,
+                completedAt: sessionListNow()
+            )
+        }
+        // 旧 generation 的结论永远不能再次命中；一次性构造并比较新字典，避免 filter 和
+        // 下标写入分别发布，且相同 completion 不应触发 WorkspaceRoot 的观察更新。
+        var nextCompletions = workspaceSessionFirstPageCompletionByKey.filter {
             $0.key.hostScope == hostScope
         }
+        nextCompletions[key] = completion
+        if nextCompletions != workspaceSessionFirstPageCompletionByKey {
+            workspaceSessionFirstPageCompletionByKey = nextCompletions
+        }
+    }
+
+    /// 弱一致性数据可以补认 child ownership，使已经完成的 20 条权威根会话窗口重新欠填。
+    /// 只有仍有安全 continuation 时才失效；真正耗尽的短列表已经是完整展示结果，不应循环重拉。
+    func invalidateAuthoritativeWorkspaceSessionPresentationCompletionIfNeeded(
+        workspace: AgentWorkspace
+    ) {
+        guard isCurrentWorkspaceIdentity(workspace) else { return }
+        let key = workspaceSessionFirstPageKey(for: workspace)
+        guard let existingCompletion = workspaceSessionFirstPageCompletionByKey[key],
+              existingCompletion.consistency == .authoritative,
+              existingCompletion.isPresentationWindowComplete,
+              sessionHasMoreByProjectID[workspace.id] == true,
+              sessions(forProjectID: workspace.id).count < Self.initialSessionPageLimit
+        else {
+            return
+        }
         workspaceSessionFirstPageCompletionByKey[key] = WorkspaceSessionFirstPageCompletion(
-            consistency: consistency,
+            consistency: .authoritative,
+            isPresentationWindowComplete: false,
             completedAt: sessionListNow()
         )
     }
@@ -1253,6 +1305,22 @@ extension SessionStore {
         updateSessionPageState(projectID: workspace.id, page: page, requestedCursor: nil)
     }
 
+    func isWorkspaceSessionPresentationWindowComplete(
+        workspace: AgentWorkspace,
+        page: SessionsPage,
+        limit: Int
+    ) -> Bool {
+        guard page.hasMore else { return true }
+        var listableIDs = Set<SessionID>()
+        for rawSession in page.sessions {
+            let session = sessionPreparedForStorage(self.session(rawSession, in: workspace))
+            if isListableSession(session) {
+                listableIDs.insert(session.id)
+            }
+        }
+        return listableIDs.count >= max(1, limit)
+    }
+
     func applyWorkspaceSessionFirstPage(
         workspace: AgentWorkspace,
         page: SessionsPage,
@@ -1261,13 +1329,25 @@ extension SessionStore {
     ) {
         guard isCurrentWorkspaceIdentity(workspace) else { return }
         let pageSessions = sessions(page.sessions, in: workspace)
+        let presentationWindowComplete = isWorkspaceSessionPresentationWindowComplete(
+            workspace: workspace,
+            page: page,
+            limit: Self.initialSessionPageLimit
+        )
         if shouldProtectAuthoritativeWorkspaceSessionFirstPage(
             workspace: workspace,
             incomingConsistency: consistency
         ) {
-            // authoritative 一旦完成，后续 State DB 稀疏页只允许补充缺失 ID；
-            // 同 ID 的 title/status 等字段必须保留精确结果，不能被迟到的弱页覆盖。
-            mergeSessionPageAddingMissingOnly(pageSessions)
+            // authoritative 一旦完成，后续 State DB 稀疏页只能补新 ID 和单调线程身份；
+            // 同 ID 的 title/status 等普通字段不能被迟到弱页覆盖。
+            mergeFastIndexedSessionPagePreservingAuthoritativeFields(
+                pageSessions,
+                workspace: workspace
+            )
+        } else if !presentationWindowComplete {
+            // 展示窗口欠填时保留旧可见行，只补充已扫描 canonical 数据；新 cursor 仍可继续推进。
+            // fast waiter 可能共享到这张 authoritative 部分页，也必须沿用 merge-only，不能再次删旧根会话。
+            mergeSessionPage(pageSessions)
         } else {
             replaceSessionsIfChanged(
                 with: pageSessionsPreservingLoadedWindow(
@@ -1285,6 +1365,7 @@ extension SessionStore {
         )
         recordWorkspaceSessionFirstPageCompletion(
             workspace: workspace,
+            page: page,
             consistency: consistency
         )
         clearWorkspaceUnavailable(workspace.id)
@@ -1416,11 +1497,15 @@ extension SessionStore {
         let client = try fixedClient ?? clientFactory()
         let requestID = UUID()
         let task = Task {
-            try await client.sessionsPage(
+            try await sessionListPageFillingPresentationWindow(
+                client: client,
                 workspace: workspace,
                 cursor: nil,
                 limit: limit,
-                consistency: consistency
+                consistency: consistency,
+                source: source,
+                expectedHostScope: hostScope,
+                fillsPresentationWindow: consistency == .authoritative
             )
         }
         sessionListFirstPageInFlightByKey[key] = SessionListFirstPageInFlight(
@@ -1434,7 +1519,17 @@ extension SessionStore {
                   !Task.isCancelled else {
                 throw CancellationError()
             }
-            sessionListFirstPageCacheByKey[key] = SessionListFirstPageCacheEntry(page: page, loadedAt: sessionListNow())
+            if consistency != .authoritative
+                || isWorkspaceSessionPresentationWindowComplete(
+                    workspace: workspace,
+                    page: page,
+                    limit: limit
+                ) {
+                sessionListFirstPageCacheByKey[key] = SessionListFirstPageCacheEntry(
+                    page: page,
+                    loadedAt: sessionListNow()
+                )
+            }
             clearSessionListCooldown(for: workspace)
             SessionListDiagnostics.completed(
                 source: source,
@@ -1451,6 +1546,124 @@ extension SessionStore {
             }
             throw error
         }
+    }
+
+    /// transport 的 limit 约束 raw rows；子 Agent 过滤和双 Runtime 短页都可能让展示层不足一页。
+    /// 精确首屏与“显示更多”必须沿 opaque cursor 补齐顶层会话，child 仍随 raw rows 进入 canonical Store。
+    func sessionListPageFillingPresentationWindow(
+        client: any SessionStoreAPIClient,
+        workspace: AgentWorkspace,
+        cursor initialCursor: String?,
+        limit: Int,
+        consistency: SessionListConsistency,
+        source: SessionListRequestSource,
+        expectedHostScope: HostScope,
+        excludingListableSessionIDs: Set<SessionID> = [],
+        fillsPresentationWindow: Bool = true,
+        isRequestCurrent: (() -> Bool)? = nil
+    ) async throws -> SessionsPage {
+        let targetCount = max(1, limit)
+        var requestedCursor = initialCursor
+        var seenCursors = Set<String>()
+        if let initialCursor {
+            seenCursors.insert(initialCursor)
+        }
+        var collectedIndexBySessionID: [SessionID: Int] = [:]
+        var listableSessionIDs = Set<SessionID>()
+        var collectedSessions: [AgentSession] = []
+        var pagesScanned = 0
+        var lastPage = SessionsPage(sessions: [])
+
+        while true {
+            try Task.checkCancellation()
+            guard isCurrentWorkspaceIdentity(workspace, hostScope: expectedHostScope) else {
+                throw CancellationError()
+            }
+            guard isRequestCurrent?() != false else {
+                throw CancellationError()
+            }
+
+            // 不退化成 limit=1：child 密集时逐条 RPC 会放大远程链路延迟；小批量最多只让最终窗口轻微超出目标。
+            let remainingCount = max(
+                min(targetCount, Self.minimumSessionPresentationFillPageLimit),
+                targetCount - listableSessionIDs.count
+            )
+            let page = try await client.sessionsPage(
+                workspace: workspace,
+                cursor: requestedCursor,
+                limit: remainingCount,
+                consistency: consistency
+            )
+            try Task.checkCancellation()
+            guard isCurrentWorkspaceIdentity(workspace, hostScope: expectedHostScope),
+                  isRequestCurrent?() != false else {
+                throw CancellationError()
+            }
+            pagesScanned += 1
+            lastPage = page
+
+            for rawSession in page.sessions {
+                // 稀疏列表可能暂时丢 parent/source；先恢复 Store 已知的 sticky ownership，
+                // 否则 child 会被误计成 root 并让 authoritative completion 提前成立。
+                let session = sessionPreparedForStorage(self.session(rawSession, in: workspace))
+                if let index = collectedIndexBySessionID[session.id] {
+                    // later-wins 更新普通字段，但 child ownership 必须跨页单调保留。
+                    let merged = sessionPreservingSubagentOwnership(
+                        session,
+                        withKnown: collectedSessions[index]
+                    )
+                    collectedSessions[index] = merged
+                    if isListableSession(merged),
+                       !excludingListableSessionIDs.contains(merged.id) {
+                        listableSessionIDs.insert(merged.id)
+                    } else {
+                        listableSessionIDs.remove(merged.id)
+                    }
+                    continue
+                }
+                collectedIndexBySessionID[session.id] = collectedSessions.count
+                collectedSessions.append(session)
+                if isListableSession(session),
+                   !excludingListableSessionIDs.contains(session.id) {
+                    listableSessionIDs.insert(session.id)
+                }
+            }
+
+            guard !page.hasMore || page.nextCursor != nil else {
+                // has_more 没有 opaque continuation 无法安全推进，不能伪装成 exhausted。
+                throw AgentAPIError.invalidResponse
+            }
+            guard fillsPresentationWindow,
+                  listableSessionIDs.count < targetCount,
+                  page.hasMore,
+                  let nextCursor = page.nextCursor
+            else {
+                break
+            }
+            // cursor 不前进时不能把 transport 完成误记成 presentation 完成，也不能形成请求风暴。
+            guard nextCursor != requestedCursor,
+                  seenCursors.insert(nextCursor).inserted
+            else {
+                throw AgentAPIError.invalidResponse
+            }
+            guard pagesScanned < Self.maximumSessionPresentationFillPageCount else { break }
+            requestedCursor = nextCursor
+        }
+
+        let hasMore = lastPage.hasMore && lastPage.nextCursor != nil
+        SessionListDiagnostics.presentationWindowCompleted(
+            source: source,
+            consistency: consistency,
+            rawCount: collectedSessions.count,
+            listableCount: listableSessionIDs.count,
+            pagesScanned: pagesScanned,
+            hasMore: hasMore
+        )
+        return SessionsPage(
+            sessions: collectedSessions,
+            nextCursor: hasMore ? lastPage.nextCursor : nil,
+            hasMore: hasMore
+        )
     }
 
     /// owner 与 waiter 都只能退休自己观察到的那一代请求，避免旧 continuation 删除同 key 的新 in-flight。
@@ -1906,11 +2119,26 @@ extension SessionStore {
         sessions = next
     }
 
-    /// 弱一致性结果迟到时只补充权威页尚未见过的会话，绝不回退同 ID 的精确字段。
-    func mergeSessionPageAddingMissingOnly(_ pageSessions: [AgentSession]) {
-        guard !pageSessions.isEmpty else { return }
-        let missingSessions = pageSessions.filter { sessionIndexByID[$0.id] == nil }
-        mergeSessionPage(missingSessions)
+    /// fastIndexed 可能晚于 authoritative 返回，或在翻页边界重复同一 ID。
+    /// 已有权威行保留普通字段，只单调吸收线程身份；新 ID 仍按正常路径完整加入。
+    func mergeFastIndexedSessionPagePreservingAuthoritativeFields(
+        _ pageSessions: [AgentSession],
+        workspace: AgentWorkspace
+    ) {
+        guard shouldProtectAuthoritativeWorkspaceSessionFirstPage(
+            workspace: workspace,
+            incomingConsistency: .fastIndexed
+        ) else {
+            mergeSessionPage(pageSessions)
+            return
+        }
+        let qualitySafeSessions = pageSessions.map { incoming in
+            guard let existing = sessionsByID[incoming.id] else {
+                return incoming
+            }
+            return sessionPreservingSubagentOwnership(existing, withKnown: incoming)
+        }
+        mergeSessionPage(qualitySafeSessions)
     }
 
     func updateSessionPageState(

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -1070,13 +1070,14 @@ extension SessionStore {
                 consistency: consistency
             )
             defer { finishSessionFirstPageRequest(projectID: projectID, token: requestToken ?? 0) }
-            let page = try await sessionListFirstPage(
+            let result = try await sessionListFirstPage(
                 workspace: workspace,
                 limit: Self.initialSessionPageLimit,
                 reuseRecent: reuseRecent ?? !showLoading,
                 consistency: consistency,
                 source: .selectedProject
             )
+            let page = result.page
             guard isCurrentSessionPageRequest(projectID: projectID, token: requestToken ?? 0) else {
                 return
             }
@@ -1087,7 +1088,8 @@ extension SessionStore {
             applyWorkspaceSessionFirstPage(
                 workspace: workspace,
                 page: page,
-                consistency: consistency
+                consistency: consistency,
+                requestedCursor: result.requestedCursor
             )
             if updateStatusMessage, canReportForeground() {
                 setStatusMessage(L10n.plural("ui.sessions_loaded_count", count: filteredSessions.count))
@@ -1115,9 +1117,9 @@ extension SessionStore {
         consistency: SessionListConsistency = .fastIndexed,
         client: (any SessionStoreAPIClient)? = nil,
         hostScope: HostScope? = nil
-    ) async -> (workspace: AgentWorkspace, page: SessionsPage?) {
+    ) async -> (workspace: AgentWorkspace, page: SessionsPage?, requestedCursor: String?) {
         do {
-            let page = try await sessionListFirstPage(
+            let result = try await sessionListFirstPage(
                 workspace: workspace,
                 limit: Self.initialSessionPageLimit,
                 reuseRecent: consistency == .fastIndexed,
@@ -1126,15 +1128,15 @@ extension SessionStore {
                 client: client,
                 hostScope: hostScope
             )
-            return (workspace, page)
+            return (workspace, result.page, result.requestedCursor)
         } catch {
             // 某个最近工作区失效不能阻断整个会话库；该项目仍可在工作区页单独重试。
-            return (workspace, nil)
+            return (workspace, nil, nil)
         }
     }
 
     func mergeSessionLibraryPages(
-        _ results: [(workspace: AgentWorkspace, page: SessionsPage?)],
+        _ results: [(workspace: AgentWorkspace, page: SessionsPage?, requestedCursor: String?)],
         generation: Int,
         consistency: SessionListConsistency = .fastIndexed
     ) {
@@ -1142,6 +1144,11 @@ extension SessionStore {
         for result in results {
             guard let page = result.page,
                   isCurrentWorkspaceIdentity(result.workspace) else { continue }
+            if consistency == .authoritative,
+               authoritativeWorkspaceSessionFirstPageContinuationCursor(workspace: result.workspace)
+                != result.requestedCursor {
+                continue
+            }
             let pageSessions = sessions(page.sessions, in: result.workspace)
             if consistency == .fastIndexed {
                 mergeFastIndexedSessionPagePreservingAuthoritativeFields(
@@ -1155,7 +1162,8 @@ extension SessionStore {
             updateWorkspaceSessionFirstPageState(
                 workspace: result.workspace,
                 page: page,
-                consistency: consistency
+                consistency: consistency,
+                requestedCursor: result.requestedCursor
             )
             recordWorkspaceSessionFirstPageCompletion(
                 workspace: result.workspace,
@@ -1209,6 +1217,35 @@ extension SessionStore {
         workspaceSessionFirstPageConsistency(projectID: projectID) != .authoritative
     }
 
+    func authoritativeWorkspaceSessionFirstPageContinuationCursor(
+        workspace: AgentWorkspace,
+        hostScope: HostScope? = nil
+    ) -> String? {
+        let completion = workspaceSessionFirstPageCompletionByKey[
+            workspaceSessionFirstPageKey(for: workspace, hostScope: hostScope)
+        ]
+        guard completion?.consistency == .authoritative,
+              completion?.isPresentationWindowComplete == false else {
+            return nil
+        }
+        return completion?.continuationCursor
+    }
+
+    func authoritativeWorkspaceSessionFirstPageProgress(
+        workspace: AgentWorkspace,
+        hostScope: HostScope? = nil
+    ) -> WorkspaceSessionFirstPageCompletion? {
+        let completion = workspaceSessionFirstPageCompletionByKey[
+            workspaceSessionFirstPageKey(for: workspace, hostScope: hostScope)
+        ]
+        guard completion?.consistency == .authoritative,
+              completion?.isPresentationWindowComplete == false,
+              completion?.continuationCursor != nil else {
+            return nil
+        }
+        return completion
+    }
+
     func recordWorkspaceSessionFirstPageCompletion(
         workspace: AgentWorkspace,
         page: SessionsPage,
@@ -1230,11 +1267,20 @@ extension SessionStore {
             page: page,
             limit: Self.initialSessionPageLimit
         )
+        let continuationCursor = consistency == .authoritative && !presentationWindowComplete
+            ? page.nextCursor
+            : nil
+        var seenSessionIDs = Set<SessionID>()
+        let scannedSessionIDs = page.sessions.compactMap { session in
+            seenSessionIDs.insert(session.id).inserted ? session.id : nil
+        }
         let existingCompletion = workspaceSessionFirstPageCompletionByKey[key]
         let completion: WorkspaceSessionFirstPageCompletion
         if let existingCompletion,
            existingCompletion.consistency == consistency,
-           existingCompletion.isPresentationWindowComplete == presentationWindowComplete {
+           existingCompletion.isPresentationWindowComplete == presentationWindowComplete,
+           existingCompletion.continuationCursor == continuationCursor,
+           existingCompletion.scannedSessionIDs == scannedSessionIDs {
             // completedAt 表示首次进入当前语义状态的时刻；相同结果不重写时间戳，
             // 也避免 @Published 在重复轮询时制造无意义的整页刷新。
             completion = existingCompletion
@@ -1242,7 +1288,14 @@ extension SessionStore {
             completion = WorkspaceSessionFirstPageCompletion(
                 consistency: consistency,
                 isPresentationWindowComplete: presentationWindowComplete,
-                completedAt: sessionListNow()
+                continuationCursor: continuationCursor,
+                scannedSessionIDs: scannedSessionIDs,
+                // cursor 推进仍属于同一个“欠填”语义状态，保留首次进入时间；
+                // 但 completion 本身必须发布，让下一批和诊断观察到新的安全 continuation。
+                completedAt: existingCompletion?.consistency == consistency
+                    && existingCompletion?.isPresentationWindowComplete == presentationWindowComplete
+                    ? existingCompletion?.completedAt ?? sessionListNow()
+                    : sessionListNow()
             )
         }
         // 旧 generation 的结论永远不能再次命中；一次性构造并比较新字典，避免 filter 和
@@ -1274,6 +1327,10 @@ extension SessionStore {
         workspaceSessionFirstPageCompletionByKey[key] = WorkspaceSessionFirstPageCompletion(
             consistency: .authoritative,
             isPresentationWindowComplete: false,
+            continuationCursor: sessionPageCursorByProjectID[workspace.id],
+            // late-child 只改变 sticky ownership；沿用原权威链实际扫描过的 ID，
+            // 续跑时会从 sessionsByID 读取最新身份并把被补认的 child 从 root 计数中减掉。
+            scannedSessionIDs: existingCompletion.scannedSessionIDs,
             completedAt: sessionListNow()
         )
     }
@@ -1291,7 +1348,8 @@ extension SessionStore {
     func updateWorkspaceSessionFirstPageState(
         workspace: AgentWorkspace,
         page: SessionsPage,
-        consistency: SessionListConsistency
+        consistency: SessionListConsistency,
+        requestedCursor: String? = nil
     ) {
         guard isCurrentWorkspaceIdentity(workspace) else { return }
         guard !shouldProtectAuthoritativeWorkspaceSessionFirstPage(
@@ -1302,7 +1360,21 @@ extension SessionStore {
             rebuildProjectSessionListSnapshot(forProjectID: workspace.id)
             return
         }
-        updateSessionPageState(projectID: workspace.id, page: page, requestedCursor: nil)
+        let pageStateRequestedCursor: String?
+        if let requestedCursor,
+           !sessionProjectsWithAdditionalPages.contains(workspace.id)
+            || sessionPageCursorByProjectID[workspace.id] == requestedCursor {
+            // 未展开窗口可直接推进；已展开窗口只有在 authoritative continuation
+            // 与当前 deep cursor 是同一条链时才推进，避免较浅 head-fill cursor 覆盖用户深层位置。
+            pageStateRequestedCursor = requestedCursor
+        } else {
+            pageStateRequestedCursor = nil
+        }
+        updateSessionPageState(
+            projectID: workspace.id,
+            page: page,
+            requestedCursor: pageStateRequestedCursor
+        )
     }
 
     func isWorkspaceSessionPresentationWindowComplete(
@@ -1321,13 +1393,22 @@ extension SessionStore {
         return listableIDs.count >= max(1, limit)
     }
 
+    @discardableResult
     func applyWorkspaceSessionFirstPage(
         workspace: AgentWorkspace,
         page: SessionsPage,
         consistency: SessionListConsistency,
+        requestedCursor: String? = nil,
         preserveAllLoaded: Bool = false
-    ) {
-        guard isCurrentWorkspaceIdentity(workspace) else { return }
+    ) -> Bool {
+        guard isCurrentWorkspaceIdentity(workspace) else { return false }
+        if consistency == .authoritative,
+           authoritativeWorkspaceSessionFirstPageContinuationCursor(workspace: workspace)
+            != requestedCursor {
+            // 同 cursor waiter 的旧结果允许首个提交者推进；其余 waiter 若观察到进度已改变，
+            // 必须丢弃，不能把 completion 或 opaque cursor 倒回上一批。
+            return false
+        }
         let pageSessions = sessions(page.sessions, in: workspace)
         let presentationWindowComplete = isWorkspaceSessionPresentationWindowComplete(
             workspace: workspace,
@@ -1361,7 +1442,8 @@ extension SessionStore {
         updateWorkspaceSessionFirstPageState(
             workspace: workspace,
             page: page,
-            consistency: consistency
+            consistency: consistency,
+            requestedCursor: requestedCursor
         )
         recordWorkspaceSessionFirstPageCompletion(
             workspace: workspace,
@@ -1369,6 +1451,7 @@ extension SessionStore {
             consistency: consistency
         )
         clearWorkspaceUnavailable(workspace.id)
+        return true
     }
 
     func sessionListFirstPage(
@@ -1379,19 +1462,27 @@ extension SessionStore {
         source: SessionListRequestSource,
         client fixedClient: (any SessionStoreAPIClient)? = nil,
         hostScope expectedHostScope: HostScope? = nil
-    ) async throws -> SessionsPage {
+    ) async throws -> SessionListFirstPageResult {
         let requestStartedAt = sessionListNow()
         let hostScope = expectedHostScope ?? appStore.activeHostScope
         guard isCurrentWorkspaceIdentity(workspace, hostScope: hostScope) else {
             throw CancellationError()
         }
+        let authoritativeProgress = consistency == .authoritative
+            ? authoritativeWorkspaceSessionFirstPageProgress(
+                workspace: workspace,
+                hostScope: hostScope
+            )
+            : nil
+        let requestedCursor = authoritativeProgress?.continuationCursor
         let key = SessionListFirstPageRequestKey(
             profileID: hostScope.profileID,
             connectionGeneration: Int(truncatingIfNeeded: hostScope.generation),
             workspaceID: workspace.id,
             workspacePath: workspace.path,
             limit: limit,
-            consistency: consistency
+            consistency: consistency,
+            cursor: requestedCursor
         )
         while true {
             // 手动刷新可以绕过短缓存，但同一时刻仍必须等待已存在的共享请求。
@@ -1404,7 +1495,7 @@ extension SessionStore {
                     count: page.sessions.count,
                     duration: sessionListNow().timeIntervalSince(requestStartedAt)
                 )
-                return page
+                return SessionListFirstPageResult(page: page, requestedCursor: key.cursor)
             }
 
             let matchesCurrentWorkspace: (SessionListFirstPageRequestKey) -> Bool = { candidate in
@@ -1435,10 +1526,31 @@ extension SessionStore {
                 continue
             }
 
+            if consistency == .fastIndexed,
+               let authoritativeContinuationInFlight = sessionListFirstPageInFlightByKey.first(where: { entry in
+                   matchesCurrentWorkspace(entry.key)
+                       && entry.key.consistency == .authoritative
+                       && entry.key.cursor != key.cursor
+               }) {
+                // continuation page 不能冒充 fastIndexed 的 nil 首屏，但 gateway 同一工作区
+                // 仍只允许一条 thread/list cursor 链：先排空权威续跑，再单独发弱首屏。
+                _ = try? await authoritativeContinuationInFlight.value.task.value
+                retireSessionListFirstPageInFlight(
+                    key: authoritativeContinuationInFlight.key,
+                    id: authoritativeContinuationInFlight.value.id
+                )
+                guard isCurrentWorkspaceIdentity(workspace, hostScope: hostScope),
+                      !Task.isCancelled else {
+                    throw CancellationError()
+                }
+                continue
+            }
+
             // 会话库只需要 8 条时，可以复用同工作区正在执行的 20 条请求；反向复用会缩短主列表，不能做。
             // 后台快速刷新也可以等待更强的权威请求；权威刷新不能复用快速索引结果，否则会重新引入漏会话问题。
             if let largerInFlight = sessionListFirstPageInFlightByKey.first(where: { entry in
                 matchesCurrentWorkspace(entry.key)
+                    && entry.key.cursor == key.cursor
                     && (
                         entry.key.consistency == key.consistency
                             || (key.consistency == .fastIndexed && entry.key.consistency == .authoritative)
@@ -1453,12 +1565,13 @@ extension SessionStore {
                     count: page.sessions.count,
                     duration: sessionListNow().timeIntervalSince(requestStartedAt)
                 )
-                return page
+                return SessionListFirstPageResult(page: page, requestedCursor: key.cursor)
             }
             break
         }
         let now = sessionListNow()
         if reuseRecent,
+           key.cursor == nil,
            let cached = sessionListFirstPageCacheByKey[key]
                 ?? cachedSessionListEntry(workspace: workspace, minimumLimit: limit),
            now.timeIntervalSince(cached.loadedAt) < sessionListFirstPageCacheTTL {
@@ -1469,7 +1582,7 @@ extension SessionStore {
                 count: cached.page.sessions.count,
                 duration: sessionListNow().timeIntervalSince(requestStartedAt)
             )
-            return cached.page
+            return SessionListFirstPageResult(page: cached.page, requestedCursor: key.cursor)
         }
 
         if let cooldownDelay = sessionListCooldownDelayNanoseconds(for: workspace) {
@@ -1484,7 +1597,7 @@ extension SessionStore {
                     count: stale.sessions.count,
                     duration: sessionListNow().timeIntervalSince(requestStartedAt)
                 )
-                return stale
+                return SessionListFirstPageResult(page: stale, requestedCursor: key.cursor)
             }
             // 冷启动或精确刷新等待窗口并继续请求，保证首屏最终自动恢复。
             await sessionListSleep(cooldownDelay)
@@ -1495,16 +1608,22 @@ extension SessionStore {
         }
 
         let client = try fixedClient ?? clientFactory()
+        // 续跑只带上当前权威链真正扫描过的 ID，不能把旧缓存或已经“显示更多”的旧页
+        // 冒充权威种子；从 sessionsByID 重建可吸收迟到的 sticky child ownership。
+        let presentationSeedSessions = authoritativeProgress?.scannedSessionIDs.compactMap {
+            sessionsByID[$0]
+        } ?? []
         let requestID = UUID()
         let task = Task {
             try await sessionListPageFillingPresentationWindow(
                 client: client,
                 workspace: workspace,
-                cursor: nil,
+                cursor: requestedCursor,
                 limit: limit,
                 consistency: consistency,
                 source: source,
                 expectedHostScope: hostScope,
+                initialSessions: presentationSeedSessions,
                 fillsPresentationWindow: consistency == .authoritative
             )
         }
@@ -1519,7 +1638,8 @@ extension SessionStore {
                   !Task.isCancelled else {
                 throw CancellationError()
             }
-            if consistency != .authoritative
+            if key.cursor == nil,
+               consistency != .authoritative
                 || isWorkspaceSessionPresentationWindowComplete(
                     workspace: workspace,
                     page: page,
@@ -1538,7 +1658,7 @@ extension SessionStore {
                 count: page.sessions.count,
                 duration: sessionListNow().timeIntervalSince(requestStartedAt)
             )
-            return page
+            return SessionListFirstPageResult(page: page, requestedCursor: key.cursor)
         } catch {
             retireSessionListFirstPageInFlight(key: key, id: requestID)
             if let policyFailure = sessionListPolicyFailure(from: error) {
@@ -1558,6 +1678,7 @@ extension SessionStore {
         consistency: SessionListConsistency,
         source: SessionListRequestSource,
         expectedHostScope: HostScope,
+        initialSessions: [AgentSession] = [],
         excludingListableSessionIDs: Set<SessionID> = [],
         fillsPresentationWindow: Bool = true,
         isRequestCurrent: (() -> Bool)? = nil
@@ -1571,6 +1692,16 @@ extension SessionStore {
         var collectedIndexBySessionID: [SessionID: Int] = [:]
         var listableSessionIDs = Set<SessionID>()
         var collectedSessions: [AgentSession] = []
+        for rawSession in initialSessions {
+            let session = sessionPreparedForStorage(self.session(rawSession, in: workspace))
+            guard collectedIndexBySessionID[session.id] == nil else { continue }
+            collectedIndexBySessionID[session.id] = collectedSessions.count
+            collectedSessions.append(session)
+            if isListableSession(session),
+               !excludingListableSessionIDs.contains(session.id) {
+                listableSessionIDs.insert(session.id)
+            }
+        }
         var pagesScanned = 0
         var lastPage = SessionsPage(sessions: [])
 
@@ -1689,6 +1820,7 @@ extension SessionStore {
                     && entry.key.connectionGeneration == appStore.connectionGeneration
                     && entry.key.workspaceID == workspace.id
                     && entry.key.workspacePath == workspace.path
+                    && entry.key.cursor == nil
                     && entry.key.limit >= minimumLimit
             }
             .max { $0.value.loadedAt < $1.value.loadedAt }?

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -55,7 +55,10 @@ extension SessionStore {
                 source: .restore
             )
             guard isCurrentWorkspaceIdentity(workspace, hostScope: hostScope) else { return nil }
-            mergeSessionPage(sessions(page.sessions, in: workspace))
+            mergeFastIndexedSessionPagePreservingAuthoritativeFields(
+                sessions(page.sessions, in: workspace),
+                workspace: workspace
+            )
             updateWorkspaceSessionFirstPageState(
                 workspace: workspace,
                 page: page,
@@ -63,6 +66,7 @@ extension SessionStore {
             )
             recordWorkspaceSessionFirstPageCompletion(
                 workspace: workspace,
+                page: page,
                 consistency: .fastIndexed
             )
         } catch {
@@ -518,8 +522,11 @@ extension SessionStore {
             sessionFirstPageWaiterCountByProjectID = sessionFirstPageWaiterCountByProjectID.filter {
                 validProjectIDs.contains($0.key)
             }
-            workspaceSessionFirstPageCompletionByKey = workspaceSessionFirstPageCompletionByKey.filter {
+            let validWorkspaceCompletions = workspaceSessionFirstPageCompletionByKey.filter {
                 validProjectIDs.contains($0.key.workspaceID)
+            }
+            if validWorkspaceCompletions != workspaceSessionFirstPageCompletionByKey {
+                workspaceSessionFirstPageCompletionByKey = validWorkspaceCompletions
             }
             rebuildProjectSessionListSnapshots()
             let projectID = requestedProjectID.flatMap { id in

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -48,12 +48,13 @@ extension SessionStore {
 
         // 先让 runtime 从真实 thread/list 建立 session→provider 路由；旧会话不在首屏时再使用本地轻量快照。
         do {
-            let page = try await sessionListFirstPage(
+            let result = try await sessionListFirstPage(
                 workspace: workspace,
                 limit: Self.initialSessionPageLimit,
                 reuseRecent: true,
                 source: .restore
             )
+            let page = result.page
             guard isCurrentWorkspaceIdentity(workspace, hostScope: hostScope) else { return nil }
             mergeFastIndexedSessionPagePreservingAuthoritativeFields(
                 sessions(page.sessions, in: workspace),
@@ -589,13 +590,14 @@ extension SessionStore {
             // refreshAll 也必须进入首屏列表 single-flight。否则它与前台轮询或手动刷新重叠时，
             // 会向 gateway 发出两个相同 thread/list，后发请求被保护策略拒绝为 -32080。
             // reuseRecent=false 只绕过短缓存，不绕过正在执行的共享请求，仍保持全量刷新的语义。
-            let page = try await sessionListFirstPage(
+            let result = try await sessionListFirstPage(
                 workspace: workspace,
                 limit: Self.initialSessionPageLimit,
                 reuseRecent: false,
                 consistency: consistency,
                 source: .bootstrap
             )
+            let page = result.page
             guard connectionGeneration == appStore.connectionGeneration else {
                 return
             }
@@ -605,7 +607,8 @@ extension SessionStore {
             applyWorkspaceSessionFirstPage(
                 workspace: workspace,
                 page: page,
-                consistency: consistency
+                consistency: consistency,
+                requestedCursor: result.requestedCursor
             )
 
             if isSelectionLeaseCurrent(foregroundLease),
@@ -711,9 +714,41 @@ extension SessionStore {
         guard needsAuthoritativeWorkspaceSessionFirstPage(projectID: projectID) else {
             return
         }
-        try await refreshWorkspaceSessions(projectID: projectID)
-        guard !needsAuthoritativeWorkspaceSessionFirstPage(projectID: projectID) else {
-            throw CancellationError()
+
+        var seenContinuationCursors = Set<String>()
+        var completedBatchCount = 0
+        while true {
+            try Task.checkCancellation()
+            guard let workspace = ensureWorkspaceForKnownProjectID(projectID) else {
+                throw WorkspaceSessionRefreshError.workspaceUnavailable
+            }
+            let startingCursor = authoritativeWorkspaceSessionFirstPageContinuationCursor(
+                workspace: workspace
+            )
+            if let startingCursor,
+               !seenContinuationCursors.insert(startingCursor).inserted {
+                // 跨批 cursor 环同样是不可信响应；不能靠下一轮继续制造请求风暴。
+                throw AgentAPIError.invalidResponse
+            }
+
+            try await refreshWorkspaceSessions(projectID: projectID)
+            guard needsAuthoritativeWorkspaceSessionFirstPage(projectID: projectID) else {
+                return
+            }
+            guard let nextCursor = authoritativeWorkspaceSessionFirstPageContinuationCursor(
+                workspace: workspace
+            ), nextCursor != startingCursor else {
+                // 请求被更新 token 取代或服务端未推进时，当前 waiter 退出；新的 owner/后续手动刷新接管。
+                throw CancellationError()
+            }
+            completedBatchCount += 1
+            if completedBatchCount.isMultiple(of: Self.sessionPresentationFillBatchCountPerBurst) {
+                // 每个 burst 的 RPC 数仍有硬上界；cursor 链整体按顺序 eventual 完成，
+                // 不把 “>12 页卡住” 推迟成另一个固定页数阈值。
+                await sessionListSleep(Self.sessionPresentationFillBurstBackoffNanoseconds)
+            }
+            try Task.checkCancellation()
+            await Task.yield()
         }
     }
 
@@ -741,7 +776,7 @@ extension SessionStore {
         defer { finishSessionFirstPageRequest(projectID: workspace.id, token: requestToken) }
 
         do {
-            let page = try await sessionListFirstPage(
+            let result = try await sessionListFirstPage(
                 workspace: workspace,
                 limit: Self.initialSessionPageLimit,
                 reuseRecent: false,
@@ -749,6 +784,7 @@ extension SessionStore {
                 consistency: .authoritative,
                 source: .workspaceForeground
             )
+            let page = result.page
             guard isCurrentSessionPageRequest(projectID: workspace.id, token: requestToken) else {
                 return
             }
@@ -757,6 +793,7 @@ extension SessionStore {
                 workspace: workspace,
                 page: page,
                 consistency: .authoritative,
+                requestedCursor: result.requestedCursor,
                 // 工作区页下拉刷新首屏时，保留用户已经翻到的旧页，避免列表突然收缩回 20 条。
                 preserveAllLoaded: sessionProjectsWithAdditionalPages.contains(workspace.id)
             )

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -905,8 +905,11 @@ extension SessionStore {
         sessionPageLoadingTokenByProjectID.removeValue(forKey: project.id)
         sessionFirstPageLoadingConsistencyByProjectID.removeValue(forKey: project.id)
         sessionFirstPageWaiterCountByProjectID.removeValue(forKey: project.id)
-        workspaceSessionFirstPageCompletionByKey = workspaceSessionFirstPageCompletionByKey.filter {
+        let retainedWorkspaceCompletions = workspaceSessionFirstPageCompletionByKey.filter {
             $0.key.workspaceID != project.id
+        }
+        if retainedWorkspaceCompletions != workspaceSessionFirstPageCompletionByKey {
+            workspaceSessionFirstPageCompletionByKey = retainedWorkspaceCompletions
         }
         clearSessionReminders(forProjectID: project.id)
         sessions = sessions.filter { $0.projectID != project.id }
@@ -1487,17 +1490,36 @@ extension SessionStore {
                     finishSessionPageRequest(projectID: projectID, token: requestToken ?? 0)
                 }
             }
-            let page = try await lease.client.sessionsPage(
+            let page = try await sessionListPageFillingPresentationWindow(
+                client: lease.client,
                 workspace: workspace,
                 cursor: cursor,
-                limit: Self.expandedSessionPageLimit
+                limit: Self.expandedSessionPageLimit,
+                consistency: .fastIndexed,
+                source: .workspaceLoadMore,
+                expectedHostScope: lease.scope,
+                // 翻页要补的是新根会话；服务端边界漂移造成的重复 ID 不能占满下一页额度。
+                excludingListableSessionIDs: Set(sessions(forProjectID: projectID).map(\.id)),
+                // 新的刷新/分页 token 取代旧请求后，旧 cursor 链必须在下一页前停止。
+                isRequestCurrent: { [weak self] in
+                    guard let self, let requestToken else { return false }
+                    return self.isCurrentSessionPageRequest(projectID: projectID, token: requestToken)
+                }
             )
             guard canApplyProjectsGitResult(lease),
                   isCurrentSessionPageRequest(projectID: projectID, token: requestToken ?? 0) else {
                 return
             }
-            mergeSessionPage(sessions(page.sessions, in: workspace))
+            mergeFastIndexedSessionPagePreservingAuthoritativeFields(
+                sessions(page.sessions, in: workspace),
+                workspace: workspace
+            )
             updateSessionPageState(projectID: projectID, page: page, requestedCursor: cursor)
+            // 显示更多也可能从弱索引补认既有 root 的 child 身份。必须在推进到本轮安全
+            // continuation 之后再失效首屏完成态，让视图自动用该游标补齐，而不是退回旧边界。
+            invalidateAuthoritativeWorkspaceSessionPresentationCompletionIfNeeded(
+                workspace: workspace
+            )
             sessionProjectsWithAdditionalPages.insert(projectID)
             clearWorkspaceUnavailable(projectID)
             setErrorMessage(nil)

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -82,6 +82,7 @@ struct WorkspaceSessionFirstPageKey: Hashable {
 
 struct WorkspaceSessionFirstPageCompletion: Equatable {
     let consistency: SessionListConsistency
+    let isPresentationWindowComplete: Bool
     let completedAt: Date
 }
 
@@ -90,7 +91,9 @@ enum SessionListRequestSource: String {
     case libraryIndex
     case restore
     case selectedProject
+    case externalActivity
     case workspaceForeground
+    case workspaceLoadMore
 }
 
 enum SessionListRequestDelivery: String {
@@ -119,6 +122,21 @@ enum SessionListDiagnostics {
         // 只记录固定枚举和计数，不写 workspace path、标题或任何用户内容。
         logger.info(
             "source=\(source.rawValue, privacy: .public) page=1 consistency=\(consistencyName, privacy: .public) delivery=\(delivery.rawValue, privacy: .public) count=\(count) duration_ms=\(durationMilliseconds)"
+        )
+    }
+
+    static func presentationWindowCompleted(
+        source: SessionListRequestSource,
+        consistency: SessionListConsistency,
+        rawCount: Int,
+        listableCount: Int,
+        pagesScanned: Int,
+        hasMore: Bool
+    ) {
+        let consistencyName = consistency == .authoritative ? "authoritative" : "fastIndexed"
+        // 这里只记录分页形态，不记录 workspace、标题、session ID 或任何用户内容。
+        logger.info(
+            "source=\(source.rawValue, privacy: .public) presentation_fill consistency=\(consistencyName, privacy: .public) raw_count=\(rawCount) listable_count=\(listableCount) pages_scanned=\(pagesScanned) has_more=\(hasMore)"
         )
     }
 }
@@ -1603,6 +1621,15 @@ extension SessionStore {
         guard let existing = sessionsByID[incoming.id] else {
             return incoming
         }
+        return sessionPreservingSubagentOwnership(incoming, withKnown: existing)
+    }
+
+    /// 同一 cursor 链也可能重复同一 ID，且后一页才携带完整 parent/source。
+    /// 分页结果尚未进入 Store 时，用当前链已知行执行同样的单调 ownership 合并。
+    func sessionPreservingSubagentOwnership(
+        _ incoming: AgentSession,
+        withKnown existing: AgentSession
+    ) -> AgentSession {
         var result = incoming
         result.createdAt = result.createdAt ?? existing.createdAt ?? existing.context?.createdAt
 

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -70,6 +70,8 @@ struct SessionListFirstPageRequestKey: Hashable {
     let workspacePath: String
     let limit: Int
     let consistency: SessionListConsistency
+    /// nil 表示真正首屏；非 nil 表示权威展示窗口从已提交边界续跑。
+    let cursor: String?
 }
 
 /// “已经有几条缓存”与“当前主机代次已完成精确首屏”是两个状态。
@@ -83,7 +85,16 @@ struct WorkspaceSessionFirstPageKey: Hashable {
 struct WorkspaceSessionFirstPageCompletion: Equatable {
     let consistency: SessionListConsistency
     let isPresentationWindowComplete: Bool
+    /// 权威展示窗口达到单批预算但仍欠填时，保存下一批唯一允许继续的 opaque cursor。
+    let continuationCursor: String?
+    /// 仅记录当前权威 cursor 链实际扫描过的有序 ID；不能用整个工作区缓存冒充权威种子。
+    let scannedSessionIDs: [SessionID]
     let completedAt: Date
+}
+
+struct SessionListFirstPageResult {
+    let page: SessionsPage
+    let requestedCursor: String?
 }
 
 enum SessionListRequestSource: String {

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -478,7 +478,10 @@ extension SessionStore {
         }
         let refreshedSessions = sessions(page.sessions, in: workspace)
         guard isCurrentWorkspaceIdentity(workspace) else { return nil }
-        mergeSessionPage(refreshedSessions)
+        mergeFastIndexedSessionPagePreservingAuthoritativeFields(
+            refreshedSessions,
+            workspace: workspace
+        )
         updateWorkspaceSessionFirstPageState(
             workspace: workspace,
             page: page,
@@ -486,6 +489,7 @@ extension SessionStore {
         )
         recordWorkspaceSessionFirstPageCompletion(
             workspace: workspace,
+            page: page,
             consistency: .fastIndexed
         )
         clearWorkspaceUnavailable(workspace.id)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -879,8 +879,8 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.statusMessage, L10n.plural("ui.session_list_retry_seconds_count", count: 15))
         XCTAssertFalse(store.statusMessage?.contains("itemsView") == true)
 
-        // 冷却窗口内继续刷新必须复用旧页，不能再撞 gateway。
-        await store.refreshSelectedProjectSessions(showLoading: true)
+        // 冷却窗口内的后台刷新必须复用旧页，不能再撞 gateway。
+        await store.refreshSelectedProjectSessions(showLoading: false)
         XCTAssertEqual(client.sessionsPageCallCount, 2)
 
         now = now.addingTimeInterval(15)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -1239,6 +1239,7 @@ final class BlockingSessionListRefreshClient: SessionStoreAPIClient {
     let blockOnCall: Int
     let blockedError: Error?
     private(set) var requestedMessageCursors: [String?] = []
+    private(set) var requestedSessionCursors: [String?] = []
     private(set) var sessionsPageCallCount = 0
     private(set) var requestedSessionListConsistencies: [SessionListConsistency] = []
     private var blockedListRefreshCount = 0
@@ -1267,6 +1268,7 @@ final class BlockingSessionListRefreshClient: SessionStoreAPIClient {
 
     func sessionsPage(projectID: String?, cursor: String?, limit: Int?) async throws -> SessionsPage {
         sessionsPageCallCount += 1
+        requestedSessionCursors.append(cursor)
         guard sessionsPageCallCount >= blockOnCall else {
             return page
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -1146,7 +1146,9 @@ final class MutableSessionPageClient: SessionStoreAPIClient {
     var historyCursorPages: [String: HistoryMessagesPage]
     var requestedMessageCursors: [String?] = []
     var requestedSessionCursors: [String?] = []
+    var requestedSessionLimits: [Int?] = []
     var requestedSessionListConsistencies: [SessionListConsistency] = []
+    var onSessionPageRequest: ((String?) -> Void)?
 
     init(
         projects: [AgentProject],
@@ -1177,6 +1179,8 @@ final class MutableSessionPageClient: SessionStoreAPIClient {
 
     func sessionsPage(projectID: String?, cursor: String?, limit: Int?) async throws -> SessionsPage {
         requestedSessionCursors.append(cursor)
+        requestedSessionLimits.append(limit)
+        onSessionPageRequest?(cursor)
         if let cursor, let page = cursorPages[cursor] {
             return page
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationMultiRuntimePaginationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationMultiRuntimePaginationTests.swift
@@ -51,44 +51,6 @@ extension ConversationDataFlowTests {
         let secondTask = Task {
             try await client.sessionsPage(workspace: workspace, cursor: firstCursor, limit: 2)
         }
-        // 旧实现把“Codex 已耗尽”重新解码成 nil cursor，会在这里重拉 Codex 首屏。
-        try await Task.sleep(nanoseconds: 50_000_000)
-        let codexMessagesWhileLoadingSecond = await codexTransport.sentMessages()
-        if codexMessagesWhileLoadingSecond.count > codexMessageCountAfterFirst {
-            let repeatedCodexFirstList = try await waitForFakeAppServerRequest(
-                codexTransport,
-                method: "thread/list",
-                after: codexMessageCountAfterFirst
-            )
-            transportResponse(codexTransport, id: repeatedCodexFirstList.id, result: appServerThreadListResult([
-                appServerThreadJSON(id: "codex-new", cwd: project.path, source: "appServer", updatedAt: 1_780_494_000)
-            ], nextCursor: nil))
-        }
-        let secondPage = try await secondTask.value
-        let codexMessageCountAfterSecond = (await codexTransport.sentMessages()).count
-        let claudeMessageCountAfterSecond = (await claudeTransport.sentMessages()).count
-
-        XCTAssertEqual(codexMessageCountAfterSecond, codexMessageCountAfterFirst, "已耗尽的 Codex 不得用 nil cursor 重拉首屏")
-        XCTAssertEqual(claudeMessageCountAfterSecond, claudeMessageCountAfterFirst, "Claude buffer 未消费完时不应提前请求下一页")
-        XCTAssertEqual(secondPage.sessions.map(\.id), ["claude-buffer"])
-        XCTAssertTrue(secondPage.hasMore)
-        let secondCursor = try XCTUnwrap(secondPage.nextCursor)
-
-        let thirdTask = Task {
-            try await client.sessionsPage(workspace: workspace, cursor: secondCursor, limit: 2)
-        }
-        try await Task.sleep(nanoseconds: 50_000_000)
-        let codexMessagesWhileLoadingThird = await codexTransport.sentMessages()
-        if codexMessagesWhileLoadingThird.count > codexMessageCountAfterSecond {
-            let repeatedCodexFirstList = try await waitForFakeAppServerRequest(
-                codexTransport,
-                method: "thread/list",
-                after: codexMessageCountAfterSecond
-            )
-            transportResponse(codexTransport, id: repeatedCodexFirstList.id, result: appServerThreadListResult([
-                appServerThreadJSON(id: "codex-new", cwd: project.path, source: "appServer", updatedAt: 1_780_494_000)
-            ], nextCursor: nil))
-        }
         let claudeSecondList = try await waitForFakeAppServerRequest(
             claudeTransport,
             method: "thread/list",
@@ -99,14 +61,14 @@ extension ConversationDataFlowTests {
             appServerThreadJSON(id: "claude-old", cwd: project.path, source: "claude", updatedAt: 1_780_491_000)
         ], nextCursor: nil))
 
-        let thirdPage = try await thirdTask.value
-        let codexMessageCountAfterThird = (await codexTransport.sentMessages()).count
-        XCTAssertEqual(codexMessageCountAfterThird, codexMessageCountAfterFirst)
-        XCTAssertEqual(thirdPage.sessions.map(\.id), ["claude-old"])
-        XCTAssertFalse(thirdPage.hasMore)
-        XCTAssertNil(thirdPage.nextCursor)
+        let secondPage = try await secondTask.value
+        let codexMessageCountAfterSecond = (await codexTransport.sentMessages()).count
+        XCTAssertEqual(codexMessageCountAfterSecond, codexMessageCountAfterFirst, "已耗尽的 Codex 不得用 nil cursor 重拉首屏")
+        XCTAssertEqual(secondPage.sessions.map(\.id), ["claude-buffer", "claude-old"])
+        XCTAssertFalse(secondPage.hasMore)
+        XCTAssertNil(secondPage.nextCursor)
 
-        let allSessions = firstPage.sessions + secondPage.sessions + thirdPage.sessions
+        let allSessions = firstPage.sessions + secondPage.sessions
         XCTAssertEqual(Set(allSessions.map(\.id)).count, allSessions.count, "连续显示更多不能重复 session ID")
         XCTAssertEqual(
             allSessions.map(SessionIndexStore.orderingDate),
@@ -167,6 +129,180 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(page.sessions.map(\.id), ["claude-legacy-old"])
         XCTAssertFalse(page.hasMore)
         XCTAssertNil(page.nextCursor)
+    }
+
+    func testMultiRuntimeUnavailableClaudeChannelReturnsWithoutDroppingContinuation() async throws {
+        let project = AgentProject(
+            id: "proj_claude_temporarily_unavailable",
+            name: "Claude Temporarily Unavailable",
+            path: "/tmp/claude-temporarily-unavailable"
+        )
+        let config = makeDirectAppServerConfig(project: project)
+        let codexTransport = FakeCodexAppServerTransport()
+        let claudeTransport = FakeCodexAppServerTransport()
+        let client = MultiRuntimeSessionAPIClient(
+            codexRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "codex",
+                transportFactory: { codexTransport },
+                configProvider: { config }
+            ),
+            claudeRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "claude",
+                transportFactory: { claudeTransport },
+                configProvider: { config }
+            )
+        )
+        // 模拟上一页仍有 Claude continuation，但下一次请求时 channel 已从 config 消失。
+        // Codex key 缺失表示该侧已耗尽，双方 buffer 也为空。
+        let legacyJSON = #"{"claude":"claude-next","codexBuffer":[],"claudeBuffer":[]}"#
+        let cursor = Data(legacyJSON.utf8).base64EncodedString()
+
+        let page = try await client.sessionsPage(projectID: project.id, cursor: cursor, limit: 2)
+
+        XCTAssertTrue(page.sessions.isEmpty)
+        XCTAssertTrue(page.hasMore, "临时不可用不能永久丢弃未消费的 Claude continuation")
+        let nextCursor = try XCTUnwrap(page.nextCursor)
+        let decodedCursor = try XCTUnwrap(Data(base64Encoded: nextCursor))
+        XCTAssertTrue(String(decoding: decodedCursor, as: UTF8.self).contains("claude-next"))
+        let codexMessages = await codexTransport.sentMessages()
+        let claudeMessages = await claudeTransport.sentMessages()
+        XCTAssertTrue(codexMessages.isEmpty)
+        XCTAssertTrue(claudeMessages.isEmpty)
+    }
+
+    func testMultiRuntimeUnavailableClaudeDefersCodexBufferUntilChannelRecovers() async throws {
+        let project = AgentProject(
+            id: "proj_claude_unavailable_buffered_codex",
+            name: "Claude Unavailable Buffered Codex",
+            path: "/tmp/claude-unavailable-buffered-codex"
+        )
+        let codexBuffered = makeSession(
+            id: "codex-buffered-old",
+            projectID: project.id,
+            title: "Codex buffered",
+            status: "history",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 1_780_491_000)
+        )
+        let sessionEncoder = JSONEncoder()
+        // Composite cursor 的生产编码器使用 ISO-8601；测试也必须沿用同一日期格式，
+        // 否则整个 payload 会被兼容逻辑当成 Codex 的 opaque cursor。
+        sessionEncoder.dateEncodingStrategy = .iso8601
+        let encodedSession = try JSONSerialization.jsonObject(
+            with: sessionEncoder.encode(codexBuffered)
+        )
+        let legacyPayload: [String: Any] = [
+            "claude": "claude-next",
+            "codexBuffer": [encodedSession],
+            "claudeBuffer": [Any]()
+        ]
+        let legacyCursor = try JSONSerialization.data(withJSONObject: legacyPayload).base64EncodedString()
+        let unavailableConfig = makeDirectAppServerConfig(project: project)
+        let unavailableCodexTransport = FakeCodexAppServerTransport()
+        let unavailableClaudeTransport = FakeCodexAppServerTransport()
+        let unavailableClient = MultiRuntimeSessionAPIClient(
+            codexRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "codex",
+                transportFactory: { unavailableCodexTransport },
+                configProvider: { unavailableConfig }
+            ),
+            claudeRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "claude",
+                transportFactory: { unavailableClaudeTransport },
+                configProvider: { unavailableConfig }
+            )
+        )
+
+        let deferredPage = try await unavailableClient.sessionsPage(
+            projectID: project.id,
+            cursor: legacyCursor,
+            limit: 2
+        )
+
+        XCTAssertTrue(deferredPage.sessions.isEmpty, "未知 Claude head 前不能越序输出较旧 Codex buffer")
+        XCTAssertTrue(deferredPage.hasMore)
+        let deferredCursor = try XCTUnwrap(deferredPage.nextCursor)
+        let decodedDeferredCursor = try XCTUnwrap(Data(base64Encoded: deferredCursor))
+        let decodedDeferredText = String(decoding: decodedDeferredCursor, as: UTF8.self)
+        XCTAssertTrue(decodedDeferredText.contains("claude-next"))
+        XCTAssertTrue(decodedDeferredText.contains(codexBuffered.id))
+        let unavailableCodexMessages = await unavailableCodexTransport.sentMessages()
+        let unavailableClaudeMessages = await unavailableClaudeTransport.sentMessages()
+        XCTAssertTrue(unavailableCodexMessages.isEmpty)
+        XCTAssertTrue(unavailableClaudeMessages.isEmpty)
+
+        let recoveredConfig = makeDirectAppServerConfig(
+            project: project,
+            channels: [makeClaudeChannelMetadata()]
+        )
+        let recoveredCodexTransport = FakeCodexAppServerTransport()
+        let recoveredClaudeTransport = FakeCodexAppServerTransport()
+        let recoveredClient = MultiRuntimeSessionAPIClient(
+            codexRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "codex",
+                transportFactory: { recoveredCodexTransport },
+                configProvider: { recoveredConfig }
+            ),
+            claudeRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "claude",
+                transportFactory: { recoveredClaudeTransport },
+                configProvider: { recoveredConfig }
+            )
+        )
+        let recoveredTask = Task {
+            try await recoveredClient.sessionsPage(
+                projectID: project.id,
+                cursor: deferredCursor,
+                limit: 2
+            )
+        }
+        let claudeInitialize = try await waitForFakeAppServerRequest(
+            recoveredClaudeTransport,
+            method: "initialize"
+        )
+        transportResponse(
+            recoveredClaudeTransport,
+            id: claudeInitialize.id,
+            result: #"{"userAgent":"fake-claude","platformFamily":"macos"}"#
+        )
+        let claudeList = try await waitForFakeAppServerRequest(
+            recoveredClaudeTransport,
+            method: "thread/list",
+            after: 1
+        )
+        XCTAssertEqual(claudeList.params?.objectValue?["cursor"]?.stringValue, "claude-next")
+        transportResponse(
+            recoveredClaudeTransport,
+            id: claudeList.id,
+            result: appServerThreadListResult([
+                appServerThreadJSON(
+                    id: "claude-recovered-new",
+                    cwd: project.path,
+                    source: "claude",
+                    updatedAt: 1_780_492_000
+                )
+            ], nextCursor: nil)
+        )
+
+        let recoveredPage = try await recoveredTask.value
+
+        XCTAssertEqual(recoveredPage.sessions.map(\.id), ["claude-recovered-new", codexBuffered.id])
+        XCTAssertFalse(recoveredPage.hasMore)
+        XCTAssertNil(recoveredPage.nextCursor)
+        let recoveredCodexMessages = await recoveredCodexTransport.sentMessages()
+        XCTAssertTrue(recoveredCodexMessages.isEmpty)
     }
 
     func testMultiRuntimePreservesBase64JSONOpaqueCodexCursor() async throws {
@@ -266,31 +402,6 @@ extension ConversationDataFlowTests {
         let secondTask = Task {
             try await client.sessionsPage(projectID: project.id, cursor: firstCursor, limit: 2)
         }
-        try await Task.sleep(nanoseconds: 50_000_000)
-        let claudeMessagesWhileLoadingSecond = await claudeTransport.sentMessages()
-        if claudeMessagesWhileLoadingSecond.count > claudeMessageCountAfterFirst {
-            let repeatedClaudeFirstList = try await waitForFakeAppServerRequest(
-                claudeTransport,
-                method: "thread/list",
-                after: claudeMessageCountAfterFirst
-            )
-            transportResponse(claudeTransport, id: repeatedClaudeFirstList.id, result: appServerThreadListResult([
-                appServerThreadJSON(id: "claude-new", cwd: project.path, source: "claude", updatedAt: 1_780_493_000)
-            ], nextCursor: nil))
-        }
-        let secondPage = try await secondTask.value
-        let codexMessageCountAfterSecond = (await codexTransport.sentMessages()).count
-        let claudeMessageCountAfterSecond = (await claudeTransport.sentMessages()).count
-
-        XCTAssertEqual(codexMessageCountAfterSecond, codexMessageCountAfterFirst, "Codex buffer 未消费完时不应提前请求下一页")
-        XCTAssertEqual(claudeMessageCountAfterSecond, claudeMessageCountAfterFirst, "已耗尽的 Claude 不得用 nil cursor 重拉首屏")
-        XCTAssertEqual(secondPage.sessions.map(\.id), ["codex-buffer"])
-        XCTAssertTrue(secondPage.hasMore)
-        let secondCursor = try XCTUnwrap(secondPage.nextCursor)
-
-        let thirdTask = Task {
-            try await client.sessionsPage(projectID: project.id, cursor: secondCursor, limit: 2)
-        }
         let codexSecondList = try await waitForFakeAppServerRequest(
             codexTransport,
             method: "thread/list",
@@ -300,27 +411,15 @@ extension ConversationDataFlowTests {
         transportResponse(codexTransport, id: codexSecondList.id, result: appServerThreadListResult([
             appServerThreadJSON(id: "codex-old", cwd: project.path, source: "appServer", updatedAt: 1_780_491_000)
         ], nextCursor: nil))
-        try await Task.sleep(nanoseconds: 50_000_000)
-        let claudeMessagesWhileLoadingThird = await claudeTransport.sentMessages()
-        if claudeMessagesWhileLoadingThird.count > claudeMessageCountAfterSecond {
-            let repeatedClaudeFirstList = try await waitForFakeAppServerRequest(
-                claudeTransport,
-                method: "thread/list",
-                after: claudeMessageCountAfterSecond
-            )
-            transportResponse(claudeTransport, id: repeatedClaudeFirstList.id, result: appServerThreadListResult([
-                appServerThreadJSON(id: "claude-new", cwd: project.path, source: "claude", updatedAt: 1_780_493_000)
-            ], nextCursor: nil))
-        }
 
-        let thirdPage = try await thirdTask.value
-        let claudeMessageCountAfterThird = (await claudeTransport.sentMessages()).count
-        XCTAssertEqual(claudeMessageCountAfterThird, claudeMessageCountAfterFirst)
-        XCTAssertEqual(thirdPage.sessions.map(\.id), ["codex-old"])
-        XCTAssertFalse(thirdPage.hasMore)
-        XCTAssertNil(thirdPage.nextCursor)
+        let secondPage = try await secondTask.value
+        let claudeMessageCountAfterSecond = (await claudeTransport.sentMessages()).count
+        XCTAssertEqual(claudeMessageCountAfterSecond, claudeMessageCountAfterFirst, "已耗尽的 Claude 不得用 nil cursor 重拉首屏")
+        XCTAssertEqual(secondPage.sessions.map(\.id), ["codex-buffer", "codex-old"])
+        XCTAssertFalse(secondPage.hasMore)
+        XCTAssertNil(secondPage.nextCursor)
 
-        let allSessions = firstPage.sessions + secondPage.sessions + thirdPage.sessions
+        let allSessions = firstPage.sessions + secondPage.sessions
         XCTAssertEqual(Set(allSessions.map(\.id)).count, allSessions.count)
         XCTAssertEqual(
             allSessions.map(SessionIndexStore.orderingDate),
@@ -405,4 +504,235 @@ extension ConversationDataFlowTests {
             allSessions.map(SessionIndexStore.orderingDate).sorted(by: >)
         )
     }
+
+    func testMultiRuntimePaginationSkipsEmptyPagesFromBothRuntimesWhileCursorsContinue() async throws {
+        let project = AgentProject(id: "proj_both_empty_pages", name: "Both Empty Pages", path: "/tmp/both-empty-pages")
+        let config = makeDirectAppServerConfig(project: project, channels: [makeClaudeChannelMetadata()])
+        let codexTransport = FakeCodexAppServerTransport()
+        let claudeTransport = FakeCodexAppServerTransport()
+        let client = MultiRuntimeSessionAPIClient(
+            codexRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "codex",
+                transportFactory: { codexTransport },
+                configProvider: { config }
+            ),
+            claudeRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "claude",
+                transportFactory: { claudeTransport },
+                configProvider: { config }
+            )
+        )
+
+        let pageTask = Task { try await client.sessionsPage(projectID: project.id, cursor: nil, limit: 2) }
+        let codexInitialize = try await waitForFakeAppServerRequest(codexTransport, method: "initialize")
+        transportResponse(codexTransport, id: codexInitialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let codexFirstList = try await waitForFakeAppServerRequest(codexTransport, method: "thread/list", after: 1)
+        let codexFirstMessageCount = (await codexTransport.sentMessages()).count
+        transportResponse(codexTransport, id: codexFirstList.id, result: appServerThreadListResult([], nextCursor: "codex-next"))
+
+        let codexSecondList = try await waitForFakeAppServerRequest(
+            codexTransport,
+            method: "thread/list",
+            after: codexFirstMessageCount
+        )
+        XCTAssertEqual(codexSecondList.params?.objectValue?["cursor"]?.stringValue, "codex-next")
+        transportResponse(codexTransport, id: codexSecondList.id, result: appServerThreadListResult([
+            appServerThreadJSON(id: "codex-visible", cwd: project.path, source: "appServer", updatedAt: 1_780_494_000)
+        ], nextCursor: nil))
+
+        let claudeInitialize = try await waitForFakeAppServerRequest(claudeTransport, method: "initialize")
+        transportResponse(claudeTransport, id: claudeInitialize.id, result: #"{"userAgent":"fake-claude","platformFamily":"macos"}"#)
+        let claudeFirstList = try await waitForFakeAppServerRequest(claudeTransport, method: "thread/list", after: 1)
+        let claudeFirstMessageCount = (await claudeTransport.sentMessages()).count
+        transportResponse(claudeTransport, id: claudeFirstList.id, result: appServerThreadListResult([], nextCursor: "claude-next"))
+
+        let claudeSecondList = try await waitForFakeAppServerRequest(
+            claudeTransport,
+            method: "thread/list",
+            after: claudeFirstMessageCount
+        )
+        XCTAssertEqual(claudeSecondList.params?.objectValue?["cursor"]?.stringValue, "claude-next")
+        transportResponse(claudeTransport, id: claudeSecondList.id, result: appServerThreadListResult([
+            appServerThreadJSON(id: "claude-visible", cwd: project.path, source: "claude", updatedAt: 1_780_493_000)
+        ], nextCursor: nil))
+
+        let page = try await pageTask.value
+        XCTAssertEqual(page.sessions.map(\.id), ["codex-visible", "claude-visible"])
+        XCTAssertFalse(page.hasMore)
+        XCTAssertNil(page.nextCursor)
+    }
+
+    func testMultiRuntimePaginationSkipsSingleRuntimeEmptyPageWhileCursorContinues() async throws {
+        let project = AgentProject(id: "proj_single_empty_page", name: "Single Empty Page", path: "/tmp/single-empty-page")
+        let config = makeDirectAppServerConfig(project: project)
+        let codexTransport = FakeCodexAppServerTransport()
+        let claudeTransport = FakeCodexAppServerTransport()
+        let client = MultiRuntimeSessionAPIClient(
+            codexRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "codex",
+                transportFactory: { codexTransport },
+                configProvider: { config }
+            ),
+            claudeRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "claude",
+                transportFactory: { claudeTransport },
+                configProvider: { config }
+            )
+        )
+
+        let pageTask = Task { try await client.sessionsPage(projectID: project.id, cursor: nil, limit: 2) }
+        let initialize = try await waitForFakeAppServerRequest(codexTransport, method: "initialize")
+        transportResponse(codexTransport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let firstList = try await waitForFakeAppServerRequest(codexTransport, method: "thread/list", after: 1)
+        let firstMessageCount = (await codexTransport.sentMessages()).count
+        transportResponse(codexTransport, id: firstList.id, result: appServerThreadListResult([], nextCursor: "codex-next"))
+
+        let secondList = try await waitForFakeAppServerRequest(
+            codexTransport,
+            method: "thread/list",
+            after: firstMessageCount
+        )
+        XCTAssertEqual(secondList.params?.objectValue?["cursor"]?.stringValue, "codex-next")
+        transportResponse(codexTransport, id: secondList.id, result: appServerThreadListResult([
+            appServerThreadJSON(id: "codex-after-empty", cwd: project.path, source: "appServer", updatedAt: 1_780_494_000)
+        ], nextCursor: nil))
+
+        let page = try await pageTask.value
+        XCTAssertEqual(page.sessions.map(\.id), ["codex-after-empty"])
+        XCTAssertFalse(page.hasMore)
+        XCTAssertNil(page.nextCursor)
+        let claudeMessages = await claudeTransport.sentMessages()
+        XCTAssertTrue(claudeMessages.isEmpty)
+    }
+
+    func testMultiRuntimePaginationStopsWhenEmptyPageRepeatsCursor() async throws {
+        let project = AgentProject(id: "proj_repeated_empty_cursor", name: "Repeated Empty Cursor", path: "/tmp/repeated-empty-cursor")
+        let config = makeDirectAppServerConfig(project: project)
+        let codexTransport = FakeCodexAppServerTransport()
+        let claudeTransport = FakeCodexAppServerTransport()
+        let client = MultiRuntimeSessionAPIClient(
+            codexRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "codex",
+                transportFactory: { codexTransport },
+                configProvider: { config }
+            ),
+            claudeRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "claude",
+                transportFactory: { claudeTransport },
+                configProvider: { config }
+            )
+        )
+
+        let pageTask = Task { try await client.sessionsPage(projectID: project.id, cursor: nil, limit: 2) }
+        let initialize = try await waitForFakeAppServerRequest(codexTransport, method: "initialize")
+        transportResponse(codexTransport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let firstList = try await waitForFakeAppServerRequest(codexTransport, method: "thread/list", after: 1)
+        let firstMessageCount = (await codexTransport.sentMessages()).count
+        transportResponse(codexTransport, id: firstList.id, result: appServerThreadListResult([], nextCursor: "repeat-cursor"))
+
+        let repeatedList = try await waitForFakeAppServerRequest(
+            codexTransport,
+            method: "thread/list",
+            after: firstMessageCount
+        )
+        XCTAssertEqual(repeatedList.params?.objectValue?["cursor"]?.stringValue, "repeat-cursor")
+        transportResponse(codexTransport, id: repeatedList.id, result: appServerThreadListResult([], nextCursor: "repeat-cursor"))
+
+        let page = try await pageTask.value
+        XCTAssertTrue(page.sessions.isEmpty)
+        XCTAssertFalse(page.hasMore)
+        XCTAssertNil(page.nextCursor)
+        let listRequestCount = (await codexTransport.sentMessages()).compactMap { message in
+            try? decodeAppServerRequest(message)
+        }.filter { $0.method == "thread/list" }.count
+        XCTAssertEqual(listRequestCount, 2, "重复 cursor 只能重试一次，不能形成空页死循环")
+        let claudeMessages = await claudeTransport.sentMessages()
+        XCTAssertTrue(claudeMessages.isEmpty)
+    }
+
+    func testMultiRuntimePaginationBoundsAdvancingEmptyPagesAndPreservesContinuation() async throws {
+        let project = AgentProject(id: "proj_empty_page_budget", name: "Empty Page Budget", path: "/tmp/empty-page-budget")
+        let config = makeDirectAppServerConfig(project: project)
+        let codexTransport = FakeCodexAppServerTransport()
+        let claudeTransport = FakeCodexAppServerTransport()
+        let client = MultiRuntimeSessionAPIClient(
+            codexRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "codex",
+                transportFactory: { codexTransport },
+                configProvider: { config }
+            ),
+            claudeRuntime: CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787",
+                token: "outer-token",
+                runtimeProvider: "claude",
+                transportFactory: { claudeTransport },
+                configProvider: { config }
+            )
+        )
+
+        let firstPageTask = Task { try await client.sessionsPage(projectID: project.id, cursor: nil, limit: 2) }
+        let initialize = try await waitForFakeAppServerRequest(codexTransport, method: "initialize")
+        transportResponse(codexTransport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let firstList = try await waitForFakeAppServerRequest(codexTransport, method: "thread/list", after: 1)
+        var messageCount = (await codexTransport.sentMessages()).count
+        transportResponse(codexTransport, id: firstList.id, result: appServerThreadListResult([], nextCursor: "empty-1"))
+
+        // 初始页之外最多跨过 8 个空 continuation 页；第 9 个 cursor 必须留给下一次调用。
+        for index in 1...8 {
+            let list = try await waitForFakeAppServerRequest(
+                codexTransport,
+                method: "thread/list",
+                after: messageCount
+            )
+            XCTAssertEqual(list.params?.objectValue?["cursor"]?.stringValue, "empty-\(index)")
+            messageCount = (await codexTransport.sentMessages()).count
+            transportResponse(
+                codexTransport,
+                id: list.id,
+                result: appServerThreadListResult([], nextCursor: "empty-\(index + 1)")
+            )
+        }
+
+        let firstPage = try await firstPageTask.value
+        XCTAssertTrue(firstPage.sessions.isEmpty)
+        XCTAssertTrue(firstPage.hasMore)
+        let continuation = try XCTUnwrap(firstPage.nextCursor)
+        let firstCallListCount = (await codexTransport.sentMessages()).compactMap { message in
+            try? decodeAppServerRequest(message)
+        }.filter { $0.method == "thread/list" }.count
+        XCTAssertEqual(firstCallListCount, 9, "单次调用只能包含初始页和 8 个空 continuation 页")
+
+        let secondPageTask = Task {
+            try await client.sessionsPage(projectID: project.id, cursor: continuation, limit: 2)
+        }
+        let resumedList = try await waitForFakeAppServerRequest(
+            codexTransport,
+            method: "thread/list",
+            after: messageCount
+        )
+        XCTAssertEqual(resumedList.params?.objectValue?["cursor"]?.stringValue, "empty-9")
+        transportResponse(codexTransport, id: resumedList.id, result: appServerThreadListResult([
+            appServerThreadJSON(id: "codex-after-budget", cwd: project.path, source: "appServer", updatedAt: 1_780_494_000)
+        ], nextCursor: nil))
+
+        let secondPage = try await secondPageTask.value
+        XCTAssertEqual(secondPage.sessions.map(\.id), ["codex-after-budget"])
+        XCTAssertFalse(secondPage.hasMore)
+        XCTAssertNil(secondPage.nextCursor)
+    }
+
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -1572,6 +1572,104 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(appStore.activeConnectionProfileID, profile.id)
     }
 
+    func testNotificationFastRefreshPreservesAuthorityAndInvalidatesWindowForLateChildren() async {
+        let project = makeProject(id: "proj_notification_late_children")
+        let workspace = AgentWorkspace(project: project)
+        let authoritativeRoots = (0..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "notification_authoritative_root_\(index)",
+                projectID: project.id,
+                title: "权威通知会话 \(index)",
+                status: index == 0 ? "running" : "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(200 - index))
+            )
+        }
+        let staleShared = makeSession(
+            id: authoritativeRoots[0].id,
+            projectID: project.id,
+            title: "过期通知标题",
+            status: "history",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let lateChildren = (1...2).map { index in
+            AgentSession(
+                id: authoritativeRoots[index].id,
+                projectID: project.id,
+                project: project.id,
+                dir: project.path,
+                title: "通知补认子会话 \(index)",
+                status: "history",
+                source: "codex",
+                resumeID: nil,
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(300 - index)),
+                parentThreadID: authoritativeRoots[0].id,
+                isSubagent: true,
+                canAcceptDirectInput: false
+            )
+        }
+        let notificationTarget = makeSession(
+            id: "notification_missing_target",
+            projectID: project.id,
+            title: "通知补入目标",
+            status: "history",
+            source: "codex"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            projectPages: [
+                project.id: SessionsPage(
+                    sessions: [staleShared] + lateChildren + [notificationTarget],
+                    nextCursor: "notification-fast-stale",
+                    hasMore: true
+                )
+            ]
+        )
+        let appStore = AppStore()
+        appStore.token = "test-token"
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: { MockWebSocketClient() }
+        )
+        store.projects = [project]
+        store.recentWorkspaces = [workspace]
+        store.sidebarProjects = [project]
+        store.applyWorkspaceSessionFirstPage(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: authoritativeRoots,
+                nextCursor: "notification-authoritative-cursor",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+        let route = SessionNotificationRoute.current(
+            profileID: appStore.notificationRoutingProfileID,
+            projectID: project.id,
+            sessionID: notificationTarget.id
+        )
+
+        let outcome = await store.openSessionFromNotification(route)
+
+        XCTAssertEqual(outcome, .opened)
+        XCTAssertEqual(store.selectedSessionID, notificationTarget.id)
+        XCTAssertEqual(store.sessionsByID[authoritativeRoots[0].id]?.title, authoritativeRoots[0].title)
+        XCTAssertEqual(store.sessionsByID[authoritativeRoots[0].id]?.status, authoritativeRoots[0].status)
+        for child in lateChildren {
+            XCTAssertTrue(store.sessionsByID[child.id]?.isSubagentThread == true)
+            XCTAssertFalse(store.sessions(forProjectID: project.id).contains { $0.id == child.id })
+        }
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "notification-authoritative-cursor")
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertEqual(client.requestedProjectIDs, [project.id])
+    }
+
     func testNotificationFromOtherMacOnlyPromptsForProfileSwitch() async throws {
         let suiteName = "ConversationDataFlowTests.NotificationOtherProfile.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -1837,7 +1935,12 @@ extension ConversationDataFlowTests {
     }
 
     func testWorkspaceLoadFailureMarksUnavailableWhenResolveRejects() async {
-        let rootProject = makeProject(id: "proj_root")
+        // 避免 macOS 将 /tmp 规范化为 /private/tmp，夹具应验证业务状态而非本机路径别名。
+        let rootProject = AgentProject(
+            id: "proj_root",
+            name: "proj_root",
+            path: "/Users/mimi-tests/proj_root"
+        )
         let workspace = makeChildWorkspace(id: "ws_gone", name: "gone", root: rootProject)
         let client = MockSessionStoreClient(
             projects: [rootProject],
@@ -1864,7 +1967,11 @@ extension ConversationDataFlowTests {
     }
 
     func testWorkspaceLoadFailureStaysTransientWhenResolveSucceeds() async {
-        let rootProject = makeProject(id: "proj_root")
+        let rootProject = AgentProject(
+            id: "proj_root",
+            name: "proj_root",
+            path: "/Users/mimi-tests/proj_root"
+        )
         let workspace = makeChildWorkspace(id: "ws_flaky", name: "flaky", root: rootProject)
         let client = MockSessionStoreClient(
             projects: [rootProject],
@@ -1891,7 +1998,11 @@ extension ConversationDataFlowTests {
     }
 
     func testForgetWorkspaceClearsUnavailableMark() async {
-        let rootProject = makeProject(id: "proj_root")
+        let rootProject = AgentProject(
+            id: "proj_root",
+            name: "proj_root",
+            path: "/Users/mimi-tests/proj_root"
+        )
         let workspace = makeChildWorkspace(id: "ws_gone", name: "gone", root: rootProject)
         let client = MockSessionStoreClient(
             projects: [rootProject],

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -271,11 +271,15 @@ extension ConversationDataFlowTests {
     }
 
     func testSessionStoreCreatesWorktreeAndOpensReturnedWorkspace() async {
-        let project = makeProject(id: "proj_1")
+        let project = AgentProject(
+            id: "proj_1",
+            name: "proj_1",
+            path: "/Users/mimi-tests/proj_1"
+        )
         let workspace = AgentWorkspace(
             id: "ws_worktree",
             name: "feature-review",
-            path: "/tmp/worktrees/proj_1/feature-review",
+            path: "/Users/mimi-tests/worktrees/proj_1/feature-review",
             rootProjectID: project.id,
             rootProjectName: project.name,
             rootProjectPath: project.path
@@ -407,7 +411,11 @@ extension ConversationDataFlowTests {
     }
 
     func testSessionStoreHandoffsSessionWithNativeForkWhenAvailable() async {
-        let project = makeProject(id: "proj_1")
+        let project = AgentProject(
+            id: "proj_1",
+            name: "proj_1",
+            path: "/Users/mimi-tests/proj_1"
+        )
         let source = makeSession(
             id: "codex_source",
             projectID: project.id,
@@ -419,7 +427,7 @@ extension ConversationDataFlowTests {
         let workspace = AgentWorkspace(
             id: "ws_handoff",
             name: "audit-handoff",
-            path: "/tmp/worktrees/proj_1/audit-handoff",
+            path: "/Users/mimi-tests/worktrees/proj_1/audit-handoff",
             rootProjectID: project.id,
             rootProjectName: project.name,
             rootProjectPath: project.path
@@ -476,7 +484,11 @@ extension ConversationDataFlowTests {
     }
 
     func testSessionStoreHandoffsSessionToNewWorktree() async throws {
-        let project = makeProject(id: "proj_1")
+        let project = AgentProject(
+            id: "proj_1",
+            name: "proj_1",
+            path: "/Users/mimi-tests/proj_1"
+        )
         let source = makeSession(
             id: "codex_source",
             projectID: project.id,
@@ -489,7 +501,7 @@ extension ConversationDataFlowTests {
         let workspace = AgentWorkspace(
             id: "ws_handoff",
             name: "audit-handoff",
-            path: "/tmp/worktrees/proj_1/audit-handoff",
+            path: "/Users/mimi-tests/worktrees/proj_1/audit-handoff",
             rootProjectID: project.id,
             rootProjectName: project.name,
             rootProjectPath: project.path
@@ -1337,7 +1349,7 @@ extension ConversationDataFlowTests {
 
     func testSessionStoreLoadsNextSessionPageWhenExpanded() async {
         let project = makeProject(id: "proj_1")
-        let firstPage = (0..<3).map { index in
+        let firstPage = (0..<20).map { index in
             makeSession(
                 id: "codex_first_\(index)",
                 projectID: project.id,
@@ -1345,7 +1357,7 @@ extension ConversationDataFlowTests {
                 status: "history",
                 source: "codex",
                 resumeID: "first_\(index)",
-                updatedAt: Date(timeIntervalSince1970: TimeInterval(20 - index))
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
             )
         }
         let secondPage = (0..<2).map { index in
@@ -1379,24 +1391,37 @@ extension ConversationDataFlowTests {
         store.selectedProjectID = project.id
         await store.refreshAll(autoAttach: false)
         XCTAssertTrue(store.canLoadMoreSessions(projectID: project.id))
-        XCTAssertEqual(store.visibleSessions(forProjectID: project.id).map(\.id), firstPage.map(\.id))
+        XCTAssertEqual(
+            store.visibleSessions(forProjectID: project.id).map(\.id),
+            Array(firstPage.prefix(SessionStore.sessionPreviewLimit)).map(\.id)
+        )
         var snapshot = store.sessionListSnapshot(forProjectID: project.id)
         XCTAssertFalse(snapshot.isShowingAll)
         XCTAssertTrue(snapshot.canLoadMore)
         XCTAssertTrue(snapshot.shouldShowActionRow)
         XCTAssertEqual(snapshot.actionTitle, L10n.text("ui.show_more"))
 
+        // 首屏固定填满 20 条；逐步展开到当前窗口边界后才请求下一 opaque cursor。
+        await store.toggleSessionListExpansion(projectID: project.id)
+        await store.toggleSessionListExpansion(projectID: project.id)
         await store.toggleSessionListExpansion(projectID: project.id)
 
         XCTAssertFalse(store.canLoadMoreSessions(projectID: project.id))
         XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), (firstPage + secondPage).map(\.id))
-        XCTAssertEqual(store.visibleSessions(forProjectID: project.id).count, 5)
+        XCTAssertEqual(store.visibleSessions(forProjectID: project.id).count, 20)
         snapshot = store.sessionListSnapshot(forProjectID: project.id)
         XCTAssertTrue(snapshot.isShowingAll)
         XCTAssertFalse(snapshot.canLoadMore)
-        XCTAssertEqual(snapshot.allSessionCount, 5)
-        XCTAssertEqual(snapshot.visibleSessions.count, 5)
-        XCTAssertFalse(snapshot.shouldShowActionRow)
+        XCTAssertEqual(snapshot.allSessionCount, 22)
+        XCTAssertEqual(snapshot.visibleSessions.count, 20)
+        XCTAssertTrue(snapshot.shouldShowActionRow)
+        XCTAssertEqual(snapshot.actionTitle, L10n.text("ui.show_more"))
+
+        await store.toggleSessionListExpansion(projectID: project.id)
+        snapshot = store.sessionListSnapshot(forProjectID: project.id)
+        XCTAssertTrue(snapshot.isShowingAll)
+        XCTAssertEqual(snapshot.visibleSessions.count, 22)
+        XCTAssertTrue(snapshot.shouldShowActionRow)
         XCTAssertEqual(snapshot.actionTitle, L10n.text("ui.show_less"))
     }
 
@@ -1554,26 +1579,26 @@ extension ConversationDataFlowTests {
 
     func testWorkspaceBackgroundRefreshPreservesDeepContinuation() async {
         let project = makeProject(id: "proj_workspace_deep_cursor")
-        let firstPage = [
+        let firstPage = (0..<20).map { index in
             makeSession(
-                id: "workspace_deep_recent",
+                id: "workspace_deep_recent_\(index)",
                 projectID: project.id,
-                title: "最近会话",
+                title: "最近会话 \(index)",
                 status: "history",
                 source: "codex",
-                updatedAt: Date(timeIntervalSince1970: 400)
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(500 - index))
             )
-        ]
-        let secondPage = [
+        }
+        let secondPage = (0..<20).map { index in
             makeSession(
-                id: "workspace_deep_middle",
+                id: "workspace_deep_middle_\(index)",
                 projectID: project.id,
-                title: "第二页会话",
+                title: "第二页会话 \(index)",
                 status: "history",
                 source: "claude",
-                updatedAt: Date(timeIntervalSince1970: 300)
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(400 - index))
             )
-        ]
+        }
         let thirdPage = [
             makeSession(
                 id: "workspace_deep_oldest",
@@ -1728,15 +1753,26 @@ extension ConversationDataFlowTests {
             clientFactory: { client }
         )
 
+        store.projects = [project]
         store.selectedProjectID = project.id
-        await store.refreshAll(autoAttach: false)
+        await store.refreshSessions(
+            forProjectID: project.id,
+            showLoading: false,
+            reuseRecent: false,
+            consistency: .fastIndexed
+        )
         var snapshot = store.sessionListSnapshot(forProjectID: project.id)
         XCTAssertTrue(snapshot.canLoadMore)
         XCTAssertTrue(snapshot.shouldShowActionRow)
         XCTAssertEqual(snapshot.actionTitle, L10n.text("ui.show_more"))
 
         client.page = SessionsPage(sessions: firstPage, hasMore: false)
-        await store.refreshAll(autoAttach: false)
+        await store.refreshSessions(
+            forProjectID: project.id,
+            showLoading: false,
+            reuseRecent: false,
+            consistency: .fastIndexed
+        )
 
         snapshot = store.sessionListSnapshot(forProjectID: project.id)
         XCTAssertFalse(snapshot.canLoadMore)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionAuthoritativeContinuationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionAuthoritativeContinuationTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testEnsureAuthoritativePresentationFillAutomaticallyResumesSavedCursorAfterBudget() async throws {
+        let project = makeProject(id: "workspace_presentation_budget_resume")
+        let firstRoot = makeSession(
+            id: "presentation_resume_root_0",
+            projectID: project.id,
+            title: "首个根会话",
+            status: "history",
+            source: "codex"
+        )
+        var cursorPages: [String: SessionsPage] = [:]
+        for index in 1..<SessionStore.maximumSessionPresentationFillPageCount {
+            cursorPages["resume-budget-\(index)"] = SessionsPage(
+                sessions: [makeSubagentSession(
+                    id: "resume_budget_child_\(index)",
+                    projectID: project.id,
+                    parentThreadID: firstRoot.id
+                )],
+                nextCursor: "resume-budget-\(index + 1)",
+                hasMore: true
+            )
+        }
+        let remainingRoots = (1..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "presentation_resume_root_\(index)",
+                projectID: project.id,
+                title: "续跑根会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        cursorPages["resume-budget-12"] = SessionsPage(
+            sessions: remainingRoots,
+            nextCursor: "resume-older",
+            hasMore: true
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [firstRoot, makeSubagentSession(
+                    id: "resume_budget_child_0",
+                    projectID: project.id,
+                    parentThreadID: firstRoot.id
+                )],
+                nextCursor: "resume-budget-1",
+                hasMore: true
+            ),
+            cursorPages: cursorPages
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        let workspace = try XCTUnwrap(store.ensureWorkspaceForKnownProjectID(project.id))
+        var observedCommittedPartialBeforeResume = false
+        client.onSessionPageRequest = { cursor in
+            guard cursor == "resume-budget-12" else { return }
+            let completion = store.workspaceSessionFirstPageCompletionByKey[
+                store.workspaceSessionFirstPageKey(for: workspace)
+            ]
+            observedCommittedPartialBeforeResume = completion?.consistency == .authoritative
+                && completion?.isPresentationWindowComplete == false
+                && completion?.continuationCursor == cursor
+                && store.sessionPageCursorByProjectID[project.id] == cursor
+        }
+
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        XCTAssertTrue(observedCommittedPartialBeforeResume, "第二批必须从 Store 已提交的 partial 状态续跑")
+        XCTAssertEqual(
+            client.requestedSessionCursors,
+            [nil]
+                + (1..<SessionStore.maximumSessionPresentationFillPageCount).map { "resume-budget-\($0)" }
+                + ["resume-budget-12"]
+        )
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, SessionStore.initialSessionPageLimit)
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+        XCTAssertNil(
+            store.workspaceSessionFirstPageCompletionByKey[
+                store.workspaceSessionFirstPageKey(for: workspace)
+            ]?.continuationCursor
+        )
+        XCTAssertNotNil(store.sessionsByID["resume_budget_child_11"], "上一批 child 仍须保留在 canonical Store")
+        XCTAssertTrue(store.sessionListFirstPageInFlightByKey.isEmpty)
+
+        let requestCount = client.requestedSessionCursors.count
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+        XCTAssertEqual(client.requestedSessionCursors.count, requestCount, "完成后再次 ensure 不应新增请求")
+    }
+
+    func testEnsureAuthoritativePresentationFillContinuesBeyondOneBurst() async throws {
+        let project = makeProject(id: "workspace_presentation_beyond_burst")
+        let firstRoot = makeSession(
+            id: "presentation_beyond_burst_root_0",
+            projectID: project.id,
+            title: "首个根会话",
+            status: "history",
+            source: "codex"
+        )
+        let pagesBeforeBackoff = SessionStore.maximumSessionPresentationFillPageCount
+            * SessionStore.sessionPresentationFillBatchCountPerBurst
+        var cursorPages: [String: SessionsPage] = [:]
+        for index in 1..<pagesBeforeBackoff {
+            cursorPages["beyond-burst-\(index)"] = SessionsPage(
+                sessions: [makeSubagentSession(
+                    id: "beyond_burst_child_\(index)",
+                    projectID: project.id,
+                    parentThreadID: firstRoot.id
+                )],
+                nextCursor: "beyond-burst-\(index + 1)",
+                hasMore: true
+            )
+        }
+        let remainingRoots = (1..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "presentation_beyond_burst_root_\(index)",
+                projectID: project.id,
+                title: "续跑根会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        cursorPages["beyond-burst-\(pagesBeforeBackoff)"] = SessionsPage(
+            sessions: remainingRoots,
+            nextCursor: "beyond-burst-older",
+            hasMore: true
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [firstRoot, makeSubagentSession(
+                    id: "beyond_burst_child_0",
+                    projectID: project.id,
+                    parentThreadID: firstRoot.id
+                )],
+                nextCursor: "beyond-burst-1",
+                hasMore: true
+            ),
+            cursorPages: cursorPages
+        )
+        var requestedSleeps: [UInt64] = []
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            sessionListSleep: { requestedSleeps.append($0) }
+        )
+        store.projects = [project]
+
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        XCTAssertEqual(
+            client.requestedSessionCursors,
+            [nil] + (1...pagesBeforeBackoff).map { "beyond-burst-\($0)" },
+            "跨 burst 必须沿唯一 continuation 前进，不能重新请求 nil"
+        )
+        XCTAssertEqual(requestedSleeps, [SessionStore.sessionPresentationFillBurstBackoffNanoseconds])
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, SessionStore.initialSessionPageLimit)
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "beyond-burst-older")
+        XCTAssertTrue(store.canLoadMoreSessions(projectID: project.id))
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
@@ -50,9 +50,30 @@ extension ConversationDataFlowTests {
         )
 
         XCTAssertNotEqual(
-            WorkspaceSessionRefreshScope(hostScope: firstHostScope, workspaceID: "workspace-a"),
-            WorkspaceSessionRefreshScope(hostScope: reconnectedHostScope, workspaceID: "workspace-a"),
+            WorkspaceSessionRefreshScope(
+                hostScope: firstHostScope,
+                workspaceID: "workspace-a",
+                needsAuthoritativeFirstPage: true
+            ),
+            WorkspaceSessionRefreshScope(
+                hostScope: reconnectedHostScope,
+                workspaceID: "workspace-a",
+                needsAuthoritativeFirstPage: true
+            ),
             "同一 workspace 在连接代次变化后必须重新触发精确首屏"
+        )
+        XCTAssertNotEqual(
+            WorkspaceSessionRefreshScope(
+                hostScope: firstHostScope,
+                workspaceID: "workspace-a",
+                needsAuthoritativeFirstPage: false
+            ),
+            WorkspaceSessionRefreshScope(
+                hostScope: firstHostScope,
+                workspaceID: "workspace-a",
+                needsAuthoritativeFirstPage: true
+            ),
+            "late-child 使完成态失效后必须重新触发精确首屏"
         )
     }
 
@@ -94,6 +115,729 @@ extension ConversationDataFlowTests {
             XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
             XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "older")
         }
+    }
+
+    func testAuthoritativeWorkspaceFirstPageFillsTopLevelWindowAcrossChildDensePages() async throws {
+        let project = makeProject(id: "workspace_child_dense_first_page")
+        let firstRoot = makeSession(
+            id: "root_0",
+            projectID: project.id,
+            title: "根会话 0",
+            status: "history",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        let children = (0..<19).map { index in
+            makeSubagentSession(
+                id: "child_\(index)",
+                projectID: project.id,
+                parentThreadID: firstRoot.id,
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(99 - index))
+            )
+        }
+        let remainingRoots = (1..<20).map { index in
+            makeSession(
+                id: "root_\(index)",
+                projectID: project.id,
+                title: "根会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(80 - index))
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [firstRoot] + children,
+                nextCursor: "after-child-dense-page",
+                hasMore: true
+            ),
+            cursorPages: [
+                "after-child-dense-page": SessionsPage(sessions: remainingRoots)
+            ]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), (0..<20).map { "root_\($0)" })
+        XCTAssertTrue(children.allSatisfy { store.sessionsByID[$0.id]?.isSubagentThread == true })
+        XCTAssertEqual(client.requestedSessionCursors, [nil, "after-child-dense-page"])
+        XCTAssertEqual(client.requestedSessionLimits, [20, 19])
+        XCTAssertEqual(client.requestedSessionListConsistencies, [.authoritative, .authoritative])
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+        XCTAssertFalse(store.canLoadMoreSessions(projectID: project.id))
+    }
+
+    func testAuthoritativeFillRestoresStickySubagentOwnershipBeforeCountingRoots() async throws {
+        let project = makeProject(id: "workspace_sticky_child_ownership")
+        let knownChildren = (0..<20).map { index in
+            makeSubagentSession(
+                id: "sticky_child_\(index)",
+                projectID: project.id,
+                parentThreadID: "sticky_parent"
+            )
+        }
+        let sparseRows = knownChildren.map { child in
+            makeSession(
+                id: child.id,
+                projectID: project.id,
+                title: "稀疏列表行",
+                status: "history",
+                source: "codex"
+            )
+        }
+        let roots = (0..<20).map { index in
+            makeSession(
+                id: "sticky_root_\(index)",
+                projectID: project.id,
+                title: "根会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: sparseRows, nextCursor: "after-sparse-children", hasMore: true),
+            cursorPages: ["after-sparse-children": SessionsPage(sessions: roots)]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        store.sessions = knownChildren
+
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), roots.map(\.id))
+        XCTAssertTrue(knownChildren.allSatisfy { store.sessionsByID[$0.id]?.isSubagentThread == true })
+        XCTAssertEqual(client.requestedSessionCursors, [nil, "after-sparse-children"])
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+    }
+
+    func testAuthoritativePresentationFillStopsAtRequestBudgetWithoutRecordingCompletion() async throws {
+        let project = makeProject(id: "workspace_presentation_budget")
+        let cachedRoot = makeSession(
+            id: "presentation_budget_cached_root",
+            projectID: project.id,
+            title: "缓存根会话",
+            status: "history",
+            source: "codex"
+        )
+        var cursorPages: [String: SessionsPage] = [:]
+        for index in 1..<SessionStore.maximumSessionPresentationFillPageCount {
+            cursorPages["budget-\(index)"] = SessionsPage(
+                sessions: [makeSubagentSession(
+                    id: "budget_child_\(index)",
+                    projectID: project.id,
+                    parentThreadID: cachedRoot.id
+                )],
+                nextCursor: "budget-\(index + 1)",
+                hasMore: true
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [makeSubagentSession(
+                    id: "budget_child_0",
+                    projectID: project.id,
+                    parentThreadID: cachedRoot.id
+                )],
+                nextCursor: "budget-1",
+                hasMore: true
+            ),
+            cursorPages: cursorPages
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        store.sessions = [cachedRoot]
+        let workspace = try XCTUnwrap(store.ensureWorkspaceForKnownProjectID(project.id))
+        store.recordWorkspaceSessionFirstPageCompletion(
+            workspace: workspace,
+            page: SessionsPage(sessions: [cachedRoot]),
+            consistency: .authoritative
+        )
+        XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+
+        try await store.refreshWorkspaceSessions(projectID: project.id)
+
+        XCTAssertEqual(client.requestedSessionCursors.count, SessionStore.maximumSessionPresentationFillPageCount)
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), [cachedRoot.id])
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "budget-12")
+        XCTAssertNotNil(store.sessionsByID["budget_child_11"], "已扫描 child 仍须进入 canonical Store")
+
+        client.page = SessionsPage(
+            sessions: [cachedRoot],
+            nextCursor: "stale-first-page-cursor",
+            hasMore: true
+        )
+        await store.refreshSessions(
+            forProjectID: project.id,
+            showLoading: false,
+            reuseRecent: false,
+            consistency: .fastIndexed
+        )
+        XCTAssertEqual(
+            store.sessionPageCursorByProjectID[project.id],
+            "budget-12",
+            "后续弱首屏不能把 budget partial 已推进的安全 continuation 倒退"
+        )
+
+        let completedRoots = [cachedRoot] + (1..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "presentation_budget_completed_root_\(index)",
+                projectID: project.id,
+                title: "补齐根会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        client.page = SessionsPage(
+            sessions: completedRoots,
+            nextCursor: "fresh-authoritative-cursor",
+            hasMore: true
+        )
+        try await store.refreshWorkspaceSessions(projectID: project.id)
+
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "fresh-authoritative-cursor")
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+
+        client.page = SessionsPage(
+            sessions: [cachedRoot],
+            nextCursor: "stale-after-completion",
+            hasMore: true
+        )
+        await store.refreshSessions(
+            forProjectID: project.id,
+            showLoading: false,
+            reuseRecent: false,
+            consistency: .fastIndexed
+        )
+        XCTAssertEqual(
+            store.sessionPageCursorByProjectID[project.id],
+            "fresh-authoritative-cursor",
+            "完整 authoritative 可以纠正 partial cursor，随后弱首屏仍不能把它降级"
+        )
+    }
+
+    func testAuthoritativeFillUsesLaterDuplicateOwnershipBeforeCompletingWindow() async throws {
+        let project = makeProject(id: "workspace_duplicate_ownership")
+        let duplicateRootShell = makeSession(
+            id: "duplicate_child",
+            projectID: project.id,
+            title: "稀疏 root 壳",
+            status: "history",
+            source: "codex"
+        )
+        let duplicateChild = makeSubagentSession(
+            id: duplicateRootShell.id,
+            projectID: project.id,
+            parentThreadID: "duplicate_parent"
+        )
+        let roots = (0..<20).map { index in
+            makeSession(
+                id: "duplicate_root_\(index)",
+                projectID: project.id,
+                title: "根会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [duplicateRootShell],
+                nextCursor: "duplicate-next",
+                hasMore: true
+            ),
+            cursorPages: [
+                "duplicate-next": SessionsPage(sessions: [duplicateChild] + roots)
+            ]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), roots.map(\.id))
+        XCTAssertTrue(store.sessionsByID[duplicateChild.id]?.isSubagentThread == true)
+        XCTAssertEqual(client.requestedSessionCursors, [nil, "duplicate-next"])
+        XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+    }
+
+    func testAuthoritativeFillRejectsHasMoreWithoutCursor() async {
+        let project = makeProject(id: "workspace_missing_cursor")
+        let cachedRoot = makeSession(
+            id: "missing_cursor_cached",
+            projectID: project.id,
+            title: "缓存会话",
+            status: "history",
+            source: "codex"
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [cachedRoot], nextCursor: nil, hasMore: true)
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        store.sessions = [cachedRoot]
+
+        await XCTAssertThrowsErrorAsync(
+            try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+        ) { error in
+            XCTAssertTrue(error is AgentAPIError)
+        }
+
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), [cachedRoot.id])
+    }
+
+    func testExternalActivityAuthoritativeRefreshUsesPresentationCompletePaging() async {
+        let project = makeProject(id: "workspace_external_activity_fill")
+        let firstRoot = makeSession(
+            id: "external_root_0",
+            projectID: project.id,
+            title: "根会话 0",
+            status: "history",
+            source: "codex"
+        )
+        let children = (0..<19).map { index in
+            makeSubagentSession(
+                id: "external_child_\(index)",
+                projectID: project.id,
+                parentThreadID: firstRoot.id
+            )
+        }
+        let olderRoots = (1..<20).map { index in
+            makeSession(
+                id: "external_root_\(index)",
+                projectID: project.id,
+                title: "根会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [firstRoot] + children,
+                nextCursor: "external-next",
+                hasMore: true
+            ),
+            cursorPages: ["external-next": SessionsPage(sessions: olderRoots)]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+
+        await store.refreshExternalActivityProject(
+            projectID: project.id,
+            client: client,
+            hostScope: store.appStore.activeHostScope
+        )
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, 20)
+        XCTAssertEqual(client.requestedSessionCursors, [nil, "external-next"])
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+    }
+
+    func testExternalActivityAndWorkspaceForegroundShareAuthoritativeFirstPage() async throws {
+        let project = makeProject(id: "workspace_external_activity_single_flight")
+        let roots = (0..<20).map { index in
+            makeSession(
+                id: "external_shared_root_\(index)",
+                projectID: project.id,
+                title: "共享根会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        let client = BlockingSessionListRefreshClient(
+            projects: [project],
+            page: SessionsPage(sessions: roots),
+            blockOnCall: 1
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+
+        let externalTask = Task { @MainActor in
+            await store.refreshExternalActivityProject(
+                projectID: project.id,
+                client: client,
+                hostScope: store.appStore.activeHostScope
+            )
+        }
+        await client.waitForBlockedSessionListRefresh()
+        let foregroundTask = Task { @MainActor in
+            try await store.refreshWorkspaceSessions(projectID: project.id)
+        }
+        for _ in 0..<5 { await Task.yield() }
+
+        XCTAssertEqual(client.sessionsPageCallCount, 1, "重叠刷新必须共享同一条 authoritative cursor 链")
+        client.releaseBlockedSessionListRefresh()
+        await externalTask.value
+        try await foregroundTask.value
+
+        XCTAssertEqual(client.sessionsPageCallCount, 1)
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, 20)
+        XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+    }
+
+    func testLoadMoreSkipsChildOnlyPagesUntilTopLevelSessionsArrive() async throws {
+        let project = makeProject(id: "workspace_child_dense_load_more")
+        let firstPageRoots = (0..<20).map { index in
+            makeSession(
+                id: "initial_root_\(index)",
+                projectID: project.id,
+                title: "首屏根会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
+        let hiddenChildren = (0..<19).map { index in
+            makeSubagentSession(
+                id: "load_more_child_\(index)",
+                projectID: project.id,
+                parentThreadID: firstPageRoots[0].id,
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(79 - index))
+            )
+        }
+        let olderRoots = (0..<2).map { index in
+            makeSession(
+                id: "older_root_\(index)",
+                projectID: project.id,
+                title: "更早根会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(40 - index))
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: firstPageRoots, nextCursor: "children-only", hasMore: true),
+            cursorPages: [
+                "children-only": SessionsPage(
+                    // 跨页重复的既有根会话不能占用“新增 20 条”的额度。
+                    sessions: [firstPageRoots[0]] + hiddenChildren,
+                    nextCursor: "older-roots",
+                    hasMore: true
+                ),
+                "older-roots": SessionsPage(sessions: olderRoots)
+            ]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        await store.loadMoreSessions(projectID: project.id)
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, 22)
+        XCTAssertTrue(olderRoots.allSatisfy { store.sessionsByID[$0.id] != nil })
+        XCTAssertTrue(hiddenChildren.allSatisfy { store.sessionsByID[$0.id]?.isSubagentThread == true })
+        XCTAssertEqual(client.requestedSessionCursors, [nil, "children-only", "older-roots"])
+        XCTAssertEqual(client.requestedSessionLimits, [20, 20, 20])
+        XCTAssertFalse(store.canLoadMoreSessions(projectID: project.id))
+    }
+
+    func testLoadMoreCannotDowngradeAuthoritativeFieldsAndAbsorbsLateChildOwnership() async throws {
+        let project = makeProject(id: "workspace_load_more_quality")
+        let authoritativeRoots = (0..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "quality_root_\(index)",
+                projectID: project.id,
+                title: "权威根会话 \(index)",
+                status: index == 0 ? "running" : "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
+        let staleBoundary = makeSession(
+            id: authoritativeRoots[0].id,
+            projectID: project.id,
+            title: "过期边界标题",
+            status: "history",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let lateChild = makeSubagentSession(
+            id: authoritativeRoots[1].id,
+            projectID: project.id,
+            parentThreadID: authoritativeRoots[0].id
+        )
+        let olderRoot = makeSession(
+            id: "quality_older_root",
+            projectID: project.id,
+            title: "新增旧根会话",
+            status: "history",
+            source: "codex"
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: authoritativeRoots,
+                nextCursor: "quality-load-more",
+                hasMore: true
+            ),
+            cursorPages: [
+                "quality-load-more": SessionsPage(
+                    sessions: [staleBoundary, lateChild, olderRoot]
+                )
+            ]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        await store.loadMoreSessions(projectID: project.id)
+
+        XCTAssertEqual(store.sessionsByID[authoritativeRoots[0].id]?.title, authoritativeRoots[0].title)
+        XCTAssertEqual(store.sessionsByID[authoritativeRoots[0].id]?.status, authoritativeRoots[0].status)
+        XCTAssertTrue(store.sessionsByID[authoritativeRoots[1].id]?.isSubagentThread == true)
+        XCTAssertFalse(store.sessions(forProjectID: project.id).contains { $0.id == authoritativeRoots[1].id })
+        XCTAssertEqual(store.sessionsByID[olderRoot.id]?.title, olderRoot.title)
+        XCTAssertFalse(store.canLoadMoreSessions(projectID: project.id))
+    }
+
+    func testLoadMoreBudgetLateChildInvalidatesCompletedWindowWithoutRegressingDeepCursor() async throws {
+        let project = makeProject(id: "workspace_load_more_late_child_budget")
+        let authoritativeRoots = (0..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "load_more_budget_root_\(index)",
+                projectID: project.id,
+                title: "权威根会话 \(index)",
+                status: index == 1 ? "running" : "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(200 - index))
+            )
+        }
+        let lateChild = makeSubagentSession(
+            id: authoritativeRoots[1].id,
+            projectID: project.id,
+            parentThreadID: authoritativeRoots[0].id,
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        var cursorPages: [String: SessionsPage] = [:]
+        for index in 0..<SessionStore.maximumSessionPresentationFillPageCount {
+            cursorPages["late-\(index)"] = SessionsPage(
+                sessions: [lateChild],
+                nextCursor: "late-\(index + 1)",
+                hasMore: true
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: authoritativeRoots,
+                nextCursor: "late-0",
+                hasMore: true
+            ),
+            cursorPages: cursorPages
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        let workspace = try XCTUnwrap(store.ensureWorkspaceForKnownProjectID(project.id))
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+        XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+
+        await store.loadMoreSessions(projectID: project.id)
+
+        let protectedSession = try XCTUnwrap(store.sessionsByID[authoritativeRoots[1].id])
+        XCTAssertEqual(protectedSession.title, authoritativeRoots[1].title)
+        XCTAssertEqual(protectedSession.status, authoritativeRoots[1].status)
+        XCTAssertEqual(protectedSession.updatedAt, authoritativeRoots[1].updatedAt)
+        XCTAssertTrue(protectedSession.isSubagentThread)
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, 19)
+        let key = store.workspaceSessionFirstPageKey(for: workspace)
+        let partialCompletion = try XCTUnwrap(store.workspaceSessionFirstPageCompletionByKey[key])
+        XCTAssertEqual(partialCompletion.consistency, .authoritative)
+        XCTAssertFalse(partialCompletion.isPresentationWindowComplete)
+        XCTAssertNil(store.workspaceSessionFirstPageConsistency(projectID: project.id))
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "late-12")
+        XCTAssertTrue(store.canLoadMoreSessions(projectID: project.id))
+        XCTAssertEqual(
+            client.requestedSessionCursors,
+            [nil] + (0..<SessionStore.maximumSessionPresentationFillPageCount).map { "late-\($0)" }
+        )
+
+        let supplementalRoot = makeSession(
+            id: "load_more_budget_supplemental",
+            projectID: project.id,
+            title: "权威补齐根会话",
+            status: "history",
+            source: "codex"
+        )
+        client.page = SessionsPage(
+            sessions: authoritativeRoots.enumerated().compactMap { index, session in
+                index == 1 ? nil : session
+            } + [supplementalRoot],
+            nextCursor: "authoritative-refilled",
+            hasMore: true
+        )
+
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, SessionStore.initialSessionPageLimit)
+        XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "late-12")
+        XCTAssertTrue(store.canLoadMoreSessions(projectID: project.id))
+    }
+
+    func testSupersededLoadMoreStopsBeforeFollowingAnotherCursor() async throws {
+        let project = makeProject(id: "workspace_superseded_load_more")
+        let roots = (0..<20).map { index in
+            makeSession(
+                id: "superseded_root_\(index)",
+                projectID: project.id,
+                title: "首屏根会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        let childPage = SessionsPage(
+            sessions: [makeSubagentSession(
+                id: "superseded_child",
+                projectID: project.id,
+                parentThreadID: roots[0].id
+            )],
+            nextCursor: "must-not-request",
+            hasMore: true
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: roots, nextCursor: "load-more", hasMore: true),
+            cursorPages: [
+                "load-more": childPage,
+                "must-not-request": SessionsPage(sessions: [makeSession(
+                    id: "must_not_arrive",
+                    projectID: project.id,
+                    title: "不应请求",
+                    status: "history",
+                    source: "codex"
+                )])
+            ]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        var supersedingToken: Int?
+        client.onSessionPageRequest = { cursor in
+            guard cursor == "load-more", supersedingToken == nil else { return }
+            supersedingToken = store.beginSessionFirstPageRequest(
+                projectID: project.id,
+                consistency: .authoritative
+            )
+        }
+        await store.loadMoreSessions(projectID: project.id)
+        if let supersedingToken {
+            store.finishSessionFirstPageRequest(projectID: project.id, token: supersedingToken)
+        }
+
+        XCTAssertEqual(client.requestedSessionCursors, [nil, "load-more"])
+        XCTAssertNil(store.sessionsByID["superseded_child"])
+        XCTAssertNil(store.sessionsByID["must_not_arrive"])
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "load-more")
+    }
+
+    func testAuthoritativePresentationFillRejectsRepeatedCursorWithoutCompletion() async throws {
+        let project = makeProject(id: "workspace_repeated_cursor")
+        let firstRoot = makeSession(
+            id: "repeated_cursor_root",
+            projectID: project.id,
+            title: "根会话",
+            status: "history",
+            source: "codex"
+        )
+        let child = makeSubagentSession(
+            id: "repeated_cursor_child",
+            projectID: project.id,
+            parentThreadID: firstRoot.id
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [firstRoot], nextCursor: "stuck", hasMore: true),
+            cursorPages: [
+                "stuck": SessionsPage(sessions: [child], nextCursor: "stuck", hasMore: true)
+            ]
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+
+        do {
+            try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+            XCTFail("不前进的 cursor 不能被记录为 authoritative 完成")
+        } catch {
+            XCTAssertTrue(error is AgentAPIError)
+        }
+
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertTrue(store.sessions(forProjectID: project.id).isEmpty)
+        XCTAssertEqual(client.requestedSessionCursors, [nil, "stuck"])
     }
 
     func testFastIndexedFirstPageCannotShrinkCompletedAuthoritativeWindowOrCursor() async throws {
@@ -281,6 +1025,16 @@ extension ConversationDataFlowTests {
             status: "history",
             source: "codex"
         )
+        let authoritativeWindow = [authoritativeSession] + (1..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "thread_library_authoritative_\(index)",
+                projectID: project.id,
+                title: "权威会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
         let store = SessionStore(
             appStore: AppStore(),
             conversationStore: ConversationStore(),
@@ -291,7 +1045,7 @@ extension ConversationDataFlowTests {
         store.applyWorkspaceSessionFirstPage(
             workspace: workspace,
             page: SessionsPage(
-                sessions: [authoritativeSession],
+                sessions: authoritativeWindow,
                 nextCursor: "authoritative-library-cursor",
                 hasMore: true
             ),
@@ -316,6 +1070,295 @@ extension ConversationDataFlowTests {
         XCTAssertNotNil(store.sessionsByID[supplementalSession.id])
         XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "authoritative-library-cursor")
         XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+    }
+
+    func testLateFastLibraryPageCannotDowngradePartialAuthoritativeData() throws {
+        let project = makeProject(id: "workspace_late_fast_partial_library")
+        let workspace = AgentWorkspace(project: project)
+        let authoritativeSession = makeSession(
+            id: "thread_partial_library_shared",
+            projectID: project.id,
+            title: "部分权威标题",
+            status: "running",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        let staleExisting = makeSession(
+            id: authoritativeSession.id,
+            projectID: project.id,
+            title: "过期部分索引标题",
+            status: "history",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let supplementalSession = makeSession(
+            id: "thread_partial_library_supplemental",
+            projectID: project.id,
+            title: "部分补充会话",
+            status: "history",
+            source: "codex"
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
+        )
+        store.recentWorkspaces = [workspace]
+        store.applyWorkspaceSessionFirstPage(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: [authoritativeSession],
+                nextCursor: "partial-authoritative-library-cursor",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+
+        store.mergeSessionLibraryPages(
+            [(
+                workspace: workspace,
+                page: SessionsPage(
+                    sessions: [staleExisting, supplementalSession],
+                    nextCursor: "partial-stale-library-cursor",
+                    hasMore: true
+                )
+            )],
+            generation: store.appStore.connectionGeneration,
+            consistency: .fastIndexed
+        )
+
+        XCTAssertEqual(store.sessionsByID[authoritativeSession.id]?.title, authoritativeSession.title)
+        XCTAssertEqual(store.sessionsByID[authoritativeSession.id]?.status, authoritativeSession.status)
+        XCTAssertNotNil(store.sessionsByID[supplementalSession.id])
+        XCTAssertEqual(
+            store.sessionPageCursorByProjectID[project.id],
+            "partial-authoritative-library-cursor"
+        )
+        XCTAssertNil(store.workspaceSessionFirstPageConsistency(projectID: project.id))
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+    }
+
+    func testNewAuthoritativeLibraryPageCanReplacePreviousAuthoritativeFields() throws {
+        let project = makeProject(id: "workspace_new_authoritative_library")
+        let workspace = AgentWorkspace(project: project)
+        let oldAuthoritative = makeSession(
+            id: "thread_new_authoritative_library_shared",
+            projectID: project.id,
+            title: "旧权威标题",
+            status: "history",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        let newAuthoritative = makeSession(
+            id: oldAuthoritative.id,
+            projectID: project.id,
+            title: "新权威标题",
+            status: "running",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+        let initialWindow = [oldAuthoritative] + (1..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "thread_old_authoritative_library_\(index)",
+                projectID: project.id,
+                title: "旧权威会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
+        )
+        store.recentWorkspaces = [workspace]
+        store.applyWorkspaceSessionFirstPage(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: initialWindow,
+                nextCursor: "old-authoritative-library-cursor",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+
+        store.mergeSessionLibraryPages(
+            [(
+                workspace: workspace,
+                page: SessionsPage(sessions: [newAuthoritative])
+            )],
+            generation: store.appStore.connectionGeneration,
+            consistency: .authoritative
+        )
+
+        XCTAssertEqual(store.sessionsByID[oldAuthoritative.id]?.title, newAuthoritative.title)
+        XCTAssertEqual(store.sessionsByID[oldAuthoritative.id]?.status, newAuthoritative.status)
+        XCTAssertEqual(store.sessionsByID[oldAuthoritative.id]?.updatedAt, newAuthoritative.updatedAt)
+        XCTAssertNil(store.sessionPageCursorByProjectID[project.id])
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+    }
+
+    func testRestoreFastPagePreservesPartialAuthoritativeFieldsAndAbsorbsThreadIdentity() async throws {
+        let project = makeProject(id: "workspace_restore_quality")
+        let workspace = AgentWorkspace(project: project)
+        let authoritativeShared = makeSession(
+            id: "restore_quality_shared",
+            projectID: project.id,
+            title: "恢复权威标题",
+            status: "running",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        let authoritativeRootBecomingChild = makeSession(
+            id: "restore_quality_late_child",
+            projectID: project.id,
+            title: "权威线程身份候选",
+            status: "history",
+            source: "codex"
+        )
+        let staleShared = makeSession(
+            id: authoritativeShared.id,
+            projectID: project.id,
+            title: "恢复过期标题",
+            status: "history",
+            source: "codex",
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let lateChild = makeSubagentSession(
+            id: authoritativeRootBecomingChild.id,
+            projectID: project.id,
+            parentThreadID: authoritativeShared.id
+        )
+        let supplemental = makeSession(
+            id: "restore_quality_supplemental",
+            projectID: project.id,
+            title: "恢复补充会话",
+            status: "history",
+            source: "codex"
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [staleShared, lateChild, supplemental],
+                nextCursor: "restore-stale-cursor",
+                hasMore: true
+            )
+        )
+        let appStore = AppStore()
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.recentWorkspaces = [workspace]
+        store.applyWorkspaceSessionFirstPage(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: [authoritativeShared, authoritativeRootBecomingChild],
+                nextCursor: "restore-authoritative-cursor",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+        let snapshot = SessionRestoreSnapshot(endpoint: appStore.endpoint, session: authoritativeShared)
+
+        let restored = await store.resolveSessionForRestore(snapshot)
+
+        XCTAssertEqual(restored?.title, authoritativeShared.title)
+        XCTAssertEqual(store.sessionsByID[authoritativeShared.id]?.status, authoritativeShared.status)
+        XCTAssertTrue(store.sessionsByID[authoritativeRootBecomingChild.id]?.isSubagentThread == true)
+        XCTAssertFalse(
+            store.sessions(forProjectID: project.id).contains { $0.id == authoritativeRootBecomingChild.id }
+        )
+        XCTAssertEqual(store.sessionsByID[supplemental.id]?.title, supplemental.title)
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "restore-authoritative-cursor")
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+    }
+
+    func testRestoreLateChildrenInvalidateCompletedWindowAndAuthoritativeRefillsIt() async throws {
+        let project = makeProject(id: "workspace_restore_late_children_refill")
+        let workspace = AgentWorkspace(project: project)
+        let authoritativeRoots = (0..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "restore_refill_root_\(index)",
+                projectID: project.id,
+                title: "权威根会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(200 - index))
+            )
+        }
+        let lateChildren = (1...3).map { index in
+            makeSubagentSession(
+                id: authoritativeRoots[index].id,
+                projectID: project.id,
+                parentThreadID: authoritativeRoots[0].id,
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(300 - index))
+            )
+        }
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(
+                sessions: [authoritativeRoots[0]] + lateChildren,
+                nextCursor: "restore-fast-next",
+                hasMore: true
+            )
+        )
+        let appStore = AppStore()
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.recentWorkspaces = [workspace]
+        store.applyWorkspaceSessionFirstPage(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: authoritativeRoots,
+                nextCursor: "restore-authoritative-old",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+        XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+
+        let snapshot = SessionRestoreSnapshot(endpoint: appStore.endpoint, session: authoritativeRoots[0])
+        _ = await store.resolveSessionForRestore(snapshot)
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, 17)
+        XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "restore-authoritative-old")
+
+        let supplementalRoots = (20..<23).map { index in
+            makeSession(
+                id: "restore_refill_root_\(index)",
+                projectID: project.id,
+                title: "补齐根会话 \(index)",
+                status: "history",
+                source: "codex",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
+        let survivingRoots = authoritativeRoots.enumerated().compactMap { index, session in
+            (1...3).contains(index) ? nil : session
+        }
+        client.page = SessionsPage(
+            sessions: survivingRoots + supplementalRoots,
+            nextCursor: "restore-authoritative-refilled",
+            hasMore: true
+        )
+
+        try await store.ensureAuthoritativeWorkspaceSessionFirstPage(projectID: project.id)
+
+        XCTAssertEqual(store.sessions(forProjectID: project.id).count, SessionStore.initialSessionPageLimit)
+        XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "restore-authoritative-refilled")
+        XCTAssertEqual(client.requestedSessionListConsistencies, [.fastIndexed, .authoritative])
     }
 
     func testRestoreFailureCannotReviveWorkspaceForgottenWhileFirstPageIsInFlight() async {
@@ -553,11 +1596,8 @@ extension ConversationDataFlowTests {
         let client = FastThenAuthoritativeSessionListClient(
             projects: [project],
             fastOutcome: .failure,
-            authoritativePage: SessionsPage(
-                sessions: [authoritativeSession],
-                nextCursor: "authoritative-after-failure",
-                hasMore: true
-            )
+            // 本用例只验证失败后的调度升级；分页补齐由 child-dense 专项用例覆盖。
+            authoritativePage: SessionsPage(sessions: [authoritativeSession])
         )
         let store = SessionStore(
             appStore: AppStore(),
@@ -598,7 +1638,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(clientSnapshot.requestedSessionListConsistencies, [.fastIndexed, .authoritative])
         XCTAssertEqual(clientSnapshot.maximumConcurrentRequestCount, 1)
         XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), [authoritativeSession.id])
-        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "authoritative-after-failure")
+        XCTAssertNil(store.sessionPageCursorByProjectID[project.id])
         XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
         XCTAssertTrue(store.sessionFirstPageLoadingConsistencyByProjectID.isEmpty)
         XCTAssertTrue(store.sessionFirstPageWaiterCountByProjectID.isEmpty)
@@ -992,6 +2032,29 @@ extension ConversationDataFlowTests {
 private enum FastThenAuthoritativeTestError: Error {
     case fastIndexedFailed
     case timedOut
+}
+
+private func makeSubagentSession(
+    id: String,
+    projectID: String,
+    parentThreadID: String,
+    updatedAt: Date = Date(timeIntervalSince1970: 2)
+) -> AgentSession {
+    AgentSession(
+        id: id,
+        projectID: projectID,
+        project: projectID,
+        dir: "/tmp/\(projectID)",
+        title: "子 Agent \(id)",
+        status: "history",
+        source: "codex",
+        resumeID: nil,
+        createdAt: Date(timeIntervalSince1970: 1),
+        updatedAt: updatedAt,
+        parentThreadID: parentThreadID,
+        isSubagent: true,
+        canAcceptDirectInput: false
+    )
 }
 
 private enum FastRequestOutcome {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
@@ -281,6 +281,12 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
         XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), [cachedRoot.id])
         XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "budget-12")
+        XCTAssertEqual(
+            store.workspaceSessionFirstPageCompletionByKey[
+                store.workspaceSessionFirstPageKey(for: workspace)
+            ]?.continuationCursor,
+            "budget-12"
+        )
         XCTAssertNotNil(store.sessionsByID["budget_child_11"], "已扫描 child 仍须进入 canonical Store")
 
         client.page = SessionsPage(
@@ -316,6 +322,7 @@ extension ConversationDataFlowTests {
         )
         try await store.refreshWorkspaceSessions(projectID: project.id)
 
+        XCTAssertEqual(client.requestedSessionCursors.last, "budget-12", "权威重试必须续跑已保存游标")
         XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "fresh-authoritative-cursor")
         XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
 
@@ -733,7 +740,11 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.sessions(forProjectID: project.id).count, SessionStore.initialSessionPageLimit)
         XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
         XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
-        XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "late-12")
+        XCTAssertEqual(
+            store.sessionPageCursorByProjectID[project.id],
+            "authoritative-refilled",
+            "权威补齐沿当前 deep chain 续跑时，显示更多 cursor 也应推进到新边界"
+        )
         XCTAssertTrue(store.canLoadMoreSessions(projectID: project.id))
     }
 
@@ -988,7 +999,7 @@ extension ConversationDataFlowTests {
 
         store.forgetWorkspace(project)
         store.mergeSessionLibraryPages(
-            [(workspace: workspace, page: SessionsPage(sessions: [lateSession]))],
+            [(workspace: workspace, page: SessionsPage(sessions: [lateSession]), requestedCursor: nil)],
             generation: store.appStore.connectionGeneration,
             consistency: .authoritative
         )
@@ -1059,7 +1070,8 @@ extension ConversationDataFlowTests {
                     sessions: [staleExisting, supplementalSession],
                     nextCursor: "stale-library-cursor",
                     hasMore: true
-                )
+                ),
+                requestedCursor: nil
             )],
             generation: store.appStore.connectionGeneration,
             consistency: .fastIndexed
@@ -1122,7 +1134,8 @@ extension ConversationDataFlowTests {
                     sessions: [staleExisting, supplementalSession],
                     nextCursor: "partial-stale-library-cursor",
                     hasMore: true
-                )
+                ),
+                requestedCursor: nil
             )],
             generation: store.appStore.connectionGeneration,
             consistency: .fastIndexed
@@ -1187,7 +1200,8 @@ extension ConversationDataFlowTests {
         store.mergeSessionLibraryPages(
             [(
                 workspace: workspace,
-                page: SessionsPage(sessions: [newAuthoritative])
+                page: SessionsPage(sessions: [newAuthoritative]),
+                requestedCursor: nil
             )],
             generation: store.appStore.connectionGeneration,
             consistency: .authoritative
@@ -1500,6 +1514,72 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), completePage.map(\.id))
         XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "authoritative-older")
         XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+    }
+
+    func testFastIndexedWaitsForAuthoritativeContinuationThenRequestsOwnNilFirstPage() async throws {
+        let project = makeProject(id: "workspace_authoritative_continuation_then_fast")
+        let completePage = (0..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "thread_authoritative_continuation_then_fast_\(index)",
+                projectID: project.id,
+                title: "会话 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        let client = BlockingSessionListRefreshClient(
+            projects: [project],
+            page: SessionsPage(sessions: completePage),
+            blockOnCall: 1
+        )
+        let store = SessionStore(
+            appStore: AppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        store.sessions = [completePage[0]]
+        let workspace = try XCTUnwrap(store.ensureWorkspaceForKnownProjectID(project.id))
+        store.recordWorkspaceSessionFirstPageCompletion(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: [completePage[0]],
+                nextCursor: "authoritative-resume-cursor",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+
+        let authoritative = Task { @MainActor in
+            try await store.refreshWorkspaceSessions(projectID: project.id)
+        }
+        await client.waitForBlockedSessionListRefresh()
+        let fastIndexed = Task { @MainActor in
+            await store.refreshSessions(
+                forProjectID: project.id,
+                showLoading: false,
+                reuseRecent: false,
+                consistency: .fastIndexed,
+                activatesProject: false
+            )
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(client.sessionsPageCallCount, 1, "权威 continuation 未结束前不能并发启动 nil 首屏")
+        XCTAssertEqual(client.requestedSessionCursors, ["authoritative-resume-cursor"])
+
+        client.releaseBlockedSessionListRefresh()
+        try await authoritative.value
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(client.sessionsPageCallCount, 2)
+        XCTAssertEqual(client.requestedSessionCursors, ["authoritative-resume-cursor", nil])
+        client.releaseBlockedSessionListRefresh()
+        await fastIndexed.value
+
+        XCTAssertEqual(client.requestedSessionListConsistencies, [.authoritative, .fastIndexed])
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+        XCTAssertTrue(store.sessionListFirstPageInFlightByKey.isEmpty)
     }
 
     func testAuthoritativeWaitsForInFlightFastIndexedThenPerformsExactlyOnePreciseRequest() async throws {
@@ -2034,7 +2114,7 @@ private enum FastThenAuthoritativeTestError: Error {
     case timedOut
 }
 
-private func makeSubagentSession(
+func makeSubagentSession(
     id: String,
     projectID: String,
     parentThreadID: String,


### PR DESCRIPTION
## 变更

- 工作区权威首屏沿游标补齐 20 条顶层会话；子 Agent 会话保留在 canonical Store，但不占展示额度。
- 单批 12 页仍不足时，从已提交 opaque cursor 自动续跑；每 4 批短暂退避，避免密集历史长期独占链路。
- 弱索引迟到时保护权威普通字段，只单调吸收 child 身份；若已完成窗口被补认后欠填，自动触发权威回补。
- 权威 continuation 与 fastIndexed nil 首屏串行但不混用结果；过期 waiter 不能回退 completion 或 cursor。
- 显示更多、恢复、通知、会话库和外部活动统一完成态与游标语义；深层游标不会被浅首屏覆盖。
- 修复双 Runtime 空页、不可用 channel 与 buffer 的全局顺序及 continuation 边界。

## 根因

thread/list 的 limit 约束原始行，子 Agent 和重复边界会消耗额度；旧逻辑按 transport 首屏完成，而不是按可展示的顶层会话完成。最密集的历史超过 12 个 transport page 后，旧实现还会从 nil 重扫，导致永远无法补齐。

## 用户影响

进入工作区后会自动获得完整的顶层最近会话窗口，无需反复刷新或等待后台轮询。此次仅修改 iOS 客户端，无后端部署变更。

## 验证

- 完整功能回归：1137 tests，4 skipped，0 failures（排除仓库既有漂移的 ConversationSnapshotTests 与 SkillModelPickerSnapshotTests）。
- 拆分后 continuation 定向回归：3 tests，0 failures。
- git diff --check：通过。
- bash ./scripts/check-source-size.sh：通过。
- 两轮独立只读审查：无 P0–P2。