### PR TITLE
MIM-103 支持 iOS 18 兼容展示并保留 iOS 26+ 高级体验

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -81,7 +81,8 @@ concurrency:
 
 jobs:
   conversation-regressions:
-    # MimiRemote 的最低版本是 iOS 26；macos-26 runner 默认提供稳定版 Xcode 26 和 iOS 26 Simulator。
+    # 使用稳定版 Xcode 26 / iOS 26 Simulator 运行回归；工程仍以 iOS 18 为 deployment target，
+    # 因此编译阶段会检查所有 iOS 26+ API 是否具备有效 availability fallback。
     runs-on: macos-26
     timeout-minutes: 35
     steps:
@@ -103,6 +104,31 @@ jobs:
           go version
           xcodebuild -version
           xcrun simctl list devices available
+
+      - name: Verify iOS 18 deployment target
+        shell: bash
+        run: |
+          set -euo pipefail
+          for target_name in \
+            MimiRemote \
+            MimiCarStatusWidgetExtension \
+            MimiRemoteTests \
+            MimiRemoteUITests
+          do
+            deployment_targets="$(
+              xcodebuild \
+                -project ios/MimiRemote/MimiRemote.xcodeproj \
+                -target "$target_name" \
+                -configuration Debug \
+                -showBuildSettings 2>/dev/null \
+                | awk '$1 == "IPHONEOS_DEPLOYMENT_TARGET" && $2 == "=" { print $3 }' \
+                | sort -u
+            )"
+            if [[ "$deployment_targets" != "18.0" ]]; then
+              echo "$target_name expected iOS deployment target 18.0, got: $deployment_targets" >&2
+              exit 1
+            fi
+          done
 
       - name: Resolve fixed CI simulator
         shell: bash

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  <a href="ios/MimiRemote/README.md"><img src="https://img.shields.io/badge/iOS%20%2F%20iPadOS-26%2B-black?logo=apple" alt="iOS and iPadOS 26 or later" /></a>
+  <a href="ios/MimiRemote/README.md"><img src="https://img.shields.io/badge/iOS%20%2F%20iPadOS-18%2B-black?logo=apple" alt="iOS and iPadOS 18 or later" /></a>
   <a href="ios/MimiRemote"><img src="https://img.shields.io/badge/SwiftUI-native-F05138?logo=swift&amp;logoColor=white" alt="Native SwiftUI app" /></a>
   <a href="https://github.com/gaixianggeng/codex-ipad-agent/actions/workflows/go-ci.yml"><img src="https://github.com/gaixianggeng/codex-ipad-agent/actions/workflows/go-ci.yml/badge.svg" alt="Go CI status" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3%20%2B%20Store%20Exception-blue.svg" alt="GPLv3 with store distribution exception" /></a>
@@ -186,7 +186,7 @@ This shape keeps deployment small and auditable, but the tradeoff is explicit: t
 
 Check these before you install:
 
-- **Required:** an iPhone or iPad running iOS/iPadOS 26 or later, a supported computer that can keep the host service running, and Codex CLI installed and ready on that host. Complete the runtime's own authentication on the host; Mimi Remote connects only to the `agentd` gateway and does not receive or manage runtime credentials or billing. See the [official Codex authentication guide](https://learn.chatgpt.com/docs/auth).
+- **Required:** an iPhone or iPad running iOS/iPadOS 18 or later, a supported computer that can keep the host service running, and Codex CLI installed and ready on that host. Complete the runtime's own authentication on the host; Mimi Remote connects only to the `agentd` gateway and does not receive or manage runtime credentials or billing. See the [official Codex authentication guide](https://learn.chatgpt.com/docs/auth). iOS 26+ keeps the full Liquid Glass and on-device Apple Speech experience; iOS 18–25 uses simpler system materials and Codex voice transcription.
 - **Network:** devices on the same trusted LAN can connect directly; Tailscale is not required. Across networks, use the same Tailnet or a secure HTTPS endpoint you administer. Never expose `agentd`'s plain HTTP endpoint directly to the public Internet.
 - **Optional runtime:** Claude Code is experimental, disabled by default, and cannot replace Codex. If you enable it, install and authenticate Claude Code separately using an option in the [official Claude Code setup guide](https://docs.anthropic.com/en/docs/claude-code/getting-started); Codex CLI remains required.
 - **iOS installation today:** there is no public App Store package. Install the app through [TestFlight](https://testflight.apple.com/join/jhGPbSk6), or build it from source with a Mac, Xcode 26 or later with the iOS 26 SDK, and XcodeGen; see the [iOS build guide](ios/MimiRemote/README.md).
@@ -280,7 +280,7 @@ Ask `$skill-installer` to install that GitHub path. Each GitHub Release also inc
 
 ### Install the iOS app
 
-Mimi Remote requires iOS/iPadOS 26 or later. Join the [Mimi Remote TestFlight](https://testflight.apple.com/join/jhGPbSk6) for the simplest installation path.
+Mimi Remote requires iOS/iPadOS 18 or later. Join the [Mimi Remote TestFlight](https://testflight.apple.com/join/jhGPbSk6) for the simplest installation path. iOS 26+ gets the full advanced visual and on-device speech experience; earlier supported systems use deliberate fallbacks for unsupported capabilities.
 
 To build the app from source instead, use a Mac with Xcode 26 or later and install XcodeGen before generating the Xcode project:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 </p>
 
 <p align="center">
-  <a href="ios/MimiRemote/README.md"><img src="https://img.shields.io/badge/iOS%20%2F%20iPadOS-26%2B-black?logo=apple" alt="要求 iOS 或 iPadOS 26 及以上版本" /></a>
+  <a href="ios/MimiRemote/README.md"><img src="https://img.shields.io/badge/iOS%20%2F%20iPadOS-18%2B-black?logo=apple" alt="要求 iOS 或 iPadOS 18 及以上版本" /></a>
   <a href="ios/MimiRemote"><img src="https://img.shields.io/badge/SwiftUI-native-F05138?logo=swift&amp;logoColor=white" alt="原生 SwiftUI App" /></a>
   <a href="https://github.com/gaixianggeng/codex-ipad-agent/actions/workflows/go-ci.yml"><img src="https://github.com/gaixianggeng/codex-ipad-agent/actions/workflows/go-ci.yml/badge.svg" alt="Go CI 状态" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3%20%2B%20Store%20Exception-blue.svg" alt="GPLv3 与商店分发例外" /></a>
@@ -194,7 +194,7 @@ Claude bridge 位于本仓库 [`bridges/claude`](bridges/claude)，与 iOS 和 `
 
 安装前先确认：
 
-- **必需：**一台运行 iOS / iPadOS 26 或更高版本的 iPhone / iPad、一台可持续运行宿主服务的受支持电脑，以及已在宿主电脑安装并可用的 Codex CLI。Runtime 自身的认证只需在宿主完成；Mimi Remote 只连接 `agentd` 网关，不接收或管理 Runtime 凭证与计费。认证方式见 [Codex 官方认证文档](https://learn.chatgpt.com/docs/auth)。
+- **必需：**一台运行 iOS / iPadOS 18 或更高版本的 iPhone / iPad、一台可持续运行宿主服务的受支持电脑，以及已在宿主电脑安装并可用的 Codex CLI。Runtime 自身的认证只需在宿主完成；Mimi Remote 只连接 `agentd` 网关，不接收或管理 Runtime 凭证与计费。认证方式见 [Codex 官方认证文档](https://learn.chatgpt.com/docs/auth)。iOS 26+ 保留完整的 Liquid Glass 与 Apple 设备端实时语音体验；iOS 18–25 使用更普通的系统材质，并回退到 Codex 录音转写。
 - **网络：**设备位于同一可信局域网时可以直连，不要求安装 Tailscale；跨网络时使用同一 Tailnet，或使用用户自行管理的安全 HTTPS 入口。不要把 `agentd` 的明文 HTTP 端口直接暴露到公网。
 - **可选 Runtime：**Claude Code 是默认关闭的实验通道，不能替代 Codex。启用时需按 [Claude Code 官方安装与认证文档](https://docs.anthropic.com/en/docs/claude-code/getting-started)单独安装和认证，Codex CLI 仍然必需。
 - **当前 iOS 安装方式：**尚无公开 App Store 包。可以通过 [TestFlight](https://testflight.apple.com/join/jhGPbSk6) 安装；也可以使用 Mac、带 iOS 26 SDK 的 Xcode 26 或更高版本和 XcodeGen 从源码构建，详见 [iOS 构建说明](ios/MimiRemote/README.md)。
@@ -287,7 +287,7 @@ https://github.com/gaixianggeng/codex-ipad-agent/tree/main/packaging/skill/insta
 
 ### 安装 iOS App
 
-Mimi Remote 要求 iOS / iPadOS 26 或更高版本。最简单的安装方式是加入 [Mimi Remote TestFlight](https://testflight.apple.com/join/jhGPbSk6)。
+Mimi Remote 要求 iOS / iPadOS 18 或更高版本。最简单的安装方式是加入 [Mimi Remote TestFlight](https://testflight.apple.com/join/jhGPbSk6)。iOS 26+ 提供完整高级视觉与设备端语音体验；较早的受支持系统会对不可用能力进行明确降级。
 
 如需从源码构建，请使用安装了 Xcode 26 或更高版本和 XcodeGen 的 Mac：
 
@@ -299,7 +299,7 @@ xcodegen generate \
 open ios/MimiRemote/MimiRemote.xcodeproj
 ```
 
-在 Xcode 中选择 `MimiRemote` scheme、开发者 Team 和目标 iPhone / iPad 后运行。工程要求 iOS / iPadOS 26 或更高版本。
+在 Xcode 中选择 `MimiRemote` scheme、开发者 Team 和目标 iPhone / iPad 后运行。工程支持 iOS / iPadOS 18 或更高版本；仍需使用带 iOS 26 SDK 的现代 Xcode 编译，以便同时保留新系统高级能力。
 
 Mac App 用户从菜单栏选择“配对设备…”，CLI 用户扫描 `agentd up` 或 `agentd pair` 显示的二维码。二维码使用 10 分钟有效的签名票据，同一二维码或复制链接可在有效期内重复兑换，且不直接包含长期 Token；扫码不可用时可以展开高级手动连接。
 
@@ -461,9 +461,9 @@ bridges/claude/          Rust Claude Code 协议 bridge
 
 不是。Mimi Remote 是采用 GNU GPLv3 并附 App Store / Google Play 分发例外的第三方开源项目，与 OpenAI、Anthropic 和 Tailscale 均无隶属或背书关系。
 
-### Why does the app require iOS / iPadOS 26? / 为什么要求 iOS 26？
+### How does the app differ before iOS / iPadOS 26? / iOS 26 之前有什么区别？
 
-当前版本优先使用较新的 SwiftUI 能力完成原生多栏工作台、输入与材质效果，以减少兼容分支和小团队维护成本。旧系统兼容会根据真实用户需求再评估。
+Mimi Remote 支持 iOS / iPadOS 18 及以上版本。iOS 26+ 继续使用 Liquid Glass、系统共享玻璃背景和 Apple 设备端实时语音；iOS 18–25 保留核心会话、工作区、附件与连接能力，但使用普通系统材质，并把不支持的 Apple 实时语音入口回退到 Codex 录音转写。兼容层只处理系统能力差异，不复制业务逻辑。
 
 ## 参与项目
 

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		18A1FB819B355E6CF6D81361 /* ConversationTimelineReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A922D9A3D4C72236D9CFBA /* ConversationTimelineReducer.swift */; };
 		19CF490ED87673609EF8C984 /* SessionInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5AA2F7FA8732CE5CD30CDE /* SessionInspectorView.swift */; };
 		1D2A6A134E0E732CBE28ED65 /* THIRD_PARTY_NOTICES.md in Resources */ = {isa = PBXBuildFile; fileRef = 8CAEACFD2E2425D3DAFDF904 /* THIRD_PARTY_NOTICES.md */; };
+		1D4173EB8DAD73A39CC78A38 /* testSessionRuntimeMetadataInDarkConversationList.1.png in Resources */ = {isa = PBXBuildFile; fileRef = F3D83CF837D1EE07A541F820 /* testSessionRuntimeMetadataInDarkConversationList.1.png */; };
 		1EE4B6E692FE06A58F118F21 /* testNotionStyleWorkspaceOnIPadMiniPortrait.1.png in Resources */ = {isa = PBXBuildFile; fileRef = EE33DEF260CD695897B70FB8 /* testNotionStyleWorkspaceOnIPadMiniPortrait.1.png */; };
 		1F58506B5DEC82FF40AE7060 /* MimiRemotePhysicalSmokeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0864CB07EFB2FEBFFC91BA /* MimiRemotePhysicalSmokeUITests.swift */; };
 		1F902DC512ED302F40F45D68 /* testPendingApprovalCardUsesWiderIPadPreview.1.png in Resources */ = {isa = PBXBuildFile; fileRef = C7F7986F901ECE53E977D767 /* testPendingApprovalCardUsesWiderIPadPreview.1.png */; };
@@ -98,6 +99,7 @@
 		55D43B731CFE9C5246B02D1C /* testComposerStatusTrayCrowdedState.1.png in Resources */ = {isa = PBXBuildFile; fileRef = E4C85188C13516219753D4ED /* testComposerStatusTrayCrowdedState.1.png */; };
 		55D520C10E168BFEA7E4A619 /* LegalDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B546C68F6A4EDDA47CD25FD7 /* LegalDocumentView.swift */; };
 		5B092289C5F40E2A9B3622B9 /* SessionStoreLifecycleWorkspaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78D8C49C36228C60EF5D096 /* SessionStoreLifecycleWorkspaces.swift */; };
+		5B378569754B50364C872318 /* WorkspaceSessionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BCF1B2E13945C6F706C8BD /* WorkspaceSessionPresentationTests.swift */; };
 		5CD51AE13B5D23F8FBE444C5 /* SessionStoreSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */; };
 		5FD1DBDBCD89B51F6B22D679 /* ConversationSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7C7C0DF7B33C596EBE5FC7 /* ConversationSnapshotTests.swift */; platformFilters = (ios, ); };
 		613A97BCD065B780C6162C8E /* ConversationTimelineReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F938DA83B5613E99E202281D /* ConversationTimelineReducerTests.swift */; };
@@ -114,6 +116,7 @@
 		6B9100C88D46D2BB9A294B6F /* testSkillCardsAndModelGridDarkAppearance.1.png in Resources */ = {isa = PBXBuildFile; fileRef = DCC3691375017B35F7E29234 /* testSkillCardsAndModelGridDarkAppearance.1.png */; };
 		6CDCE158780313AFAA5C93D5 /* testComposerStatusTrayExpandedCrowdedState.1.png in Resources */ = {isa = PBXBuildFile; fileRef = C523CEAE7C15DEC88BF93FEC /* testComposerStatusTrayExpandedCrowdedState.1.png */; };
 		6D9C8B57410AFA9A87956C6D /* ConversationSessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121E340DD237BE03706546CA /* ConversationSessionStoreTests.swift */; };
+		6DEFFD87BEBE13C2409FE183 /* testComposerSurfaceIPadMiniIncreasedContrast.1.png in Resources */ = {isa = PBXBuildFile; fileRef = E322989D4007390096CA127C /* testComposerSurfaceIPadMiniIncreasedContrast.1.png */; };
 		6EE0372C42829D55A92DA504 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FAD5B8DE8A8FD7FC216867 /* L10n.swift */; };
 		705F1646646DBB454684A718 /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163EC3A1080DFD2A3BB8F098 /* ComposerView.swift */; };
 		7380C6ED244A91FE8786269B /* QRCodeScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D29856557B35AE9C7C9B5EA /* QRCodeScannerSheet.swift */; };
@@ -139,8 +142,6 @@
 		89DCEF26CCF404A369DFDE80 /* PairingLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EABFF317C695883ECE910D0 /* PairingLinkTests.swift */; };
 		8B704ED612394635B98E9D56 /* SubagentHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3359185FAA3E42EA9C7A5392 /* SubagentHistoryTests.swift */; };
 		8C027A403C453281A5BD7812 /* WorkspaceRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D283CD0291735DA4425D91A4 /* WorkspaceRootView.swift */; };
-		F1A95C100000000000000002 /* WorkspaceSessionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A95C100000000000000001 /* WorkspaceSessionPresentation.swift */; };
-		F1A95C100000000000000004 /* WorkspaceSessionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A95C100000000000000003 /* WorkspaceSessionPresentationTests.swift */; };
 		8D054BA1EEC76A1C436CF8BA /* testEmptyConversationShowsCurrentDirectoryAcrossAppearances.iphone-long-path-light.png in Resources */ = {isa = PBXBuildFile; fileRef = 4FCDE6ACD44D941797C6186A /* testEmptyConversationShowsCurrentDirectoryAcrossAppearances.iphone-long-path-light.png */; };
 		8EEEC2243F3EE20F96B3B62D /* direct_app_server_approval_stream.jsonl in Resources */ = {isa = PBXBuildFile; fileRef = 5591601BA7CA64C8C0CF7931 /* direct_app_server_approval_stream.jsonl */; };
 		8F03A9837B537D6CBA7D532A /* TailscaleStableHostnameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0B86402960D3109AD10CE7 /* TailscaleStableHostnameTests.swift */; };
@@ -173,6 +174,7 @@
 		A9672A5CCD14CB34B13ED66A /* CodexAppServerThreadOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3F9E8A8ED2FD8317FB92F2 /* CodexAppServerThreadOwnership.swift */; };
 		AADCBC7617C842DC51799171 /* MimiInteractionFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C746BA73EAA9E0C19B0C0E4 /* MimiInteractionFeedback.swift */; };
 		AD2BA4EB75791D6DA68D6A46 /* ConversationConnectionRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */; };
+		AE11B5ADD6FFE67C2F363868 /* WorkspaceSessionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E08C1C5B74CE6DA6772054 /* WorkspaceSessionPresentation.swift */; };
 		AFE6EEB69B15A356E950F6AC /* AnsiCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9145366BE7345CD146DFA0AE /* AnsiCleaner.swift */; };
 		B1015E389669F77748949820 /* ProjectSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640F92290AC3DAED201E1CD0 /* ProjectSidebarView.swift */; };
 		B2628282609AF897C62B6178 /* testProjectSessionDashboard.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 2E4A0A29797384D5BD5002D1 /* testProjectSessionDashboard.1.png */; };
@@ -213,14 +215,15 @@
 		D07503C7468E7547ABA072EE /* testCompactModelGridDarkFastModeOn.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 7C6A770A18111A38D48BF68F /* testCompactModelGridDarkFastModeOn.1.png */; };
 		D277DCC60CB55D50D1C0731A /* DebugLaunchConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D8E5F1F33563965409D9D4 /* DebugLaunchConfiguration.swift */; };
 		D3F4D53A1BACAEA7FF62CA1F /* WorkspaceSessionRuntimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFC45E69D906A49E9EB6310 /* WorkspaceSessionRuntimePicker.swift */; };
-		A10700000000000000000001 /* WorkspaceAppearancePickers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10700000000000000000002 /* WorkspaceAppearancePickers.swift */; };
 		D4B700AC9DF628887258F469 /* SessionStoreTurns.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38A8CE5A8F1D7EE3889F078 /* SessionStoreTurns.swift */; };
 		D502C332F16B48F95CAAA518 /* HostInstallationSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D9D8852662655DFC4D9FA0 /* HostInstallationSetupView.swift */; };
+		D681218B9C336370B3C784B7 /* WorkspaceAppearancePickers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15CA396BC1238F85AAB82FC /* WorkspaceAppearancePickers.swift */; };
 		D8263551DECB2E7EBCD66E3B /* testSessionRuntimeBadgesInConversationList.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */; };
 		DAAB5AD21F6B77F6D691B94F /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373EDA921B7F6B3F6B680140 /* ConversationStore.swift */; };
 		DC2F420929F4E30D3B6AC6DE /* ConnectionProfileModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6C8F9B82DA43620543124E /* ConnectionProfileModels.swift */; };
 		DDCFB91D621190F7BA26678D /* AppExternalLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28C291AC46CF73586F8764A /* AppExternalLinks.swift */; };
 		E158B34D71964DBF782D1DDF /* MimiRemoteApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B337007E06BFD01501A0C9BD /* MimiRemoteApp.swift */; };
+		E16971051CD43D45FB6F1AC2 /* testComposerStatusTrayCollapsedBlockedObserveDark.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 73D66A2386FC885F7D813B26 /* testComposerStatusTrayCollapsedBlockedObserveDark.1.png */; };
 		E19C681FE60B4E63CF29AA69 /* WorkspaceAppearanceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D0FB9DA0913B603240372D /* WorkspaceAppearanceStore.swift */; };
 		E229F6F4224F8B1594F5B934 /* ProtocolContract.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995395FD72E3386DFD66F143 /* ProtocolContract.generated.swift */; };
 		E25AEFACDD0E53EFD916F7C0 /* FileAttachmentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED654AD3DE587C9B773238A8 /* FileAttachmentModels.swift */; };
@@ -398,6 +401,7 @@
 		5F0B86402960D3109AD10CE7 /* TailscaleStableHostnameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailscaleStableHostnameTests.swift; sourceTree = "<group>"; };
 		5F6590638B16083675339655 /* testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png; sourceTree = "<group>"; };
 		608F5B2621676207DEE92BA8 /* testComposerModelTriggerFastIndicator.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerModelTriggerFastIndicator.1.png; sourceTree = "<group>"; };
+		60E08C1C5B74CE6DA6772054 /* WorkspaceSessionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionPresentation.swift; sourceTree = "<group>"; };
 		61B287032A29ABBC9D670E94 /* NewSessionPresentationSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionPresentationSourceTests.swift; sourceTree = "<group>"; };
 		640F92290AC3DAED201E1CD0 /* ProjectSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSidebarView.swift; sourceTree = "<group>"; };
 		64E9EA7D6A93EB6697C0B874 /* ComposerTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTextEditor.swift; sourceTree = "<group>"; };
@@ -413,6 +417,7 @@
 		7348A6FCD28C7489CC7097AD /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		735BE2C721373586AD49D470 /* SessionStoreExternalActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreExternalActivity.swift; sourceTree = "<group>"; };
 		73BF91C2135478711BB991B2 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		73D66A2386FC885F7D813B26 /* testComposerStatusTrayCollapsedBlockedObserveDark.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCollapsedBlockedObserveDark.1.png; sourceTree = "<group>"; };
 		7587EB164AF1902FAD735D90 /* testExpandedWorkGroupRendering.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testExpandedWorkGroupRendering.1.png; sourceTree = "<group>"; };
 		760E3B9BE51D633691ED9C56 /* testCollapsedWorkGroupRendering.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCollapsedWorkGroupRendering.1.png; sourceTree = "<group>"; };
 		7712F41D687B3B2A7FFFEB8A /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-320.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-320.png"; sourceTree = "<group>"; };
@@ -450,6 +455,7 @@
 		9811B3CE215E02A0D371878C /* AgentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentModels.swift; sourceTree = "<group>"; };
 		995395FD72E3386DFD66F143 /* ProtocolContract.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolContract.generated.swift; sourceTree = "<group>"; };
 		A0E1C34623582EDA99D6B917 /* LogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStoreTests.swift; sourceTree = "<group>"; };
+		A15CA396BC1238F85AAB82FC /* WorkspaceAppearancePickers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceAppearancePickers.swift; sourceTree = "<group>"; };
 		A19B006BD6C8E1D836A53FB3 /* testPendingApprovalCardFitsIPhoneTouchLayout.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testPendingApprovalCardFitsIPhoneTouchLayout.1.png; sourceTree = "<group>"; };
 		A212E188D5551C6460E12DA8 /* ThirdPartyNoticesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyNoticesView.swift; sourceTree = "<group>"; };
 		A30F059863E0778E0B00065D /* TokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenStore.swift; sourceTree = "<group>"; };
@@ -477,7 +483,6 @@
 		B9F486B1F9E0E676B63B7084 /* testEmptyConversationShowsCurrentDirectoryAcrossAppearances.ipad-dark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testEmptyConversationShowsCurrentDirectoryAcrossAppearances.ipad-dark.png"; sourceTree = "<group>"; };
 		BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerTransport.swift; sourceTree = "<group>"; };
 		BEFC45E69D906A49E9EB6310 /* WorkspaceSessionRuntimePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionRuntimePicker.swift; sourceTree = "<group>"; };
-		A10700000000000000000002 /* WorkspaceAppearancePickers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceAppearancePickers.swift; sourceTree = "<group>"; };
 		C01D29CF13ECEA0EBF33BF7C /* HostSwitcherMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostSwitcherMenu.swift; sourceTree = "<group>"; };
 		C0764989DE2B4FAEF1543FF5 /* CodexAppServerEventProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerEventProjection.swift; sourceTree = "<group>"; };
 		C0FE3675988DBD54585B3A79 /* ConversationDirectRuntimeSubscriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeSubscriptionTests.swift; sourceTree = "<group>"; };
@@ -491,7 +496,6 @@
 		C6D12A6459F0F6B768F4F068 /* ConversationCommentaryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCommentaryRow.swift; sourceTree = "<group>"; };
 		C7F7986F901ECE53E977D767 /* testPendingApprovalCardUsesWiderIPadPreview.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testPendingApprovalCardUsesWiderIPadPreview.1.png; sourceTree = "<group>"; };
 		C896DA13C5A44DA224A17CAB /* WorkspaceSessionLoadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionLoadingTests.swift; sourceTree = "<group>"; };
-		F1A95C100000000000000003 /* WorkspaceSessionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionPresentationTests.swift; sourceTree = "<group>"; };
 		CA2BF4F63781123B8E297F7E /* ConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationView.swift; sourceTree = "<group>"; };
 		CB64B805952E5CC416C28EAF /* testCrossSessionContinuationHidesInternalAddresses.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCrossSessionContinuationHidesInternalAddresses.1.png; sourceTree = "<group>"; };
 		CC5A74E63F1B363F7C8143C1 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png"; sourceTree = "<group>"; };
@@ -500,7 +504,6 @@
 		CEE63E1F88F94DC3D0C543CF /* testComposerStatusTrayExtremelyNarrowCompactWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayExtremelyNarrowCompactWidth.1.png; sourceTree = "<group>"; };
 		D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionRuntime.swift; sourceTree = "<group>"; };
 		D283CD0291735DA4425D91A4 /* WorkspaceRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRootView.swift; sourceTree = "<group>"; };
-		F1A95C100000000000000001 /* WorkspaceSessionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionPresentation.swift; sourceTree = "<group>"; };
 		D28C291AC46CF73586F8764A /* AppExternalLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExternalLinks.swift; sourceTree = "<group>"; };
 		D2F4BF550566258A06CF1F9B /* testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390-remote-url.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390-remote-url.png"; sourceTree = "<group>"; };
 		D36F897C3DF848C89B87C926 /* testInlineUserInputCardMatchesApprovalChromeOnIPad.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testInlineUserInputCardMatchesApprovalChromeOnIPad.1.png; sourceTree = "<group>"; };
@@ -516,6 +519,7 @@
 		DE04A73144E31515A65F5830 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E033E7A8267D3C3494835305 /* SessionContextModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContextModels.swift; sourceTree = "<group>"; };
 		E2791378963B2ED7657F13BD /* ExternalActivitySessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalActivitySessionStoreTests.swift; sourceTree = "<group>"; };
+		E322989D4007390096CA127C /* testComposerSurfaceIPadMiniIncreasedContrast.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerSurfaceIPadMiniIncreasedContrast.1.png; sourceTree = "<group>"; };
 		E4C85188C13516219753D4ED /* testComposerStatusTrayCrowdedState.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCrowdedState.1.png; sourceTree = "<group>"; };
 		E55DE1D530ABE8EE097ECB59 /* testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png; sourceTree = "<group>"; };
 		E5D0FB9DA0913B603240372D /* WorkspaceAppearanceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceAppearanceStore.swift; sourceTree = "<group>"; };
@@ -523,6 +527,7 @@
 		E68C2F3A2CDF72BEF743E31B /* SessionContextSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContextSidebarView.swift; sourceTree = "<group>"; };
 		E86C009EEF7D400DE35ADBD1 /* ImageAttachmentEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentEncoder.swift; sourceTree = "<group>"; };
 		E9A21AAEB96727E4907BCCB3 /* SubagentSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubagentSessionTests.swift; sourceTree = "<group>"; };
+		E9BCF1B2E13945C6F706C8BD /* WorkspaceSessionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionPresentationTests.swift; sourceTree = "<group>"; };
 		EBF24E2B6355EF529578DE9D /* testComposerStatusTrayIPadMiniPortraitWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayIPadMiniPortraitWidth.1.png; sourceTree = "<group>"; };
 		EC0864CB07EFB2FEBFFC91BA /* MimiRemotePhysicalSmokeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiRemotePhysicalSmokeUITests.swift; sourceTree = "<group>"; };
 		ECDC4F6FDDB66F610BF6FC2D /* FloatingSidebarPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingSidebarPresentation.swift; sourceTree = "<group>"; };
@@ -532,6 +537,7 @@
 		EE5AA2F7FA8732CE5CD30CDE /* SessionInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionInspectorView.swift; sourceTree = "<group>"; };
 		EF8E25B79CBECB1CB0EDBD5B /* ProtocolContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolContractTests.swift; sourceTree = "<group>"; };
 		F22DB51885C0903C5E9212F9 /* ConversationTimelineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTimelineModels.swift; sourceTree = "<group>"; };
+		F3D83CF837D1EE07A541F820 /* testSessionRuntimeMetadataInDarkConversationList.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionRuntimeMetadataInDarkConversationList.1.png; sourceTree = "<group>"; };
 		F55F20982430C816BB70A7F5 /* FileAttachmentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAttachmentModelsTests.swift; sourceTree = "<group>"; };
 		F5EF45DF782D873112FB24F1 /* MimiRemoteUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MimiRemoteUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7A631C01496AAA7C083AA6B /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-popover-420.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-popover-420.png"; sourceTree = "<group>"; };
@@ -570,9 +576,9 @@
 			isa = PBXGroup;
 			children = (
 				640F92290AC3DAED201E1CD0 /* ProjectSidebarView.swift */,
+				A15CA396BC1238F85AAB82FC /* WorkspaceAppearancePickers.swift */,
 				D283CD0291735DA4425D91A4 /* WorkspaceRootView.swift */,
-				A10700000000000000000002 /* WorkspaceAppearancePickers.swift */,
-				F1A95C100000000000000001 /* WorkspaceSessionPresentation.swift */,
+				60E08C1C5B74CE6DA6772054 /* WorkspaceSessionPresentation.swift */,
 				BEFC45E69D906A49E9EB6310 /* WorkspaceSessionRuntimePicker.swift */,
 				CEB7A4F02C5EC7121D1BB6B9 /* WorktreeManagementViews.swift */,
 			);
@@ -714,7 +720,7 @@
 				85879EDF3D64609C3C6BA873 /* WorkspaceGitSummaryTests.swift */,
 				B75153DC244B9C9543B87E2E /* WorkspaceSessionAuthoritativeContinuationTests.swift */,
 				C896DA13C5A44DA224A17CAB /* WorkspaceSessionLoadingTests.swift */,
-				F1A95C100000000000000003 /* WorkspaceSessionPresentationTests.swift */,
+				E9BCF1B2E13945C6F706C8BD /* WorkspaceSessionPresentationTests.swift */,
 				327AF69020E348B4AE9F7BBE /* WorkspaceVisualSnapshotTests.swift */,
 				7DD567ECF6024FEEF09274D5 /* __Snapshots__ */,
 				89403F8D35BD5D42FF3A98B9 /* Fixtures */,
@@ -793,6 +799,7 @@
 				760E3B9BE51D633691ED9C56 /* testCollapsedWorkGroupRendering.1.png */,
 				C37E5D5C19C4592F82C8F319 /* testCommentaryAndTrailingProcessRendering.1.png */,
 				2EBD11FEEFA3EA7C03993BE1 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png */,
+				73D66A2386FC885F7D813B26 /* testComposerStatusTrayCollapsedBlockedObserveDark.1.png */,
 				00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */,
 				E4C85188C13516219753D4ED /* testComposerStatusTrayCrowdedState.1.png */,
 				C523CEAE7C15DEC88BF93FEC /* testComposerStatusTrayExpandedCrowdedState.1.png */,
@@ -801,6 +808,7 @@
 				495CF4F9BDB35ED685F879F7 /* testComposerStatusTrayIPadMiniLandscapeDetailWidth.1.png */,
 				EBF24E2B6355EF529578DE9D /* testComposerStatusTrayIPadMiniPortraitWidth.1.png */,
 				D4D9B1DC813DAB2FBDAA9084 /* testComposerStatusTrayIPadMiniSplitViewWidth.1.png */,
+				E322989D4007390096CA127C /* testComposerSurfaceIPadMiniIncreasedContrast.1.png */,
 				0FC920B8D7FE7F76E2C18FD7 /* testConversationBubbleAlignment.1.png */,
 				CB64B805952E5CC416C28EAF /* testCrossSessionContinuationHidesInternalAddresses.1.png */,
 				8E5FA820000C5AD8FB8E1300 /* testDefaultDarkConversationPalette.1.png */,
@@ -818,6 +826,7 @@
 				2E4A0A29797384D5BD5002D1 /* testProjectSessionDashboard.1.png */,
 				2ACC589478ECDD4A4FB9BEB0 /* testRichMarkdownConversationRendering.1.png */,
 				433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */,
+				F3D83CF837D1EE07A541F820 /* testSessionRuntimeMetadataInDarkConversationList.1.png */,
 				776EDC1EF2FA8453E4DF949F /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-700.png */,
 				7EC08924AD866CA7D83CCD6E /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-landscape.png */,
 				D51F224075928990E52845C8 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-wide-1024.png */,
@@ -1256,6 +1265,7 @@
 				9F4EA8644B1E67A1F3CC863C /* testCompactModelGridLightFastModeOff.1.png in Resources */,
 				3942D0F45FDBA6578D875940 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png in Resources */,
 				E52FF51E6A66678EBAEF7F9E /* testComposerModelTriggerFastIndicator.1.png in Resources */,
+				E16971051CD43D45FB6F1AC2 /* testComposerStatusTrayCollapsedBlockedObserveDark.1.png in Resources */,
 				26F460F34C7BA2C10839F2CA /* testComposerStatusTrayCrowdedCompactWidth.1.png in Resources */,
 				55D43B731CFE9C5246B02D1C /* testComposerStatusTrayCrowdedState.1.png in Resources */,
 				6CDCE158780313AFAA5C93D5 /* testComposerStatusTrayExpandedCrowdedState.1.png in Resources */,
@@ -1264,6 +1274,7 @@
 				B7F45B51F9933CD5BED26A48 /* testComposerStatusTrayIPadMiniLandscapeDetailWidth.1.png in Resources */,
 				E930993420D89B0942BB732C /* testComposerStatusTrayIPadMiniPortraitWidth.1.png in Resources */,
 				7B8635C1AC4CE37A11877487 /* testComposerStatusTrayIPadMiniSplitViewWidth.1.png in Resources */,
+				6DEFFD87BEBE13C2409FE183 /* testComposerSurfaceIPadMiniIncreasedContrast.1.png in Resources */,
 				E7EE1A6D1A2A19F69E8F6513 /* testConversationBubbleAlignment.1.png in Resources */,
 				FF30D18FE63EA561E779924B /* testCrossSessionContinuationHidesInternalAddresses.1.png in Resources */,
 				7CD5F621C651FF6A32ACAE47 /* testDefaultDarkConversationPalette.1.png in Resources */,
@@ -1289,6 +1300,7 @@
 				B2628282609AF897C62B6178 /* testProjectSessionDashboard.1.png in Resources */,
 				9CDA4F02261EE4460043EC2B /* testRichMarkdownConversationRendering.1.png in Resources */,
 				D8263551DECB2E7EBCD66E3B /* testSessionRuntimeBadgesInConversationList.1.png in Resources */,
+				1D4173EB8DAD73A39CC78A38 /* testSessionRuntimeMetadataInDarkConversationList.1.png in Resources */,
 				09A90025E5F3FB50D65C14A8 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-700.png in Resources */,
 				4B13DBFDB232284E99D2BE1F /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-landscape.png in Resources */,
 				69C750B399975CEDCEBC84B6 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-wide-1024.png in Resources */,
@@ -1386,7 +1398,7 @@
 				951475AE3120CB42A905E3B3 /* WorkspaceGitSummaryTests.swift in Sources */,
 				B7D06C05B900E3DC9336891D /* WorkspaceSessionAuthoritativeContinuationTests.swift in Sources */,
 				EA70EC72EE3F9B6B81CF4E71 /* WorkspaceSessionLoadingTests.swift in Sources */,
-				F1A95C100000000000000004 /* WorkspaceSessionPresentationTests.swift in Sources */,
+				5B378569754B50364C872318 /* WorkspaceSessionPresentationTests.swift in Sources */,
 				626E053AFAE30F345EEFC01D /* WorkspaceVisualSnapshotTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1523,10 +1535,10 @@
 				B5BAC2CFD69E8F6E30996369 /* VoiceInputPreferences.swift in Sources */,
 				26187C1CD9C32B84B41153D0 /* WorkbenchChrome.swift in Sources */,
 				94E3CCCEB33D4DB58965C7DB /* WorkbenchSidebarComponents.swift in Sources */,
+				D681218B9C336370B3C784B7 /* WorkspaceAppearancePickers.swift in Sources */,
 				E19C681FE60B4E63CF29AA69 /* WorkspaceAppearanceStore.swift in Sources */,
-				F1A95C100000000000000002 /* WorkspaceSessionPresentation.swift in Sources */,
 				8C027A403C453281A5BD7812 /* WorkspaceRootView.swift in Sources */,
-				A10700000000000000000001 /* WorkspaceAppearancePickers.swift in Sources */,
+				AE11B5ADD6FFE67C2F363868 /* WorkspaceSessionPresentation.swift in Sources */,
 				D3F4D53A1BACAEA7FF62CA1F /* WorkspaceSessionRuntimePicker.swift in Sources */,
 				0E20F441A1A1B56E39868A44 /* WorkspaceView.swift in Sources */,
 				3F150075A258BDF73AFB8ED6 /* WorktreeManagementViews.swift in Sources */,
@@ -1659,7 +1671,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1814,7 +1826,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;

--- a/ios/MimiRemote/README.md
+++ b/ios/MimiRemote/README.md
@@ -2,7 +2,7 @@
 
 ## Build from source (English)
 
-Mimi Remote is a native iPhone/iPad client for coding agents running on your own Mac. It requires iOS/iPadOS 26 or later, Xcode 26 or later with the iOS 26 SDK, and XcodeGen; there is no public App Store release. From the repository root, install XcodeGen, then generate and open the project:
+Mimi Remote is a native iPhone/iPad client for coding agents running on your own Mac. It supports iOS/iPadOS 18 or later. Building from source still requires Xcode 26 or later with the iOS 26 SDK plus XcodeGen so the same binary can keep iOS 26+ Liquid Glass and Apple Speech features behind availability checks. There is no public App Store release. From the repository root, install XcodeGen, then generate and open the project:
 
 ```bash
 brew install xcodegen
@@ -43,7 +43,7 @@ Mac agentd control plane / thin gateway
 
 已下线旧链路：`/api/sessions*`、`/api/sessions/{id}/ws`、Web/PWA 和 iOS PTY 文本解析回退都已经删除。后续不要再基于这些入口增加功能。
 
-目标体验按 iOS/iPadOS 26 推进，`project.yml` 的 deployment target 为 iOS 26.0。MVP 不在 iPad 上运行 Codex；Mac Catalyst 只自动检测同机固定 loopback，不扫描局域网或其它 Mac。用户先在 Mac 上执行：
+高级体验继续按 iOS/iPadOS 26+ 推进，但 `project.yml` 的 deployment target 为 iOS 18.0。iOS 18–25 使用普通系统材质，并隐藏或回退无法提供的系统能力；iOS 26+ 保留 Liquid Glass 与 Apple 设备端实时语音。MVP 不在 iPad 上运行 Codex；Mac Catalyst 只自动检测同机固定 loopback，不扫描局域网或其它 Mac。用户先在 Mac 上执行：
 
 ```bash
 codex --version

--- a/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
@@ -2,7 +2,7 @@ import AVFoundation
 import os
 import Speech
 
-/// SpeechTranscriber 会交替发布可变结果和最终结果；这里只保留一个可变尾段，
+/// 系统转写器会交替发布可变结果和最终结果；这里只保留一个可变尾段，
 /// 最终结果按系统给出的顺序拼接，避免实时刷新时把同一段文字重复插入草稿。
 struct AppleSpeechTranscriptAccumulator: Equatable {
     private(set) var finalizedText = ""
@@ -162,8 +162,9 @@ enum AppleSpeechTranscriptionError: LocalizedError {
     }
 }
 
-/// iOS 26 的 SpeechAnalyzer 只负责分析，实时麦克风采集仍由 App 管理。
+/// iOS 26 的实时分析器只负责分析，实时麦克风采集仍由 App 管理。
 /// 该对象限定在主线程持有生命周期；音频 tap 里只做同步格式转换和 AsyncStream yield。
+@available(iOS 26.0, *)
 @MainActor
 final class AppleSpeechTranscriptionSession {
     private static let logger = Logger(
@@ -554,7 +555,7 @@ final class AppleSpeechTranscriptionSession {
     }
 }
 
-/// Xcode 26 没有 AnalyzerInputConverter，使用 AVAudioConverter 保持 iOS 26 最低版本兼容。
+/// Xcode 26 没有系统音频格式转换器，使用 AVAudioConverter 保持最低版本兼容。
 private final class AppleSpeechAudioBufferConverter: @unchecked Sendable {
     private let converter: AVAudioConverter
     private let outputFormat: AVAudioFormat

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -219,7 +219,7 @@ extension ComposerView {
     }
 
     var selectedVoiceInputProvider: VoiceInputProvider {
-        VoiceInputProvider(rawValue: voiceInputProviderRawValue) ?? .codex
+        VoiceInputProvider.resolved(rawValue: voiceInputProviderRawValue)
     }
 
     var isPhoneComposer: Bool {
@@ -725,7 +725,7 @@ extension ComposerView {
         composerState.beginVoiceInput()
         let context = VoiceTranscriptionContext(sessionID: sessionStore.selectedSessionID)
         activeVoiceTranscriptionContext = context
-        if selectedVoiceInputProvider == .apple {
+        if selectedVoiceInputProvider == .apple, #available(iOS 26.0, *) {
             voiceInput.startAppleTranscription(
                 locale: .autoupdatingCurrent,
                 onTranscript: { transcript in
@@ -776,7 +776,7 @@ extension ComposerView {
             composerState.endVoiceInput()
             return
         }
-        if selectedVoiceInputProvider == .apple {
+        if selectedVoiceInputProvider == .apple, #available(iOS 26.0, *) {
             // Apple 在录音过程中已持续写入草稿；停止后只等待最后一个稳定结果。
             isVoiceTranscribing = true
         }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -578,7 +578,9 @@ final class VoiceInputController: NSObject, ObservableObject {
     private var pressStartedAt: Date?
     private var recordingStartedAt: Date?
     private var activeProvider: VoiceInputProvider?
-    private var appleSession: AppleSpeechTranscriptionSession?
+    // Swift 不允许 stored property 自身标记 availability；用不透明引用保存会话，
+    // 只在 iOS 26+ 方法内部还原成 AppleSpeechTranscriptionSession。
+    private var appleSession: AnyObject?
     private var appleLifecycleTask: Task<Void, Never>?
     private var appleFinishHandler: (() -> Void)?
     private let audioSessionCoordinator: VoiceAudioSessionCoordinator
@@ -662,6 +664,7 @@ final class VoiceInputController: NSObject, ObservableObject {
         }
     }
 
+    @available(iOS 26.0, *)
     func startAppleTranscription(
         locale: Locale,
         onTranscript: @escaping @MainActor (String) -> Void,
@@ -761,7 +764,12 @@ final class VoiceInputController: NSObject, ObservableObject {
 
     func stop() {
         if activeProvider == .apple {
-            finishAppleTranscription()
+            if #available(iOS 26.0, *) {
+                finishAppleTranscription()
+            } else {
+                // Apple 提供方不会在旧系统被选中；此分支只保护历史状态，直接收尾而不触碰 Speech API。
+                completeUnavailableAppleInteraction(notifyFinish: true)
+            }
             return
         }
         let shouldFinishImmediately = !isRecording && recorder == nil
@@ -775,7 +783,11 @@ final class VoiceInputController: NSObject, ObservableObject {
 
     func cancel() {
         if activeProvider == .apple {
-            cancelAppleTranscription(notifyFinish: false)
+            if #available(iOS 26.0, *) {
+                cancelAppleTranscription(notifyFinish: false)
+            } else {
+                completeUnavailableAppleInteraction(notifyFinish: false)
+            }
             return
         }
         let fileURL = recordingURL
@@ -787,9 +799,10 @@ final class VoiceInputController: NSObject, ObservableObject {
         }
     }
 
+    @available(iOS 26.0, *)
     private func finishAppleTranscription() {
         guard activeProvider == .apple else { return }
-        guard let session = appleSession else {
+        guard let session = appleSession as? AppleSpeechTranscriptionSession else {
             completeAppleInteraction(notifyFinish: true)
             return
         }
@@ -811,8 +824,9 @@ final class VoiceInputController: NSObject, ObservableObject {
         }
     }
 
+    @available(iOS 26.0, *)
     private func cancelAppleTranscription(notifyFinish: Bool) {
-        let session = appleSession
+        let session = appleSession as? AppleSpeechTranscriptionSession
         let lifecycleTask = appleLifecycleTask
         lifecycleTask?.cancel()
         let previousCleanup = audioSessionCleanupTask
@@ -826,10 +840,26 @@ final class VoiceInputController: NSObject, ObservableObject {
         completeAppleInteraction(notifyFinish: notifyFinish)
     }
 
+    @available(iOS 26.0, *)
     private func completeAppleInteraction(notifyFinish: Bool) {
         let handler = appleFinishHandler
         appleFinishHandler = nil
         appleSession = nil
+        appleLifecycleTask = nil
+        activeProvider = nil
+        startRequestID = nil
+        isPreparing = false
+        isRecording = false
+        levelMeter.reset()
+        if notifyFinish {
+            handler?()
+        }
+    }
+
+    private func completeUnavailableAppleInteraction(notifyFinish: Bool) {
+        let handler = appleFinishHandler
+        appleFinishHandler = nil
+        appleLifecycleTask?.cancel()
         appleLifecycleTask = nil
         activeProvider = nil
         startRequestID = nil

--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
@@ -1029,37 +1029,59 @@ private struct ConversationReturnToTailButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: "arrow.down")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(tokens.primaryText)
-                .frame(width: 44, height: 44)
-                .background {
-                    if reduceTransparency {
-                        Circle().fill(tokens.elevatedSurface)
-                    }
-                }
-                // 回到最新是漂浮在内容之上的瞬时控件，使用更通透的原生 Liquid Glass；
-                // 开启“降低透明度”时关闭玻璃并保留上面的实色主题表面。
-                .glassEffect(
-                    reduceTransparency ? .identity : .clear.interactive(),
-                    in: .circle
-                )
-                .overlay {
-                    Circle()
-                        .stroke(
-                            tokens.border.opacity(reduceTransparency ? 0.72 : 0.42),
-                            lineWidth: 0.75
-                        )
-                }
-                .shadow(
-                    color: Color.black.opacity(reduceTransparency ? 0.14 : 0.10),
-                    radius: 7,
-                    y: 3
-                )
+            buttonLabel
         }
         .buttonStyle(.plain)
         .contentShape(Circle())
         .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var buttonLabel: some View {
+        Group {
+            if #available(iOS 26.0, *) {
+                baseLabel
+                    .background {
+                        if reduceTransparency {
+                            Circle().fill(tokens.elevatedSurface)
+                        }
+                    }
+                    // iOS 26+ 保留原生交互玻璃；Reduce Transparency 关闭玻璃动画与透明度。
+                    .glassEffect(
+                        reduceTransparency ? .identity : .clear.interactive(),
+                        in: .circle
+                    )
+            } else {
+                baseLabel
+                    .background {
+                        if reduceTransparency {
+                            Circle().fill(tokens.elevatedSurface)
+                        } else {
+                            // iOS 18–25 使用普通系统材质，只保留浮层层级和 44pt 命中区域。
+                            Circle().fill(.regularMaterial)
+                        }
+                    }
+            }
+        }
+        .overlay {
+            Circle()
+                .stroke(
+                    tokens.border.opacity(reduceTransparency ? 0.72 : 0.42),
+                    lineWidth: 0.75
+                )
+        }
+        .shadow(
+            color: Color.black.opacity(reduceTransparency ? 0.14 : 0.10),
+            radius: 7,
+            y: 3
+        )
+    }
+
+    private var baseLabel: some View {
+        Image(systemName: "arrow.down")
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(tokens.primaryText)
+            .frame(width: 44, height: 44)
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -448,8 +448,10 @@ struct SessionListView: View {
                         manageConnections: manageConnections
                     )
                 }
-                // 全局 Mac 入口与列表筛选是不同作用域，固定间隔让系统分别生成圆形材质。
-                ToolbarSpacer(.fixed, placement: .topBarLeading)
+                // iOS 26+ 用固定间隔拆分玻璃组；旧系统依靠普通工具栏布局即可。
+                if #available(iOS 26.0, *) {
+                    ToolbarSpacer(.fixed, placement: .topBarLeading)
+                }
             }
             if placesFilterInTrailingToolbar {
                 // 真浮层只会改变详情内容的 leading safe area，系统 topBarLeading 仍按整窗放置。
@@ -492,7 +494,7 @@ struct SessionListView: View {
 
     @ToolbarContentBuilder
     private func newSessionToolbarItem(tokens: ThemeTokens) -> some ToolbarContent {
-        if let newSessionPresentationNamespace {
+        if let newSessionPresentationNamespace, #available(iOS 26.0, *) {
             ToolbarItem(placement: .topBarTrailing) {
                 newSessionToolbarButton(
                     tokens: tokens,
@@ -507,6 +509,7 @@ struct SessionListView: View {
                 in: newSessionPresentationNamespace
             )
         } else {
+            // iOS 18–25 保留新建入口，但不注册仅新系统支持的 Toolbar zoom 来源。
             ToolbarItem(placement: .topBarTrailing) {
                 newSessionToolbarButton(
                     tokens: tokens,

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -288,7 +288,7 @@ struct SettingsView: View {
                 .accessibilityIdentifier("settings.language")
 
                 Picker(selection: voiceInputProviderSelection) {
-                    ForEach(VoiceInputProvider.allCases) { provider in
+                    ForEach(VoiceInputProvider.availableProviders()) { provider in
                         Text(provider.title)
                             .tag(provider)
                     }
@@ -480,7 +480,9 @@ struct SettingsView: View {
 
     private var voiceInputProviderSelection: Binding<VoiceInputProvider> {
         Binding(
-            get: { VoiceInputProvider(rawValue: voiceInputProviderRawValue) ?? .codex },
+            get: {
+                VoiceInputProvider.resolved(rawValue: voiceInputProviderRawValue)
+            },
             set: { voiceInputProviderRawValue = $0.rawValue }
         )
     }

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -1092,7 +1092,9 @@ struct UnifiedWorkbenchShell: View {
                         }
                         .accessibilityLabel(L10n.text("ui.options"))
                     }
-                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
+                    if #available(iOS 26.0, *) {
+                        ToolbarSpacer(.fixed, placement: .topBarTrailing)
+                    }
                 }
 
                 ToolbarItem(placement: .topBarTrailing) {
@@ -1105,8 +1107,10 @@ struct UnifiedWorkbenchShell: View {
                         Task { await sessionStore.refreshCurrentContext() }
                     }
                 }
-                // 宽屏保留两个独立动作；手机端已经收进单一更多菜单。
-                ToolbarSpacer(.fixed, placement: .topBarTrailing)
+                // iOS 26+ 用固定间隔保持独立玻璃组；旧系统直接沿用普通工具栏间距。
+                if #available(iOS 26.0, *) {
+                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
+                }
                 inspectorToolbarItem(layout: layout, tokens: tokens)
             }
         }
@@ -1441,7 +1445,7 @@ struct UnifiedWorkbenchShell: View {
         layout: WorkbenchLayout,
         tokens: ThemeTokens
     ) -> some ToolbarContent {
-        if layout.usesSheetInspectorNavigation {
+        if layout.usesSheetInspectorNavigation, #available(iOS 26.0, *) {
             ToolbarItem(placement: .topBarTrailing) {
                 inspectorToolbarButton(
                     layout: layout,
@@ -1457,6 +1461,7 @@ struct UnifiedWorkbenchShell: View {
                 in: presentationNamespace
             )
         } else {
+            // iOS 18–25 仍可打开 Inspector，只取消依赖新 Toolbar API 的 zoom 来源。
             ToolbarItem(placement: .topBarTrailing) {
                 inspectorToolbarButton(
                     layout: layout,
@@ -1706,7 +1711,7 @@ private struct NewSessionSheet: View {
                             }
                         }
                         .frame(minWidth: 48)
-                        .buttonStyle(.glassProminent)
+                        .workbenchProminentActionStyle()
                         .disabled(isCreating || selectedProject == nil)
                         .tint(tokens.primaryAction)
                         .keyboardShortcut(.defaultAction)

--- a/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
@@ -385,12 +385,13 @@ struct WorkbenchSidebarFooter: View {
         let safeAreaVisualOffset = min(max(bottomSafeAreaInset, 0) / 2, 10)
 
         Group {
-            if usesFloatingSurface, !reduceTransparency {
+            if #available(iOS 26.0, *), usesFloatingSurface, !reduceTransparency {
                 // 两个按钮由系统统一合成，但间距足够大，不会在静止状态下粘连成一整块玻璃。
                 GlassEffectContainer(spacing: 16) {
                     footerButtonRow
                 }
             } else {
+                // iOS 18–25 直接使用同一行普通按钮，不额外模拟玻璃合成。
                 footerButtonRow
             }
         }
@@ -419,7 +420,7 @@ struct WorkbenchSidebarFooter: View {
     @ViewBuilder
     private var meButton: some View {
         Group {
-            if usesFloatingSurface, !reduceTransparency {
+            if #available(iOS 26.0, *), usesFloatingSurface, !reduceTransparency {
                 Button(action: onOpenSettings) {
                     compactMeButtonLabel
                 }
@@ -435,10 +436,16 @@ struct WorkbenchSidebarFooter: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(isMeSelected ? tokens.primaryAction : tokens.secondaryText)
-                .background(
-                    isMeSelected ? tokens.selectionFill : tokens.surface.opacity(0.72),
-                    in: Capsule()
-                )
+                .background {
+                    if usesFloatingSurface, !reduceTransparency {
+                        // 旧系统的浮动侧栏使用普通材质，保留层级但不仿制 Liquid Glass。
+                        Capsule().fill(.regularMaterial)
+                    } else {
+                        Capsule().fill(
+                            isMeSelected ? tokens.selectionFill : tokens.surface.opacity(0.72)
+                        )
+                    }
+                }
                 .overlay {
                     Capsule()
                         .stroke(tokens.border.opacity(0.6), lineWidth: 1)
@@ -490,7 +497,7 @@ struct WorkbenchSidebarFooter: View {
     @ViewBuilder
     private var newSessionButtonContent: some View {
         Group {
-            if usesFloatingSurface, !reduceTransparency {
+            if #available(iOS 26.0, *), usesFloatingSurface, !reduceTransparency {
                 Button(action: onNewSession) {
                     WorkbenchChromeIcon(systemName: "plus")
                 }
@@ -506,6 +513,7 @@ struct WorkbenchSidebarFooter: View {
                 .tint(tokens.primaryAction)
                 .foregroundStyle(tokens.primaryActionForeground)
             } else {
+                // iOS 18–25 与 Reduce Transparency 共用清晰的实色主操作按钮。
                 Button(action: onNewSession) {
                     WorkbenchChromeIcon(systemName: "plus")
                         .frame(width: 36, height: 36)

--- a/ios/MimiRemote/Sources/State/VoiceInputPreferences.swift
+++ b/ios/MimiRemote/Sources/State/VoiceInputPreferences.swift
@@ -16,6 +16,37 @@ enum VoiceInputProvider: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// Apple 实时语音 API 只在 iOS 26 及以上可用；通过系统能力判断集中管理提供方列表，
+    /// 避免旧系统在设置页展示一个实际无法启动的 Apple 选项。
+    static var supportsAppleRealtimeTranscription: Bool {
+        if #available(iOS 26.0, *) {
+            return true
+        }
+        return false
+    }
+
+    /// 返回当前系统可以真正使用的提供方。参数允许纯逻辑测试显式模拟旧系统能力。
+    static func availableProviders(supportsAppleSpeech: Bool? = nil) -> [Self] {
+        let supportsAppleSpeech = supportsAppleSpeech ?? Self.supportsAppleRealtimeTranscription
+        return supportsAppleSpeech ? Array(allCases) : [.codex]
+    }
+
+    /// 将存储值解析为当前系统可用的提供方；旧系统读取到历史 apple 偏好时确定性回退 Codex，
+    /// 但不改写 UserDefaults，从而保留用户原有偏好，待升级到 iOS 26 后仍可恢复选择。
+    static func resolved(
+        rawValue: String?,
+        supportsAppleSpeech: Bool? = nil
+    ) -> Self {
+        guard let provider = rawValue.flatMap(Self.init(rawValue:)) else {
+            return .codex
+        }
+        let supportsAppleSpeech = supportsAppleSpeech ?? Self.supportsAppleRealtimeTranscription
+        guard provider != .apple || supportsAppleSpeech else {
+            return .codex
+        }
+        return provider
+    }
+
     var title: String {
         switch self {
         case .codex:
@@ -46,11 +77,14 @@ enum VoiceInputProvider: String, CaseIterable, Identifiable {
         }
     }
 
-    static func stored(in defaults: UserDefaults = .standard) -> VoiceInputProvider {
+    static func stored(
+        in defaults: UserDefaults = .standard,
+        supportsAppleSpeech: Bool? = nil
+    ) -> VoiceInputProvider {
         // 新安装默认复用主机已有的 Codex 登录态；用户主动选择设备端后仍保留该偏好。
-        guard let rawValue = defaults.string(forKey: storageKey) else {
-            return .codex
-        }
-        return VoiceInputProvider(rawValue: rawValue) ?? .codex
+        resolved(
+            rawValue: defaults.string(forKey: storageKey),
+            supportsAppleSpeech: supportsAppleSpeech
+        )
     }
 }

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -658,11 +658,18 @@ struct WorkbenchSidebarContainer<
             content
                 .background(tokens.sidebarBackground.ignoresSafeArea())
                 .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        toolbarHeader
+                    if #available(iOS 26.0, *) {
+                        ToolbarItem(placement: .topBarLeading) {
+                            toolbarHeader
+                        }
+                        // 品牌标题不是独立按钮；隐藏 iPadOS 26 自动添加的共享玻璃底板。
+                        .sharedBackgroundVisibility(.hidden)
+                    } else {
+                        // iOS 18–25 没有系统共享玻璃底板，保留普通 ToolbarItem 即可。
+                        ToolbarItem(placement: .topBarLeading) {
+                            toolbarHeader
+                        }
                     }
-                    // 品牌标题不是独立按钮；隐藏 iPadOS 26 自动添加的共享玻璃底板。
-                    .sharedBackgroundVisibility(.hidden)
                 }
         }
     }
@@ -734,20 +741,27 @@ private struct WorkbenchFloatingSidebarToggleButton: View {
 
     @ViewBuilder
     var body: some View {
-        if reduceTransparency {
-            button
-                .buttonStyle(.plain)
-                .background(tokens.elevatedSurface, in: Circle())
-                .overlay {
-                    Circle()
-                        .stroke(tokens.border, lineWidth: 1)
-                }
-        } else {
+        if #available(iOS 26.0, *), !reduceTransparency {
             button
                 .buttonStyle(.plain)
                 // 把原生交互玻璃直接作用在确定的 44pt 标签上，避免系统 ButtonStyle
                 // 根据紧凑图标再次缩小或放大圆面；按压和指针反馈仍由 Liquid Glass 提供。
                 .glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            button
+                .buttonStyle(.plain)
+                .background {
+                    if reduceTransparency {
+                        Circle().fill(tokens.elevatedSurface)
+                    } else {
+                        // iOS 18–25 使用稳定的系统材质，不模拟 Liquid Glass 的折射与高光。
+                        Circle().fill(.regularMaterial)
+                    }
+                }
+                .overlay {
+                    Circle()
+                        .stroke(tokens.border, lineWidth: 1)
+                }
         }
     }
 
@@ -763,6 +777,19 @@ private struct WorkbenchFloatingSidebarToggleButton: View {
         .foregroundStyle(tokens.primaryText)
         // 与触控、指针和 VoiceOver 共用同一个 action，不新增第二套 visibility 状态。
         .keyboardShortcut("s", modifiers: [.control, .command])
+    }
+}
+
+extension View {
+    /// 主操作在 iOS 26+ 使用原生突出玻璃；旧系统回退到系统强调按钮，
+    /// 只降低材质表现，不改变按钮的 action、禁用态、键盘快捷键或无障碍语义。
+    @ViewBuilder
+    func workbenchProminentActionStyle() -> some View {
+        if #available(iOS 26.0, *) {
+            buttonStyle(.glassProminent)
+        } else {
+            buttonStyle(.borderedProminent)
+        }
     }
 }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
@@ -304,6 +304,39 @@ final class LocalizationTests: XCTestCase {
         XCTAssertEqual(VoiceInputProvider.stored(in: defaults), .codex)
     }
 
+    func testVoiceInputProviderAvailabilityFiltersAppleOnUnsupportedSystems() {
+        XCTAssertEqual(
+            VoiceInputProvider.availableProviders(supportsAppleSpeech: false),
+            [.codex]
+        )
+        XCTAssertEqual(
+            VoiceInputProvider.availableProviders(supportsAppleSpeech: true),
+            [.codex, .apple]
+        )
+    }
+
+    func testSavedAppleVoiceProviderFallsBackWithoutOverwritingStoredValue() {
+        let suiteName = "VoiceInputProviderCompatibilityTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(VoiceInputProvider.apple.rawValue, forKey: VoiceInputProvider.storageKey)
+
+        XCTAssertEqual(
+            VoiceInputProvider.stored(in: defaults, supportsAppleSpeech: false),
+            .codex
+        )
+        XCTAssertEqual(
+            defaults.string(forKey: VoiceInputProvider.storageKey),
+            VoiceInputProvider.apple.rawValue,
+            "旧系统回退时不应清除升级后可恢复的历史偏好"
+        )
+        XCTAssertEqual(
+            VoiceInputProvider.stored(in: defaults, supportsAppleSpeech: true),
+            .apple
+        )
+    }
+
     func testVoiceInputProvidersExposeDistinctNativeSystemIcons() {
         XCTAssertEqual(VoiceInputProvider.codex.icon, .system("waveform"))
         XCTAssertEqual(VoiceInputProvider.apple.icon, .system("siri"))

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -4,12 +4,13 @@ options:
   # 与当前工程的 Xcode 27 元数据保持一致，避免每次 XcodeGen 把 scheme 降级到旧版本。
   xcodeVersion: "27.0"
   deploymentTarget:
-    iOS: "26.0"
+    iOS: "18.0"
 settings:
   base:
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: 9HZ89R58PZ
-    IPHONEOS_DEPLOYMENT_TARGET: "26.0"
+    # iOS 18–25 走普通材质与功能降级；iOS 26+ 继续启用 Liquid Glass 和新 Speech API。
+    IPHONEOS_DEPLOYMENT_TARGET: "18.0"
     MACOSX_DEPLOYMENT_TARGET: "26.0"
     SDKROOT: auto
 packages:


### PR DESCRIPTION
## 目标

让 Mimi Remote 支持 iOS/iPadOS 18+ 安装与核心功能展示，同时保持 iOS 26+ 的 Liquid Glass、Toolbar 动效与 Apple 实时语音能力。

## 改动

- 将 App、Widget、Unit Tests、UI Tests 的 deployment target 调整为 iOS 18.0
- 为 Liquid Glass、ToolbarSpacer、Toolbar transition source 增加 iOS 26 availability 分支
- iOS 18–25 使用普通系统材质与标准按钮样式
- iOS 18–25 隐藏 Apple 实时语音，并将历史 Apple 偏好运行时回退为 Codex 转写
- 增加语音 Provider 兼容逻辑测试和 CI deployment target 门禁
- 更新中英文 README 与 iOS 构建文档

## 验证

- 已重放到最新 main 并重新生成 Xcode 工程
- USB 实体 iPad Pro（iPadOS 27.0）构建、安装、启动成功
- MimiRemote 与 MimiCarStatusWidget 真机进程运行正常
- Swift target 为 arm64-apple-ios18.0
- git diff --check 通过

## 已知缺口

本机尚未安装 iOS 18 Runtime，因此 iOS 18 运行态验收仍需后续补充；编译期 availability 与最低版本产物已验证。