### PR TITLE
MIM-98 Add TestFlight badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 </p>
 
 <p align="center">
+  <a href="https://testflight.apple.com/join/jhGPbSk6"><img src="https://img.shields.io/badge/TestFlight-Join%20Beta-0D96F6?logo=apple&amp;logoColor=white" alt="Join the Mimi Remote beta on TestFlight" /></a>
   <a href="ios/MimiRemote/README.md"><img src="https://img.shields.io/badge/iOS%20%2F%20iPadOS-26%2B-black?logo=apple" alt="iOS and iPadOS 26 or later" /></a>
   <a href="ios/MimiRemote"><img src="https://img.shields.io/badge/SwiftUI-native-F05138?logo=swift&amp;logoColor=white" alt="Native SwiftUI app" /></a>
   <a href="https://github.com/gaixianggeng/codex-ipad-agent/actions/workflows/go-ci.yml"><img src="https://github.com/gaixianggeng/codex-ipad-agent/actions/workflows/go-ci.yml/badge.svg" alt="Go CI status" /></a>


### PR DESCRIPTION
## What changed

- Added a prominent TestFlight badge to the first badge row in the GitHub README.
- Linked the badge to the public Mimi Remote beta: https://testflight.apple.com/join/jhGPbSk6
- Used the TestFlight brand blue with an Apple icon and descriptive alternative text.

## Why

The README already mentioned TestFlight lower on the page, but visitors could not discover the install path from the repository hero area.

## Impact

Visitors can now open the public beta directly from the GitHub repository homepage. No app, release, or build configuration changed.

## Validation

- `git diff --check`
- TestFlight URL returned HTTP 200
- Shields.io badge returned HTTP 200 as SVG
- GitHub Markdown API rendered the expected link, badge source, and alt text

Linear: MIM-98