### PR TITLE
MIM-47 修复 Claude 会话跨设备历史不一致

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -143,6 +143,7 @@ struct EventDriverRegistration {
 
 enum EventDriverCommand {
     BeginTurn {
+        state: Arc<ConnectionState>,
         turn_id: String,
         started_at: i64,
         turn_guard: TurnGuard,
@@ -323,7 +324,9 @@ pub async fn handle_turn_start(
 
     let started_at = now_unix_secs();
     let turn_guard = state.session().begin_turn();
-    if let Err(error) = begin_driver_turn(&driver, &turn_id, started_at, turn_guard).await {
+    if let Err(error) =
+        begin_driver_turn(&driver, Arc::clone(state), &turn_id, started_at, turn_guard).await
+    {
         return match error {
             BeginDriverTurnError::AlreadyActive(active_turn_id) => {
                 // 竞态中的失败属于现有轮次，不能把进程池错误标成 idle。
@@ -817,6 +820,7 @@ fn ensure_event_driver(
 
 async fn begin_driver_turn(
     driver: &mpsc::UnboundedSender<EventDriverCommand>,
+    state: Arc<ConnectionState>,
     turn_id: &str,
     started_at: i64,
     turn_guard: TurnGuard,
@@ -824,6 +828,7 @@ async fn begin_driver_turn(
     let (ready_tx, ready_rx) = oneshot::channel();
     driver
         .send(EventDriverCommand::BeginTurn {
+            state,
             turn_id: turn_id.to_string(),
             started_at,
             turn_guard,
@@ -859,6 +864,7 @@ async fn run_event_driver(mut args: EventDriverArgs) {
             command = args.commands_rx.recv() => {
                 match command {
                     Some(EventDriverCommand::BeginTurn {
+                        state,
                         turn_id,
                         started_at,
                         turn_guard,
@@ -870,6 +876,10 @@ async fn run_event_driver(mut args: EventDriverArgs) {
                             )));
                             continue;
                         }
+                        // driver 跨页面和连接常驻，但每个被接受的 turn 必须归属
+                        // 发起它的 ConnectionState。只在确认当前空闲后 rebind，
+                        // 避免被 AlreadyActive 拒绝的请求偷走正在运行 turn 的事件。
+                        args.state = state;
                         // 当前 turn 的 guard 已覆盖 session；后台等待 guard 暂时
                         // 释放，结束时如果仍有 cron/wakeup 会重新建立。
                         background.session_guard.take();
@@ -1317,7 +1327,10 @@ fn state_should_emit(state: &Arc<ConnectionState>, notif: &p::ServerNotification
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
+    use serde_json::json;
 
     async fn dummy_state() -> Arc<ConnectionState> {
         let dir = tempfile::tempdir().unwrap();
@@ -1333,6 +1346,111 @@ mod tests {
             Default::default(),
         );
         state
+    }
+
+    async fn paired_states() -> (
+        Arc<ConnectionState>,
+        tokio::sync::mpsc::UnboundedReceiver<alleycat_bridge_core::session::Sequenced>,
+        Arc<ConnectionState>,
+        tokio::sync::mpsc::UnboundedReceiver<alleycat_bridge_core::session::Sequenced>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let index = alleycat_bridge_core::ThreadIndex::<crate::index::ClaudeSessionRef>::open_at(
+            dir.path().join("t.json"),
+        )
+        .await
+        .unwrap();
+        std::mem::forget(dir);
+
+        let pool = Arc::new(crate::pool::ClaudePool::new("/dev/null"));
+        let (first, first_rx) =
+            ConnectionState::for_test(Arc::clone(&pool), index.clone(), Default::default());
+        let (second, second_rx) = ConnectionState::for_test(pool, index, Default::default());
+        (first, first_rx, second, second_rx)
+    }
+
+    fn emit_successful_text_turn(
+        events: &broadcast::Sender<ClaudeEvent>,
+        text: &str,
+        event_id: &str,
+    ) {
+        let outbound = |value| serde_json::from_value(value).expect("valid claude event");
+        for payload in [
+            outbound(json!({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""}
+                },
+                "session_id": "test-session",
+                "uuid": format!("{event_id}-start")
+            })),
+            outbound(json!({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": text}
+                },
+                "session_id": "test-session",
+                "uuid": format!("{event_id}-delta")
+            })),
+            outbound(json!({
+                "type": "stream_event",
+                "event": {"type": "content_block_stop", "index": 0},
+                "session_id": "test-session",
+                "uuid": format!("{event_id}-stop")
+            })),
+            outbound(json!({
+                "type": "result",
+                "subtype": "success",
+                "is_error": false,
+                "result": text,
+                "session_id": "test-session",
+                "uuid": format!("{event_id}-result"),
+                "permission_denials": []
+            })),
+        ] {
+            events
+                .send(ClaudeEvent::new(payload))
+                .expect("event driver subscribed");
+        }
+    }
+
+    async fn wait_for_completed_turn(state: &ConnectionState, thread_id: &str, turn_id: &str) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if state
+                    .thread_log(thread_id)
+                    .iter()
+                    .any(|turn| turn.id == turn_id && turn.status == p::TurnStatus::Completed)
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("turn should complete");
+    }
+
+    fn drain_turn_methods(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<alleycat_bridge_core::session::Sequenced>,
+        turn_id: &str,
+    ) -> Vec<String> {
+        let mut methods = Vec::new();
+        while let Ok(frame) = rx.try_recv() {
+            if frame.payload.to_string().contains(turn_id)
+                && let Some(method) = frame
+                    .payload
+                    .get("method")
+                    .and_then(serde_json::Value::as_str)
+            {
+                methods.push(method.to_string());
+            }
+        }
+        methods
     }
 
     #[tokio::test]
@@ -1538,6 +1656,89 @@ mod tests {
         assert_eq!(active.turn_id, "tu1");
         clear_active_turn(&thread_id);
         assert!(active_turn(&thread_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn reused_event_driver_rebinds_each_turn_to_its_connection_state() {
+        let thread_id = format!("test-{}", Uuid::now_v7());
+        let (first, mut first_rx, second, mut second_rx) = paired_states().await;
+        let (writer_tx, _writer_rx) = mpsc::unbounded_channel();
+        let (events_tx, _events_rx) = broadcast::channel(16);
+        let handle = Arc::new(ClaudeProcessHandle::__test_dangling(
+            writer_tx,
+            events_tx.clone(),
+            PathBuf::from("/tmp"),
+        ));
+
+        let first_driver = ensure_event_driver(&first, &thread_id, &handle);
+        begin_driver_turn(
+            &first_driver,
+            Arc::clone(&first),
+            "turn-first",
+            1,
+            first.session().begin_turn(),
+        )
+        .await
+        .expect("first turn accepted");
+        first.record_turn_started(&thread_id, "turn-first".into(), 1);
+        emit_successful_text_turn(&events_tx, "first reply", "first");
+        wait_for_completed_turn(&first, &thread_id, "turn-first").await;
+
+        assert!(second.thread_log(&thread_id).is_empty());
+        assert!(
+            drain_turn_methods(&mut first_rx, "turn-first")
+                .iter()
+                .any(|method| method == "turn/completed")
+        );
+        assert!(drain_turn_methods(&mut second_rx, "turn-first").is_empty());
+
+        // 第二个页面复用同一个进程和 driver；事件、live cache 和完成通知都应
+        // 跟随新 turn 的 ConnectionState，不能继续写回首次建 driver 的连接。
+        let second_driver = ensure_event_driver(&second, &thread_id, &handle);
+        begin_driver_turn(
+            &second_driver,
+            Arc::clone(&second),
+            "turn-second",
+            2,
+            second.session().begin_turn(),
+        )
+        .await
+        .expect("second turn accepted");
+        second.record_turn_started(&thread_id, "turn-second".into(), 2);
+        emit_successful_text_turn(&events_tx, "second reply", "second");
+        wait_for_completed_turn(&second, &thread_id, "turn-second").await;
+
+        assert!(
+            first
+                .thread_log(&thread_id)
+                .iter()
+                .all(|turn| turn.id != "turn-second")
+        );
+        let second_turn = second
+            .thread_log(&thread_id)
+            .into_iter()
+            .find(|turn| turn.id == "turn-second")
+            .expect("second state owns second turn");
+        assert!(second_turn.items.iter().any(|item| {
+            matches!(item, p::ThreadItem::AgentMessage { text, .. } if text == "second reply")
+        }));
+        assert!(drain_turn_methods(&mut first_rx, "turn-second").is_empty());
+        let second_methods = drain_turn_methods(&mut second_rx, "turn-second");
+        assert!(
+            second_methods
+                .iter()
+                .any(|method| method == "item/completed")
+        );
+        assert!(
+            second_methods
+                .iter()
+                .any(|method| method == "turn/completed")
+        );
+
+        drop(first_driver);
+        drop(second_driver);
+        drop(handle);
+        drop(events_tx);
     }
 
     #[test]

--- a/bridges/claude/crates/claude-bridge/src/state.rs
+++ b/bridges/claude/crates/claude-bridge/src/state.rs
@@ -25,6 +25,7 @@ use alleycat_codex_proto::{
 use crate::index::ClaudeSessionRef;
 use crate::pool::ClaudePool;
 use crate::pool::claude_protocol::{McpServerInit, RateLimitInfo, SystemInit};
+use crate::translate::items::normalize_dynamic_tool_call_output;
 
 /// Compat re-export so the daemon's
 /// `Arc<dyn alleycat_claude_bridge::state::ThreadIndexHandle>` keeps spelling
@@ -528,14 +529,22 @@ impl ConnectionState {
                 }
                 if live.status == TurnStatus::Completed
                     && persisted_has_successful_output(&persisted_turn.items)
-                    && !persisted_has_successful_output(&live.items)
-                    && persisted_turn.items != live.items
                 {
-                    // 只修补“live 只有用户输入、JSONL 已有完整输出”的明确缺口。
-                    // 两边都已有输出时，items 数量相等/更多并不能证明 persisted 是
-                    // superset；整体替换会把刚收到的 live 内容回滚成较旧快照。
-                    live.items = persisted_turn.items;
-                    report.repaired_turns += 1;
+                    let repaired = if !persisted_has_successful_output(&live.items)
+                        && persisted_turn.items != live.items
+                    {
+                        // live 只有用户输入时，JSONL 的完整成功结果可以整体接管。
+                        live.items = persisted_turn.items;
+                        true
+                    } else {
+                        // live 已有部分输出时不能按数量或临时 item id 判断 superset。
+                        // 只在可见内容构成严格顺序前缀时追加权威尾部：既补齐断流
+                        // 后缺失的最终回复，也不会用较旧 JSONL 回滚更新的 live 内容。
+                        append_strict_persisted_output_tail(&mut live.items, &persisted_turn.items)
+                    };
+                    if repaired {
+                        report.repaired_turns += 1;
+                    }
                 } else if live.status != TurnStatus::Completed {
                     report.protected_turns += 1;
                 }
@@ -714,6 +723,315 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn persisted_completed_tail_repairs_partially_observed_live_output_without_duplicates() {
+        let state = test_state().await;
+        state.record_turn_started("thread", "live-partial".into(), 1);
+        state.record_item(
+            "thread",
+            "live-partial",
+            user("live-user", "检查历史一致性"),
+        );
+        state.record_item(
+            "thread",
+            "live-partial",
+            ThreadItem::AgentMessage {
+                id: "live-progress".into(),
+                text: "先读取状态".into(),
+                phase: None,
+                memory_citation: None,
+            },
+        );
+        state.record_item(
+            "thread",
+            "live-partial",
+            ThreadItem::CommandExecution {
+                id: "live-command".into(),
+                command: "git status".into(),
+                cwd: "/tmp".into(),
+                process_id: None,
+                source: Default::default(),
+                status: alleycat_codex_proto::CommandExecutionStatus::Completed,
+                command_actions: Vec::new(),
+                aggregated_output: Some("工作区干净".into()),
+                exit_code: Some(0),
+                duration_ms: Some(10),
+            },
+        );
+        state.record_turn_completed("thread", "live-partial", 2, TurnStatus::Completed, None);
+
+        // 跨设备冷读时，live cache 可能已有部分成功输出，而 JSONL 才包含完整尾部；
+        // 对账必须补齐权威历史，不能因为 live 已有成功 item 就跳过这次修复。
+        let persisted = Turn {
+            id: "disk-turn".into(),
+            items: vec![
+                user("disk-user", "检查历史一致性"),
+                ThreadItem::AgentMessage {
+                    id: "disk-progress".into(),
+                    text: "先读取状态".into(),
+                    phase: None,
+                    memory_citation: None,
+                },
+                ThreadItem::CommandExecution {
+                    id: "disk-command".into(),
+                    command: "git status".into(),
+                    cwd: "/tmp".into(),
+                    process_id: None,
+                    source: Default::default(),
+                    status: alleycat_codex_proto::CommandExecutionStatus::Completed,
+                    command_actions: Vec::new(),
+                    aggregated_output: Some("工作区干净".into()),
+                    exit_code: Some(0),
+                    duration_ms: Some(10),
+                },
+                ThreadItem::AgentMessage {
+                    id: "disk-final".into(),
+                    text: "最终完整回复".into(),
+                    phase: None,
+                    memory_citation: None,
+                },
+            ],
+            items_view: alleycat_codex_proto::default_items_view(),
+            status: TurnStatus::Completed,
+            error: None,
+            started_at: Some(1_000),
+            completed_at: Some(2_000),
+            duration_ms: Some(1_000),
+        };
+
+        let report = state.reconcile_thread_log("thread", vec![persisted]);
+        let turns = state.thread_log("thread");
+        assert_eq!(turns.len(), 1, "同一 user anchor 不应产生重复 turn");
+        let items = &turns[0].items;
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| matches!(item, ThreadItem::UserMessage { content, .. } if content.iter().any(|input| matches!(input, UserInput::Text { text, .. } if text == "检查历史一致性"))))
+                .count(),
+            1,
+            "同一 user anchor 只能保留一份"
+        );
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| matches!(item, ThreadItem::AgentMessage { text, .. } if text == "先读取状态"))
+                .count(),
+            1,
+            "已有 live assistant 输出只能保留一份"
+        );
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| matches!(item, ThreadItem::CommandExecution { command, .. } if command == "git status"))
+                .count(),
+            1,
+            "已有 live command execution 只能保留一份"
+        );
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| matches!(item, ThreadItem::AgentMessage { text, .. } if text == "最终完整回复"))
+                .count(),
+            1,
+            "persisted 最终 assistant 尾部必须补齐"
+        );
+        assert_eq!(report.seeded_turns, 0, "匹配到的 turn 不应重复 seed");
+    }
+
+    #[tokio::test]
+    async fn persisted_completed_tail_includes_missing_file_change_before_final_message() {
+        let state = test_state().await;
+        record_completed_live_turn(
+            &state,
+            "thread",
+            "live-partial",
+            Some("修改配置"),
+            "先检查配置",
+            1,
+            2,
+        );
+
+        let persisted = Turn {
+            id: "disk-turn".into(),
+            items: vec![
+                user("disk-user", "修改配置"),
+                ThreadItem::AgentMessage {
+                    id: "disk-progress".into(),
+                    text: "先检查配置".into(),
+                    phase: None,
+                    memory_citation: None,
+                },
+                ThreadItem::FileChange {
+                    id: "disk-file-change".into(),
+                    changes: vec![alleycat_codex_proto::FileUpdateChange {
+                        path: "/tmp/config.json".into(),
+                        kind: alleycat_codex_proto::PatchChangeKind::Update { move_path: None },
+                        diff: "-old\n+new".into(),
+                    }],
+                    status: alleycat_codex_proto::PatchApplyStatus::Completed,
+                },
+                ThreadItem::AgentMessage {
+                    id: "disk-final".into(),
+                    text: "配置已更新".into(),
+                    phase: None,
+                    memory_citation: None,
+                },
+            ],
+            items_view: alleycat_codex_proto::default_items_view(),
+            status: TurnStatus::Completed,
+            error: None,
+            started_at: Some(1_000),
+            completed_at: Some(2_000),
+            duration_ms: Some(1_000),
+        };
+
+        let report = state.reconcile_thread_log("thread", vec![persisted]);
+        assert_eq!(report.repaired_turns, 1);
+        let items = &state.thread_log("thread")[0].items;
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| matches!(item, ThreadItem::FileChange { .. }))
+                .count(),
+            1,
+            "缺失的文件修改必须随 persisted 尾部一起补齐"
+        );
+        assert!(items.iter().any(
+            |item| matches!(item, ThreadItem::AgentMessage { text, .. } if text == "配置已更新")
+        ));
+    }
+
+    #[test]
+    fn output_signatures_ignore_known_live_disk_representation_differences() {
+        let dynamic_live = ThreadItem::DynamicToolCall {
+            id: "live-dynamic".into(),
+            namespace: Some("claude".into()),
+            tool: "CustomTool".into(),
+            arguments: serde_json::json!({"path": "/tmp/a"}),
+            status: alleycat_codex_proto::DynamicToolCallStatus::Completed,
+            content_items: Some(vec![serde_json::json!({
+                "type": "text",
+                "text": "done"
+            })]),
+            success: Some(true),
+            duration_ms: Some(12),
+        };
+        let dynamic_disk = ThreadItem::DynamicToolCall {
+            id: "disk-dynamic".into(),
+            namespace: Some("claude".into()),
+            tool: "CustomTool".into(),
+            arguments: serde_json::json!({"path": "/tmp/a"}),
+            status: alleycat_codex_proto::DynamicToolCallStatus::Completed,
+            content_items: Some(vec![serde_json::json!({
+                "type": "inputText",
+                "text": "done"
+            })]),
+            success: Some(true),
+            duration_ms: None,
+        };
+        assert_eq!(
+            turn_output_signature(&dynamic_live),
+            turn_output_signature(&dynamic_disk),
+            "dynamic tool result 的 live/disk 包装差异不应破坏同一调用的前缀匹配"
+        );
+        let mut dynamic_diverged = dynamic_disk.clone();
+        if let ThreadItem::DynamicToolCall { content_items, .. } = &mut dynamic_diverged {
+            *content_items = Some(vec![serde_json::json!({
+                "type": "inputText",
+                "text": "different result"
+            })]);
+        }
+        assert_ne!(
+            turn_output_signature(&dynamic_live),
+            turn_output_signature(&dynamic_diverged),
+            "相同参数但真实结果不同的 dynamic call 必须阻止旧尾部拼接"
+        );
+
+        let mcp_live = ThreadItem::McpToolCall {
+            id: "live-mcp".into(),
+            server: "server".into(),
+            tool: "lookup".into(),
+            status: alleycat_codex_proto::McpToolCallStatus::Completed,
+            arguments: serde_json::json!({"query": "MIM-47"}),
+            mcp_app_resource_uri: None,
+            result: Some(Box::new(alleycat_codex_proto::McpToolCallResult {
+                content: vec![serde_json::json!({"type": "text", "text": "new result"})],
+                structured_content: None,
+                is_error: None,
+                meta: None,
+            })),
+            error: None,
+            duration_ms: Some(20),
+        };
+        let mut mcp_disk = mcp_live.clone();
+        if let ThreadItem::McpToolCall {
+            id, duration_ms, ..
+        } = &mut mcp_disk
+        {
+            *id = "disk-mcp".into();
+            *duration_ms = None;
+        }
+        assert_eq!(
+            turn_output_signature(&mcp_live),
+            turn_output_signature(&mcp_disk),
+            "MCP 的临时 id 和耗时差异不应破坏前缀匹配"
+        );
+        if let ThreadItem::McpToolCall { result, .. } = &mut mcp_disk {
+            result.as_mut().unwrap().content =
+                vec![serde_json::json!({"type": "text", "text": "old result"})];
+        }
+        assert_ne!(
+            turn_output_signature(&mcp_live),
+            turn_output_signature(&mcp_disk),
+            "相同参数但真实结果不同的 MCP call 必须阻止旧尾部拼接"
+        );
+
+        let receiver_id = "subagent-toolu_1".to_string();
+        let mut live_states = std::collections::HashMap::new();
+        live_states.insert(
+            receiver_id.clone(),
+            alleycat_codex_proto::CollabAgentState {
+                status: alleycat_codex_proto::CollabAgentStatus::Completed,
+                message: Some("researcher".into()),
+            },
+        );
+        let collab_live = ThreadItem::CollabAgentToolCall {
+            id: "toolu_1".into(),
+            tool: alleycat_codex_proto::CollabAgentTool::SpawnAgent,
+            status: alleycat_codex_proto::CollabAgentToolCallStatus::Completed,
+            sender_thread_id: "real-thread-id".into(),
+            receiver_thread_ids: vec![receiver_id.clone()],
+            prompt: Some("检查实现".into()),
+            model: None,
+            reasoning_effort: None,
+            agents_states: live_states,
+        };
+        let mut disk_states = std::collections::HashMap::new();
+        disk_states.insert(
+            receiver_id.clone(),
+            alleycat_codex_proto::CollabAgentState {
+                status: alleycat_codex_proto::CollabAgentStatus::Completed,
+                message: Some("researcher".into()),
+            },
+        );
+        let collab_disk = ThreadItem::CollabAgentToolCall {
+            id: "toolu_1".into(),
+            tool: alleycat_codex_proto::CollabAgentTool::SpawnAgent,
+            status: alleycat_codex_proto::CollabAgentToolCallStatus::Completed,
+            sender_thread_id: String::new(),
+            receiver_thread_ids: vec![receiver_id],
+            prompt: Some("检查实现".into()),
+            model: None,
+            reasoning_effort: None,
+            agents_states: disk_states,
+        };
+        assert_eq!(
+            turn_output_signature(&collab_live),
+            turn_output_signature(&collab_disk),
+            "disk 缺失 sender thread 不应让同一 subagent 调用被判成内容分叉"
+        );
+    }
+
+    #[tokio::test]
     async fn persisted_success_does_not_overwrite_active_or_failed_terminal() {
         for status in [TurnStatus::InProgress, TurnStatus::Failed] {
             let state = test_state().await;
@@ -788,7 +1106,7 @@ mod tests {
         };
 
         let report = state.reconcile_thread_log("thread", vec![persisted]);
-        assert_eq!(report.repaired_turns, 0);
+        assert_eq!(report.repaired_turns, 1);
         let turns = state.thread_log("thread");
         assert_eq!(turns.len(), 1, "同一自主 turn 不应 seed 后再 append");
         assert_eq!(turns[0].id, "live-autonomous");
@@ -796,10 +1114,61 @@ mod tests {
             .items
             .iter()
             .any(|item| matches!(item, ThreadItem::AgentMessage { text, .. } if text.contains("五分钟到了"))));
-        assert!(!turns[0]
+        assert!(turns[0]
             .items
             .iter()
             .any(|item| matches!(item, ThreadItem::AgentMessage { text, .. } if text.contains("14:06:06"))));
+    }
+
+    #[tokio::test]
+    async fn persisted_tail_does_not_overwrite_diverged_completed_live_output() {
+        let state = test_state().await;
+        record_completed_live_turn(
+            &state,
+            "thread",
+            "live-turn",
+            Some("检查状态"),
+            "live 中更新的结果",
+            1,
+            2,
+        );
+
+        let persisted = Turn {
+            id: "disk-turn".into(),
+            items: vec![
+                user("disk-user", "检查状态"),
+                ThreadItem::AgentMessage {
+                    id: "disk-old".into(),
+                    text: "JSONL 中较旧的结果".into(),
+                    phase: None,
+                    memory_citation: None,
+                },
+                ThreadItem::AgentMessage {
+                    id: "disk-tail".into(),
+                    text: "不能盲目追加的尾部".into(),
+                    phase: None,
+                    memory_citation: None,
+                },
+            ],
+            items_view: alleycat_codex_proto::default_items_view(),
+            status: TurnStatus::Completed,
+            error: None,
+            started_at: Some(1_000),
+            completed_at: Some(2_000),
+            duration_ms: Some(1_000),
+        };
+
+        let report = state.reconcile_thread_log("thread", vec![persisted]);
+        assert_eq!(report.repaired_turns, 0);
+        let turns = state.thread_log("thread");
+        assert!(turns[0]
+            .items
+            .iter()
+            .any(|item| matches!(item, ThreadItem::AgentMessage { text, .. } if text == "live 中更新的结果")));
+        assert!(!turns[0]
+            .items
+            .iter()
+            .any(|item| matches!(item, ThreadItem::AgentMessage { text, .. } if text == "不能盲目追加的尾部")));
     }
 
     #[tokio::test]
@@ -1027,23 +1396,156 @@ fn completed_turn_windows_overlap(persisted: &Turn, live: &RecordedTurn) -> bool
 }
 
 fn turn_visible_signatures(items: &[ThreadItem]) -> Vec<String> {
-    items
+    items.iter().filter_map(turn_visible_signature).collect()
+}
+
+fn turn_visible_signature(item: &ThreadItem) -> Option<String> {
+    match item {
+        ThreadItem::AgentMessage { text, .. } => Some(format!("agent:{text}")),
+        ThreadItem::Plan { text, .. } => Some(format!("plan:{text}")),
+        ThreadItem::Reasoning {
+            summary, content, ..
+        } => Some(format!("reasoning:{summary:?}:{content:?}")),
+        ThreadItem::CommandExecution {
+            command,
+            aggregated_output,
+            ..
+        } => Some(format!("command:{command}:{aggregated_output:?}")),
+        ThreadItem::HookPrompt { fragments, .. } => Some(format!("hook:{fragments:?}")),
+        _ => None,
+    }
+}
+
+/// 历史尾部对账需要覆盖全部用户可见输出，而不仅是用于 autonomous turn
+/// 粗匹配的文本类指纹。签名排除实时/JSONL 之间不稳定的 item id 和耗时字段，
+/// 但保留工具输入、结果与状态；内容分叉时宁可不修，也不盲目拼接旧快照。
+fn turn_output_signature(item: &ThreadItem) -> Option<String> {
+    if let Some(signature) = turn_visible_signature(item) {
+        return Some(signature);
+    }
+    match item {
+        ThreadItem::FileChange {
+            changes, status, ..
+        } => Some(format!("fileChange:{status:?}:{changes:?}")),
+        ThreadItem::McpToolCall {
+            server,
+            tool,
+            status,
+            arguments,
+            result,
+            error,
+            ..
+        } => {
+            let result = result
+                .as_ref()
+                .map(|result| (&result.content, &result.structured_content, result.is_error));
+            let error = error
+                .as_ref()
+                .map(|error| (&error.message, error.code, &error.data));
+            Some(format!(
+                "mcp:{server}:{tool}:{status:?}:{arguments}:{result:?}:{error:?}"
+            ))
+        }
+        ThreadItem::DynamicToolCall {
+            namespace,
+            tool,
+            arguments,
+            status,
+            content_items,
+            success,
+            ..
+        } => {
+            let normalized_content = content_items
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .flat_map(normalize_dynamic_tool_call_output)
+                .collect::<Vec<_>>();
+            Some(format!(
+                "dynamic:{namespace:?}:{tool}:{arguments}:{status:?}:{success:?}:{normalized_content:?}"
+            ))
+        }
+        ThreadItem::CollabAgentToolCall {
+            tool,
+            status,
+            receiver_thread_ids,
+            prompt,
+            model,
+            reasoning_effort,
+            agents_states,
+            ..
+        } => {
+            let mut messages = agents_states
+                .values()
+                .filter_map(|state| state.message.as_deref())
+                .collect::<Vec<_>>();
+            messages.sort_unstable();
+            Some(format!(
+                "collab:{tool:?}:{status:?}:{receiver_thread_ids:?}:{prompt:?}:{model:?}:{reasoning_effort:?}:{messages:?}"
+            ))
+        }
+        ThreadItem::WebSearch { query, action, .. } => {
+            Some(format!("webSearch:{query}:{action:?}"))
+        }
+        ThreadItem::ImageView { path, .. } => Some(format!("imageView:{path}")),
+        ThreadItem::ImageGeneration {
+            status,
+            revised_prompt,
+            result,
+            saved_path,
+            ..
+        } => Some(format!(
+            "imageGeneration:{status}:{revised_prompt:?}:{result}:{saved_path:?}"
+        )),
+        ThreadItem::EnteredReviewMode { review, .. } => Some(format!("enteredReview:{review}")),
+        ThreadItem::ExitedReviewMode { review, .. } => Some(format!("exitedReview:{review}")),
+        ThreadItem::ContextCompaction { .. } => Some("contextCompaction".into()),
+        ThreadItem::UserMessage { .. }
+        | ThreadItem::HookPrompt { .. }
+        | ThreadItem::AgentMessage { .. }
+        | ThreadItem::Plan { .. }
+        | ThreadItem::Reasoning { .. }
+        | ThreadItem::CommandExecution { .. } => None,
+    }
+}
+
+/// 当 live 已观测到的全部可见输出是 persisted 的严格顺序前缀时，补入 JSONL
+/// 中尚未到达实时事件流的尾部。这里故意使用不含临时 id 的内容签名；Claude 的
+/// 实时 AgentMessage id 是 bridge 生成的 UUID，而 JSONL 使用 message id 派生值。
+fn append_strict_persisted_output_tail(
+    live_items: &mut Vec<ThreadItem>,
+    persisted_items: &[ThreadItem],
+) -> bool {
+    let live_visible = live_items
         .iter()
-        .filter_map(|item| match item {
-            ThreadItem::AgentMessage { text, .. } => Some(format!("agent:{text}")),
-            ThreadItem::Plan { text, .. } => Some(format!("plan:{text}")),
-            ThreadItem::Reasoning {
-                summary, content, ..
-            } => Some(format!("reasoning:{summary:?}:{content:?}")),
-            ThreadItem::CommandExecution {
-                command,
-                aggregated_output,
-                ..
-            } => Some(format!("command:{command}:{aggregated_output:?}")),
-            ThreadItem::HookPrompt { fragments, .. } => Some(format!("hook:{fragments:?}")),
-            _ => None,
-        })
-        .collect()
+        .filter_map(turn_output_signature)
+        .collect::<Vec<_>>();
+    let persisted_visible = persisted_items
+        .iter()
+        .filter_map(turn_output_signature)
+        .collect::<Vec<_>>();
+    if live_visible.is_empty()
+        || live_visible.len() >= persisted_visible.len()
+        || !persisted_visible.starts_with(&live_visible)
+    {
+        return false;
+    }
+
+    let first_missing_visible = live_visible.len();
+    let mut visible_index = 0;
+    let Some(first_missing_item) = persisted_items.iter().position(|item| {
+        if turn_output_signature(item).is_none() {
+            return false;
+        }
+        let is_first_missing = visible_index == first_missing_visible;
+        visible_index += 1;
+        is_first_missing
+    }) else {
+        return false;
+    };
+
+    live_items.extend_from_slice(&persisted_items[first_missing_item..]);
+    true
 }
 
 fn persisted_has_successful_output(items: &[ThreadItem]) -> bool {

--- a/bridges/claude/crates/claude-bridge/src/translate/items.rs
+++ b/bridges/claude/crates/claude-bridge/src/translate/items.rs
@@ -328,7 +328,7 @@ fn user_message_to_item(content: &Value, ts: i64, turn_index: usize) -> ThreadIt
 /// arbitrary structured payloads all need to land as one of those two
 /// shapes — otherwise litter's typed deserializer rejects the whole
 /// `thread/resume` response.
-fn normalize_dynamic_tool_call_output(value: &Value) -> Vec<Value> {
+pub(crate) fn normalize_dynamic_tool_call_output(value: &Value) -> Vec<Value> {
     match value {
         Value::String(s) => vec![serde_json::json!({"type": "inputText", "text": s})],
         Value::Array(arr) => arr


### PR DESCRIPTION
## 目标

修复同一 Claude Code 会话在多个客户端之间切换后，流式回复写入错误连接、当前设备需要手动刷新才能看到完整回复的问题。

Linear: MIM-47

## 根因

- Claude event driver 按 thread 复用，但内部长期持有首次连接的 `ConnectionState`。
- 后续设备发起 turn 时，用户消息写入新连接，assistant item、terminal event 和通知却仍写入旧连接。
- Completed turn 重新读取磁盘历史时，只会在 live output 完全为空时回填，无法补齐“已收到部分输出但缺少尾部”的情况。

## 实现

- 每个被接受的 `BeginTurn` 都重新绑定当前连接状态；并发拒绝路径不会改变正在运行 turn 的通知归属。
- 对 Completed turn 增加严格语义前缀判断，仅在 live 输出确实是持久化输出前缀时追加缺失尾部。
- 为 FileChange、Dynamic、MCP、Collab 等输出建立稳定语义签名，忽略临时 ID、duration 和 live/disk 表示差异。
- 增加跨连接 driver 复用、部分历史尾部、内容分叉和工具输出归一化回归测试。

## 影响

- 切换设备后，当前客户端可以持续收到本次 Claude 回复和完成事件。
- 刷新或重连时可安全补齐持久化的末尾输出，不重复已有 item，也不覆盖已经分叉的 live 内容。

## 验证

- `cargo test --manifest-path bridges/claude/crates/claude-bridge/Cargo.toml`
  - 201 个 lib tests、4 个 main tests、全部集成测试通过。
- `cargo fmt --manifest-path bridges/claude/crates/claude-bridge/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path bridges/claude/crates/claude-bridge/Cargo.toml --lib -- -A clippy::collapsible-if -A clippy::useless-conversion -A clippy::collapsible-match -D warnings`
- 独立 Sol reviewer：SHIP。

## 待人工验证

- 在三台实体设备上打开同一 Claude Code session，分别发起 turn，确认流式 item 和 terminal event 都出现在当前设备。
- 刷新会话后确认历史完整、顺序正确且无重复。
