### PR TITLE
MIM-89 正确呈现 Claude 额度预警与用户中断

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -16,9 +16,8 @@
 //! `turn/steer` writes another user envelope on stdin while a turn is in
 //! flight; the existing driver folds the new events into the same `turn_id`.
 //!
-//! `turn/interrupt` sends SIGINT to the claude child (Unix) or
-//! `child.start_kill()` (Windows) and waits for the driver to emit a Failed
-//! `turn/completed`.
+//! `turn/interrupt` uses Claude's control protocol and waits for the driver to
+//! emit an Interrupted `turn/completed`.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -44,7 +43,8 @@ use crate::pool::claude_protocol::{ClaudeEvent, ClaudeOutbound, ControlRequestBo
 use crate::pool::process::ClaudeProcessError;
 use crate::state::ConnectionState;
 use crate::translate::events::{
-    EventTranslatorState, is_claude_authentication_failure, turn_status_from_result,
+    EventTranslatorState, is_claude_authentication_failure, is_user_interrupted_result,
+    turn_status_from_result,
 };
 use crate::translate::input::translate_user_input;
 
@@ -133,6 +133,7 @@ static EVENT_DRIVERS: LazyLock<SyncMutex<HashMap<String, EventDriverRegistration
 #[derive(Clone)]
 struct ActiveTurn {
     turn_id: String,
+    interrupt_requested: bool,
 }
 
 struct EventDriverRegistration {
@@ -551,6 +552,7 @@ pub async fn handle_turn_interrupt(
                 actual: active.turn_id,
             });
         }
+        mark_active_turn_interrupt_requested(&params.thread_id, &params.turn_id);
     }
     interrupt_handle(&handle).await;
     Ok(p::TurnInterruptResponse::default())
@@ -613,12 +615,26 @@ fn register_active_turn(thread_id: &str, turn_id: &str) {
         thread_id.to_string(),
         ActiveTurn {
             turn_id: turn_id.to_string(),
+            interrupt_requested: false,
         },
     );
 }
 
 fn active_turn(thread_id: &str) -> Option<ActiveTurn> {
     ACTIVE_TURNS.lock().unwrap().get(thread_id).cloned()
+}
+
+fn mark_active_turn_interrupt_requested(thread_id: &str, turn_id: &str) {
+    if let Some(active) = ACTIVE_TURNS.lock().unwrap().get_mut(thread_id)
+        && active.turn_id == turn_id
+    {
+        active.interrupt_requested = true;
+    }
+}
+
+fn active_turn_interrupt_requested(thread_id: &str, turn_id: &str) -> bool {
+    active_turn(thread_id)
+        .is_some_and(|active| active.turn_id == turn_id && active.interrupt_requested)
 }
 
 pub(super) fn active_turn_id(thread_id: &str) -> Option<String> {
@@ -672,6 +688,7 @@ struct DrivenTurn {
     started_at: i64,
     translator: EventTranslatorState,
     error_message: Option<String>,
+    interrupted: bool,
     interaction_gate: Arc<AsyncMutex<()>>,
     /// Claude control request id → mobile interaction task. A typed
     /// `control_cancel_request` can abort only the waiter it invalidates.
@@ -693,6 +710,7 @@ impl DrivenTurn {
             turn_id,
             started_at,
             error_message: None,
+            interrupted: false,
             interaction_gate: Arc::new(AsyncMutex::new(())),
             interaction_tasks: HashMap::new(),
             turn_guard,
@@ -1042,7 +1060,14 @@ async fn run_event_driver(mut args: EventDriverArgs) {
                     && result.result.as_deref().is_some_and(is_claude_authentication_failure)
         );
         if let ClaudeOutbound::Result(ref r) = payload {
-            if r.is_error || r.subtype != "success" {
+            let interrupt_requested =
+                active_turn_interrupt_requested(&args.thread_id, &turn.turn_id);
+            if is_user_interrupted_result(r, interrupt_requested) {
+                // 用户主动停止只结束当前 turn，不污染错误栏，也不触发任何重试。
+                turn.interrupted = true;
+                turn.error_message = None;
+                turn.translator.mark_user_interrupt_requested();
+            } else if r.is_error || r.subtype != "success" {
                 turn.error_message = Some(
                     r.result
                         .clone()
@@ -1186,10 +1211,14 @@ async fn finish_driven_turn(
         task.abort();
     }
 
-    let dangling_reason = driven
-        .error_message
-        .as_deref()
-        .unwrap_or("claude turn ended before the item completed");
+    let dangling_reason = if driven.interrupted {
+        "claude turn interrupted by user"
+    } else {
+        driven
+            .error_message
+            .as_deref()
+            .unwrap_or("claude turn ended before the item completed")
+    };
     for notif in driven.translator.abort_open_items(dangling_reason) {
         if let p::ServerNotification::ItemCompleted(ref n) = notif {
             args.state
@@ -1200,7 +1229,8 @@ async fn finish_driven_turn(
         }
     }
 
-    let (status, error) = turn_status_from_result(driven.error_message.as_deref());
+    let (status, error) =
+        turn_status_from_result(driven.interrupted, driven.error_message.as_deref());
     let completed_at = now_unix_secs();
     let duration_ms = ((completed_at - driven.started_at) * 1000).max(0);
     let turn = p::Turn {
@@ -1536,6 +1566,9 @@ mod tests {
         register_active_turn(&thread_id, "tu1");
         let active = active_turn(&thread_id).unwrap();
         assert_eq!(active.turn_id, "tu1");
+        assert!(!active.interrupt_requested);
+        mark_active_turn_interrupt_requested(&thread_id, "tu1");
+        assert!(active_turn_interrupt_requested(&thread_id, "tu1"));
         clear_active_turn(&thread_id);
         assert!(active_turn(&thread_id).is_none());
     }

--- a/bridges/claude/crates/claude-bridge/src/index/claude_session_scan.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/claude_session_scan.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::fs;
 
-use crate::translate::items::is_internal_local_command_text;
+use crate::translate::items::is_internal_user_text;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ClaudeSessionInfo {
@@ -231,7 +231,7 @@ enum RealUserMessage {
 }
 
 fn real_message_preview(text: &str) -> Option<String> {
-    if is_internal_local_command_text(text) {
+    if is_internal_user_text(text) {
         return None;
     }
     text.lines()
@@ -310,6 +310,7 @@ mod tests {
             r#"{"type":"user","isMeta":true,"cwd":"/private/tmp","message":{"role":"user","content":"<local-command-caveat>internal</local-command-caveat>"},"timestamp":"2026-07-17T05:11:50Z"}"#,
             r#"{"type":"user","message":{"role":"user","content":"<command-name>/model</command-name>\n<command-message>model</command-message>\n<command-args>sonnet</command-args>"},"timestamp":"2026-07-17T05:11:51Z"}"#,
             r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"done"}]},"timestamp":"2026-07-17T05:11:52Z"}"#,
+            r#"{"type":"user","message":{"role":"user","content":"[Request interrupted by user]"},"timestamp":"2026-07-17T05:11:52.500Z"}"#,
             r#"{"type":"user","message":{"role":"user","content":"\n  真正的用户消息\n第二行"},"timestamp":"2026-07-17T05:11:53Z"}"#,
         ];
         std::fs::write(&path, records.join("\n")).unwrap();

--- a/bridges/claude/crates/claude-bridge/src/index/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/mod.rs
@@ -26,7 +26,7 @@ pub use alleycat_bridge_core::{
 };
 use alleycat_codex_proto::{SessionSource, Thread, ThreadSourceKind, ThreadStatus};
 
-use crate::translate::items::is_internal_local_command_text;
+use crate::translate::items::is_internal_user_text;
 
 /// Bridge CLI version string baked into `Thread.cli_version`.
 pub const CLI_VERSION: &str = concat!("alleycat-claude-bridge/", env!("CARGO_PKG_VERSION"));
@@ -207,9 +207,7 @@ fn is_legacy_invalid_preview(preview: &str) -> bool {
     ]
     .iter()
     .any(|prefix| preview.starts_with(prefix));
-    preview == "(no messages)"
-        || truncated_internal_prefix
-        || is_internal_local_command_text(preview)
+    preview == "(no messages)" || truncated_internal_prefix || is_internal_user_text(preview)
 }
 
 /// Compat shim. Today's daemon calls

--- a/bridges/claude/crates/claude-bridge/src/translate/events.rs
+++ b/bridges/claude/crates/claude-bridge/src/translate/events.rs
@@ -64,6 +64,7 @@ const SUBAGENT_BUFFER_CAP_PER_PARENT: usize = 32;
 pub struct EventTranslatorState {
     thread_id: String,
     turn_id: String,
+    user_interrupt_requested: bool,
 
     /// Open text content blocks keyed by their `content_block.index`.
     open_message_items: HashMap<u32, OpenItem>,
@@ -150,6 +151,7 @@ impl EventTranslatorState {
         Self {
             thread_id: thread_id.into(),
             turn_id: turn_id.into(),
+            user_interrupt_requested: false,
             open_message_items: HashMap::new(),
             open_thinking_items: HashMap::new(),
             open_tool_calls: HashMap::new(),
@@ -169,6 +171,12 @@ impl EventTranslatorState {
 
     pub fn turn_id(&self) -> &str {
         &self.turn_id
+    }
+
+    /// 由 turn handler 在确认本地 interrupt intent 后调用。translator 自身不根据
+    /// 模糊错误文本推断用户意图，避免吞掉真实的流式故障。
+    pub(crate) fn mark_user_interrupt_requested(&mut self) {
+        self.user_interrupt_requested = true;
     }
 
     /// Translate one outbound claude event into zero or more codex
@@ -999,22 +1007,11 @@ impl EventTranslatorState {
     // rate_limit / result
     // ------------------------------------------------------------------
 
-    fn translate_rate_limit(&self, env: RateLimitEnvelope) -> Vec<ServerNotification> {
-        if env.rate_limit_info.status == "allowed" {
-            return Vec::new();
-        }
-        let message = format!(
-            "claude rate-limit status: {}{}",
-            env.rate_limit_info.status,
-            env.rate_limit_info
-                .resets_at
-                .map(|t| format!(" (resets_at={t})"))
-                .unwrap_or_default()
-        );
-        vec![ServerNotification::Warning(WarningNotification {
-            thread_id: Some(self.thread_id.clone()),
-            message,
-        })]
+    fn translate_rate_limit(&self, _env: RateLimitEnvelope) -> Vec<ServerNotification> {
+        // rate_limit_event 已由 event driver 写入账号快照，并通过
+        // account/rateLimits/updated 通知 App。这里不再生成时间线 Warning：
+        // allowed_warning 只是接近阈值，rejected 也应由阻塞额度横幅统一表达。
+        Vec::new()
     }
 
     fn translate_result(&mut self, result: ResultEnvelope) -> Vec<ServerNotification> {
@@ -1038,7 +1035,9 @@ impl EventTranslatorState {
         // For non-success terminal results, also surface a top-level error so
         // the codex client doesn't have to dig into the matching
         // turn/completed payload.
-        if result.is_error || result.subtype != "success" {
+        if (result.is_error || result.subtype != "success")
+            && !is_user_interrupted_result(&result, self.user_interrupt_requested)
+        {
             let message = result
                 .result
                 .clone()
@@ -1919,7 +1918,13 @@ fn first_context_window(model_usage: &Value) -> Option<i64> {
 
 /// Helper for `handlers/turn.rs`: derive a `TurnStatus`/`TurnError` pair from
 /// the optional error string carried out of a result envelope.
-pub fn turn_status_from_result(error_message: Option<&str>) -> (TurnStatus, Option<TurnError>) {
+pub fn turn_status_from_result(
+    interrupted: bool,
+    error_message: Option<&str>,
+) -> (TurnStatus, Option<TurnError>) {
+    if interrupted {
+        return (TurnStatus::Interrupted, None);
+    }
     if let Some(message) = error_message {
         (
             TurnStatus::Failed,
@@ -1933,6 +1938,19 @@ pub fn turn_status_from_result(error_message: Option<&str>) -> (TurnStatus, Opti
     } else {
         (TurnStatus::Completed, None)
     }
+}
+
+/// Claude Code 把用户主动停止流式输出表示成 error result，但这不是运行故障。
+/// 只匹配协议的稳定 terminal_reason 或完整内部标记，避免吞掉普通执行错误。
+pub(crate) fn is_user_interrupted_result(
+    result: &ResultEnvelope,
+    interrupt_requested: bool,
+) -> bool {
+    result
+        .result
+        .as_deref()
+        .is_some_and(|message| message.trim() == "[Request interrupted by user]")
+        || (interrupt_requested && result.terminal_reason.as_deref() == Some("aborted_streaming"))
 }
 
 pub(crate) const CLAUDE_AUTHENTICATION_REQUIRED_CODE: &str = "claude_authentication_required";
@@ -2434,7 +2452,7 @@ mod tests {
     }
 
     #[test]
-    fn rate_limit_allowed_is_silent_and_non_allowed_warns() {
+    fn rate_limit_events_only_update_account_snapshot() {
         let mut s = state();
         let allowed = ClaudeOutbound::RateLimitEvent(RateLimitEnvelope {
             rate_limit_info: crate::pool::claude_protocol::RateLimitInfo {
@@ -2451,21 +2469,22 @@ mod tests {
         });
         assert!(s.translate(allowed).is_empty());
 
-        let warning = ClaudeOutbound::RateLimitEvent(RateLimitEnvelope {
-            rate_limit_info: crate::pool::claude_protocol::RateLimitInfo {
-                status: "warning".into(),
-                utilization: Some(0.91),
-                resets_at: Some(123),
-                rate_limit_type: Some("five_hour".into()),
-                overage_status: None,
-                is_using_overage: None,
-                extra: Default::default(),
-            },
-            uuid: "u1".into(),
-            session_id: "s1".into(),
-        });
-        let out = s.translate(warning);
-        assert!(matches!(&out[0], ServerNotification::Warning(_)));
+        for status in ["allowed_warning", "rejected"] {
+            let event = ClaudeOutbound::RateLimitEvent(RateLimitEnvelope {
+                rate_limit_info: crate::pool::claude_protocol::RateLimitInfo {
+                    status: status.into(),
+                    utilization: Some(0.91),
+                    resets_at: Some(123),
+                    rate_limit_type: Some("five_hour".into()),
+                    overage_status: None,
+                    is_using_overage: None,
+                    extra: Default::default(),
+                },
+                uuid: "u1".into(),
+                session_id: "s1".into(),
+            });
+            assert!(s.translate(event).is_empty(), "status={status}");
+        }
     }
 
     #[test]
@@ -2491,6 +2510,69 @@ mod tests {
         });
         let out = s.translate(result);
         assert!(matches!(&out[0], ServerNotification::Error(_)));
+    }
+
+    #[test]
+    fn user_interrupted_result_does_not_emit_error_notification() {
+        let mut s = state();
+        let result = ResultEnvelope {
+            subtype: "error_during_execution".into(),
+            is_error: true,
+            duration_ms: None,
+            duration_api_ms: None,
+            num_turns: None,
+            result: Some("[Request interrupted by user]".into()),
+            stop_reason: None,
+            session_id: "s1".into(),
+            uuid: "u1".into(),
+            total_cost_usd: None,
+            usage: None,
+            model_usage: None,
+            permission_denials: vec![],
+            terminal_reason: Some("aborted_streaming".into()),
+            api_error_status: None,
+            extra: Default::default(),
+        };
+
+        assert!(is_user_interrupted_result(&result, false));
+        assert!(s.translate(ClaudeOutbound::Result(result)).is_empty());
+
+        let aborted_without_marker = ResultEnvelope {
+            subtype: "error_during_execution".into(),
+            is_error: true,
+            duration_ms: None,
+            duration_api_ms: None,
+            num_turns: None,
+            result: None,
+            stop_reason: None,
+            session_id: "s1".into(),
+            uuid: "u2".into(),
+            total_cost_usd: None,
+            usage: None,
+            model_usage: None,
+            permission_denials: vec![],
+            terminal_reason: Some("aborted_streaming".into()),
+            api_error_status: None,
+            extra: Default::default(),
+        };
+        assert!(!is_user_interrupted_result(&aborted_without_marker, false));
+        let mut without_intent = state();
+        assert!(matches!(
+            &without_intent.translate(ClaudeOutbound::Result(aborted_without_marker.clone()))[0],
+            ServerNotification::Error(_)
+        ));
+        let mut with_intent = state();
+        with_intent.mark_user_interrupt_requested();
+        assert!(is_user_interrupted_result(&aborted_without_marker, true));
+        assert!(
+            with_intent
+                .translate(ClaudeOutbound::Result(aborted_without_marker))
+                .is_empty()
+        );
+        assert_eq!(
+            turn_status_from_result(true, Some("aborted_streaming")),
+            (TurnStatus::Interrupted, None)
+        );
     }
 
     #[test]
@@ -2526,9 +2608,10 @@ mod tests {
             Some(CLAUDE_AUTHENTICATION_REQUIRED_CODE)
         );
 
-        let (status, turn_error) = turn_status_from_result(Some(
-            "Failed to authenticate: OAuth session expired and could not be refreshed",
-        ));
+        let (status, turn_error) = turn_status_from_result(
+            false,
+            Some("Failed to authenticate: OAuth session expired and could not be refreshed"),
+        );
         assert_eq!(status, TurnStatus::Failed);
         assert_eq!(
             turn_error.and_then(|error| error.code).as_deref(),
@@ -2544,7 +2627,7 @@ mod tests {
             "Could not be refreshed after a third-party OAuth failure",
         ] {
             assert!(!is_claude_authentication_failure(unrelated_error));
-            let (_, turn_error) = turn_status_from_result(Some(unrelated_error));
+            let (_, turn_error) = turn_status_from_result(false, Some(unrelated_error));
             assert_eq!(turn_error.and_then(|error| error.code), None);
         }
     }

--- a/bridges/claude/crates/claude-bridge/src/translate/items.rs
+++ b/bridges/claude/crates/claude-bridge/src/translate/items.rs
@@ -81,7 +81,7 @@ pub fn list_user_message_ids_from_text(text: &str) -> Vec<String> {
             continue;
         };
         let content = message.get("content").unwrap_or(&Value::Null);
-        if is_internal_local_command_content(content) {
+        if is_internal_user_content(content) {
             continue;
         }
         // Skip tool-result-only user records (these are claude's tool loop
@@ -376,18 +376,19 @@ fn image_source_to_data_url(source: &Value) -> Option<String> {
 /// Claude Code 把 `/model` 等本地命令以顶层 `user` 记录写入 transcript，
 /// 但这些记录只服务 CLI 自身，不能在移动端伪装成用户发送的对话消息。
 /// 这里只识别完整的保留标签包装，避免误删普通文本中对标签的讨论。
-fn is_internal_local_command_content(content: &Value) -> bool {
+fn is_internal_user_content(content: &Value) -> bool {
     let Some(text) = content.as_str() else {
         return false;
     };
-    is_internal_local_command_text(text)
+    is_internal_user_text(text)
 }
 
-/// Claude CLI 内部命令会伪装成 user 文本；索引扫描和历史翻译必须复用同一判定，
-/// 否则列表标题会展示 `<local-command-*>`，打开后又因为历史层过滤而看起来像空会话。
-pub(crate) fn is_internal_local_command_text(text: &str) -> bool {
+/// Claude CLI 内部命令和中断标记会伪装成 user 文本；索引扫描和历史翻译必须
+/// 复用同一判定，避免污染会话标题、用户气泡和 turn 锚点。
+pub(crate) fn is_internal_user_text(text: &str) -> bool {
     let text = text.trim();
-    is_complete_reserved_tag(text, "local-command-caveat")
+    text == "[Request interrupted by user]"
+        || is_complete_reserved_tag(text, "local-command-caveat")
         || is_complete_reserved_tag(text, "local-command-stdout")
         || is_complete_reserved_tag(text, "local-command-stderr")
         || (text.starts_with("<command-name>")
@@ -1025,7 +1026,7 @@ impl OnDiskRecord {
                     return ClassifiedRecord::Skip;
                 };
                 let content = message.get("content").cloned().unwrap_or(Value::Null);
-                if is_internal_local_command_content(&content) {
+                if is_internal_user_content(&content) {
                     return ClassifiedRecord::Skip;
                 }
                 if self.is_meta {
@@ -1189,6 +1190,50 @@ mod tests {
             },
             other => panic!("expected UserMessage, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn user_interrupt_marker_is_not_a_user_turn() {
+        let records = vec![
+            record(json!({
+                "type": "user",
+                "message": {"role": "user", "content": "[Request interrupted by user]"},
+                "timestamp": "2026-07-17T05:11:52.109Z",
+                "uuid": "interrupt"
+            })),
+            record(json!({
+                "type": "user",
+                "message": {"role": "user", "content": "继续"},
+                "timestamp": "2026-07-17T05:11:53.109Z",
+                "uuid": "real"
+            })),
+        ];
+
+        let turns = records_to_turns(&records);
+        assert_eq!(turns.len(), 1);
+        assert!(matches!(
+            &turns[0].items[0],
+            ThreadItem::UserMessage { content, .. }
+                if matches!(&content[0], UserInput::Text { text, .. } if text == "继续")
+        ));
+
+        let text = [
+            json!({
+                "type": "user",
+                "message": {"role": "user", "content": "[Request interrupted by user]"},
+                "uuid": "interrupt"
+            }),
+            json!({
+                "type": "user",
+                "message": {"role": "user", "content": "继续"},
+                "uuid": "real"
+            }),
+        ]
+        .iter()
+        .map(Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+        assert_eq!(list_user_message_ids_from_text(&text), vec!["real"]);
     }
 
     #[test]

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -31854,6 +31854,23 @@
         }
       }
     },
+    "ui.value_message_quota_has_been_exhausted" : {
+      "comment" : "Quota-blocking banner title. The placeholder is the active runtime display name, for example Codex or Claude.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ message quota has been exhausted"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 消息额度已用尽"
+          }
+        }
+      }
+    },
     "ui.value_minutes" : {
       "comment" : "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "extractionState" : "stale",

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -1468,17 +1468,7 @@ extension CodexAppServerSessionRuntime {
     }
 
     func isVisibleUserHistoryMessage(_ text: String) -> Bool {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return false
-        }
-        let hiddenPrefixes = [
-            "<subagent_notification>",
-            "<turn_aborted>",
-            "<environment_context>",
-            "<codex_internal_context>"
-        ]
-        return !hiddenPrefixes.contains { trimmed.hasPrefix($0) }
+        isVisibleAppServerUserMessageText(text)
     }
 
     func appServerHistoryMessageID(turnID: TurnID?, itemID: AgentItemID) -> MessageID {

--- a/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+/// app-server 的内部用户记录不能进入用户气泡或历史标题。中断标记只按完整文本
+/// 过滤，普通用户讨论该字符串时仍可正常展示；既有协议标签继续沿用前缀规则。
+func isVisibleAppServerUserMessageText(_ text: String) -> Bool {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, trimmed != "[Request interrupted by user]" else {
+        return false
+    }
+    let hiddenPrefixes = [
+        "<subagent_notification>",
+        "<turn_aborted>",
+        "<environment_context>",
+        "<codex_internal_context>"
+    ]
+    return !hiddenPrefixes.contains { trimmed.hasPrefix($0) }
+}
+
 // Codex 0.146+ 会把 MCP 工具审批编码成一个空 schema 的 form elicitation。
 // 必须依赖私有元数据精确识别，不能把所有空表单都当成审批，否则第三方 MCP 的普通表单会被误授权。
 enum CodexMCPToolApprovalProtocol {
@@ -809,7 +825,13 @@ struct CodexAppServerEventProjector {
         case "serverRequest/resolved":
             return .approvalResolved(metadata)
         case "warning":
-            return .warning(errorPayload(from: params, fallback: "app-server warning"), metadata)
+            let payload = errorPayload(from: params, fallback: "app-server warning")
+            // 兼容尚未升级的 Claude bridge：allowed_warning 只表示接近额度阈值，
+            // 账号快照会单独更新用量，不应再生成红色时间线故障卡。
+            guard !isNonBlockingClaudeRateLimitWarning(payload) else {
+                return nil
+            }
+            return .warning(payload, metadata)
         case "error":
             clearStreamedText(sessionID: metadata.sessionID, turnID: metadata.turnID)
             return .error(errorPayload(from: params, fallback: "app-server error"), metadata)
@@ -981,7 +1003,7 @@ struct CodexAppServerEventProjector {
         }
         .joined(separator: " ")
         .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !content.isEmpty else {
+        guard isVisibleAppServerUserMessageText(content) else {
             return nil
         }
         let itemID = metadata.itemID ?? item["id"]?.stringValue
@@ -1568,6 +1590,13 @@ struct CodexAppServerEventProjector {
                 ?? nestedString(in: params, key: "error", nestedKey: "code"),
             retryable: params["retryable"]?.boolValue ?? params["willRetry"]?.boolValue
         )
+    }
+
+    private func isNonBlockingClaudeRateLimitWarning(_ payload: AgentErrorPayload) -> Bool {
+        payload.message
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .hasPrefix("claude rate-limit status: allowed_warning")
     }
 
     private func appServerMessageID(turnID: TurnID?, itemID: AgentItemID?) -> MessageID? {

--- a/ios/MimiRemote/Sources/Core/Models/AgentRuntimeModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentRuntimeModels.swift
@@ -566,7 +566,7 @@ struct CodexQuotaNotice: Equatable {
             let suffix = resetText.map { L10n.format("ui.expected_value_recovery_you_can_also_click_increase", $0) }
                 ?? L10n.text("ui.you_can_click_increase_quota_or_reset_usage")
             return CodexQuotaNotice(
-                title: L10n.text("ui.codex_message_quota_has_been_exhausted"),
+                title: L10n.format("ui.value_message_quota_has_been_exhausted", rateLimit.displayName),
                 message: L10n.format("ui.value_the_current_quota_is_not_available_value", rateLimit.displayName, suffix),
                 resetDate: resetDate,
                 blocksSending: true,

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
@@ -496,7 +496,7 @@ struct ComposerStatusTray: View {
         traySegment(tokens: tokens, minWidth: 230, layoutPriority: 1) {
             HStack(spacing: 8) {
                 segmentIcon("speedometer", tint: tokens.warning)
-                Text(notice.blocksSending ? L10n.text("ui.quota_has_been_exhausted") : notice.title)
+                Text(notice.title)
                     .font(themeStore.uiFont(.caption, weight: .semibold))
                     .foregroundStyle(tokens.warning)
                     .lineLimit(1)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationAppServerProjectorTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationAppServerProjectorTests.swift
@@ -3,6 +3,32 @@ import XCTest
 
 @MainActor
 extension ConversationDataFlowTests {
+    func testClaudeQuotaPresentationFiltersCompatibilityWarningsAndUsesRuntimeName() throws {
+        var projector = CodexAppServerEventProjector()
+
+        let claudeQuotaWarning = try decodeAppServerNotification(#"{"method":"warning","params":{"threadId":"thr_demo","message":"claude rate-limit status: allowed_warning (resets_at=123)"}}"#)
+        XCTAssertNil(projector.project(claudeQuotaWarning))
+
+        let interruptMarker = try decodeAppServerNotification(#"{"method":"item/completed","params":{"threadId":"thr_demo","turnId":"turn_demo","item":{"type":"userMessage","id":"interrupt_marker","clientId":"client_interrupt","content":[{"type":"text","text":"[Request interrupted by user]\n"}]}}}"#)
+        XCTAssertNil(projector.project(interruptMarker))
+        XCTAssertFalse(isVisibleAppServerUserMessageText("[Request interrupted by user]\n"))
+        XCTAssertTrue(isVisibleAppServerUserMessageText("讨论 [Request interrupted by user] 的含义"))
+
+        let now = Date(timeIntervalSince1970: 1_780_490_700)
+        let claudeNotice = try XCTUnwrap(CodexQuotaNotice.make(
+            rateLimit: RateLimitSummary(
+                limitID: "claude",
+                limitName: "Claude",
+                reachedType: "rejected",
+                primaryUsedPercent: 91,
+                primaryResetsAt: Int64(now.timeIntervalSince1970) + 3_600
+            ),
+            errorMessage: nil,
+            now: now
+        ))
+        XCTAssertEqual(claudeNotice.title, L10n.format("ui.value_message_quota_has_been_exhausted", "Claude"))
+    }
+
     func testCodexAppServerProjectorKeepsLiveToolActionAndLifecycleSemantics() throws {
         var projector = CodexAppServerEventProjector()
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1999,6 +1999,14 @@ extension ConversationDataFlowTests {
             XCTFail("Expected warning")
         }
 
+        let claudeQuotaWarning = try decodeAppServerNotification(#"{"method":"warning","params":{"threadId":"thr_demo","message":"claude rate-limit status: allowed_warning (resets_at=123)"}}"#)
+        XCTAssertNil(projector.project(claudeQuotaWarning))
+
+        let interruptMarker = try decodeAppServerNotification(#"{"method":"item/completed","params":{"threadId":"thr_demo","turnId":"turn_demo","item":{"type":"userMessage","id":"interrupt_marker","clientId":"client_interrupt","content":[{"type":"text","text":"[Request interrupted by user]\n"}]}}}"#)
+        XCTAssertNil(projector.project(interruptMarker))
+        XCTAssertFalse(isVisibleAppServerUserMessageText("[Request interrupted by user]\n"))
+        XCTAssertTrue(isVisibleAppServerUserMessageText("讨论 [Request interrupted by user] 的含义"))
+
         let error = try decodeAppServerNotification(#"{"method":"error","params":{"threadId":"thr_demo","turnId":"turn_demo","error":{"message":"Failed to authenticate","code":"claude_authentication_required"},"willRetry":false}}"#)
         if case .error(let payload, let meta) = try XCTUnwrap(projector.project(error)) {
             XCTAssertEqual(payload.message, "Failed to authenticate")
@@ -2289,7 +2297,20 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(exhaustedDisplay.isExhausted)
         let exhaustedNotice = try XCTUnwrap(CodexQuotaNotice.make(rateLimit: exhaustedLimit, errorMessage: nil, now: now))
         XCTAssertTrue(exhaustedNotice.blocksSending)
-        XCTAssertEqual(exhaustedNotice.title, L10n.text("ui.codex_message_quota_has_been_exhausted"))
+        XCTAssertEqual(exhaustedNotice.title, L10n.format("ui.value_message_quota_has_been_exhausted", "Codex"))
+
+        let claudeNotice = try XCTUnwrap(CodexQuotaNotice.make(
+            rateLimit: RateLimitSummary(
+                limitID: "claude",
+                limitName: "Claude",
+                reachedType: "rejected",
+                primaryUsedPercent: 91,
+                primaryResetsAt: resetEpoch
+            ),
+            errorMessage: nil,
+            now: now
+        ))
+        XCTAssertEqual(claudeNotice.title, L10n.format("ui.value_message_quota_has_been_exhausted", "Claude"))
 
         let secondaryResetEpoch: Int64 = 1_780_497_900
         let secondaryDriven = try XCTUnwrap(CodexUsageDisplaySummary.make(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1999,14 +1999,6 @@ extension ConversationDataFlowTests {
             XCTFail("Expected warning")
         }
 
-        let claudeQuotaWarning = try decodeAppServerNotification(#"{"method":"warning","params":{"threadId":"thr_demo","message":"claude rate-limit status: allowed_warning (resets_at=123)"}}"#)
-        XCTAssertNil(projector.project(claudeQuotaWarning))
-
-        let interruptMarker = try decodeAppServerNotification(#"{"method":"item/completed","params":{"threadId":"thr_demo","turnId":"turn_demo","item":{"type":"userMessage","id":"interrupt_marker","clientId":"client_interrupt","content":[{"type":"text","text":"[Request interrupted by user]\n"}]}}}"#)
-        XCTAssertNil(projector.project(interruptMarker))
-        XCTAssertFalse(isVisibleAppServerUserMessageText("[Request interrupted by user]\n"))
-        XCTAssertTrue(isVisibleAppServerUserMessageText("讨论 [Request interrupted by user] 的含义"))
-
         let error = try decodeAppServerNotification(#"{"method":"error","params":{"threadId":"thr_demo","turnId":"turn_demo","error":{"message":"Failed to authenticate","code":"claude_authentication_required"},"willRetry":false}}"#)
         if case .error(let payload, let meta) = try XCTUnwrap(projector.project(error)) {
             XCTAssertEqual(payload.message, "Failed to authenticate")
@@ -2298,19 +2290,6 @@ extension ConversationDataFlowTests {
         let exhaustedNotice = try XCTUnwrap(CodexQuotaNotice.make(rateLimit: exhaustedLimit, errorMessage: nil, now: now))
         XCTAssertTrue(exhaustedNotice.blocksSending)
         XCTAssertEqual(exhaustedNotice.title, L10n.format("ui.value_message_quota_has_been_exhausted", "Codex"))
-
-        let claudeNotice = try XCTUnwrap(CodexQuotaNotice.make(
-            rateLimit: RateLimitSummary(
-                limitID: "claude",
-                limitName: "Claude",
-                reachedType: "rejected",
-                primaryUsedPercent: 91,
-                primaryResetsAt: resetEpoch
-            ),
-            errorMessage: nil,
-            now: now
-        ))
-        XCTAssertEqual(claudeNotice.title, L10n.format("ui.value_message_quota_has_been_exhausted", "Claude"))
 
         let secondaryResetEpoch: Int64 = 1_780_497_900
         let secondaryDriven = try XCTUnwrap(CodexUsageDisplaySummary.make(


### PR DESCRIPTION
## 目标

修复 Claude allowed_warning 被显示为红色运行异常、额度横幅错误显示 Codex，以及用户中断产生重复错误和内部用户气泡的问题。

## 实现

- 主机 bridge 仅通过 account/rateLimits/updated 发布额度状态；allowed_warning 不再进入时间线，rejected 仍由额度快照阻止发送。
- turn/interrupt 记录精确的本地 interrupt intent；仅对应 turn 的 aborted_streaming 映射为 Interrupted，不吞掉其他流故障，也不新增自动重试。
- Claude transcript 的内部中断标记不再成为用户气泡、回滚锚点或会话标题。
- App 对旧 bridge 的 allowed_warning 和中断用户标记做兼容过滤，并按当前 runtime 显示 Codex/Claude 额度标题。

## 验证

- cargo test -p alleycat-claude-bridge：198 个库测试、4 个二进制测试及全部集成测试通过。
- 固定 iPad Pro 13-inch (M5) Simulator：2 个定向 XCTest 通过。
- Localizable.xcstrings JSON 校验通过；git diff --check 通过。

## 发布边界

- 主机服务候选提交：209ffed4
- App 候选提交：47dd5556
- 关联：MIM-89、MIM-90