### PR TITLE
修复按 Profile 隔离延迟 delta 的测试在真机偶发失败

### DIFF
--- a/ios/MimiRemote/Sources/State/ConversationStore.swift
+++ b/ios/MimiRemote/Sources/State/ConversationStore.swift
@@ -25,6 +25,11 @@ final class ConversationStore: ObservableObject {
 #if DEBUG
     private(set) var historyMergeInvocationCountForTesting = 0
     private(set) var retainedByteFullRecalculationCountForTesting = 0
+    /// 测试用：是否还有未落地的流式 delta 合并缓冲（跨所有 Profile）。
+    /// 定向测试靠它等待 80ms flush 真正执行，而不是用固定 sleep 猜定时器落地顺序。
+    var hasPendingAssistantDeltasForTesting: Bool {
+        !pendingAssistantDeltasBySessionID.isEmpty
+    }
 #endif
 
     private let assistantDeltaFlushDelay: UInt64 = 80_000_000

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -1979,7 +1979,9 @@ extension ConversationDataFlowTests {
         )
 
         // A 的 80ms delta flush 在切换后完成，也只能回写捕获的 A scoped key。
-        try await Task.sleep(nanoseconds: 160_000_000)
+        // 必须让 mac-b 一直保持激活直到 flush 真正执行：若 flush 改回用 activeProfileID
+        // 重算缓存键，就会在 mac-b 命名空间里查不到 A 的 pending 而静默丢弃。
+        try await waitForPendingAssistantDeltaFlush(in: store)
         XCTAssertEqual(store.messages(for: sessionID).map(\.content), ["B only"])
         XCTAssertNotEqual(store.messages(for: sessionID).first?.id, macAMessageID)
 
@@ -2477,7 +2479,7 @@ extension ConversationDataFlowTests {
         )
         XCTAssertEqual(store.messages(for: sessionID).first?.content, "A")
 
-        try await Task.sleep(nanoseconds: 160_000_000)
+        try await waitForPendingAssistantDeltaFlush(in: store)
 
         XCTAssertEqual(store.messages(for: sessionID).first?.content, "AB")
         XCTAssertEqual(store.messages(for: sessionID).first?.revision, 2)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -1733,6 +1733,26 @@ func payloadContainsSkill(_ payload: CodexAppServerTurnPayload?, name expectedNa
     } ?? false
 }
 
+/// 等待流式 delta 的合并缓冲真正 flush 落地。
+///
+/// 不能用固定 sleep 代替：ConversationStore 的 80ms flush 和测试自己的等待是两个
+/// 独立定时器，落地先后没有任何保证。真机满负载跑全量时调度会停顿到秒级，足以让
+/// 测试先醒来读到未 flush 的旧内容（实测正常余量只有约 84ms）。
+@MainActor
+func waitForPendingAssistantDeltaFlush(
+    in store: ConversationStore,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async throws {
+    for _ in 0..<500 {
+        if !store.hasPendingAssistantDeltasForTesting {
+            return
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTFail("流式 delta 合并缓冲未在 5s 内 flush", file: file, line: line)
+}
+
 @MainActor
 func waitForConversationMessages(
     in store: ConversationStore,

--- a/scripts/test-conversation-regressions.sh
+++ b/scripts/test-conversation-regressions.sh
@@ -51,6 +51,7 @@ bash "$ROOT_DIR/scripts/ios-dev.sh" test \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testTurnInterruptAcknowledgementPollsUntilAuthoritativeTerminalTurn \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testTargetedInterruptRecoveryWorksWithoutCachedActiveTurnAndProtectsNewerTurn \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testTerminalStreamStoreSeparatesSameSessionAcrossHostScopes \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testConversationStoreScopesSameSessionAndDelayedDeltaByProfile \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testWebSocketFailureAutoReconnectsWithLatestReplayWatermark \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testStaleWebSocketStatusDoesNotRetireCurrentReconnect \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testOfflineSuspendsReconnectAndPreservesSessionQueueAndMessages \


### PR DESCRIPTION
## 背景

真机 iPad mini (A17 Pro) 上跑全量 `MimiRemoteTests` 时，`ConversationDataFlowTests/testConversationStoreScopesSameSessionAndDelayedDeltaByProfile` 偶发失败：

```
XCTAssertEqual failed: ("["A"]") is not equal to ("["A delayed"]")
```

同一个测试在 iPad Pro 13-inch (M5) 模拟器上跑全量则一直通过。

## 根因：测试夹具，不是产品逻辑

测试用固定 `Task.sleep(160ms)` 等 `ConversationStore` 内部的 80ms delta flush。这两个是互不相关的定时器，落地先后没有任何保证。

插桩实测（5 轮真机全量，均通过）：

| 轮次 | flush 实际落地 | 测试 sleep 醒来 | 余量 |
|---|---|---|---|
| 1 | 80.5ms | 170.9ms | 90ms |
| 2 | 84.9ms | 169.0ms | 84ms |
| 3 | 85.5ms | 170.9ms | 85ms |
| 4 | 85.5ms | 168.8ms | 83ms |
| 5 | 85.5ms | 167.5ms | 82ms |

余量只有约 84ms。而真机满负载跑全量时调度会停摆到秒级——同一批日志里 **mock** 客户端的 session list 交付出现 `duration_ms=2609 / 2469 / 1498`，足以让测试先醒来读到未 flush 的旧内容。

## 产品侧没有竞态

- `scheduleAssistantDeltaFlush` 在排期时即捕获 `ScopedSessionID`，`flushPendingAssistantDelta(scopedSessionID:)` 全程使用该捕获键（索引查找、字节记账、append 都走 scoped 重载），没有一处回头读 `activeProfileID`。
- 生产链路 `commitPreparedConnection` 先 `disconnectWebSocket()` 再 `activate(profileID:)`，且 `socket.onEvent` 受 `connectedHostScope == hostScope && appStore.activeHostScope == hostScope` 双重门保护，旧 Mac 的实时 delta 不可能在新 Mac 激活后被应用。

失败信号本身也排除了归属错误。三种失败长相不同：

| 假设 | 会看到 |
|---|---|
| flush 归属到 mac-b（真 bug） | mac-b 读到 `["B onlydelayed"]` |
| flush 索引查不到、另起气泡 | mac-a 读到 `["A", " delayed"]` |
| **flush 还没执行**（时序） | **mac-a 读到 `["A"]`** ← 实际观测 |

## 改动

- `ConversationStore` 新增 `#if DEBUG` 的只读 `hasPendingAssistantDeltasForTesting`，沿用文件里已有的 `…ForTesting` 约定，Release 不编入。
- 新增 `waitForPendingAssistantDeltaFlush(in:)`，轮询到缓冲真正落地，5s 预算。
- 两处固定 sleep 换成它：目标测试，以及同文件同缺陷的 `testStructuredAssistantDeltaFlushesBufferedTextOnTimer`。
- 把目标用例加入 `scripts/test-conversation-regressions.sh`。

**等待期间保持 mac-b 激活**，所以断言强度不降反升：原来 160ms sleep 只是「大概率」让 flush 在 mac-b 激活时落地，现在是保证。若有人把 flush 改回用 `activeProfileID` 重算缓存键，pending 会永远留在缓冲里并超时报错——比原来的信号更准。

## 验证

| 环境 | 范围 | 结果 |
|---|---|---|
| 模拟器 iPad Pro 13-inch (M5) | `ConversationDataFlowTests` 710 个 | 0 失败 |
| 模拟器 | 全量 `MimiRemoteTests` 1203 个 | 3 失败，全部改动前就有 |
| 真机 iPad mini | 全量 × 3 轮 | 两个测试均通过；失败集合与改动前逐条一致（65 → 65，diff 为空） |
| 模拟器（CI locale） | 新白名单条目 | `Executed 2 tests, 0 failures` |
| CI 门 | `check-source-size.sh` | 通过 |

修复后这两个测试从 0.17s 降到 0.090s（flush 一落地就返回，不再空等）。

## Reviewer 需要知道的

**1. 为什么选 DEBUG 口子而不是纯测试侧方案。** 替代方案是轮询 `messages(for:)`，但它需要在等待期间来回切 profile，flush 可能落在 mac-a 激活的窗口里——那样即使有人把 key 改错，测试也会绿。为省一个只读 DEBUG 属性而换掉测试的判别力，不划算。

**2. 白名单只加了一个。** 按脚本第 30 行既定标准（「…审批/中断、Host 隔离和 fake smoke；其余大集合不无条件进入 PR Gate」），Profile 隔离这条属于收录范围，和已在列的 `testTerminalStreamStoreSeparatesSameSessionAcrossHostScopes` 同族；`testStructuredAssistantDeltaFlushesBufferedTextOnTimer` 守的是 UI 节流实现细节，不加。注意加白名单**不防这次的 flake**（CI 跑模拟器，旧写法在模拟器上从没失败过），它防的是归属逻辑被改回按当前 profile 重算。

## 本次发现但未在此 PR 处理

均为既有问题，混进来会污染可回滚性，建议单开：

1. **3 张快照基线在指定模拟器上对不上**（`testEmptyConversationState`、`testExpandedGoalTrayDarkMaterialSeparatesBackdropContent`、`testSkillInvocationCardLightAppearance`）。已 stash 改动、在干净的 `67b4efb9` 上复跑确认同样 3 个全挂。
2. **`testCompletionReconciliationBypassesRecentSessionListCache` 在真机全量里活锁**，实测 23 分钟无进展，日志反复刷同一条 session list 拉取。
3. **测试套件里还有约 177 处固定 `Task.sleep`**，同一类隐患。不建议无差别清扫（多数在等 mock/gate 条件而非内部定时器），按需治理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)