### PR TITLE
MIM-101 Add workspace back navigation

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -1716,6 +1716,7 @@ private struct WorkspaceDetailView: View {
                         }
                         .buttonStyle(.plain)
                         .sessionRowActions(session)
+                        .accessibilityIdentifier("workspace.session.\(session.id)")
                     }
 
                     if canLoadMoreSessions || isLoadingMoreSessions {

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -367,6 +367,9 @@ struct UnifiedWorkbenchShell: View {
         let keepsClosedEdgeInteractive = didRestoreFloatingSidebarVisibility
             ? floatingSidebarPresentation.keepsClosedEdgeInteractive
             : !storedFloatingSidebarVisible
+        let reservesWorkspaceBackButton = navigationState.showsWorkspaceBackButton(
+            usesCompactNavigation: layout.usesCompactNavigation
+        )
 
         return FloatingSidebarAnimatedScene(sidebarWidth: sidebarWidth) {
             // detail 与 sidebar 从同一个 animatableData 排版，避免目标状态与屏幕位置分裂。
@@ -414,7 +417,14 @@ struct UnifiedWorkbenchShell: View {
                     toggleFloatingSidebarVisibility()
                 }
                 .padding(.leading, WorkbenchSidebarSurfaceMetrics.outerInset)
-                .padding(.top, 6)
+                // 工作区会话详情已有 leading 返回按钮；侧栏关闭时把恢复入口放到导航栏下方。
+                // 只横向移动仍会落在 NavigationBar 的命中表面内，视觉分开但按钮不可点击。
+                .padding(
+                    .top,
+                    6 + (reservesWorkspaceBackButton
+                        ? WorkbenchChromeIconMetrics.minimumHitTarget + 12
+                        : 0)
+                )
                 .accessibilitySortPriority(10)
             }
         }
@@ -1007,6 +1017,24 @@ struct UnifiedWorkbenchShell: View {
         .navigationTitle(sessionStore.selectedSession?.title ?? L10n.text("ui.session"))
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            if navigationState.showsWorkspaceBackButton(
+                usesCompactNavigation: layout.usesCompactNavigation
+            ) {
+                ToolbarItem(placement: .navigation) {
+                    Button {
+                        open(.workspaces, layout: layout)
+                    } label: {
+                        Label(L10n.text("ui.workspace"), systemImage: "chevron.backward")
+                    }
+                    // 宽屏需要显式动作，紧凑布局由外层 NavigationStack 提供系统返回。
+                    // 保留原生 toolbar 样式，同时显式扩展交互形状，避免只按图标可见区域命中。
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(.interaction, Rectangle())
+                    .accessibilityLabel(L10n.text("ui.workspace"))
+                    .accessibilityHint(L10n.text("ui.return_to_previous_level"))
+                    .accessibilityIdentifier("sessionDetail.workspaceBack")
+                }
+            }
             ToolbarItem(placement: .principal) {
                 // 会话详情优先展示当前任务；Mac 切换保留在上一级主界面，避免全局信息挤占标题。
                 Text(sessionStore.selectedSession?.title ?? L10n.text("ui.session"))

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -52,6 +52,15 @@ struct WorkbenchNavigationState: Equatable {
         return sessionID
     }
 
+    /// 宽屏详情不是一次 push，系统不会自动提供返回工作区的按钮；紧凑布局由外层
+    /// `NavigationStack` 管理 path，保留系统返回即可，避免顶栏出现两个返回控件。
+    func showsWorkspaceBackButton(usesCompactNavigation: Bool) -> Bool {
+        guard !usesCompactNavigation, route.detailSessionID != nil else {
+            return false
+        }
+        return route.rootPage == .workspaces
+    }
+
     @discardableResult
     mutating func reduce(
         _ event: WorkbenchNavigationEvent,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -2707,6 +2707,25 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(state.compactWorkspacePath.isEmpty)
     }
 
+    func testWorkbenchNavigationWorkspaceBackButtonOnlyShowsForWideWorkspaceDetail() {
+        let cases: [(WorkbenchRestorationRoute, Bool, Bool)] = [
+            (.session(id: "workspace-session", source: .workspaces), false, true),
+            (.session(id: "workspace-session", source: .workspaces), true, false),
+            (.session(id: "sessions-session", source: .sessions), false, false),
+            (.session(id: "sessions-session", source: .sessions), true, false),
+            (.workspaces, false, false),
+        ]
+
+        for (route, usesCompactNavigation, expected) in cases {
+            let state = WorkbenchNavigationState(route: route)
+            XCTAssertEqual(
+                state.showsWorkspaceBackButton(usesCompactNavigation: usesCompactNavigation),
+                expected,
+                "route=\(route), compact=\(usesCompactNavigation)"
+            )
+        }
+    }
+
     func testWorkbenchNavigationWorkspaceEmptyStateActionOpensWorkspaceInBothLayouts() {
         for usesCompactNavigation in [true, false] {
             var state = WorkbenchNavigationState(route: .sessions)

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -742,6 +742,64 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         complete?.tap()
     }
 
+    func testWideIPadWorkspaceSessionDetailShowsWorkspaceBackButton() throws {
+        try XCTSkipUnless(
+            UIDevice.current.userInterfaceIdiom == .pad,
+            "工作区宽屏返回按钮只在 iPad regular width 下验收。"
+        )
+        try relaunchDirectlyIntoWorkspaces()
+        rotate(to: .landscapeLeft)
+
+        let workspaceBrowser = app.descendant(identifier: "workspace.browser")
+        XCTAssertTrue(workspaceBrowser.waitForExistence(timeout: 10), "工作区内容应保持可访问")
+
+        let session = app.descendant(identifier: "workspace.session.debug-session-layout")
+        XCTAssertTrue(scrollUntilHittable(session), "工作区应提供可点击的 Debug 会话入口")
+        session.tap()
+
+        let workspaceBack = app.descendant(identifier: "sessionDetail.workspaceBack")
+        XCTAssertTrue(
+            workspaceBack.waitForExistence(timeout: 12),
+            "宽屏从工作区进入会话详情后应展示显式返回按钮"
+        )
+        XCTAssertTrue(workspaceBack.isHittable, "工作区返回按钮应可直接点击")
+        // 系统 toolbar 对 XCUI 暴露的是控件可见区域，不包含 SwiftUI 扩展后的 interaction shape；
+        // 这里用真实点击与返回结果验证命中行为，避免把 36pt 的可见 frame 误判为点击热区。
+
+        let showSidebar = app.descendant(identifier: "sidebar.show")
+        if !showSidebar.waitForExistence(timeout: 2) {
+            guard let collapseSidebar = firstExistingButton(
+                labels: ["收起会话列表", "Collapse conversation list"],
+                timeout: 5
+            ) else {
+                XCTFail("会话详情应能收起浮动侧栏以验证两个 leading 控件")
+                return
+            }
+            collapseSidebar.tap()
+            XCTAssertTrue(showSidebar.waitForExistence(timeout: 8), "收起侧栏后应展示恢复入口")
+        }
+        assertMinimumTouchTarget(showSidebar, named: "侧栏恢复入口")
+        XCTAssertGreaterThanOrEqual(
+            showSidebar.frame.minY,
+            workspaceBack.frame.maxY + 8,
+            "侧栏恢复入口不能覆盖工作区返回按钮"
+        )
+
+        workspaceBack.tap()
+        XCTAssertTrue(
+            workspaceBrowser.waitForExistence(timeout: 12),
+            "点击返回后应回到工作区浏览器"
+        )
+        XCTAssertTrue(
+            workspaceBack.waitForNonExistence(timeout: 8),
+            "回到工作区后不应残留会话详情返回按钮"
+        )
+        if showSidebar.exists {
+            // 恢复共享的 SceneStorage 状态，避免影响后续 UI 用例。
+            showSidebar.tap()
+        }
+    }
+
     func testWorkspaceRemoveDirectoryConfirmationAnchorsToCardAcrossIPadLayouts() throws {
         try XCTSkipUnless(
             UIDevice.current.userInterfaceIdiom == .pad,


### PR DESCRIPTION
## 目标

在 iPad 宽屏工作区进入会话详情后提供明确的“工作区”返回按钮；紧凑布局继续使用系统返回。

## 实现

- 仅在宽屏、工作区来源的会话详情展示原生 toolbar 返回按钮
- 保留 44pt 交互区域与无障碍标识
- 增加导航状态单测和 iPad UI 真实返回链路回归

## 验证

- iPad Pro 真机构建、安装、启动成功
- 用户已在实体 iPad Pro 验收通过
- 目标单测：1 passed, 0 failed
- iPad Pro 13-inch (M5) UI 回归：1 passed, 0 failed
- Swift 语法、String Catalog、git diff 检查通过

Linear: MIM-101