### PR TITLE
MIM-96: open TestFlight 1.2 release train

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -1571,7 +1571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gaixianggeng.mimi;
 				PRODUCT_MODULE_NAME = MimiRemote;
 				PRODUCT_NAME = MimiRemote;
@@ -1702,7 +1702,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gaixianggeng.mimi;
 				PRODUCT_MODULE_NAME = MimiRemote;
 				PRODUCT_NAME = MimiRemote;
@@ -1747,7 +1747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gaixianggeng.mimi.carstatuswidget;
 				PRODUCT_NAME = MimiCarStatusWidget;
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "$(IOS_WIDGET_PROVISIONING_PROFILE_SPECIFIER)";
@@ -1835,7 +1835,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gaixianggeng.mimi.carstatuswidget;
 				PRODUCT_NAME = MimiCarStatusWidget;
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "$(IOS_WIDGET_PROVISIONING_PROFILE_SPECIFIER)";

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -87,9 +87,9 @@ targets:
         "ENABLE_HARDENED_RUNTIME[sdk=macosx*]": "YES"
         # UI 文案统一由显式 L10n key 管理，关闭编译器自动提取，避免 Xcode 把技术字符串写回目录。
         SWIFT_EMIT_LOC_STRINGS: "NO"
-        # 1.0 已在 App Store Connect 关闭新构建上传，发布 1.1 时同步固定递增构建号。
+        # 1.1 已在 App Store Connect 关闭新构建上传，本次发布切换到 1.2 通道。
         CURRENT_PROJECT_VERSION: "100068"
-        MARKETING_VERSION: "1.1"
+        MARKETING_VERSION: "1.2"
   MimiCarStatusWidgetExtension:
     type: app-extension
     platform: iOS
@@ -116,7 +116,7 @@ targets:
         SKIP_INSTALL: "YES"
         TARGETED_DEVICE_FAMILY: "1,2"
         CURRENT_PROJECT_VERSION: "100068"
-        MARKETING_VERSION: "1.1"
+        MARKETING_VERSION: "1.2"
         SWIFT_EMIT_LOC_STRINGS: "NO"
   MimiRemoteTests:
     type: bundle.unit-test


### PR DESCRIPTION
## 目标

App Store Connect 已关闭 1.1 的新构建上传，切换主 App 与 Widget 到 1.2 预发布通道。

## 修改

- 同步更新 project.yml 与生成后的 Xcode 工程
- 主 App、Widget 的 MARKETING_VERSION 统一为 1.2

## 验证

- `bash ./scripts/ios-dev.sh build` 通过
- 主 App Info.plist: 1.2
- Widget Info.plist: 1.2
- `git diff --check` 通过