### PR TITLE
MIM-81 修复 Mac LaunchAgent 缺失记录后的自动恢复

### DIFF
--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -59,7 +59,7 @@ struct MenuBarContentView: View {
 
             if needsPrimaryAction {
                 Button {
-                    presentWindow(.dashboard)
+                    performPrimaryAction()
                 } label: {
                     Label(primaryActionTitle, systemImage: primaryActionSymbol)
                         .fontWeight(.semibold)
@@ -67,6 +67,7 @@ struct MenuBarContentView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
+                .disabled(store.isBusy)
                 .padding(.top, 10)
             }
 
@@ -154,6 +155,17 @@ struct MenuBarContentView: View {
         Task { await store.refresh() }
     }
 
+    private func performPrimaryAction() {
+        switch store.lifecycle {
+        case .notConfigured, .migrationRequired:
+            presentWindow(.dashboard)
+        case .degraded, .stopped, .failed:
+            Task { await store.repairAndStartService() }
+        case .loading, .starting, .ready:
+            break
+        }
+    }
+
     private func presentWindow(_ window: AppWindow) {
         openWindow(id: window.rawValue)
         activateApplication()
@@ -186,15 +198,38 @@ struct MenuBarContentView: View {
     }
 
     private var needsPrimaryAction: Bool {
-        store.lifecycle == .notConfigured || store.lifecycle == .migrationRequired
+        switch store.lifecycle {
+        case .notConfigured, .migrationRequired, .degraded, .stopped, .failed:
+            true
+        case .loading, .starting, .ready:
+            false
+        }
     }
 
     private var primaryActionTitle: String {
-        store.lifecycle == .notConfigured ? "完成首次设置…" : "迁移到 Mimi Remote Mac…"
+        switch store.lifecycle {
+        case .notConfigured:
+            "完成首次设置…"
+        case .migrationRequired:
+            "迁移到 Mimi Remote Mac…"
+        case .degraded, .stopped, .failed:
+            "修复并启动服务"
+        case .loading, .starting, .ready:
+            ""
+        }
     }
 
     private var primaryActionSymbol: String {
-        store.lifecycle == .notConfigured ? "slider.horizontal.3" : "arrow.triangle.2.circlepath"
+        switch store.lifecycle {
+        case .notConfigured:
+            "slider.horizontal.3"
+        case .migrationRequired:
+            "arrow.triangle.2.circlepath"
+        case .degraded, .stopped, .failed:
+            "wrench.and.screwdriver"
+        case .loading, .starting, .ready:
+            ""
+        }
     }
 }
 

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
@@ -2,6 +2,7 @@ import ServiceManagement
 
 struct ServiceManagementClient {
     var agentStatus: @MainActor () -> ServiceRegistrationState
+    var agentConfigurationError: @MainActor () -> String?
     var isAgentRegistrationCurrent: @MainActor () -> Bool
     var markAgentRegistrationCurrent: @MainActor () -> Void
     var registerAgent: @MainActor () throws -> Void
@@ -19,6 +20,9 @@ extension ServiceManagementClient {
         return ServiceManagementClient(
             agentStatus: {
                 registrationState(for: agentService.status)
+            },
+            agentConfigurationError: {
+                validateAgentConfiguration()
             },
             isAgentRegistrationCurrent: {
                 guard let registrationRevision else { return true }
@@ -67,11 +71,45 @@ extension ServiceManagementClient {
 
     @MainActor
     private static var agentService: SMAppService {
-        SMAppService.agent(plistName: "com.gaixianggeng.mimi.mac.agentd.plist")
+        SMAppService.agent(plistName: agentPlistName)
     }
 
     private static let agentRegistrationRevisionKey =
         "MimiRemoteMac.agentRegistrationRevision"
+
+    private static let agentPlistName = "com.gaixianggeng.mimi.mac.agentd.plist"
+
+    /// `.notFound` 只表示 ServiceManagement 没找到服务记录，不能据此判断安装包漏文件。
+    /// 这里直接核对包内 plist 与 BundleProgram，只有资源真的损坏时才要求重新安装。
+    static func validateAgentConfiguration(
+        bundleURL: URL = Bundle.main.bundleURL,
+        fileManager: FileManager = .default
+    ) -> String? {
+        let plistURL = bundleURL
+            .appending(path: "Contents/Library/LaunchAgents", directoryHint: .isDirectory)
+            .appending(path: agentPlistName, directoryHint: .notDirectory)
+        guard fileManager.fileExists(atPath: plistURL.path) else {
+            return "App 包内缺少 LaunchAgent 配置，请重新安装正式版本。"
+        }
+        guard let data = try? Data(contentsOf: plistURL),
+              let propertyList = try? PropertyListSerialization.propertyList(
+                  from: data,
+                  options: [],
+                  format: nil
+              ),
+              let dictionary = propertyList as? [String: Any],
+              let bundleProgram = dictionary["BundleProgram"] as? String,
+              !bundleProgram.isEmpty
+        else {
+            return "App 包内的 LaunchAgent 配置无效，请重新安装正式版本。"
+        }
+
+        let executableURL = bundleURL.appending(path: bundleProgram, directoryHint: .notDirectory)
+        guard fileManager.isExecutableFile(atPath: executableURL.path) else {
+            return "App 包内缺少可执行的 agentd，请重新安装正式版本。"
+        }
+        return nil
+    }
 
     /// SMAppService 不会自动刷新已登记的 LaunchAgent 可执行文件。正式发布的
     /// build number 每次都会递增，因此用 App 版本与构建号识别需要重新注册的升级。

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -361,6 +361,41 @@ final class HostStore {
         }
     }
 
+    /// failed/stopped 状态下的显式恢复入口。只执行一次启动闭环，失败后保留诊断信息，
+    /// 不在后台无限重试，也不改变现有 Token 和配对关系。
+    func repairAndStartService() async {
+        guard !isBusy else { return }
+        if owner == .macApp {
+            await restartService()
+            return
+        }
+
+        isBusy = true
+        lifecycle = .starting
+        lastError = nil
+        defer { isBusy = false }
+
+        guard agent.configExists() else {
+            lifecycle = .notConfigured
+            return
+        }
+        if await homebrew.isLoaded() {
+            homebrewLoaded = true
+            owner = .homebrew
+            lifecycle = .migrationRequired
+            await refreshHomebrewStatus()
+            return
+        }
+        if services.agentStatus() == .requiresApproval {
+            owner = .none
+            lifecycle = .degraded("请在系统设置的登录项中允许 Mimi Remote Mac。")
+            services.openLoginItemsSettings()
+            return
+        }
+        await enableLoginLaunchBestEffort()
+        await startMacAgentIfNeeded()
+    }
+
     /// 菜单栏弹窗关闭后对应 View 可能立即销毁，因此停止任务必须由长生命周期的 Store 持有。
     /// 这个同步入口还会立即更新 UI，让用户明确知道点击已经生效。
     func requestStopServiceAndQuit() {
@@ -401,45 +436,100 @@ final class HostStore {
         switch services.agentStatus() {
         case .enabled:
             owner = .macApp
-            do {
-                if !services.isAgentRegistrationCurrent() {
-                    // Apple 要求 LaunchAgent 的 plist 或可执行文件更新后重新注册。
-                    // 先于状态命令处理，才能修复旧签名约束在进程启动前直接 SIGKILL 的升级。
-                    lifecycle = .starting
+            if !services.isAgentRegistrationCurrent() {
+                // Apple 要求 LaunchAgent 的 plist 或可执行文件更新后重新注册。
+                // 先于状态命令处理，才能修复旧签名约束在进程启动前直接 SIGKILL 的升级。
+                lifecycle = .starting
+                do {
                     try await unregisterMacAgentAndWait(endpoint: status?.endpoint)
-                    try await registerMacAgentAndWaitForReady()
-                    return
+                    try await registerMacAgentAndWaitForReady(allowAutomaticRepair: false)
+                } catch {
+                    fail(error)
                 }
-                let current = try await agent.status()
-                status = current
-                doctor = current.doctor
-                if current.hasAgentVersionMismatch {
-                    // 覆盖安装不会自动替换 launchd 已映射的旧二进制。只在 App
-                    // 启动阶段发现明确版本漂移时做一次受控换代，避免长期半更新。
-                    lifecycle = .starting
-                    try await unregisterMacAgentAndWait(endpoint: current.endpoint)
-                    try await registerMacAgentAndWaitForReady()
-                } else {
-                    apply(current)
-                }
+                return
+            }
+
+            let current: AgentStatus
+            do {
+                current = try await agent.status()
+            } catch is CancellationError {
+                return
             } catch {
-                fail(error)
+                // 已登记却无法执行 status，常见原因是覆盖安装后仍复用旧的 Launch Constraint。
+                // 自动执行一次完整换代，成功后即停止；失败则交给用户诊断，不循环重启。
+                await repairEnabledMacAgent(after: error)
+                return
+            }
+
+            status = current
+            doctor = current.doctor
+            if current.hasAgentVersionMismatch {
+                // 覆盖安装不会自动替换 launchd 已映射的旧二进制。只在 App
+                // 启动阶段发现明确版本漂移时做一次受控换代，避免长期半更新。
+                lifecycle = .starting
+                do {
+                    try await unregisterMacAgentAndWait(endpoint: current.endpoint)
+                    try await registerMacAgentAndWaitForReady(allowAutomaticRepair: false)
+                } catch {
+                    fail(error)
+                }
+            } else {
+                apply(current)
             }
         case .notRegistered:
-            lifecycle = .starting
-            do {
-                try await prepareAutomaticNetworkBeforeServiceStart()
-                owner = .macApp
-                try await registerMacAgentAndWaitForReady()
-            } catch {
-                fail(error)
-            }
+            await registerAvailableMacAgent(recoveringMissingRecord: false)
         case .requiresApproval:
             owner = .none
             lifecycle = .degraded("请在系统设置的登录项中允许 Mimi Remote Mac。")
         case .notFound:
+            // `.notFound` 是 ServiceManagement 的泛化状态，不代表包内 plist 缺失。
+            // 资源完整时主动登记一次，正好覆盖 BTM 丢记录和首次安装两种现场。
+            await registerAvailableMacAgent(recoveringMissingRecord: true)
+        }
+    }
+
+    private func registerAvailableMacAgent(recoveringMissingRecord: Bool) async {
+        if let configurationError = services.agentConfigurationError() {
             owner = .none
-            lifecycle = .failed("App 内缺少 LaunchAgent 配置，请重新安装。")
+            lifecycle = .failed(configurationError)
+            lastError = configurationError
+            return
+        }
+
+        lifecycle = .starting
+        do {
+            try await prepareAutomaticNetworkBeforeServiceStart()
+            owner = .macApp
+            try await registerMacAgentAndWaitForReady()
+        } catch {
+            switch services.agentStatus() {
+            case .requiresApproval:
+                owner = .none
+                lifecycle = .degraded("请在系统设置的登录项中允许 Mimi Remote Mac。")
+            case .enabled:
+                owner = .macApp
+                fail(error)
+            case .notRegistered, .notFound:
+                owner = .none
+                if recoveringMissingRecord {
+                    fail(ServiceLifecycleError.agentRegistrationFailed(error.localizedDescription))
+                } else {
+                    fail(error)
+                }
+            }
+        }
+    }
+
+    private func repairEnabledMacAgent(after initialError: Error) async {
+        lifecycle = .starting
+        do {
+            try await unregisterMacAgentAndWait(endpoint: status?.endpoint)
+            try await registerMacAgentAndWaitForReady(allowAutomaticRepair: false)
+        } catch {
+            fail(ServiceLifecycleError.automaticRepairFailed(
+                initial: initialError.localizedDescription,
+                recovery: error.localizedDescription
+            ))
         }
     }
 
@@ -458,25 +548,44 @@ final class HostStore {
         throw AgentClientError.commandFailed(detail)
     }
 
-    private func registerMacAgentAndWaitForReady() async throws {
-        try services.registerAgent()
-        try await waitForMacAgentReady()
-        // 只有新登记的进程真正通过就绪检查后才记账；失败时下次启动仍会重试迁移。
-        services.markAgentRegistrationCurrent()
+    private func registerMacAgentAndWaitForReady(
+        allowAutomaticRepair: Bool = true
+    ) async throws {
+        do {
+            try services.registerAgent()
+            try await waitForMacAgentReady()
+            // 只有新登记的进程真正通过就绪检查后才记账；失败时下次启动仍会重试迁移。
+            services.markAgentRegistrationCurrent()
+        } catch {
+            guard allowAutomaticRepair, services.agentStatus() == .enabled else {
+                throw error
+            }
+
+            let initialError = error
+            do {
+                // register 已落入 enabled 但进程未就绪时，完整换代一次以刷新 BTM
+                // 的 Launch Constraint；递归调用关闭修复开关，保证最多只重试一次。
+                try await unregisterMacAgentAndWait(endpoint: status?.endpoint)
+                try await registerMacAgentAndWaitForReady(allowAutomaticRepair: false)
+            } catch {
+                throw ServiceLifecycleError.automaticRepairFailed(
+                    initial: initialError.localizedDescription,
+                    recovery: error.localizedDescription
+                )
+            }
+        }
     }
 
     private func waitForMacAgentUnregistered() async throws {
         for attempt in 0..<40 {
             try Task.checkCancellation()
             switch services.agentStatus() {
-            case .notRegistered:
+            case .notRegistered, .notFound:
                 return
             case .enabled:
                 break
             case .requiresApproval:
                 throw ServiceLifecycleError.requiresApproval
-            case .notFound:
-                throw ServiceLifecycleError.agentNotFound
             }
 
             if attempt < 39 {
@@ -543,7 +652,8 @@ final class HostStore {
         case .notRegistered:
             lifecycle = .stopped
         case .notFound:
-            lifecycle = .failed("App 内缺少 LaunchAgent 配置，请重新安装。")
+            owner = .none
+            await startMacAgentIfNeeded()
         }
     }
 
@@ -881,6 +991,7 @@ final class HostStore {
         )
         let services = ServiceManagementClient(
             agentStatus: { .enabled },
+            agentConfigurationError: { nil },
             isAgentRegistrationCurrent: { true },
             markAgentRegistrationCurrent: {},
             registerAgent: {},
@@ -914,7 +1025,8 @@ private enum ServiceLifecycleError: LocalizedError {
     case unregisterTimedOut
     case stopTimedOut
     case requiresApproval
-    case agentNotFound
+    case agentRegistrationFailed(String)
+    case automaticRepairFailed(initial: String, recovery: String)
 
     var errorDescription: String? {
         switch self {
@@ -924,8 +1036,10 @@ private enum ServiceLifecycleError: LocalizedError {
             "旧服务仍占用当前 Endpoint，未继续启动新版本；请稍后重试。"
         case .requiresApproval:
             "请先在系统设置的登录项中允许 Mimi Remote Mac。"
-        case .agentNotFound:
-            "App 内缺少 LaunchAgent 配置，请重新安装。"
+        case .agentRegistrationFailed(let detail):
+            "系统没有找到原服务记录，自动重新登记失败：\(detail)。请运行诊断并重试。"
+        case .automaticRepairFailed(let initial, let recovery):
+            "服务首次启动失败（\(initial)），自动重新登记仍未恢复（\(recovery)）。请运行诊断。"
         }
     }
 }

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -4,6 +4,145 @@ import XCTest
 
 @MainActor
 final class HostStoreTests: XCTestCase {
+    func testBootstrapRegistersBundledAgentWhenServiceRecordIsNotFound() async {
+        let events = EventRecorder()
+        var registrationState = ServiceRegistrationState.notFound
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            registerAgent: {
+                events.append("register-mac")
+                registrationState = .enabled
+            }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, ["register-mac"])
+        XCTAssertEqual(store.owner, .macApp)
+        XCTAssertEqual(store.lifecycle, .ready)
+        XCTAssertNil(store.lastError)
+    }
+
+    func testBootstrapReportsMissingBundledConfigurationWithoutRegistering() async {
+        let events = EventRecorder()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .notFound },
+            agentConfigurationError: { "App 包内缺少 LaunchAgent 配置，请重新安装正式版本。" },
+            registerAgent: { events.append("register-mac") }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, [])
+        XCTAssertEqual(store.owner, .none)
+        XCTAssertEqual(
+            store.lifecycle,
+            .failed("App 包内缺少 LaunchAgent 配置，请重新安装正式版本。")
+        )
+    }
+
+    func testPartialRegistrationFailureTriggersOneBoundedReregistration() async {
+        let events = EventRecorder()
+        var registrationState = ServiceRegistrationState.notRegistered
+        var registrationAttempts = 0
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            registerAgent: {
+                registrationAttempts += 1
+                events.append("register-\(registrationAttempts)")
+                registrationState = .enabled
+                if registrationAttempts == 1 {
+                    throw TestError.expected
+                }
+            },
+            unregisterAgent: {
+                events.append("unregister-mac")
+                registrationState = .notRegistered
+            }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, ["register-1", "unregister-mac", "register-2"])
+        XCTAssertEqual(registrationAttempts, 2)
+        XCTAssertEqual(store.owner, .macApp)
+        XCTAssertEqual(store.lifecycle, .ready)
+    }
+
+    func testEnabledAgentStatusFailureTriggersOneBoundedReregistration() async {
+        let events = EventRecorder()
+        let statusEvents = EventRecorder()
+        var registrationState = ServiceRegistrationState.enabled
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            status: {
+                statusEvents.append("status")
+                if statusEvents.values.count == 1 {
+                    throw TestError.expected
+                }
+                return Self.readyStatus
+            },
+            registerAgent: {
+                events.append("register-mac")
+                registrationState = .enabled
+            },
+            unregisterAgent: {
+                events.append("unregister-mac")
+                registrationState = .notRegistered
+            }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, ["unregister-mac", "register-mac"])
+        XCTAssertEqual(statusEvents.values, ["status", "status"])
+        XCTAssertEqual(store.owner, .macApp)
+        XCTAssertEqual(store.lifecycle, .ready)
+    }
+
+    func testAgentConfigurationValidatorChecksPlistAndExecutable() throws {
+        let fileManager = FileManager.default
+        let bundleURL = fileManager.temporaryDirectory
+            .appending(path: "mimi-agent-bundle-\(UUID().uuidString)", directoryHint: .isDirectory)
+        defer { try? fileManager.removeItem(at: bundleURL) }
+
+        XCTAssertTrue(
+            ServiceManagementClient.validateAgentConfiguration(bundleURL: bundleURL)?
+                .contains("缺少 LaunchAgent 配置") == true
+        )
+
+        let launchAgentsURL = bundleURL.appending(
+            path: "Contents/Library/LaunchAgents",
+            directoryHint: .isDirectory
+        )
+        let resourcesURL = bundleURL.appending(path: "Contents/Resources", directoryHint: .isDirectory)
+        try fileManager.createDirectory(at: launchAgentsURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        let propertyList: [String: Any] = [
+            "Label": "com.gaixianggeng.mimi.mac.agentd",
+            "BundleProgram": "Contents/Resources/agentd",
+        ]
+        let propertyListData = try PropertyListSerialization.data(
+            fromPropertyList: propertyList,
+            format: .xml,
+            options: 0
+        )
+        try propertyListData.write(
+            to: launchAgentsURL.appending(path: "com.gaixianggeng.mimi.mac.agentd.plist")
+        )
+
+        let executableURL = resourcesURL.appending(path: "agentd")
+        try Data().write(to: executableURL)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
+
+        XCTAssertNil(ServiceManagementClient.validateAgentConfiguration(bundleURL: bundleURL))
+    }
+
     func testBootstrapRequiresSetupWhenConfigIsMissing() async {
         let store = makeStore(configExists: false)
 
@@ -440,6 +579,7 @@ final class HostStoreTests: XCTestCase {
         configExists: Bool,
         homebrewLoaded: Bool = false,
         agentStatus: @escaping @MainActor () -> ServiceRegistrationState = { .notRegistered },
+        agentConfigurationError: @escaping @MainActor () -> String? = { nil },
         isAgentRegistrationCurrent: @escaping @MainActor () -> Bool = { true },
         markAgentRegistrationCurrent: @escaping @MainActor () -> Void = {},
         status: @escaping @Sendable () async throws -> AgentStatus = {
@@ -470,6 +610,7 @@ final class HostStoreTests: XCTestCase {
         )
         let services = ServiceManagementClient(
             agentStatus: agentStatus,
+            agentConfigurationError: agentConfigurationError,
             isAgentRegistrationCurrent: isAgentRegistrationCurrent,
             markAgentRegistrationCurrent: markAgentRegistrationCurrent,
             registerAgent: registerAgent,


### PR DESCRIPTION
## 改动

- 将 `SMAppService.Status.notFound` 视为“系统未找到服务记录”，在包内 LaunchAgent 资源完整时主动重新登记，而不是误报安装包缺文件。
- 对已登记但无法启动、以及登记后未就绪的状态执行最多一次 unregister/register 修复，避免无限重试。
- 只有 plist、`BundleProgram` 或 `agentd` 确实缺失/无效时才提示重新安装。
- 在菜单栏失败/停止状态增加“修复并启动服务”入口，并补充对应状态机回归测试。

## 根因与影响

0.2.11 安装包中的 LaunchAgent plist 和 `agentd` 实际完整且签名有效，但系统 BTM/ServiceManagement 中没有对应服务记录。旧逻辑把 `.notFound` 直接映射为“App 内缺少 LaunchAgent 配置”，因此不会尝试注册服务，导致重新安装也无法恢复。

修复后首次安装、BTM 记录缺失以及覆盖安装后残留旧 Launch Constraint 的场景都会走一次有界恢复；失败时保留可诊断的真实错误。

## 验证

- `HostStoreTests`：21/21 通过。
- Mac 完整测试：44/44 通过。
- `bash ./scripts/check-packaging.sh` 通过。
- 本机 Apple Development 签名 Release 构建成功：0.2.12 (10)。
- 覆盖安装到 `/Applications` 后，系统成功创建 BTM agent 记录；`process_ok`、`service_ok`、`doctor_ok` 均为 true。
- 显式重启服务后 PID 从 44940 切换为 45687，readyz 返回 200，App/服务版本一致为 `0.2.12+mac.10`。

关联：MIM-81
