### PR TITLE
MIM-11 放大主机平台图标

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
@@ -156,18 +156,20 @@ struct HostSwitcherMenu: View {
             // 顶栏只表达当前主机可切换；多设备时用服务端真实平台增强辨识度，
             // 单设备和未知平台继续使用通用电脑，避免根据名称或地址猜测系统。
             ZStack(alignment: .bottomTrailing) {
-                HostPlatformGlyph(kind: currentHostIconKind)
-                    .frame(width: 18, height: 18)
+                // 圆形按钮的触控范围保持不变，只放大品牌图形的光学占比。
+                HostPlatformGlyph(kind: currentHostIconKind, size: 22)
+                    .frame(width: 22, height: 22)
 
                 if isSwitching {
                     ProgressView()
                         .controlSize(.mini)
-                        .offset(x: 3, y: 3)
+                        .offset(x: 4, y: 4)
                 } else {
                     Circle()
                         .fill(currentConnectionColor)
                         .frame(width: 6, height: 6)
-                        .offset(x: 2, y: 2)
+                        // 徽标同步外移，避免放大后的品牌图形与连接状态挤在一起。
+                        .offset(x: 4, y: 4)
                 }
             }
             // 主机入口恢复原始主题主色；连接状态仍由右下角语义色圆点表达。


### PR DESCRIPTION
## 改动

- 将顶栏主机平台图标从 18pt 放大到 22pt
- 同步外移连接状态徽标，避免与品牌图形拥挤
- 保持圆形按钮与触控范围不变，侧栏和设置页图标尺寸不变

## 原因

真机视觉验证发现彩虹 Apple 图标在顶栏圆形按钮内偏小，平台辨识度不足。

## 影响

Apple、Windows、Linux 及通用主机图标在顶栏的视觉重量更合适，不改变交互与布局尺寸。

## 验证

- bash ./scripts/ios-dev.sh build：通过
- iPhone 17 Pro 深色模式运行验证：Apple、Windows、Linux 图标均无裁切
- 状态点与主图标间距正常
- git diff --check：通过