### PR TITLE
MIM-82 Mac 启动自动检测并管理 Claude Runtime

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -229,7 +229,7 @@ Linux 使用 `"$HOME/.local/bin/agentd" pair --qr-only`。
 
 Codex 是默认 Runtime。不要写死模型版本；未显式选择模型时交给本机 Codex rollout。保持现有 Codex 登录态、app-server Token 和审批策略。
 
-Claude Code 默认关闭并属于实验通道。它使用一个由 `agentd` 监督的 resident bridge；每个 Claude thread 对应一个 headless 进程。移动端断线不会自动重试 `turn/start`，重连使用 sequence replay 或 `thread/read`，避免重复写文件或执行命令。
+Claude Code 属于实验通道。Mimi Remote Mac 启动时会在本机检测随包 bridge、Claude CLI 和登录态：三项都通过且用户没有明确关闭时自动启用，否则保持关闭；设置页中的明确开关会覆盖后续自动检测。Homebrew / Linux 不执行这项 App 启动策略。它使用一个由 `agentd` 监督的 resident bridge；每个 Claude thread 对应一个 headless 进程。移动端断线不会自动重试 `turn/start`，重连使用 sequence replay 或 `thread/read`，避免重复写文件或执行命令。
 
 启用 Claude 前确认用户接受以下边界：
 
@@ -240,7 +240,7 @@ Claude Code 默认关闭并属于实验通道。它使用一个由 `agentd` 监�
 
 按安装形态处理 bridge：
 
-- **Mimi Remote Mac**：使用 App 内置 bridge，不执行 `cargo install`，不写入其他机器的绝对路径。只修改 `claude.enabled` 等必要字段，保留或清空 `bridge_bin` 以使用随包 sibling；不要打印完整配置文件。
+- **Mimi Remote Mac**：使用 App 内置 bridge，不执行 `cargo install`，不写入其他机器的 bridge 绝对路径。App 通过 `agentd runtime --claude=auto|enabled|disabled` 原子更新 `claude.enabled`、`claude.activation` 和检测到的本机 Claude CLI 路径，保留其他字段与 `0600` 权限；不要打印完整配置文件。
 - **Homebrew / Linux**：安装 `alleycat-claude-bridge >= 0.2.1`，把实际绝对路径写入 `claude.bridge_bin`。
 
 CLI 外置 bridge 安装命令：
@@ -251,7 +251,7 @@ cargo install --git https://github.com/gaixianggeng/codex-ipad-agent.git \
 command -v alleycat-claude-bridge
 ```
 
-配置文件含长期 Token。修改前创建权限为用户私有的本地备份，使用 JSON 解析器原子修改，只更新 `claude` 字段，保持文件权限为 `0600`；不要用 `cat`、日志或聊天展示完整内容。Mac App 当前没有 Runtime 开关时，让用户确认后再执行这一步。
+配置文件含长期 Token。修改前创建权限为用户私有的本地备份，使用 JSON 解析器原子修改，只更新 `claude` 字段，保持文件权限为 `0600`；不要用 `cat`、日志或聊天展示完整内容。Mac App 优先使用设置页开关；用户明确关闭后，不得在后续启动中重新自动启用。
 
 修改后从当前 service owner 的入口重启：
 

--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -77,12 +77,14 @@ func run(args []string) error {
 		return runPair(args)
 	case "network":
 		return runNetwork(args)
+	case "runtime":
+		return runRuntime(args)
 	case "doctor":
 		return runDoctor(args)
 	case "serve":
 		return runServe(args)
 	default:
-		return fmt.Errorf("未知命令 %q，可用命令：up、setup、start、restart、stop、status、logs、pair、network、serve、doctor、version", cmd)
+		return fmt.Errorf("未知命令 %q，可用命令：up、setup、start、restart、stop、status、logs、pair、network、runtime、serve、doctor、version", cmd)
 	}
 }
 

--- a/cmd/agentd/runtime.go
+++ b/cmd/agentd/runtime.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+	agentsetup "github.com/gaixianggeng/mimi-remote/internal/setup"
+)
+
+func runRuntime(args []string) error {
+	return runRuntimeWithWriters(args, os.Stdout, os.Stderr)
+}
+
+func runRuntimeWithWriters(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("runtime", flag.ExitOnError)
+	configPath := fs.String("config", config.DefaultPath(), "配置文件路径")
+	claudePreference := fs.String("claude", "", "Claude 启用策略：auto、enabled 或 disabled")
+	restoreEnabled := fs.Bool("restore-enabled", false, "服务重载失败时恢复先前 enabled 状态")
+	asJSON := fs.Bool("json", false, "输出 JSON")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*claudePreference) == "" {
+		return fmt.Errorf("必须显式传入 --claude=auto、--claude=enabled 或 --claude=disabled")
+	}
+	if err := prepareDefaultConfigMigration(fs, *configPath, stderr); err != nil {
+		return err
+	}
+	preference, err := agentsetup.ParseClaudeActivationPreference(*claudePreference)
+	if err != nil {
+		return err
+	}
+	var restored *bool
+	fs.Visit(func(item *flag.Flag) {
+		if item.Name == "restore-enabled" {
+			value := *restoreEnabled
+			restored = &value
+		}
+	})
+	result, err := agentsetup.ConfigureClaude(
+		context.Background(),
+		*configPath,
+		preference,
+		restored,
+	)
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		return printJSONTo(stdout, result)
+	}
+	state := "关闭"
+	if result.Enabled {
+		state = "开启"
+	}
+	fmt.Fprintf(stdout, "Claude 实验通道：%s\n", state)
+	if strings.TrimSpace(result.Message) != "" {
+		fmt.Fprintln(stdout, result.Message)
+	}
+	if result.RestartRequired {
+		fmt.Fprintln(stdout, "配置已更新，需要重启 agentd 后生效。")
+	}
+	return nil
+}

--- a/docs/claude-bridge-architecture.md
+++ b/docs/claude-bridge-architecture.md
@@ -1,6 +1,6 @@
 # Claude bridge 架构
 
-更新日期：2026-07-26
+更新日期：2026-08-03
 
 ## 目标
 
@@ -53,7 +53,10 @@ sequenceDiagram
 
 ### 生命周期
 
-- `claude.enabled=false` 是默认状态，配置接口只返回 Codex channel。
+- 新配置以 `claude.enabled=false`、`claude.activation=auto` 开始。Mimi Remote Mac 启动时依次检查随包 bridge 兼容版本、Claude CLI 和 `claude auth status`；全部通过才自动启用，否则保持关闭且不影响 Codex 主通道。
+- `claude.activation` 记录用户意图：`auto` 跟随启动检测，`enabled` / `disabled` 是设置页中的明确选择。明确关闭后不得在后续启动中自动启用；明确开启但前置条件暂时失败时，运行状态仍 fail closed，同时保留偏好，环境恢复后可在下次启动自动恢复。兼容旧配置时，没有 `activation` 的 `enabled=true` 视为用户明确开启。
+- 检测到的 Claude CLI 使用本机绝对路径写入 `claude.env.CLAUDE_BRIDGE_CLAUDE_BIN`，避免 LaunchAgent 的精简 `PATH` 导致运行态找不到 CLI；写入过程保留未知字段与配置文件 `0600` 权限。
+- 开关变化由 Mac App 重新加载其管理的 LaunchAgent，并等待 Claude Runtime 达到目标状态；失败时恢复修改前的 `activation` / `enabled` 并再次加载服务。
 - 启用后，`agentd` 用 `--version` 探测 bridge；低于 `0.2.1`、无标准版本或二进制不存在时 fail closed。
 - bridge 与 iOS / Go 代码同仓维护，并随 Mac App 一起构建、签名和安装；`agentd` 优先使用显式配置，否则使用与自身同目录的 `alleycat-claude-bridge`。
 - `agentd` 监督一个 resident bridge，通过 Unix socket 为多次 WebSocket 连接复用同一进程。

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -1,0 +1,413 @@
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/claudebridge"
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+const claudeBinaryEnvKey = "CLAUDE_BRIDGE_CLAUDE_BIN"
+
+type ClaudeActivationPreference string
+
+const (
+	ClaudeActivationAuto     ClaudeActivationPreference = "auto"
+	ClaudeActivationEnabled  ClaudeActivationPreference = "enabled"
+	ClaudeActivationDisabled ClaudeActivationPreference = "disabled"
+)
+
+type ClaudeConfigurationResult struct {
+	Enabled            bool                       `json:"claude_enabled"`
+	Available          bool                       `json:"available"`
+	Preference         ClaudeActivationPreference `json:"preference"`
+	PreviousEnabled    bool                       `json:"previous_enabled"`
+	PreviousPreference ClaudeActivationPreference `json:"previous_preference"`
+	Changed            bool                       `json:"changed"`
+	RestartRequired    bool                       `json:"restart_required"`
+	Reason             string                     `json:"reason"`
+	Message            string                     `json:"message"`
+}
+
+type claudePreflightResult struct {
+	OK        bool
+	ClaudeBin string
+	Reason    string
+	Message   string
+}
+
+func ParseClaudeActivationPreference(raw string) (ClaudeActivationPreference, error) {
+	preference := ClaudeActivationPreference(strings.ToLower(strings.TrimSpace(raw)))
+	switch preference {
+	case ClaudeActivationAuto, ClaudeActivationEnabled, ClaudeActivationDisabled:
+		return preference, nil
+	default:
+		return "", fmt.Errorf("Claude 启用策略只支持 auto、enabled 或 disabled，实际为 %q", raw)
+	}
+}
+
+// ConfigureClaude 只更新 claude.enabled、claude.activation 和检测到的 Claude CLI
+// 绝对路径。其余配置（包括 Token、bridge 参数和未来字段）按原 JSON 原样保留。
+// restoreEnabled 仅供 Mac App 在服务重载失败时恢复调用前状态。
+func ConfigureClaude(
+	ctx context.Context,
+	configPath string,
+	requested ClaudeActivationPreference,
+	restoreEnabled *bool,
+) (ClaudeConfigurationResult, error) {
+	requested, err := ParseClaudeActivationPreference(string(requested))
+	if err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	cfgPath, err := resolveConfigPath(configPath)
+	if err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	info, err := os.Lstat(cfgPath)
+	if err != nil {
+		return ClaudeConfigurationResult{}, fmt.Errorf("读取配置文件状态失败：%w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return ClaudeConfigurationResult{}, fmt.Errorf("配置文件必须是 regular file，不能是目录或符号链接")
+	}
+
+	original, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return ClaudeConfigurationResult{}, fmt.Errorf("读取配置文件失败：%w", err)
+	}
+	document := map[string]json.RawMessage{}
+	if err := json.Unmarshal(original, &document); err != nil {
+		return ClaudeConfigurationResult{}, fmt.Errorf("解析配置文件失败：%w", err)
+	}
+	if document == nil {
+		return ClaudeConfigurationResult{}, fmt.Errorf("配置文件必须是 JSON object")
+	}
+	claudeDocument, err := decodeClaudeDocument(document)
+	if err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	currentEnabled, err := decodeClaudeEnabled(claudeDocument)
+	if err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	previousPreference, err := decodeClaudePreference(claudeDocument, currentEnabled)
+	if err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	result := ClaudeConfigurationResult{
+		Enabled:            currentEnabled,
+		Preference:         previousPreference,
+		PreviousEnabled:    currentEnabled,
+		PreviousPreference: previousPreference,
+	}
+
+	// 启动阶段的 auto 不能覆盖用户已经在设置页做出的明确选择。
+	targetPreference := requested
+	if restoreEnabled == nil && requested == ClaudeActivationAuto && previousPreference != ClaudeActivationAuto {
+		targetPreference = previousPreference
+	}
+
+	cfg, err := config.LoadForDoctor(cfgPath)
+	if err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	targetEnabled := currentEnabled
+	preflight := claudePreflightResult{}
+	if restoreEnabled != nil {
+		targetEnabled = *restoreEnabled
+		preflight = claudePreflightResult{
+			OK:      targetEnabled,
+			Reason:  "restored",
+			Message: "已恢复 Claude 设置。",
+		}
+	} else {
+		switch targetPreference {
+		case ClaudeActivationDisabled:
+			targetEnabled = false
+			preflight = claudePreflightResult{
+				Reason:  "disabled_by_user",
+				Message: "Claude 实验通道已关闭；后续启动不会自动重新启用。",
+			}
+		case ClaudeActivationAuto, ClaudeActivationEnabled:
+			preflight = preflightClaude(ctx, cfg)
+			if preflight.OK {
+				targetEnabled = true
+			} else if requested == ClaudeActivationEnabled {
+				// 用户手动开启但前置条件不满足时不落盘，让 Toggle 回到真实状态。
+				result.Available = false
+				result.Reason = preflight.Reason
+				result.Message = preflight.Message
+				return result, nil
+			} else {
+				// 启动检测始终 fail closed；保留明确偏好，后续环境恢复时可自动重新启用。
+				targetEnabled = false
+			}
+		}
+	}
+
+	currentClaudeBin, err := decodeClaudeBinary(claudeDocument)
+	if err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	targetClaudeBin := currentClaudeBin
+	if targetEnabled && preflight.ClaudeBin != "" {
+		targetClaudeBin = preflight.ClaudeBin
+	}
+	if err := encodeClaudeDocument(
+		claudeDocument,
+		targetEnabled,
+		targetPreference,
+		targetClaudeBin,
+	); err != nil {
+		return ClaudeConfigurationResult{}, err
+	}
+	encodedClaude, err := json.Marshal(claudeDocument)
+	if err != nil {
+		return ClaudeConfigurationResult{}, fmt.Errorf("编码 claude 配置失败：%w", err)
+	}
+	document["claude"] = encodedClaude
+	updated, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return ClaudeConfigurationResult{}, fmt.Errorf("编码配置文件失败：%w", err)
+	}
+	updated = append(updated, '\n')
+	changed := string(updated) != string(original)
+	if changed {
+		if err := writePrivateFileAtomically(cfgPath, updated); err != nil {
+			return ClaudeConfigurationResult{}, fmt.Errorf("原子更新配置文件失败：%w", err)
+		}
+	}
+
+	result.Enabled = targetEnabled
+	result.Available = preflight.OK
+	result.Preference = targetPreference
+	result.Changed = changed
+	result.RestartRequired = currentEnabled != targetEnabled || currentClaudeBin != targetClaudeBin
+	result.Reason = preflight.Reason
+	result.Message = preflight.Message
+	if targetEnabled && preflight.OK && preflight.Message == "" {
+		result.Reason = "ready"
+		result.Message = "已检测到 Claude Code 和兼容的 Claude bridge。"
+	}
+	return result, nil
+}
+
+func decodeClaudeDocument(document map[string]json.RawMessage) (map[string]json.RawMessage, error) {
+	claudeDocument := map[string]json.RawMessage{}
+	if rawClaude, ok := document["claude"]; ok && string(rawClaude) != "null" {
+		if err := json.Unmarshal(rawClaude, &claudeDocument); err != nil {
+			return nil, fmt.Errorf("解析 claude 配置失败：%w", err)
+		}
+		if claudeDocument == nil {
+			claudeDocument = map[string]json.RawMessage{}
+		}
+	}
+	return claudeDocument, nil
+}
+
+func decodeClaudeEnabled(document map[string]json.RawMessage) (bool, error) {
+	current := false
+	if raw, ok := document["enabled"]; ok {
+		if err := json.Unmarshal(raw, &current); err != nil {
+			return false, fmt.Errorf("解析 claude.enabled 失败：%w", err)
+		}
+	}
+	return current, nil
+}
+
+func decodeClaudePreference(
+	document map[string]json.RawMessage,
+	enabled bool,
+) (ClaudeActivationPreference, error) {
+	if raw, ok := document["activation"]; ok {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return "", fmt.Errorf("解析 claude.activation 失败：%w", err)
+		}
+		return ParseClaudeActivationPreference(value)
+	}
+	// 老版本没有设置入口；enabled=true 只可能来自用户手动配置，必须视为明确开启。
+	if enabled {
+		return ClaudeActivationEnabled, nil
+	}
+	return ClaudeActivationAuto, nil
+}
+
+func decodeClaudeBinary(document map[string]json.RawMessage) (string, error) {
+	rawEnv, ok := document["env"]
+	if !ok || string(rawEnv) == "null" {
+		return "", nil
+	}
+	env := map[string]json.RawMessage{}
+	if err := json.Unmarshal(rawEnv, &env); err != nil {
+		return "", fmt.Errorf("解析 claude.env 失败：%w", err)
+	}
+	raw, ok := env[claudeBinaryEnvKey]
+	if !ok {
+		return "", nil
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", fmt.Errorf("解析 claude.env.%s 失败：%w", claudeBinaryEnvKey, err)
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func encodeClaudeDocument(
+	document map[string]json.RawMessage,
+	enabled bool,
+	preference ClaudeActivationPreference,
+	claudeBin string,
+) error {
+	encodedEnabled, _ := json.Marshal(enabled)
+	encodedPreference, _ := json.Marshal(preference)
+	document["enabled"] = encodedEnabled
+	document["activation"] = encodedPreference
+	if claudeBin == "" {
+		return nil
+	}
+	env := map[string]json.RawMessage{}
+	if rawEnv, ok := document["env"]; ok && string(rawEnv) != "null" {
+		if err := json.Unmarshal(rawEnv, &env); err != nil {
+			return fmt.Errorf("解析 claude.env 失败：%w", err)
+		}
+		if env == nil {
+			env = map[string]json.RawMessage{}
+		}
+	}
+	encodedBin, _ := json.Marshal(claudeBin)
+	env[claudeBinaryEnvKey] = encodedBin
+	encodedEnv, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("编码 claude.env 失败：%w", err)
+	}
+	document["env"] = encodedEnv
+	return nil
+}
+
+func preflightClaude(ctx context.Context, cfg config.Config) claudePreflightResult {
+	bridge, ok := claudebridge.ResolveBinary(cfg.Claude.BridgeBin)
+	if !ok {
+		return claudePreflightResult{
+			Reason:  "bridge_missing",
+			Message: "App 内没有可用的 Claude bridge，请重新安装 Mimi Remote Mac。",
+		}
+	}
+	bridgeCtx, cancelBridge := context.WithTimeout(ctx, 2*time.Second)
+	bridgeCommand := exec.CommandContext(
+		bridgeCtx,
+		bridge,
+		append(append([]string{}, cfg.Claude.Args...), "--version")...,
+	)
+	bridgeCommand.Env = claudeCommandEnvironment(cfg.Claude.Env)
+	bridgeVersionOutput, bridgeErr := bridgeCommand.Output()
+	cancelBridge()
+	bridgeVersion, parsed := claudebridge.ParseVersion(string(bridgeVersionOutput))
+	if bridgeErr != nil || !parsed {
+		return claudePreflightResult{
+			Reason:  "bridge_version_unknown",
+			Message: "无法确认 Claude bridge 版本，请重新安装 Mimi Remote Mac。",
+		}
+	}
+	if !claudebridge.IsSupported(bridgeVersion) {
+		return claudePreflightResult{
+			Reason:  "bridge_unsupported",
+			Message: "Claude bridge 版本不兼容，请升级 Mimi Remote Mac。",
+		}
+	}
+
+	configuredClaudeBin := strings.TrimSpace(cfg.Claude.Env[claudeBinaryEnvKey])
+	claudeBin, err := resolveClaudeBin(configuredClaudeBin)
+	if err != nil {
+		return claudePreflightResult{
+			Reason:  "claude_missing",
+			Message: "未检测到 Claude Code。安装并登录后，重新打开 Mimi Remote Mac 即可自动启用。",
+		}
+	}
+	authCtx, cancelAuth := context.WithTimeout(ctx, 5*time.Second)
+	authCommand := exec.CommandContext(authCtx, claudeBin, "auth", "status")
+	authCommand.Env = claudeCommandEnvironment(cfg.Claude.Env)
+	authCommand.Stdout = io.Discard
+	authCommand.Stderr = io.Discard
+	authErr := authCommand.Run()
+	cancelAuth()
+	if authErr != nil {
+		return claudePreflightResult{
+			ClaudeBin: claudeBin,
+			Reason:    "claude_signed_out",
+			Message:   "已检测到 Claude Code，但尚未登录。请先在 Claude Code 中完成登录。",
+		}
+	}
+	return claudePreflightResult{
+		OK:        true,
+		ClaudeBin: claudeBin,
+		Reason:    "ready",
+		Message:   "已检测到 Claude Code 和兼容的 Claude bridge。",
+	}
+}
+
+func resolveClaudeBin(configured string) (string, error) {
+	candidates := []string{strings.TrimSpace(configured), "claude"}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".local", "bin", "claude"),
+			filepath.Join(home, ".npm-global", "bin", "claude"),
+		)
+		if runtime.GOOS == "windows" {
+			candidates = append(candidates,
+				filepath.Join(home, "AppData", "Roaming", "npm", "claude.cmd"),
+			)
+		}
+	}
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		resolved, err := lookupUsableCodexExecutable(candidate)
+		if err != nil {
+			continue
+		}
+		absolute, err := filepath.Abs(resolved)
+		if err == nil {
+			return filepath.Clean(absolute), nil
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
+func claudeCommandEnvironment(extra map[string]string) []string {
+	environment := append([]string{}, os.Environ()...)
+	values := map[string]string{}
+	for _, item := range environment {
+		if key, value, ok := strings.Cut(item, "="); ok {
+			values[key] = value
+		}
+	}
+	for key, value := range extra {
+		key = strings.TrimSpace(key)
+		if key != "" && !strings.Contains(key, "=") {
+			values[key] = value
+		}
+	}
+	values["CLAUDE_BRIDGE_BYPASS_PERMISSIONS"] = "false"
+	environment = environment[:0]
+	for key, value := range values {
+		environment = append(environment, key+"="+value)
+	}
+	return environment
+}

--- a/internal/setup/claude_test.go
+++ b/internal/setup/claude_test.go
@@ -1,0 +1,261 @@
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+func TestConfigureClaudeAutoEnablesReadyRuntimeAndPreservesConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix 可执行脚本模拟 Claude CLI")
+	}
+	configPath := writeClaudeConfigurationFixture(t, 0, false)
+
+	result, err := ConfigureClaude(
+		context.Background(),
+		configPath,
+		ClaudeActivationAuto,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Enabled || !result.Available || !result.Changed || !result.RestartRequired {
+		t.Fatalf("就绪环境应自动开启并要求重启：%+v", result)
+	}
+	if result.Preference != ClaudeActivationAuto || result.Reason != "ready" {
+		t.Fatalf("自动检测结果异常：%+v", result)
+	}
+
+	document := readClaudeConfigurationFixture(t, configPath)
+	claude := document["claude"].(map[string]any)
+	if claude["enabled"] != true || claude["activation"] != "auto" {
+		t.Fatalf("Claude 开关未按 auto 结果写入：%v", claude)
+	}
+	if claude["future_option"] != "keep" || document["future_top_level"] == nil {
+		t.Fatalf("未知配置字段不应丢失：%v", document)
+	}
+	env := claude["env"].(map[string]any)
+	if env["FUTURE_ENV"] != "keep" || env[claudeBinaryEnvKey] == "" {
+		t.Fatalf("Claude env 应保留未知字段并记录 CLI 绝对路径：%v", env)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("配置权限必须保持 0600，实际 %v", info.Mode().Perm())
+	}
+}
+
+func TestConfigureClaudeAutoKeepsRuntimeOffWhenSignedOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix 可执行脚本模拟 Claude CLI")
+	}
+	configPath := writeClaudeConfigurationFixture(t, 1, false)
+
+	result, err := ConfigureClaude(
+		context.Background(),
+		configPath,
+		ClaudeActivationAuto,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Enabled || result.Available || result.Reason != "claude_signed_out" {
+		t.Fatalf("未登录时必须保持关闭并给出明确原因：%+v", result)
+	}
+	document := readClaudeConfigurationFixture(t, configPath)
+	claude := document["claude"].(map[string]any)
+	if claude["enabled"] != false || claude["activation"] != "auto" {
+		t.Fatalf("未登录时应保持 auto + disabled：%v", claude)
+	}
+}
+
+func TestConfigureClaudeExplicitDisableSurvivesLaterAutoDetection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix 可执行脚本模拟 Claude CLI")
+	}
+	configPath := writeClaudeConfigurationFixture(t, 0, true)
+
+	disabled, err := ConfigureClaude(
+		context.Background(),
+		configPath,
+		ClaudeActivationDisabled,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled.Enabled || disabled.Preference != ClaudeActivationDisabled {
+		t.Fatalf("显式关闭结果异常：%+v", disabled)
+	}
+
+	automatic, err := ConfigureClaude(
+		context.Background(),
+		configPath,
+		ClaudeActivationAuto,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if automatic.Enabled || automatic.Preference != ClaudeActivationDisabled ||
+		automatic.Reason != "disabled_by_user" {
+		t.Fatalf("后续启动不得覆盖用户显式关闭：%+v", automatic)
+	}
+}
+
+func TestConfigureClaudeLegacyEnabledFailsClosedButPreservesExplicitChoice(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	document := map[string]any{
+		"auth": map[string]any{"token": "0123456789abcdef0123456789abcdef"},
+		"claude": map[string]any{
+			"enabled":                true,
+			"bridge_bin":             filepath.Join(t.TempDir(), "missing-bridge"),
+			"max_concurrent_bridges": 3,
+		},
+	}
+	writeClaudeDocument(t, configPath, document)
+
+	result, err := ConfigureClaude(
+		context.Background(),
+		configPath,
+		ClaudeActivationAuto,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Enabled || result.Preference != ClaudeActivationEnabled ||
+		!result.RestartRequired || result.Reason != "bridge_missing" {
+		t.Fatalf("旧版手工偏好应保留，但运行状态必须 fail closed：%+v", result)
+	}
+	document = readClaudeConfigurationFixture(t, configPath)
+	claude := document["claude"].(map[string]any)
+	if claude["enabled"] != false || claude["activation"] != "enabled" {
+		t.Fatalf("启动检测失败后应关闭运行状态并保留明确偏好：%v", claude)
+	}
+}
+
+func TestConfigureClaudeFailedManualEnableDoesNotChangeConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix 可执行脚本模拟 Claude CLI")
+	}
+	configPath := writeClaudeConfigurationFixture(t, 1, false)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ConfigureClaude(
+		context.Background(),
+		configPath,
+		ClaudeActivationEnabled,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Changed || result.Enabled || result.Reason != "claude_signed_out" {
+		t.Fatalf("前置条件失败时不应把设置显示为成功：%+v", result)
+	}
+	if string(before) != string(after) {
+		t.Fatal("手动启用失败时配置文件不应发生变化")
+	}
+}
+
+func TestConfigureClaudeRestoreWritesExactPreviousState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix 可执行脚本模拟 Claude CLI")
+	}
+	configPath := writeClaudeConfigurationFixture(t, 0, true)
+	restoreEnabled := false
+
+	result, err := ConfigureClaude(
+		context.Background(),
+		configPath,
+		ClaudeActivationAuto,
+		&restoreEnabled,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Enabled || result.Preference != ClaudeActivationAuto ||
+		result.Reason != "restored" {
+		t.Fatalf("回滚必须精确恢复 auto + disabled：%+v", result)
+	}
+}
+
+func TestParseClaudeActivationPreferenceRejectsUnknownValue(t *testing.T) {
+	if _, err := ParseClaudeActivationPreference("sometimes"); err == nil {
+		t.Fatal("未知 Claude 启用策略必须拒绝")
+	}
+}
+
+func writeClaudeConfigurationFixture(t *testing.T, authExit int, enabled bool) string {
+	t.Helper()
+	root := t.TempDir()
+	bridge := filepath.Join(root, "alleycat-claude-bridge")
+	claude := filepath.Join(root, "claude")
+	writeExecutableFixture(t, bridge, "printf 'alleycat-claude-bridge 0.2.6\\n'\n")
+	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then exit "+strconv.Itoa(authExit)+"; fi\nprintf 'claude 2.1.220\\n'\n")
+	configPath := filepath.Join(root, "config.json")
+	document := map[string]any{
+		"auth": map[string]any{"token": "0123456789abcdef0123456789abcdef"},
+		"claude": map[string]any{
+			"enabled":    enabled,
+			"bridge_bin": bridge,
+			"env": map[string]any{
+				claudeBinaryEnvKey: claude,
+				"FUTURE_ENV":       "keep",
+			},
+			"max_concurrent_bridges": 3,
+			"future_option":          "keep",
+		},
+		"future_top_level": map[string]any{"keep": true},
+	}
+	writeClaudeDocument(t, configPath, document)
+	return configPath
+}
+
+func writeExecutableFixture(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeClaudeDocument(t *testing.T, path string, document map[string]any) {
+	t.Helper()
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readClaudeConfigurationFixture(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := map[string]any{}
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	return document
+}

--- a/macos/MimiRemoteMac/README.md
+++ b/macos/MimiRemoteMac/README.md
@@ -81,7 +81,8 @@ bash scripts/check-macos-installer.sh dist-macos/Mimi-Remote-Mac.dmg
 
 - 正式 Mac App 使用与 `agentd` 同目录的随包 bridge，不要求用户单独安装 Rust 或运行 `cargo install`。
 - `agentd` 监督一个 resident bridge；每个 Claude thread 对应一个 Claude Code headless 进程。移动端重连使用稳定 session 和事件 cursor，不重复提交 `turn/start`。
-- Claude 仍需用户在 Mac 安装并登录 Claude Code，并显式设置 `claude.enabled=true`。保持 `CLAUDE_BRIDGE_BYPASS_PERMISSIONS=false`。
+- App 启动时会检测随包 bridge、Claude CLI 和登录态；三项都可用且用户没有明确关闭时自动启用 Claude，否则保持关闭。用户可在设置页明确开启或关闭，明确关闭会在后续启动中保留。
+- 设置变更通过内嵌 `agentd` 原子更新私有配置并重新加载 App 管理的 LaunchAgent；重载失败会恢复原设置。始终保持 `CLAUDE_BRIDGE_BYPASS_PERMISSIONS=false`，Claude 失败不影响 Codex 主通道。
 - 当前不支持 `goal`、`archive`、`fork`、APNs 后台 push 和跨设备云同步。完整边界见 [Claude bridge 架构](../../docs/claude-bridge-architecture.md)。
 
 ### 运行数据

--- a/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
+++ b/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
@@ -91,6 +91,36 @@ struct NetworkConfigurationResult: Codable, Equatable, Sendable {
     }
 }
 
+enum ClaudeActivationPreference: String, Codable, Equatable, Sendable {
+    case automatic = "auto"
+    case enabled
+    case disabled
+}
+
+struct ClaudeConfigurationResult: Codable, Equatable, Sendable {
+    let enabled: Bool
+    let available: Bool
+    let preference: ClaudeActivationPreference
+    let previousEnabled: Bool
+    let previousPreference: ClaudeActivationPreference
+    let changed: Bool
+    let restartRequired: Bool
+    let reason: String
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case enabled = "claude_enabled"
+        case available
+        case preference
+        case previousEnabled = "previous_enabled"
+        case previousPreference = "previous_preference"
+        case changed
+        case restartRequired = "restart_required"
+        case reason
+        case message
+    }
+}
+
 struct AgentCheck: Codable, Equatable, Identifiable, Sendable {
     let name: String
     let ok: Bool

--- a/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
@@ -32,6 +32,34 @@ struct MacSettingsView: View {
                 }
             }
 
+            Section("Claude") {
+                Toggle("启用 Claude 实验通道", isOn: Binding(
+                    get: { store.claudeEnabled },
+                    set: { enabled in
+                        Task { await store.setClaudeEnabled(enabled) }
+                    }
+                ))
+                .disabled(!store.canChangeClaude)
+
+                LabeledContent("运行状态") {
+                    HStack(spacing: 6) {
+                        if store.isUpdatingClaude {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(store.isUpdatingClaude ? "正在更新" : store.claudeStatusTitle)
+                    }
+                }
+
+                Text(store.claudeStatusDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text("需要本机安装并登录 Claude Code。启用或关闭时会安全地重新加载 agentd；Codex 主通道不受影响。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("隐私") {
                 Text("Mimi Remote Mac 不上传日志、代码、Token 或使用数据。长期 Token 只保存在 agentd 的私有配置中，App 只处理短期配对票据。")
                     .font(.caption)
@@ -40,7 +68,7 @@ struct MacSettingsView: View {
         }
         .formStyle(.grouped)
         .scenePadding()
-        .frame(width: 480, height: 390)
+        .frame(width: 500, height: 540)
         .alert("恢复 Homebrew 服务？", isPresented: $confirmsRestore) {
             Button("取消", role: .cancel) {}
             Button("停止 App 服务并恢复", role: .destructive) {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
@@ -6,6 +6,10 @@ struct AgentCommandClient: Sendable {
     var status: @Sendable () async throws -> AgentStatus
     var statusAt: @Sendable (_ binary: URL) async throws -> AgentStatus
     var doctor: @Sendable (_ fix: Bool) async throws -> DoctorFixResults
+    var configureClaude: @Sendable (
+        _ preference: ClaudeActivationPreference,
+        _ restoreEnabled: Bool?
+    ) async throws -> ClaudeConfigurationResult
     var setLANAccess: @Sendable (_ enabled: Bool) async throws -> NetworkConfigurationResult
     var pair: @Sendable (_ network: PairingNetwork) async throws -> PairingInfo
     var version: @Sendable () async throws -> String
@@ -103,6 +107,17 @@ extension AgentCommandClient {
                 let results = try decode(AgentDoctorResults.self, from: result)
                 return DoctorFixResults(fixes: [], results: results)
             },
+            configureClaude: { preference, restoreEnabled in
+                let binary = try requireEmbeddedBinary()
+                return try decode(ClaudeConfigurationResult.self, from: try await execute(
+                    binary: binary,
+                    arguments: claudeConfigurationArguments(
+                        preference: preference,
+                        restoreEnabled: restoreEnabled
+                    ),
+                    timeout: .seconds(10)
+                ))
+            },
             setLANAccess: { enabled in
                 let binary = try requireEmbeddedBinary()
                 return try decode(NetworkConfigurationResult.self, from: try await execute(
@@ -148,6 +163,21 @@ extension AgentCommandClient {
         var arguments = ["status", "--json"]
         if includeRuntime {
             arguments.append("--runtime")
+        }
+        return arguments
+    }
+
+    static func claudeConfigurationArguments(
+        preference: ClaudeActivationPreference,
+        restoreEnabled: Bool? = nil
+    ) -> [String] {
+        var arguments = [
+            "runtime",
+            "--claude=\(preference.rawValue)",
+            "--json",
+        ]
+        if let restoreEnabled {
+            arguments.append("--restore-enabled=\(restoreEnabled)")
         }
         return arguments
     }

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -18,10 +18,62 @@ final class HostStore {
     private(set) var isRefreshingStatus = false
     private(set) var homebrewLoaded = false
     private(set) var launchesAtLogin = false
+    private(set) var claudeConfiguration: ClaudeConfigurationResult?
+    private(set) var isUpdatingClaude = false
+    private(set) var claudeError: String?
     var lastError: String?
 
     var canRestoreHomebrew: Bool {
         owner == .macApp && homebrew.installedAgentBinary() != nil
+    }
+
+    var claudeEnabled: Bool {
+        claudeConfiguration?.enabled ?? claudeRuntime?.enabled ?? false
+    }
+
+    var canChangeClaude: Bool {
+        owner == .macApp && !isBusy && lifecycle != .loading && lifecycle != .starting
+    }
+
+    var claudeStatusTitle: String {
+        guard owner != .homebrew else { return "等待接管 App 服务" }
+        guard let runtime = claudeRuntime else {
+            return claudeEnabled ? "正在检查" : "已关闭"
+        }
+        switch runtime.state {
+        case .connected: return "已连接"
+        case .available: return "可用"
+        case .signedOut: return "需要登录"
+        case .disabled: return "已关闭"
+        case .unavailable: return "暂不可用"
+        }
+    }
+
+    var claudeStatusDetail: String {
+        if owner == .homebrew {
+            return "先完成 App 服务接管，再由 Mimi Remote Mac 管理 Claude 实验通道。"
+        }
+        if let claudeError {
+            return claudeError
+        }
+        if let runtime = claudeRuntime, runtime.enabled {
+            switch runtime.state {
+            case .connected, .available:
+                return "Claude Code 与 resident bridge 已就绪。"
+            case .signedOut:
+                return "已检测到 Claude Code，但尚未登录。请先在 Claude Code 中完成登录。"
+            case .unavailable:
+                return "Claude Runtime 暂不可用；请检查登录状态或打开诊断查看详情。"
+            case .disabled:
+                break
+            }
+        }
+        return claudeConfiguration?.message
+            ?? "启动时会检测 Claude Code；可用且已登录时自动启用，检测不到时保持关闭。"
+    }
+
+    private var claudeRuntime: AgentRuntimeStatus? {
+        status?.runtimeStatus?.runtimes.first { $0.id.caseInsensitiveCompare("claude") == .orderedSame }
     }
 
     private let agent: AgentCommandClient
@@ -83,7 +135,8 @@ final class HostStore {
             lifecycle = .migrationRequired
             await refreshHomebrewStatus()
         } else {
-            await startMacAgentIfNeeded()
+            let reloadClaudeConfiguration = await reconcileClaudeConfigurationAtLaunch()
+            await startMacAgentIfNeeded(reloadConfiguration: reloadClaudeConfiguration)
         }
         if owner == .macApp, runtimeStatusNeedsFollowUp {
             // App 启动时就把服务端占位快照追到可展示结果，用户第一次展开
@@ -110,6 +163,7 @@ final class HostStore {
             let nextPairing = try await agent.setup(workspaceRoot)
             pairing = nextPairing
             pairingNetwork = nextPairing.network
+            _ = await reconcileClaudeConfigurationAtLaunch()
             await enableLoginLaunchBestEffort()
             owner = .macApp
             try await registerMacAgentAndWaitForReady()
@@ -142,6 +196,7 @@ final class HostStore {
             try await homebrew.stop()
             homebrewLoaded = false
             owner = .macApp
+            _ = await reconcileClaudeConfigurationAtLaunch()
             try await registerMacAgentAndWaitForReady()
         } catch {
             let takeoverError = error
@@ -347,6 +402,47 @@ final class HostStore {
         }
     }
 
+    func setClaudeEnabled(_ enabled: Bool) async {
+        guard !isBusy, owner == .macApp else {
+            claudeError = "请先启动并接管 Mimi Remote Mac 服务。"
+            return
+        }
+        isBusy = true
+        isUpdatingClaude = true
+        claudeError = nil
+        defer {
+            isUpdatingClaude = false
+            isBusy = false
+        }
+
+        do {
+            let preference: ClaudeActivationPreference = enabled ? .enabled : .disabled
+            let result = try await agent.configureClaude(preference, nil)
+            claudeConfiguration = result
+            guard !enabled || result.enabled else {
+                claudeError = result.message
+                return
+            }
+            if result.restartRequired {
+                do {
+                    try await reloadMacAgentForConfigurationChange()
+                    try await waitForClaudeRuntime(enabled: result.enabled)
+                } catch {
+                    let updateError = error
+                    let rolledBack = await rollbackClaudeConfiguration(result)
+                    let rollbackDetail = rolledBack
+                        ? "已恢复修改前的 Claude 设置。"
+                        : "自动恢复也失败，请打开诊断后重试。"
+                    claudeError = "更新 Claude 设置失败：\(updateError.localizedDescription) \(rollbackDetail)"
+                }
+            } else {
+                await refreshMacAgentStatus()
+            }
+        } catch {
+            claudeError = error.localizedDescription
+        }
+    }
+
     func restartService() async {
         guard !isBusy, owner == .macApp else { return }
         isBusy = true
@@ -397,11 +493,15 @@ final class HostStore {
         }
     }
 
-    private func startMacAgentIfNeeded() async {
+    private func startMacAgentIfNeeded(reloadConfiguration: Bool = false) async {
         switch services.agentStatus() {
         case .enabled:
             owner = .macApp
             do {
+                if reloadConfiguration {
+                    try await reloadMacAgentForConfigurationChange()
+                    return
+                }
                 if !services.isAgentRegistrationCurrent() {
                     // Apple 要求 LaunchAgent 的 plist 或可执行文件更新后重新注册。
                     // 先于状态命令处理，才能修复旧签名约束在进程启动前直接 SIGKILL 的升级。
@@ -440,6 +540,93 @@ final class HostStore {
         case .notFound:
             owner = .none
             lifecycle = .failed("App 内缺少 LaunchAgent 配置，请重新安装。")
+        }
+    }
+
+    /// 启动检测只在 Mac App owner 上执行；auto 会尊重配置中已经记录的显式开关。
+    private func reconcileClaudeConfigurationAtLaunch() async -> Bool {
+        do {
+            let result = try await agent.configureClaude(.automatic, nil)
+            claudeConfiguration = result
+            claudeError = result.available || result.preference == .disabled
+                ? nil
+                : result.message
+            return result.restartRequired
+        } catch {
+            // Claude 是实验通道；预检失败不能破坏 Codex 主服务启动。
+            claudeError = "Claude 自动检测失败：\(error.localizedDescription)"
+            return false
+        }
+    }
+
+    private func reloadMacAgentForConfigurationChange() async throws {
+        lifecycle = .starting
+        let endpoint: String?
+        if let currentEndpoint = status?.endpoint {
+            endpoint = currentEndpoint
+        } else {
+            endpoint = (try? await agent.status())?.endpoint
+        }
+        switch services.agentStatus() {
+        case .enabled:
+            try await unregisterMacAgentAndWait(endpoint: endpoint)
+        case .notRegistered:
+            break
+        case .requiresApproval:
+            throw ServiceLifecycleError.requiresApproval
+        case .notFound:
+            throw ServiceLifecycleError.agentNotFound
+        }
+        owner = .macApp
+        try await registerMacAgentAndWaitForReady()
+    }
+
+    private func waitForClaudeRuntime(enabled: Bool) async throws {
+        for attempt in 0..<12 {
+            try Task.checkCancellation()
+            if let current = try? await agent.status() {
+                apply(current)
+                if let runtime = current.runtimeStatus?.runtimes.first(where: {
+                    $0.id.caseInsensitiveCompare("claude") == .orderedSame
+                }) {
+                    if !enabled, !runtime.enabled || runtime.state == .disabled {
+                        return
+                    }
+                    if enabled {
+                        switch runtime.state {
+                        case .connected, .available:
+                            return
+                        case .signedOut:
+                            throw ClaudeRuntimeControlError.signedOut
+                        case .unavailable where runtime.reason != "refresh_in_progress":
+                            throw ClaudeRuntimeControlError.unavailable
+                        case .disabled:
+                            throw ClaudeRuntimeControlError.disabled
+                        case .unavailable:
+                            break
+                        }
+                    }
+                }
+            }
+            if attempt < 11 {
+                try await Task.sleep(for: .seconds(1))
+            }
+        }
+        throw ClaudeRuntimeControlError.timedOut(enabled: enabled)
+    }
+
+    private func rollbackClaudeConfiguration(_ changed: ClaudeConfigurationResult) async -> Bool {
+        do {
+            let restored = try await agent.configureClaude(
+                changed.previousPreference,
+                changed.previousEnabled
+            )
+            claudeConfiguration = restored
+            try await reloadMacAgentForConfigurationChange()
+            try await waitForClaudeRuntime(enabled: restored.enabled)
+            return true
+        } catch {
+            return false
         }
     }
 
@@ -861,6 +1048,22 @@ final class HostStore {
             status: { status },
             statusAt: { _ in status },
             doctor: { _ in DoctorFixResults(fixes: [], results: doctor) },
+            configureClaude: { preference, restoreEnabled in
+                let enabled = restoreEnabled ?? (preference != .disabled)
+                return ClaudeConfigurationResult(
+                    enabled: enabled,
+                    available: enabled,
+                    preference: preference,
+                    previousEnabled: true,
+                    previousPreference: .enabled,
+                    changed: false,
+                    restartRequired: false,
+                    reason: enabled ? "ready" : "disabled_by_user",
+                    message: enabled
+                        ? "已检测到 Claude Code 和兼容的 Claude bridge。"
+                        : "Claude 实验通道已关闭。"
+                )
+            },
             setLANAccess: { enabled in
                 NetworkConfigurationResult(
                     lanEnabled: enabled,
@@ -926,6 +1129,26 @@ private enum ServiceLifecycleError: LocalizedError {
             "请先在系统设置的登录项中允许 Mimi Remote Mac。"
         case .agentNotFound:
             "App 内缺少 LaunchAgent 配置，请重新安装。"
+        }
+    }
+}
+
+private enum ClaudeRuntimeControlError: LocalizedError {
+    case signedOut
+    case unavailable
+    case disabled
+    case timedOut(enabled: Bool)
+
+    var errorDescription: String? {
+        switch self {
+        case .signedOut:
+            "Claude Code 尚未登录。"
+        case .unavailable:
+            "Claude Runtime 未能连接。"
+        case .disabled:
+            "服务重载后 Claude 仍处于关闭状态。"
+        case .timedOut(let enabled):
+            enabled ? "等待 Claude Runtime 连接超时。" : "等待 Claude Runtime 停止超时。"
         }
     }
 }

--- a/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
@@ -26,6 +26,20 @@ final class AgentCommandClientTests: XCTestCase {
         )
     }
 
+    func testClaudeConfigurationArgumentsKeepNormalAndRollbackCallsExplicit() {
+        XCTAssertEqual(
+            AgentCommandClient.claudeConfigurationArguments(preference: .automatic),
+            ["runtime", "--claude=auto", "--json"]
+        )
+        XCTAssertEqual(
+            AgentCommandClient.claudeConfigurationArguments(
+                preference: .disabled,
+                restoreEnabled: true
+            ),
+            ["runtime", "--claude=disabled", "--json", "--restore-enabled=true"]
+        )
+    }
+
     func testProcessCancellationIsReportedAsCancellation() async {
         let executor = ProcessExecutor()
         let task = Task {

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -13,6 +13,129 @@ final class HostStoreTests: XCTestCase {
         XCTAssertEqual(store.owner, .none)
     }
 
+    func testBootstrapAutoEnablesClaudeAndReloadsRunningMacAgent() async {
+        let events = EventRecorder()
+        let registration = LaggingAgentRegistration()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registration.nextStatus() },
+            registerAgent: { events.append("register-mac") },
+            unregisterAgent: { events.append("unregister-mac") },
+            configureClaude: { preference, _ in
+                events.append("configure-\(preference.rawValue)")
+                return Self.claudeConfiguration(
+                    enabled: true,
+                    preference: .automatic,
+                    previousEnabled: false,
+                    previousPreference: .automatic,
+                    changed: true,
+                    restartRequired: true
+                )
+            },
+            healthCheck: { _ in false }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, [
+            "configure-auto", "unregister-mac", "register-mac",
+        ])
+        XCTAssertTrue(store.claudeEnabled)
+        XCTAssertEqual(store.owner, .macApp)
+        XCTAssertEqual(store.lifecycle, .ready)
+    }
+
+    func testDisablingClaudeReloadsServiceAndWaitsForDisabledRuntime() async {
+        let events = EventRecorder()
+        let disabledStatus = Self.statusWithClaude(enabled: false, state: .disabled)
+        let store = makeStore(
+            configExists: true,
+            status: { disabledStatus },
+            registerAgent: { events.append("register-mac") },
+            configureClaude: { preference, restoreEnabled in
+                events.append("configure-\(preference.rawValue)")
+                if preference == .automatic {
+                    return Self.claudeConfiguration(enabled: true, preference: .enabled)
+                }
+                return Self.claudeConfiguration(
+                    enabled: restoreEnabled ?? false,
+                    preference: preference,
+                    previousEnabled: true,
+                    previousPreference: .enabled,
+                    changed: true,
+                    restartRequired: true
+                )
+            }
+        )
+        await store.bootstrap()
+
+        await store.setClaudeEnabled(false)
+
+        XCTAssertEqual(events.values, [
+            "configure-auto", "register-mac", "configure-disabled", "register-mac",
+        ])
+        XCTAssertFalse(store.claudeEnabled)
+        XCTAssertNil(store.claudeError)
+        XCTAssertEqual(store.lifecycle, .ready)
+    }
+
+    func testClaudeServiceReloadFailureRestoresPreviousConfiguration() async {
+        let events = EventRecorder()
+        let registrations = CallCounter()
+        let enabledStatus = Self.statusWithClaude(enabled: true, state: .connected)
+        let store = makeStore(
+            configExists: true,
+            status: { enabledStatus },
+            registerAgent: {
+                let call = registrations.increment()
+                events.append("register-\(call)")
+                if call == 2 {
+                    throw TestError.expected
+                }
+            },
+            configureClaude: { preference, restoreEnabled in
+                events.append("configure-\(preference.rawValue)-\(restoreEnabled.map(String.init) ?? "normal")")
+                if preference == .automatic {
+                    return Self.claudeConfiguration(enabled: true, preference: .enabled)
+                }
+                if let restoreEnabled {
+                    return Self.claudeConfiguration(
+                        enabled: restoreEnabled,
+                        preference: preference,
+                        previousEnabled: false,
+                        previousPreference: .disabled,
+                        changed: true,
+                        restartRequired: true,
+                        reason: "restored"
+                    )
+                }
+                return Self.claudeConfiguration(
+                    enabled: false,
+                    preference: .disabled,
+                    previousEnabled: true,
+                    previousPreference: .enabled,
+                    changed: true,
+                    restartRequired: true
+                )
+            }
+        )
+        await store.bootstrap()
+
+        await store.setClaudeEnabled(false)
+
+        XCTAssertEqual(events.values, [
+            "configure-auto-normal",
+            "register-1",
+            "configure-disabled-normal",
+            "register-2",
+            "configure-enabled-true",
+            "register-3",
+        ])
+        XCTAssertTrue(store.claudeEnabled)
+        XCTAssertTrue(store.claudeError?.contains("已恢复修改前") == true)
+        XCTAssertEqual(store.lifecycle, .ready)
+    }
+
     func testBootstrapDetectsRunningHomebrewServiceWithoutChangingIt() async {
         let store = makeStore(configExists: true, homebrewLoaded: true)
 
@@ -449,6 +572,17 @@ final class HostStoreTests: XCTestCase {
         unregisterAgent: @escaping @MainActor () async throws -> Void = {},
         homebrewStart: @escaping @Sendable () async throws -> Void = {},
         homebrewStop: @escaping @Sendable () async throws -> Void = {},
+        configureClaude: @escaping @Sendable (
+            ClaudeActivationPreference,
+            Bool?
+        ) async throws -> ClaudeConfigurationResult = { preference, restoreEnabled in
+            HostStoreTests.claudeConfiguration(
+                enabled: restoreEnabled ?? false,
+                preference: preference,
+                previousEnabled: false,
+                previousPreference: .automatic
+            )
+        },
         setLANAccess: @escaping @Sendable (Bool) async throws -> NetworkConfigurationResult = {
             NetworkConfigurationResult(lanEnabled: $0, changed: false, restartRequired: false)
         },
@@ -464,6 +598,7 @@ final class HostStoreTests: XCTestCase {
             status: status,
             statusAt: { _ in readyStatus },
             doctor: { _ in DoctorFixResults(fixes: [], results: doctor) },
+            configureClaude: configureClaude,
             setLANAccess: setLANAccess,
             pair: pair ?? { _ in Self.pairing },
             version: { readyStatus.version }
@@ -527,6 +662,64 @@ final class HostStoreTests: XCTestCase {
             pairExpires: nil
         )
     }()
+
+    private nonisolated static func statusWithClaude(
+        enabled: Bool,
+        state: AgentRuntimeConnectionState
+    ) -> AgentStatus {
+        AgentStatus(
+            processOK: readyStatus.processOK,
+            serviceOK: readyStatus.serviceOK,
+            processError: readyStatus.processError,
+            serviceError: readyStatus.serviceError,
+            version: readyStatus.version,
+            endpoint: readyStatus.endpoint,
+            configPath: readyStatus.configPath,
+            projects: readyStatus.projects,
+            doctorOK: readyStatus.doctorOK,
+            doctor: readyStatus.doctor,
+            pairExpires: nil,
+            runtimeStatus: AgentRuntimeStatusSnapshot(
+                checkedAt: "2026-08-03T03:00:00Z",
+                runtimes: [
+                    AgentRuntimeStatus(
+                        id: "claude",
+                        title: "Claude",
+                        enabled: enabled,
+                        state: state,
+                        authMode: enabled ? "oauth" : nil,
+                        planType: enabled ? "pro" : nil,
+                        reason: enabled ? nil : "disabled",
+                        rateLimits: nil
+                    ),
+                ]
+            )
+        )
+    }
+
+    private nonisolated static func claudeConfiguration(
+        enabled: Bool,
+        preference: ClaudeActivationPreference,
+        previousEnabled: Bool = false,
+        previousPreference: ClaudeActivationPreference = .automatic,
+        changed: Bool = false,
+        restartRequired: Bool = false,
+        reason: String? = nil
+    ) -> ClaudeConfigurationResult {
+        ClaudeConfigurationResult(
+            enabled: enabled,
+            available: enabled,
+            preference: preference,
+            previousEnabled: previousEnabled,
+            previousPreference: previousPreference,
+            changed: changed,
+            restartRequired: restartRequired,
+            reason: reason ?? (enabled ? "ready" : "disabled_by_user"),
+            message: enabled
+                ? "已检测到 Claude Code 和兼容的 Claude bridge。"
+                : "Claude 实验通道已关闭。"
+        )
+    }
 }
 
 @MainActor
@@ -560,5 +753,17 @@ private final class EventRecorder: @unchecked Sendable {
         lock.lock()
         storage.append(value)
         lock.unlock()
+    }
+}
+
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
     }
 }

--- a/packaging/public/README.md
+++ b/packaging/public/README.md
@@ -122,7 +122,7 @@ macOS 上的 `agentd restart` 使用 launchd 单次原子重启，可以从当�
 
 ### Claude Code 可选通道
 
-Claude 通道默认关闭，需要 `alleycat-claude-bridge >= 0.2.1`。Mimi Remote Mac 已内置经过签名的兼容 bridge，不要为 DMG 安装重复执行 `cargo install`；只需在私有备份后显式设置 `claude.enabled=true`，保留或清空 `bridge_bin` 以使用随包 sibling。
+Claude 通道需要 `alleycat-claude-bridge >= 0.2.1`。Mimi Remote Mac 已内置经过签名的兼容 bridge，不要为 DMG 安装重复执行 `cargo install`。App 启动时会检测随包 bridge、Claude CLI 和登录态；全部通过且用户没有明确关闭时自动启用，否则保持关闭。设置页可明确开启或关闭，明确关闭会在后续启动中保留。
 
 Homebrew、Linux 或独立开发环境才需要从完整源码仓库安装外置 bridge：
 
@@ -133,7 +133,7 @@ cargo install --git https://github.com/gaixianggeng/codex-ipad-agent.git \
 command -v alleycat-claude-bridge
 ```
 
-把最后一条命令返回的绝对路径写入配置的 `claude.bridge_bin`，设置 `claude.enabled=true`，然后执行：
+Homebrew / Linux 用户把最后一条命令返回的绝对路径写入配置的 `claude.bridge_bin`，设置 `claude.enabled=true`，然后执行：
 
 ```bash
 agentd restart

--- a/packaging/skill/install-mimi-remote/SKILL.md
+++ b/packaging/skill/install-mimi-remote/SKILL.md
@@ -229,7 +229,7 @@ Linux 使用 `"$HOME/.local/bin/agentd" pair --qr-only`。
 
 Codex 是默认 Runtime。不要写死模型版本；未显式选择模型时交给本机 Codex rollout。保持现有 Codex 登录态、app-server Token 和审批策略。
 
-Claude Code 默认关闭并属于实验通道。它使用一个由 `agentd` 监督的 resident bridge；每个 Claude thread 对应一个 headless 进程。移动端断线不会自动重试 `turn/start`，重连使用 sequence replay 或 `thread/read`，避免重复写文件或执行命令。
+Claude Code 属于实验通道。Mimi Remote Mac 启动时会在本机检测随包 bridge、Claude CLI 和登录态：三项都通过且用户没有明确关闭时自动启用，否则保持关闭；设置页中的明确开关会覆盖后续自动检测。Homebrew / Linux 不执行这项 App 启动策略。它使用一个由 `agentd` 监督的 resident bridge；每个 Claude thread 对应一个 headless 进程。移动端断线不会自动重试 `turn/start`，重连使用 sequence replay 或 `thread/read`，避免重复写文件或执行命令。
 
 启用 Claude 前确认用户接受以下边界：
 
@@ -240,7 +240,7 @@ Claude Code 默认关闭并属于实验通道。它使用一个由 `agentd` 监�
 
 按安装形态处理 bridge：
 
-- **Mimi Remote Mac**：使用 App 内置 bridge，不执行 `cargo install`，不写入其他机器的绝对路径。只修改 `claude.enabled` 等必要字段，保留或清空 `bridge_bin` 以使用随包 sibling；不要打印完整配置文件。
+- **Mimi Remote Mac**：使用 App 内置 bridge，不执行 `cargo install`，不写入其他机器的 bridge 绝对路径。App 通过 `agentd runtime --claude=auto|enabled|disabled` 原子更新 `claude.enabled`、`claude.activation` 和检测到的本机 Claude CLI 路径，保留其他字段与 `0600` 权限；不要打印完整配置文件。
 - **Homebrew / Linux**：安装 `alleycat-claude-bridge >= 0.2.1`，把实际绝对路径写入 `claude.bridge_bin`。
 
 CLI 外置 bridge 安装命令：
@@ -251,7 +251,7 @@ cargo install --git https://github.com/gaixianggeng/codex-ipad-agent.git \
 command -v alleycat-claude-bridge
 ```
 
-配置文件含长期 Token。修改前创建权限为用户私有的本地备份，使用 JSON 解析器原子修改，只更新 `claude` 字段，保持文件权限为 `0600`；不要用 `cat`、日志或聊天展示完整内容。Mac App 当前没有 Runtime 开关时，让用户确认后再执行这一步。
+配置文件含长期 Token。修改前创建权限为用户私有的本地备份，使用 JSON 解析器原子修改，只更新 `claude` 字段，保持文件权限为 `0600`；不要用 `cat`、日志或聊天展示完整内容。Mac App 优先使用设置页开关；用户明确关闭后，不得在后续启动中重新自动启用。
 
 修改后从当前 service owner 的入口重启：
 


### PR DESCRIPTION
## 变更内容

- 新增 `agentd runtime --claude=auto|enabled|disabled`，原子更新 Claude 有效开关与用户偏好，并保留未知配置字段、Token 和 `0600` 权限。
- Mac App 启动时检测随包 bridge 版本、Claude CLI 与登录态；全部通过才自动启用，检测失败时 fail closed，且不影响 Codex 主通道。
- 设置页新增 Claude 实验通道开关与运行状态。服务重载或 Runtime 就绪失败时恢复修改前配置。
- 更新 Mac、公开安装说明、架构文档与安装 Skill，统一自动检测和显式关闭语义。

## 原因与用户影响

此前菜单能提示 Claude Runtime，但 Mac 设置页没有入口，用户只能手工编辑私有配置，而且 App 启动不会根据本机实际环境收敛开关。本改动让默认行为成为确定性的本机检测，同时确保用户明确关闭后不会被下次启动覆盖。

## 验证

- `go test ./...`
- `go vet ./...`
- `xcodebuild -project MimiRemoteMac.xcodeproj -scheme MimiRemoteMac -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -quiet`
- `bash ./scripts/check-source-size.sh`
- `bash ./scripts/check-packaging.sh`
- `git diff --check`

Linear: MIM-82
