### PR TITLE
MIM-77 Fit iPhone model picker to content height

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -21,6 +21,7 @@ struct ComposerView: View {
     @EnvironmentObject var themeStore: ThemeStore
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) var reduceMotion
     @Environment(\.accessibilityReduceTransparency) var reduceTransparency
     @State var composerState = ComposerState()
@@ -1658,13 +1659,20 @@ struct ComposerView: View {
             )
             .environmentObject(themeStore)
             .presentationCompactAdaptation(horizontal: .sheet, vertical: .sheet)
-            // Picker 自身按实际模型行数提供 184/236/288pt 的标准内容高度；
-            // iOS 26 的 fitted presentation 直接贴合该高度，Claude 不会再继承
-            // Codex 三行 + 快速按钮的固定空白。
-            .presentationSizing(.fitted)
+            // compact popover 转成 sheet 后，iOS 26 不会稳定采用 fitted 内容高度。
+            // 标准字号只保留与实际模型行数一致的 detent；辅助功能字号则使用
+            // large detent，并继续由 Picker 内部滚动，避免放大文字被裁切。
+            .presentationDetents(modelPickerPresentationDetents)
             .presentationDragIndicator(.visible)
             .presentationBackground(themeStore.tokens(for: colorScheme).surface)
         }
+    }
+
+    var modelPickerPresentationDetents: Set<PresentationDetent> {
+        if dynamicTypeSize.isAccessibilitySize {
+            return [.large]
+        }
+        return [.height(modelReasoningGridLayout.standardContentHeight)]
     }
 
     var effectiveModelID: String? {

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -491,10 +491,21 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         let model = app.descendant(identifier: "composer.model")
         XCTAssertTrue(model.waitForExistence(timeout: 10), "Composer 应展示模型入口")
         model.tap()
+        let modelPicker = app.descendant(identifier: "composer.modelPicker")
         XCTAssertTrue(
-            app.descendant(identifier: "composer.modelPicker").waitForExistence(timeout: 8),
+            modelPicker.waitForExistence(timeout: 8),
             "模型选择浮层应能正常构建，不能触发 compact toolbar 栈溢出"
         )
+        assertCompactModelPickerFitsWindow(modelPicker)
+        dismissPresentedMenuOrPopover()
+
+        rotate(to: .landscapeLeft)
+        let landscapeModel = app.descendant(identifier: "composer.model")
+        XCTAssertTrue(landscapeModel.waitForExistence(timeout: 10), "横屏后 Composer 应保留模型入口")
+        landscapeModel.tap()
+        let landscapePicker = app.descendant(identifier: "composer.modelPicker")
+        XCTAssertTrue(landscapePicker.waitForExistence(timeout: 8), "横屏模型选择浮层应能正常构建")
+        assertCompactModelPickerFitsWindow(landscapePicker)
         dismissPresentedMenuOrPopover()
         XCTAssertEqual(app.state, .runningForeground, "完成紧凑工具栏操作后 App 应保持前台运行")
     }
@@ -972,6 +983,28 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         // 真机读取的是系统最终命中矩形，可同时覆盖 SwiftUI 内容形状和平台适配结果。
         XCTAssertGreaterThanOrEqual(element.frame.width, 44, "\(name)宽度应至少为 44pt", file: file, line: line)
         XCTAssertGreaterThanOrEqual(element.frame.height, 44, "\(name)高度应至少为 44pt", file: file, line: line)
+    }
+
+    private func assertCompactModelPickerFitsWindow(
+        _ modelPicker: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let windowFrame = app.windows.firstMatch.frame
+        guard min(windowFrame.width, windowFrame.height) < 600 else {
+            return
+        }
+        // 标准字号的 Picker 为 132/184/236pt；辅助功能字号会随 large detent
+        // 增长并在内部滚动。系统没有把 adapted sheet 暴露为 XCUIElement，
+        // 因此用 Picker 到窗口底部的剩余区域守住“不超过一行空白”的用户结果。
+        let maximumUnusedHeight: CGFloat = 52
+        XCTAssertLessThanOrEqual(
+            windowFrame.maxY - modelPicker.frame.maxY,
+            maximumUnusedHeight,
+            "模型 Sheet 应贴合内容，不能在网格上下保留大面积空白",
+            file: file,
+            line: line
+        )
     }
 
     private func assertPopover(


### PR DESCRIPTION
## What changed

- Replaced the compact model picker's fitted presentation sizing with a content-row detent.
- Kept accessibility Dynamic Type on a large, internally scrollable sheet.
- Extended the Composer UI smoke test to guard against a large blank region in iPhone portrait and landscape.

## Why

On iPhone, SwiftUI adapts the model popover into a sheet. Under iOS 26, `.presentationSizing(.fitted)` did not reliably constrain that adapted sheet, so the 236pt three-row picker was centered inside an almost full-height presentation.

The compact sheet now uses the picker's calculated 132/184/236pt content height. Regular-width iPad continues to use the anchored system popover.

## User impact

The model picker opens at the height of its visible rows on iPhone, without the large blank area. Accessibility sizes retain enough room and scrolling instead of clipping enlarged controls.

## Validation

- iPhone 17 Pro Simulator: portrait and landscape UI regression passed.
- iPhone 17 Pro Simulator: accessibility-extra-extra-extra-large checked; controls remain visible in the large sheet.
- iPad Pro 13-inch (M5) Simulator: regular-width anchored popover checked.
- Targeted model picker unit/snapshot tests: 2 passed.
- Full MimiRemote test run: 1,183 executed, 4 skipped; 7 unrelated existing snapshot-baseline mismatches, while all MIM-77 model picker tests passed. Xcode 27 beta stalled while saving the failed run's test log and was terminated after the test summary.

Linear: MIM-77
