### PR TITLE
MIM-94 支持 Claude 历史热刷新与终端恢复

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alleycat-claude-bridge"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alleycat-bridge-core",
  "alleycat-codex-proto",

--- a/bridges/claude/crates/claude-bridge/Cargo.toml
+++ b/bridges/claude/crates/claude-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alleycat-claude-bridge"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license = "GPL-3.0-only"
 authors.workspace = true

--- a/bridges/claude/crates/claude-bridge/src/bridge.rs
+++ b/bridges/claude/crates/claude-bridge/src/bridge.rs
@@ -18,7 +18,10 @@ use dashmap::DashMap;
 use serde_json::Value;
 
 use crate::handlers;
-use crate::index::{ClaudeHydrator, open_index_and_hydrate};
+use crate::index::{
+    ClaudeHistoryRefresher, ClaudeHydrator, DEFAULT_HISTORY_REFRESH_INTERVAL,
+    open_index_and_hydrate,
+};
 use crate::pool::{ClaudePool, PoolPolicy};
 use crate::state::{ConnectionState, ThreadDefaults};
 
@@ -37,6 +40,7 @@ fn default_codex_home() -> PathBuf {
 pub struct ClaudeBridge {
     pool: Arc<ClaudePool>,
     thread_index: ThreadIndexHandle,
+    history_refresher: Option<Arc<ClaudeHistoryRefresher>>,
     codex_home: PathBuf,
     /// Held so embedders (Litter) can swap launchers; the pool already has its
     /// own `Arc<dyn ProcessLauncher>` clone for spawning agent processes.
@@ -92,13 +96,14 @@ impl ClaudeBridge {
             state.rebind_session(Arc::clone(session));
             return state;
         }
-        let state = Arc::new(ConnectionState::with_launcher(
+        let state = Arc::new(ConnectionState::with_launcher_and_history_refresher(
             Arc::clone(ctx.session()),
             Arc::clone(&self.pool),
             Arc::clone(&self.thread_index),
             ThreadDefaults::default(),
             Some(Arc::clone(&self.launcher)),
             self.trust_persisted_cwd,
+            self.history_refresher.as_ref().map(Arc::clone),
         ));
         // Insert; concurrent calls may race — entry/or_insert resolves the
         // race deterministically.
@@ -128,6 +133,7 @@ impl ClaudeBridge {
         Self {
             pool,
             thread_index,
+            history_refresher: None,
             codex_home,
             launcher,
             per_conn,
@@ -148,6 +154,7 @@ pub struct ClaudeBridgeBuilder {
     /// Override for the claude `projects/` directory (test hook). `None`
     /// uses [`crate::index::claude_projects_dir`].
     projects_dir_override: Option<PathBuf>,
+    history_refresh_interval: Duration,
 }
 
 impl Default for ClaudeBridgeBuilder {
@@ -161,6 +168,7 @@ impl Default for ClaudeBridgeBuilder {
             bypass_permissions: PoolPolicy::default().bypass_permissions,
             trust_persisted_cwd: false,
             projects_dir_override: None,
+            history_refresh_interval: DEFAULT_HISTORY_REFRESH_INTERVAL,
         }
     }
 }
@@ -203,6 +211,12 @@ impl ClaudeBridgeBuilder {
 
     pub fn projects_dir_override(mut self, dir: PathBuf) -> Self {
         self.projects_dir_override = Some(dir);
+        self
+    }
+
+    /// 调整显式历史扫描冷却窗口。生产使用默认值，测试可用更长窗口验证限频。
+    pub fn history_refresh_interval(mut self, interval: Duration) -> Self {
+        self.history_refresh_interval = interval;
         self
     }
 
@@ -264,11 +278,17 @@ impl ClaudeBridgeBuilder {
             None => ClaudeHydrator::new(),
         };
         let index = open_index_and_hydrate(codex_home.join("threads.json"), &hydrator).await?;
+        let history_refresher = Arc::new(ClaudeHistoryRefresher::with_interval(
+            Arc::clone(&index),
+            hydrator,
+            self.history_refresh_interval,
+        ));
         let thread_index: ThreadIndexHandle = index;
 
         Ok(Arc::new(ClaudeBridge {
             pool,
             thread_index,
+            history_refresher: Some(history_refresher),
             codex_home,
             launcher,
             per_conn: DashMap::new(),

--- a/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
@@ -584,6 +584,33 @@ pub async fn handle_thread_list(
     state: &Arc<ConnectionState>,
     params: p::ThreadListParams,
 ) -> Result<p::ThreadListResponse, ThreadError> {
+    if params.refresh_history {
+        if params.cursor.is_some() {
+            return Err(ThreadError::InvalidParams(
+                "refreshHistory is only valid on the first page".to_string(),
+            ));
+        }
+        if params.use_state_db_only {
+            return Err(ThreadError::InvalidParams(
+                "refreshHistory cannot be combined with useStateDbOnly".to_string(),
+            ));
+        }
+        if let Some(refresher) = state.history_refresher() {
+            match refresher
+                .refresh_if_due()
+                .await
+                .map_err(ThreadError::from)?
+            {
+                crate::index::HistoryRefreshResult::Refreshed { inserted } => {
+                    tracing::info!(inserted, "refreshed Claude history index");
+                }
+                crate::index::HistoryRefreshResult::RateLimited => {
+                    tracing::debug!("skipped rate-limited Claude history refresh");
+                }
+            }
+        }
+    }
+
     // Match codex-rs semantics: omitted `archived` means "non-archived only"
     // (`unwrap_or(false)`), not "all".
     let archived = Some(params.archived.unwrap_or(false));
@@ -600,10 +627,7 @@ pub async fn handle_thread_list(
         direction: params.sort_direction.unwrap_or(p::SortDirection::Desc),
     };
     let limit = alleycat_bridge_core::resolve_list_limit(params.limit);
-    // `use_state_db_only` is accepted but always-true for this bridge: list
-    // is served from the threads.json index, and the JSONL scan-and-repair
-    // hydration happens at startup, not per-list.
-    let _ = params.use_state_db_only;
+    // 普通请求始终只读 threads.json；只有上面的显式 refreshHistory 首屏会触发受限扫描。
 
     let page = state
         .thread_index()

--- a/bridges/claude/crates/claude-bridge/src/index/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/mod.rs
@@ -13,6 +13,7 @@ pub mod claude_session_scan;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -27,6 +28,11 @@ pub use alleycat_bridge_core::{
 use alleycat_codex_proto::{SessionSource, Thread, ThreadSourceKind, ThreadStatus};
 
 use crate::translate::items::is_internal_local_command_text;
+
+/// 同一 bridge 进程内两次显式历史扫描的最小间隔。
+///
+/// 扫描只由 `refreshHistory` 首屏请求触发；冷却窗口继续保护用户快速重复点击和多连接竞态。
+pub const DEFAULT_HISTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Bridge CLI version string baked into `Thread.cli_version`.
 pub const CLI_VERSION: &str = concat!("alleycat-claude-bridge/", env!("CARGO_PKG_VERSION"));
@@ -131,6 +137,61 @@ impl ClaudeHydrator {
 impl Default for ClaudeHydrator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistoryRefreshResult {
+    Refreshed { inserted: usize },
+    RateLimited,
+}
+
+/// 运行期显式历史扫描器。
+///
+/// `gate` 在扫描期间保持锁定，既让多个连接共享同一冷却窗口，也避免同时遍历
+/// `~/.claude/projects`。这里只把新 session ID 写入索引，不覆盖已有名称、归档等用户状态。
+pub struct ClaudeHistoryRefresher {
+    index: Arc<CoreThreadIndex<ClaudeSessionRef>>,
+    hydrator: ClaudeHydrator,
+    min_interval: Duration,
+    gate: tokio::sync::Mutex<Option<tokio::time::Instant>>,
+}
+
+impl ClaudeHistoryRefresher {
+    pub fn new(index: Arc<CoreThreadIndex<ClaudeSessionRef>>, hydrator: ClaudeHydrator) -> Self {
+        Self::with_interval(index, hydrator, DEFAULT_HISTORY_REFRESH_INTERVAL)
+    }
+
+    pub fn with_interval(
+        index: Arc<CoreThreadIndex<ClaudeSessionRef>>,
+        hydrator: ClaudeHydrator,
+        min_interval: Duration,
+    ) -> Self {
+        Self {
+            index,
+            hydrator,
+            min_interval,
+            gate: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    pub async fn refresh_if_due(&self) -> Result<HistoryRefreshResult> {
+        let mut last_finished_at = self.gate.lock().await;
+        let now = tokio::time::Instant::now();
+        if last_finished_at.is_some_and(|last| now.duration_since(last) < self.min_interval) {
+            return Ok(HistoryRefreshResult::RateLimited);
+        }
+
+        let refresh_result = async {
+            let scanned = self.hydrator.scan().await?;
+            self.index.hydrate_entries(scanned).await
+        }
+        .await;
+        // 成功和失败都从整轮扫描与落盘结束时进入冷却，避免慢磁盘
+        // 缩短实际冷却窗口，也避免坏目录被快速重复扫描。
+        *last_finished_at = Some(tokio::time::Instant::now());
+        let inserted = refresh_result?;
+        Ok(HistoryRefreshResult::Refreshed { inserted })
     }
 }
 

--- a/bridges/claude/crates/claude-bridge/src/main.rs
+++ b/bridges/claude/crates/claude-bridge/src/main.rs
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn package_is_the_compatibility_release() {
-        assert_eq!(env!("CARGO_PKG_VERSION"), "0.2.6");
+        assert_eq!(env!("CARGO_PKG_VERSION"), "0.2.7");
     }
 
     #[test]

--- a/bridges/claude/crates/claude-bridge/src/state.rs
+++ b/bridges/claude/crates/claude-bridge/src/state.rs
@@ -22,7 +22,7 @@ use alleycat_codex_proto::{
     ReasoningEffort, RequestId, SandboxMode, ThreadItem, Turn, TurnError, TurnStatus,
 };
 
-use crate::index::ClaudeSessionRef;
+use crate::index::{ClaudeHistoryRefresher, ClaudeSessionRef};
 use crate::pool::ClaudePool;
 use crate::pool::claude_protocol::{McpServerInit, RateLimitInfo, SystemInit};
 use crate::translate::items::normalize_dynamic_tool_call_output;
@@ -54,6 +54,8 @@ pub struct ConnectionState {
     session: RwLock<Arc<Session>>,
     claude_pool: Arc<ClaudePool>,
     thread_index: Arc<dyn ThreadIndexHandle>,
+    /// 仅生产 builder 注入；旧的测试 helper 沿用 `None`，普通列表行为不变。
+    history_refresher: Option<Arc<ClaudeHistoryRefresher>>,
     /// Launcher used for `command/exec` shell tools. `None` falls back to a
     /// bridge-default [`alleycat_bridge_core::LocalLauncher`] (preserves the
     /// pre-refactor behavior of the legacy `for_test` helper).
@@ -196,11 +198,32 @@ impl ConnectionState {
         launcher: Option<Arc<dyn ProcessLauncher>>,
         trust_persisted_cwd: bool,
     ) -> Self {
+        Self::with_launcher_and_history_refresher(
+            session,
+            claude_pool,
+            thread_index,
+            defaults,
+            launcher,
+            trust_persisted_cwd,
+            None,
+        )
+    }
+
+    pub fn with_launcher_and_history_refresher(
+        session: Arc<Session>,
+        claude_pool: Arc<ClaudePool>,
+        thread_index: Arc<dyn ThreadIndexHandle>,
+        defaults: ThreadDefaults,
+        launcher: Option<Arc<dyn ProcessLauncher>>,
+        trust_persisted_cwd: bool,
+        history_refresher: Option<Arc<ClaudeHistoryRefresher>>,
+    ) -> Self {
         Self {
             defaults: Mutex::new(defaults),
             session: RwLock::new(session),
             claude_pool,
             thread_index,
+            history_refresher,
             launcher,
             trust_persisted_cwd,
             caches: Mutex::new(ClaudeCaches::default()),
@@ -215,6 +238,10 @@ impl ConnectionState {
 
     pub fn trust_persisted_cwd(&self) -> bool {
         self.trust_persisted_cwd
+    }
+
+    pub fn history_refresher(&self) -> Option<&Arc<ClaudeHistoryRefresher>> {
+        self.history_refresher.as_ref()
     }
 
     pub fn session(&self) -> Arc<Session> {

--- a/bridges/claude/crates/claude-bridge/tests/history_refresh.rs
+++ b/bridges/claude/crates/claude-bridge/tests/history_refresh.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use alleycat_bridge_core::framing::write_json_line;
+use alleycat_bridge_core::{
+    ATTACH_METHOD, SessionRegistry, SessionRegistryConfig, serve_stream_attached,
+};
+use alleycat_claude_bridge::ClaudeBridge;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
+use tokio::time::timeout;
+
+const STEP_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[tokio::test]
+async fn explicit_first_page_refresh_discovers_new_history_and_rate_limits_repeat_scans() {
+    let fixture = TempDir::new().expect("fixture");
+    let codex_home = fixture.path().join("codex-home");
+    let projects = fixture.path().join("claude-projects");
+    let encoded_cwd = projects.join("-private-tmp-mimi-history-refresh");
+    std::fs::create_dir_all(&encoded_cwd).expect("projects dir");
+    let cwd = "/private/tmp/mimi-history-refresh";
+
+    let bridge = ClaudeBridge::builder()
+        .codex_home(codex_home)
+        // Builder 的 override 是单个 encoded-cwd 目录；生产默认路径才会遍历 projects 根目录。
+        .projects_dir_override(encoded_cwd.clone())
+        .history_refresh_interval(Duration::from_secs(60))
+        .build()
+        .await
+        .expect("build bridge");
+    let registry = SessionRegistry::new(SessionRegistryConfig::default());
+    let (client_io, bridge_io) = tokio::io::duplex(64 * 1024);
+    let bridge_for_server = Arc::clone(&bridge);
+    let registry_for_server = Arc::clone(&registry);
+    let server = tokio::spawn(async move {
+        serve_stream_attached(bridge_for_server, bridge_io, &registry_for_server, "claude").await
+    });
+    let (client_reader, mut client_writer) = tokio::io::split(client_io);
+    let mut client_reader = BufReader::new(client_reader);
+
+    write_json_line(
+        &mut client_writer,
+        &json!({"jsonrpc":"2.0","method":ATTACH_METHOD,"params":{"sessionKey":"history-refresh"}}),
+    )
+    .await
+    .expect("attach");
+    let _ = next_message(&mut client_reader).await;
+
+    write_session(&encoded_cwd, "first-session", cwd, "first prompt");
+    let ordinary = request_list(&mut client_writer, &mut client_reader, 1, cwd, false).await;
+    assert!(thread_ids(&ordinary).is_empty(), "普通列表不得扫描新 JSONL");
+
+    let refreshed = request_list(&mut client_writer, &mut client_reader, 2, cwd, true).await;
+    assert_eq!(thread_ids(&refreshed), vec!["first-session"]);
+
+    write_session(&encoded_cwd, "second-session", cwd, "second prompt");
+    let limited = request_list(&mut client_writer, &mut client_reader, 3, cwd, true).await;
+    assert_eq!(
+        thread_ids(&limited),
+        vec!["first-session"],
+        "冷却窗口内重复刷新不得再次遍历目录"
+    );
+
+    drop(client_writer);
+    drop(client_reader);
+    timeout(STEP_TIMEOUT, server)
+        .await
+        .expect("server timeout")
+        .expect("server join")
+        .expect("server result");
+}
+
+fn write_session(dir: &std::path::Path, id: &str, cwd: &str, prompt: &str) {
+    let record = json!({
+        "type": "user",
+        "cwd": cwd,
+        "message": {"role": "user", "content": prompt},
+        "timestamp": "2026-08-06T09:00:00Z"
+    });
+    std::fs::write(dir.join(format!("{id}.jsonl")), format!("{record}\n")).expect("write session");
+}
+
+async fn request_list<R, W>(
+    writer: &mut W,
+    reader: &mut R,
+    id: i64,
+    cwd: &str,
+    refresh_history: bool,
+) -> Value
+where
+    R: AsyncBufRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    write_json_line(
+        writer,
+        &json!({
+            "jsonrpc":"2.0",
+            "id":id,
+            "method":"thread/list",
+            "params":{"cwd":cwd,"refreshHistory":refresh_history}
+        }),
+    )
+    .await
+    .expect("thread/list");
+    await_response(reader, id).await
+}
+
+fn thread_ids(response: &Value) -> Vec<&str> {
+    response["result"]["data"]
+        .as_array()
+        .expect("thread/list data")
+        .iter()
+        .filter_map(|thread| thread["id"].as_str())
+        .collect()
+}
+
+async fn await_response<R: AsyncBufRead + Unpin>(reader: &mut R, id: i64) -> Value {
+    loop {
+        let frame = next_message(reader).await;
+        if frame["id"] == id {
+            return frame;
+        }
+    }
+}
+
+async fn next_message<R: AsyncBufRead + Unpin>(reader: &mut R) -> Value {
+    timeout(STEP_TIMEOUT, async {
+        let mut line = String::new();
+        let count = reader.read_line(&mut line).await.expect("read frame");
+        assert!(count > 0, "bridge closed before response");
+        serde_json::from_str(line.trim_end()).expect("valid JSON frame")
+    })
+    .await
+    .expect("frame timeout")
+}

--- a/bridges/claude/crates/codex-proto/src/thread.rs
+++ b/bridges/claude/crates/codex-proto/src/thread.rs
@@ -326,6 +326,9 @@ pub struct ThreadListParams {
     pub cwd: Option<Value>,
     #[serde(default)]
     pub use_state_db_only: bool,
+    /// Mimi 的显式历史刷新标记。仅 Claude bridge 消费；普通列表与分页保持只读索引路径。
+    #[serde(default)]
+    pub refresh_history: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_term: Option<String>,
 }

--- a/docs/claude-bridge-architecture.md
+++ b/docs/claude-bridge-architecture.md
@@ -54,7 +54,7 @@ sequenceDiagram
 ### 生命周期
 
 - `claude.enabled=false` 是默认状态，配置接口只返回 Codex channel。
-- 启用后，`agentd` 用 `--version` 探测 bridge；低于 `0.2.1`、无标准版本或二进制不存在时 fail closed。
+- 启用后，`agentd` 用 `--version` 探测 bridge；低于 `0.2.7`、无标准版本或二进制不存在时 fail closed。`0.2.7` 是首个支持运行期 `thread/list.refreshHistory` 的版本，旧版会静默忽略该字段，不能继续当作兼容实现。
 - bridge 与 iOS / Go 代码同仓维护，并随 Mac App 一起构建、签名和安装；`agentd` 优先使用显式配置，否则使用与自身同目录的 `alleycat-claude-bridge`。
 - `agentd` 监督一个 resident bridge，通过 Unix socket 为多次 WebSocket 连接复用同一进程。
 - iOS 每个 runtime 使用稳定 session key；重新连接携带最后处理的 sequence cursor。bridge session 保存有界 replay ring 和未完成的反向请求。

--- a/docs/codex-protocol-support.md
+++ b/docs/codex-protocol-support.md
@@ -32,11 +32,11 @@ Go Gateway 当前开放 26 个 client frame method，其中 `initialized` 是 no
 
 所有带 `threadId` 的管理操作都要求该 thread 已由当前 Gateway 连接通过 allowlist cwd 授权。
 
-Claude 实验通道使用更小的独立 allowlist。`alleycat-claude-bridge >= 0.2.1` 时额外开放 `account/rateLimits/read`，请求参数固定改写为 `{}`；`0.2.3` 起补齐事件百分比映射。`0.2.5` 起优先复用 Claude Code 已登录凭据主动读取 OAuth usage：macOS 从登录 Keychain 的 `Claude Code-credentials` 获取短期 access token，其他平台可使用权限收紧的 `~/.claude/.credentials.json`，随后请求固定的 Anthropic OAuth usage beta endpoint，将 5h/7d 窗口映射为现有协议。`0.2.6` 起，macOS token 过期或接口返回 401 时通过系统 PTY 执行 Claude CLI `/status` 认证路径，等待 Keychain 更新后只重试一次；bridge 不直接读取、消费或覆盖 refresh token。access token 只通过子进程 stdin 传给禁用 `.curlrc` 的系统 `curl`，不进入命令参数、日志或磁盘缓存；成功快照缓存 60 秒，Keychain、scope、续期、网络、HTTP 或解析失败均不影响会话链路。
+Claude 实验通道使用更小的独立 allowlist，当前要求 `alleycat-claude-bridge >= 0.2.7`。`0.2.1` 首次开放 `account/rateLimits/read`，请求参数固定改写为 `{}`；`0.2.3` 起补齐事件百分比映射。`0.2.5` 起优先复用 Claude Code 已登录凭据主动读取 OAuth usage：macOS 从登录 Keychain 的 `Claude Code-credentials` 获取短期 access token，其他平台可使用权限收紧的 `~/.claude/.credentials.json`，随后请求固定的 Anthropic OAuth usage beta endpoint，将 5h/7d 窗口映射为现有协议。`0.2.6` 起，macOS token 过期或接口返回 401 时通过系统 PTY 执行 Claude CLI `/status` 认证路径，等待 Keychain 更新后只重试一次；`0.2.7` 起支持受控的运行期 `thread/list.refreshHistory`。bridge 不直接读取、消费或覆盖 refresh token。access token 只通过子进程 stdin 传给禁用 `.curlrc` 的系统 `curl`，不进入命令参数、日志或磁盘缓存；成功快照缓存 60 秒，Keychain、scope、续期、网络、HTTP 或解析失败均不影响会话链路。
 
 OAuth usage endpoint 不是稳定公开 API，可能被 Anthropic 调整。主动查询失败时 bridge 继续降级到官方 `rate_limit_event`：按 `rateLimitType` 合并缓存 5h/7d 窗口，把事件中的 0...1 `utilization` 映射为 `usedPercent`。未观测到 utilization 的窗口保留 `unavailableReason=usage_percentage_unavailable`，不会伪造为 `0%`；只有 `rejected` 会映射为额度耗尽，`allowed_warning` 不阻断发送。主动查询和事件缓存都不可用时返回 `rateLimits.availability=unavailable`、`unavailableReason=headless_statusline_unavailable`。
 
-Claude bridge 必须通过标准 `--version` 门禁才会被标记为可用；审批反向请求的响应和随后到达的 `serverRequest/resolved` notification 均透明透传。bridge 版本缺失、低于 `0.2.1` 或运行中退出时，Gateway 返回结构化错误并终止等待。正式 Mimi Remote Mac 已内置并签名兼容 bridge；Homebrew、Linux 和独立开发环境可执行 `cargo install --git https://github.com/gaixianggeng/codex-ipad-agent.git --locked --force --bin alleycat-claude-bridge alleycat-claude-bridge` 安装外置版本。导入来源固定记录在 `bridges/claude/UPSTREAM.md`。
+Claude bridge 必须通过标准 `--version` 门禁才会被标记为可用；审批反向请求的响应和随后到达的 `serverRequest/resolved` notification 均透明透传。bridge 版本缺失、低于 `0.2.7` 或运行中退出时，Gateway 返回结构化错误并终止等待。正式 Mimi Remote Mac 已内置并签名兼容 bridge；Homebrew、Linux 和独立开发环境可执行 `cargo install --git https://github.com/gaixianggeng/codex-ipad-agent.git --locked --force --bin alleycat-claude-bridge alleycat-claude-bridge` 安装外置版本。导入来源固定记录在 `bridges/claude/UPSTREAM.md`。
 
 `thread/search` 是跨工作区全文搜索，额外执行以下边界：
 

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -46,7 +46,7 @@ iPhone / iPad SwiftUI App
 | 输入输出 | 富 Markdown、图片输入、历史图片按需加载、语音转写、文件安全读取和 QuickLook；当前会话可导出 ANSI 清洗后的有界 UTF-8 日志，导出头部不读取连接凭据 | PDF/大型 artifact 的富预览和后台下载尚未实现；日志正文可能包含用户命令、代码和工具输出，分享前需自行检查 |
 | 能力发现 | Skills 和 MCP 配置只读浏览、allowlist actions | 不在 iPad 上启停 MCP、修改 Codex 配置或处理 OAuth |
 | 移动体验 | iPhone/iPad 自适应、深浅色、主题和字号、Codex 5h/7d 用量、提醒、运行态通知、通知点击回到当前 Mac 会话；通知未授权时提醒仍可保留为 App 内状态并明确告知，冷启动/回前台清理过期提醒；通知 payload 不含 Token 或明文 endpoint，错 Mac 只提示手动切换档案；凭据失效终止重试；NWPath 事件按递增序号交付并丢弃迟到旧状态，离线暂停、恢复单次重连和 jitter 退避，首次 unknown→在线只在已有网络错误或挂起会话时恢复一次；首次配对提交后最多等待 45 秒恢复项目/会话，已有档案修复或切换等待 10 秒，超时保留 Keychain 凭据且打开设置可直接重试；保存、重命名和删除多台 Mac 档案，每台独立 Keychain Token 和稳定安装身份，候选连接验证后原子单活切换；非当前 Mac 只在菜单打开后轻量探测，不加载业务状态；缓存、媒体、通知和异步任务按 Profile 隔离；重命名只更新非敏感显示名，不重建连接；忘记/删除凭据必须二次确认并统一清理 Profile 数据；AI 用量刷新按 runtime 独立 loading 和去重，Claude 慢查询不禁用其他设置操作 | 后台 push、离线通知、连接档案云同步和离线队列持久化尚未实现；快速切换发布前仍需通过 Release 真机性能门禁 |
-| Claude | 仓库内 `alleycat-claude-bridge >= 0.2.1` 实验通道，当前 `0.2.6` 支持 resident bridge、稳定 session + sequence replay、审批闭环、历史记录过滤、OAuth 额度查询、过期凭据委托续期、事件降级和 Fable 5 模型目录；正式 Mac App 已内置并签名兼容 bridge | 默认关闭；每个 Claude thread 一个 headless 进程，不跟单次 WebSocket 生命周期绑定；不支持 goal、archive、fork；优先复用 Claude Code Keychain/凭据文件只读查询 Anthropic OAuth usage beta endpoint，返回 5h/7d 百分比与重置时间并短缓存；macOS access token 过期或接口返回 401 时，通过 Claude CLI `/status` 让凭据所有者更新 Keychain，bridge 不直接消费 refresh token；内部 beta endpoint 变化、凭据缺少 `user:profile`、续期或查询失败时降级到官方 `rate_limit_event`，两者均不可用才显示暂无数据；CLI 登录整体失效时仍需在 Mac 重新登录 |
+| Claude | 仓库内 `alleycat-claude-bridge >= 0.2.7` 实验通道，当前 `0.2.7` 支持 resident bridge、稳定 session + sequence replay、审批闭环、运行期历史热刷新、历史记录过滤、OAuth 额度查询、过期凭据委托续期、事件降级和 Fable 5 模型目录；正式 Mac App 已内置并签名兼容 bridge | 默认关闭；每个 Claude thread 一个 headless 进程，不跟单次 WebSocket 生命周期绑定；不支持 goal、archive、fork；优先复用 Claude Code Keychain/凭据文件只读查询 Anthropic OAuth usage beta endpoint，返回 5h/7d 百分比与重置时间并短缓存；macOS access token 过期或接口返回 401 时，通过 Claude CLI `/status` 让凭据所有者更新 Keychain，bridge 不直接消费 refresh token；内部 beta endpoint 变化、凭据缺少 `user:profile`、续期或查询失败时降级到官方 `rate_limit_event`，两者均不可用才显示暂无数据；CLI 登录整体失效时仍需在 Mac 重新登录 |
 
 完整能力矩阵见 [Codex Mac App 功能对照](codex-mac-feature-parity.md)。
 
@@ -120,6 +120,6 @@ Mimi TestFlight 使用本机 `git testflight-push`：先推送并核对远端 co
 - Tailscale 未连接时不会回退公网；Mac 与移动设备在同一局域网时可重新生成 LAN 配对信息，否则必须恢复 Tailnet。
 - 当前 Endpoint 仍可能是 Tailscale 裸 IP 上的 HTTP；ATS 已收窄为本地网络和 `ts.net` 例外，并由应用层拒绝公网 HTTP。公开发布前继续完成真机验收并评估 MagicDNS `*.ts.net` + HTTPS。
 - 旧 REST runtime、PTY session manager 和 stdio app-server client 仍有测试/兼容代码，但不在生产主链路。删除前必须先做可达性复核和全量回归。
-- Claude 通道依赖外部 CLI 与 bridge，鉴权和生命周期仍弱于 Codex 主通道，不能作为默认路径；agentd 对 bridge 执行 `>=0.2.1` 版本门禁、强制关闭 bypass permissions，版本不兼容时 fail closed 并给出升级命令。
+- Claude 通道依赖外部 CLI 与 bridge，鉴权和生命周期仍弱于 Codex 主通道，不能作为默认路径；agentd 对 bridge 执行 `>=0.2.7` 版本门禁、强制关闭 bypass permissions，版本不兼容时 fail closed 并给出升级命令。
 - 多 Mac 的本地单活档案已完成；Bonjour/SSH 自动发现、跨设备档案同步、Cloud thread、后台 push、IDE sync、Browser / Computer Use 后置。在真实需求明确前不增加云端控制面或复杂分布式架构。
 - 设计文档只描述目标或历史方案，不能覆盖当前代码事实。功能完成后要同步更新本文和对应专题文档，避免再次依赖会话历史判断现状。

--- a/internal/claudebridge/version.go
+++ b/internal/claudebridge/version.go
@@ -8,7 +8,9 @@ import (
 )
 
 const (
-	MinimumVersion = "0.2.1"
+	// 0.2.7 新增 thread/list.refreshHistory。旧版 serde 会静默忽略未知字段，
+	// 因此必须整体 fail closed，不能让客户端看到“刷新成功”但仍返回旧索引。
+	MinimumVersion = "0.2.7"
 	// Claude bridge 与 agentd 同仓维护，安装提示只指向主仓库，避免两套 revision 和 Release 漂移。
 	BridgeRepository = "https://github.com/gaixianggeng/codex-ipad-agent.git"
 	InstallHint      = "cargo install --git " + BridgeRepository + " --locked --force --bin alleycat-claude-bridge alleycat-claude-bridge"

--- a/internal/claudebridge/version_test.go
+++ b/internal/claudebridge/version_test.go
@@ -32,10 +32,13 @@ func TestIsSupported(t *testing.T) {
 	if IsSupported("0.2.0") {
 		t.Fatal("0.2.0 不应通过最低版本门禁")
 	}
-	if !IsSupported("0.2.1") || !IsSupported("1.0.0") {
-		t.Fatal("0.2.1 及更高版本应通过最低版本门禁")
+	if IsSupported("0.2.6") {
+		t.Fatal("0.2.6 会静默忽略 refreshHistory，不应通过最低版本门禁")
 	}
-	if IsSupported("0.2.1-beta.1") {
+	if !IsSupported("0.2.7") || !IsSupported("1.0.0") {
+		t.Fatal("0.2.7 及更高版本应通过最低版本门禁")
+	}
+	if IsSupported("0.2.7-beta.1") {
 		t.Fatal("最低正式版门禁不能被预发布版本绕过")
 	}
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -289,7 +289,7 @@ func TestClaudeBridgeCheckRequiresCompatibleVersion(t *testing.T) {
 		wantOK     bool
 		want       string
 	}{
-		{name: "compatible", versionOut: "alleycat-claude-bridge 0.2.1", wantOK: true, want: "0.2.1 可用"},
+		{name: "compatible", versionOut: "alleycat-claude-bridge 0.2.7", wantOK: true, want: "0.2.7 可用"},
 		{name: "too old", versionOut: "alleycat-claude-bridge 0.2.0", wantOK: false, want: "低于最低兼容版本"},
 		{name: "missing standard version", versionOut: "bridge starting", wantOK: false, want: "版本无法解析"},
 	}
@@ -333,9 +333,9 @@ func TestClaudeBridgeCheckFallsBackToBundledCopy(t *testing.T) {
 	if _, err := os.Stat(sibling); err == nil {
 		t.Skip("测试二进制旁已存在同名文件，跳过以免干扰")
 	}
-	body := []byte("#!/bin/sh\nprintf 'alleycat-claude-bridge 0.2.6\\n'\n")
+	body := []byte("#!/bin/sh\nprintf 'alleycat-claude-bridge 0.2.7\\n'\n")
 	if runtime.GOOS == "windows" {
-		body = []byte("@echo off\r\necho alleycat-claude-bridge 0.2.6\r\n")
+		body = []byte("@echo off\r\necho alleycat-claude-bridge 0.2.7\r\n")
 	}
 	if err := os.WriteFile(
 		sibling,
@@ -353,7 +353,7 @@ func TestClaudeBridgeCheckFallsBackToBundledCopy(t *testing.T) {
 		},
 	})
 	check := checker.claudeBridgeCheck(context.Background())
-	if !check.OK || !strings.Contains(check.Message, "0.2.6 可用") {
+	if !check.OK || !strings.Contains(check.Message, "0.2.7 可用") {
 		t.Fatalf("Doctor 应回退检查 Mac App 随包 bridge：%+v", check)
 	}
 }

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -270,6 +270,7 @@ type appServerGatewayPendingHistoryRequest struct {
 	sortDirection     string
 	itemsView         string
 	useStateDBOnly    string
+	refreshHistory    string
 	filterFingerprint string
 	includeTurns      bool
 	fingerprint       string

--- a/internal/httpapi/appserver_gateway_history.go
+++ b/internal/httpapi/appserver_gateway_history.go
@@ -132,8 +132,10 @@ func gatewayHistoryRequestFromParams(method string, params map[string]any) (appS
 		return appServerGatewayPendingHistoryRequest{
 			method: method, cwd: cwd, cursor: gatewayOptionalStringParam(params, "cursor"),
 			limit: gatewayOptionalInt64Param(params, "limit"), sortKey: gatewayOptionalStringParam(params, "sortKey"),
-			sortDirection: gatewayOptionalStringParam(params, "sortDirection"),
-			itemsView:     "list", useStateDBOnly: gatewayOptionalBoolFingerprintParam(params, "useStateDbOnly"),
+			sortDirection:  gatewayOptionalStringParam(params, "sortDirection"),
+			itemsView:      "list",
+			useStateDBOnly: gatewayOptionalBoolFingerprintParam(params, "useStateDbOnly"),
+			refreshHistory: gatewayOptionalBoolFingerprintParam(params, "refreshHistory"),
 		}, true
 	case "thread/search":
 		// 搜索没有 cwd/threadId，请求指纹必须包含完整的安全参数；预算 subject 则使用固定
@@ -203,11 +205,13 @@ func gatewayHistoryRequestFingerprint(runtimeID string, request appServerGateway
 		SortDirection  string `json:"sortDirection,omitempty"`
 		ItemsView      string `json:"itemsView,omitempty"`
 		UseStateDBOnly string `json:"useStateDbOnly,omitempty"`
+		RefreshHistory string `json:"refreshHistory,omitempty"`
 		Filter         string `json:"filter,omitempty"`
 	}{
 		Runtime: normalizeAppServerRuntimeID(runtimeID), Method: request.method, ThreadID: request.threadID,
 		CWD: request.cwd, Cursor: request.cursor, Limit: request.limit, SortKey: request.sortKey, SortDirection: request.sortDirection,
-		ItemsView: request.itemsView, UseStateDBOnly: request.useStateDBOnly, Filter: request.filterFingerprint,
+		ItemsView: request.itemsView, UseStateDBOnly: request.useStateDBOnly,
+		RefreshHistory: request.refreshHistory, Filter: request.filterFingerprint,
 	})
 	return string(encoded)
 }

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -374,7 +374,7 @@ func rewriteGatewaySafeDefaults(payload []byte, runtimeID string, method string,
 	case "plugin/installed":
 		sanitized = sanitizedGatewayPluginInstalledParams(validated.cwd)
 	case "thread/list":
-		sanitized = sanitizedGatewayThreadListParams(params)
+		sanitized = sanitizedGatewayThreadListParams(runtimeID, params)
 	case "thread/search":
 		sanitized = sanitizedGatewayThreadSearchParams(params)
 	case "thread/read":
@@ -544,8 +544,12 @@ func sanitizedGatewayThreadTurnsListParams(params map[string]any) map[string]any
 	return safe
 }
 
-func sanitizedGatewayThreadListParams(params map[string]any) map[string]any {
-	return copyGatewayParams(params, "cwd", "limit", "cursor", "sortKey", "sortDirection", "sourceKinds", "archived", "useStateDbOnly")
+func sanitizedGatewayThreadListParams(runtimeID string, params map[string]any) map[string]any {
+	keys := []string{"cwd", "limit", "cursor", "sortKey", "sortDirection", "sourceKinds", "archived", "useStateDbOnly"}
+	if normalizeAppServerRuntimeID(runtimeID) == "claude" {
+		keys = append(keys, "refreshHistory")
+	}
+	return copyGatewayParams(params, keys...)
 }
 
 func sanitizedGatewayThreadSearchParams(params map[string]any) map[string]any {
@@ -738,6 +742,23 @@ func validateGatewayThreadListParams(params map[string]any) error {
 	if value, ok := params["useStateDbOnly"]; ok && value != nil {
 		if _, ok := value.(bool); !ok {
 			return fmt.Errorf("thread/list.useStateDbOnly 必须是布尔值")
+		}
+	}
+	refreshHistory := false
+	if value, ok := params["refreshHistory"]; ok && value != nil {
+		var valid bool
+		refreshHistory, valid = value.(bool)
+		if !valid {
+			return fmt.Errorf("thread/list.refreshHistory 必须是布尔值")
+		}
+	}
+	if refreshHistory {
+		// 运行期扫描只能绑定首屏显式刷新；cursor 分页和 State DB 快速路径继续保持纯索引读取。
+		if cursor, ok := params["cursor"]; ok && cursor != nil {
+			return fmt.Errorf("thread/list.refreshHistory 只允许用于首屏")
+		}
+		if useStateDBOnly, ok := params["useStateDbOnly"].(bool); ok && useStateDBOnly {
+			return fmt.Errorf("thread/list.refreshHistory 不能与 useStateDbOnly=true 同时使用")
 		}
 	}
 	return nil

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -1599,19 +1599,39 @@ func TestGatewayThreadListAllowsStateDBFastPathWithinLimit(t *testing.T) {
 		"sortDirection":  "desc",
 		"sourceKinds":    []any{"cli", "vscode", "appServer", "subAgent"},
 		"useStateDbOnly": true,
+		"refreshHistory": false,
 		"unsafe":         "drop-me",
 	}
 	if err := validateGatewayThreadListParams(params); err != nil {
 		t.Fatalf("thread/list 合法快速路径参数不应被拒绝：%v", err)
 	}
 
-	sanitized := sanitizedGatewayThreadListParams(params)
+	sanitized := sanitizedGatewayThreadListParams("codex", params)
 	assertGatewayParamsOnly(t, sanitized, "cwd", "limit", "sortKey", "sortDirection", "sourceKinds", "useStateDbOnly")
 	if sanitized["useStateDbOnly"] != true {
 		t.Fatalf("thread/list 应保留 useStateDbOnly：%v", sanitized)
 	}
 	if sanitized["sortKey"] != "recency_at" {
 		t.Fatalf("thread/list 应保留 recency_at：%v", sanitized)
+	}
+}
+
+func TestGatewayThreadListAllowsExplicitHistoryRefreshOnFirstPage(t *testing.T) {
+	params := map[string]any{
+		"cwd":            "/tmp/project",
+		"limit":          json.Number("20"),
+		"useStateDbOnly": false,
+		"refreshHistory": true,
+		"unsafe":         "drop-me",
+	}
+	if err := validateGatewayThreadListParams(params); err != nil {
+		t.Fatalf("thread/list 合法显式历史刷新不应被拒绝：%v", err)
+	}
+
+	sanitized := sanitizedGatewayThreadListParams("claude", params)
+	assertGatewayParamsOnly(t, sanitized, "cwd", "limit", "useStateDbOnly", "refreshHistory")
+	if sanitized["refreshHistory"] != true {
+		t.Fatalf("thread/list 应保留 refreshHistory：%v", sanitized)
 	}
 }
 
@@ -1631,6 +1651,15 @@ func TestGatewayThreadListFingerprintIncludesSortKey(t *testing.T) {
 	if gatewayHistoryRequestFingerprint("codex", updated) == gatewayHistoryRequestFingerprint("codex", recency) {
 		t.Fatal("不同 sortKey 的 thread/list 不能共享并发请求指纹")
 	}
+	refresh, ok := gatewayHistoryRequestFromParams("thread/list", map[string]any{
+		"cwd": "/tmp/project", "limit": json.Number("20"), "sortKey": "updated_at", "refreshHistory": true,
+	})
+	if !ok {
+		t.Fatal("显式刷新的 thread/list 应进入历史请求指纹")
+	}
+	if gatewayHistoryRequestFingerprint("claude", updated) == gatewayHistoryRequestFingerprint("claude", refresh) {
+		t.Fatal("普通列表与显式历史刷新不能共享并发请求指纹")
+	}
 }
 
 func TestGatewayThreadListRejectsUnsafeFastPathParams(t *testing.T) {
@@ -1641,6 +1670,9 @@ func TestGatewayThreadListRejectsUnsafeFastPathParams(t *testing.T) {
 	}{
 		{name: "limit over hard max", params: map[string]any{"limit": json.Number("51")}, want: "不能超过 50"},
 		{name: "state db flag must be bool", params: map[string]any{"useStateDbOnly": "true"}, want: "必须是布尔值"},
+		{name: "refresh flag must be bool", params: map[string]any{"refreshHistory": "true"}, want: "必须是布尔值"},
+		{name: "refresh only on first page", params: map[string]any{"refreshHistory": true, "cursor": "next"}, want: "只允许用于首屏"},
+		{name: "refresh rejects state db fast path", params: map[string]any{"refreshHistory": true, "useStateDbOnly": true}, want: "不能与 useStateDbOnly=true"},
 		{name: "source kinds must be array", params: map[string]any{"sourceKinds": "subAgent"}, want: "必须是字符串数组"},
 		{name: "source kinds reject internal source", params: map[string]any{"sourceKinds": []any{"exec"}}, want: "sourceKinds 不支持"},
 	}

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -165,7 +165,7 @@ func TestAppServerConfigMarksClaudeChannelUnavailableWhenBridgeMissing(t *testin
 }
 
 func TestAppServerConfigRejectsOldClaudeBridgeVersion(t *testing.T) {
-	bridgePath := writeTestBridgeWithVersion(t, "alleycat-claude-bridge 0.1.9")
+	bridgePath := writeTestBridgeWithVersion(t, "alleycat-claude-bridge 0.2.6")
 	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
 	handler, _ := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, func(cfg *config.Config) {
 		cfg.Claude.Enabled = true
@@ -177,10 +177,10 @@ func TestAppServerConfigRejectsOldClaudeBridgeVersion(t *testing.T) {
 	claude := body["channels"].([]any)[1].(map[string]any)
 	bridge := claude["bridge"].(map[string]any)
 	capabilities := claude["capabilities"].(map[string]any)
-	if claude["gateway_available"] != false || bridge["status"] != "unsupported_version" || bridge["version"] != "0.1.9" {
+	if claude["gateway_available"] != false || bridge["status"] != "unsupported_version" || bridge["version"] != "0.2.6" {
 		t.Fatalf("旧 Claude bridge 必须 fail closed：%v", claude)
 	}
-	if bridge["minimum_version"] != "0.2.1" || !strings.Contains(bridge["fix"].(string), "cargo install") {
+	if bridge["minimum_version"] != "0.2.7" || !strings.Contains(bridge["fix"].(string), "cargo install") {
 		t.Fatalf("旧 bridge 应返回最低版本和可执行修复提示：%v", bridge)
 	}
 	if capabilities["rate_limits"] != false {
@@ -199,8 +199,8 @@ func TestAppServerConfigRejectsOldClaudeBridgeVersion(t *testing.T) {
 	defer conn.Close()
 	raw := readGatewayRaw(t, conn)
 	if !bytes.Contains(raw, []byte(`"code":"CLAUDE_BRIDGE_VERSION_UNSUPPORTED"`)) ||
-		!bytes.Contains(raw, []byte(`"bridgeVersion":"0.1.9"`)) ||
-		!bytes.Contains(raw, []byte(`"minimumVersion":"0.2.1"`)) ||
+		!bytes.Contains(raw, []byte(`"bridgeVersion":"0.2.6"`)) ||
+		!bytes.Contains(raw, []byte(`"minimumVersion":"0.2.7"`)) ||
 		!bytes.Contains(raw, []byte(`"fix":"cargo install`)) {
 		t.Fatalf("旧 bridge WS 错误应包含结构化版本诊断：%s", raw)
 	}
@@ -210,7 +210,7 @@ func TestClaudeBridgeProbeRejectsMissingStandardVersion(t *testing.T) {
 	bridgePath := writeTestBridgeWithVersion(t, "")
 	router := &Router{cfg: config.Config{Claude: config.ClaudeConfig{Enabled: true, BridgeBin: bridgePath}}}
 	probe := router.refreshClaudeBridgeProbe(true)
-	if probe.Healthy || probe.Status != "missing_version" || !strings.Contains(probe.Error, "需要 >= 0.2.1") {
+	if probe.Healthy || probe.Status != "missing_version" || !strings.Contains(probe.Error, "需要 >= 0.2.7") {
 		t.Fatalf("无标准 --version 的 bridge 必须 fail closed：%+v", probe)
 	}
 }

--- a/internal/httpapi/runtime_status_test.go
+++ b/internal/httpapi/runtime_status_test.go
@@ -351,7 +351,7 @@ while IFS= read -r line; do :; done
 func TestRuntimeVersionFromUserAgent(t *testing.T) {
 	tests := map[string]string{
 		"codex_cli_rs/0.146.0-alpha.3.1":  "0.146.0-alpha.3.1",
-		"alleycat-claude-bridge/0.2.6":    "0.2.6",
+		"alleycat-claude-bridge/0.2.7":    "0.2.7",
 		"codex-cli v1.2.3-beta.1 (macOS)": "1.2.3-beta.1",
 		"  fake-runtime  ":                "fake-runtime",
 		"":                                "",

--- a/internal/httpapi/testdata/fakebridge/main.go
+++ b/internal/httpapi/testdata/fakebridge/main.go
@@ -26,7 +26,7 @@ func main() {
 		log.Fatalf("fakebridge: executable: %v", err)
 	}
 	if len(os.Args) == 2 && os.Args[1] == "--version" {
-		version := "alleycat-claude-bridge 0.2.1"
+		version := "alleycat-claude-bridge 0.2.7"
 		if configured, readErr := os.ReadFile(executable + ".version"); readErr == nil {
 			version = strings.TrimSpace(string(configured))
 		}

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -502,6 +502,91 @@
         }
       }
     },
+    "ui.claude_headless_picker_note" : {
+      "comment" : "Explains why a Claude session started in headless mode may not appear in Claude Code's native resume picker.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mimi runs this session through Claude Code's headless mode, so it may not appear in the native `/resume` picker. The session is still stored on the computer; use the command above to resume it exactly."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mimi 通过 Claude Code 的无界面模式运行此会话，因此它可能不会出现在原生 `/resume` 列表中。会话仍保存在电脑上，可用上方命令精确恢复。"
+          }
+        }
+      }
+    },
+    "ui.claude_recovery_command" : {
+      "comment" : "Label for the shell command that resumes a Claude session.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovery command"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复命令"
+          }
+        }
+      }
+    },
+    "ui.claude_recovery_command_copied" : {
+      "comment" : "Confirmation after copying the Claude session recovery command.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovery command copied"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复命令已复制"
+          }
+        }
+      }
+    },
+    "ui.claude_session_id" : {
+      "comment" : "Label for the complete Claude Code session identifier shown in the Inspector.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session ID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session ID"
+          }
+        }
+      }
+    },
+    "ui.claude_terminal_recovery" : {
+      "comment" : "Inspector section containing the Claude session ID, working directory, and terminal recovery command.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recover in terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在终端恢复"
+          }
+        }
+      }
+    },
     "ui.claude_request_sent_again" : {
       "comment" : "Confirmation after explicitly retrying a request that failed because Claude Code authentication expired.",
       "localizations" : {
@@ -6840,6 +6925,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制"
+          }
+        }
+      }
+    },
+    "ui.copy_claude_recovery_command" : {
+      "comment" : "Button that copies the shell command used to resume a Claude session.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy recovery command"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制恢复命令"
+          }
+        }
+      }
+    },
+    "ui.copy_claude_recovery_command_hint" : {
+      "comment" : "VoiceOver hint for the Claude session recovery command copy button.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copies a safe command to the clipboard without running it."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制安全命令到剪贴板，不会执行命令。"
           }
         }
       }
@@ -17870,6 +17989,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "路径"
+          }
+        }
+      }
+    },
+    "ui.working_directory" : {
+      "comment" : "Label for the directory where a Claude session can be resumed.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Working directory"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作目录"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1271,7 +1271,12 @@ actor CodexAppServerSessionRuntime {
                     limit: limit,
                     cursor: cursor,
                     useStateDBOnly: canUseIndexedList,
-                    sortKey: sortKey
+                    sortKey: sortKey,
+                    refreshHistory: Self.shouldRefreshHistory(
+                        runtimeProvider: runtimeProvider,
+                        consistency: consistency,
+                        cursor: cursor
+                    )
                 ),
                 timeout: longRunningRequestTimeout
             )
@@ -1337,6 +1342,18 @@ actor CodexAppServerSessionRuntime {
             timeout: longRunningRequestTimeout
         )
         return threadListPage(from: result, projects: projects, fallbackProject: fallbackProject)
+    }
+
+    /// Claude 的目录扫描只能由用户主动发起的权威首屏触发；其余请求保持索引/分页语义，
+    /// 避免翻页或兼容性回退把全量 JSONL 扫描变成无界后台工作。
+    static func shouldRefreshHistory(
+        runtimeProvider: String,
+        consistency: SessionListConsistency,
+        cursor: String?
+    ) -> Bool {
+        normalizedRuntimeProvider(runtimeProvider) == "claude"
+            && consistency == .authoritative
+            && cursor == nil
     }
 
     func indexedThreadListNeedsRepair(_ page: SessionsPage, cwd: String) -> Bool {

--- a/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
@@ -387,7 +387,8 @@ struct CodexAppServerRequestBuilder {
         limit: Int? = 20,
         cursor: String? = nil,
         useStateDBOnly: Bool = true,
-        sortKey: String = "recency_at"
+        sortKey: String = "recency_at",
+        refreshHistory: Bool = false
     ) throws -> CodexAppServerRequestSpec {
         let path = try allowlistedPath(cwd)
         return CodexAppServerRequestSpec(method: "thread/list", params: CodexAppServerJSONValue.objectValue([
@@ -398,7 +399,9 @@ struct CodexAppServerRequestBuilder {
             "sortKey": .string(sortKey),
             "sortDirection": .string("desc"),
             "archived": .bool(false),
-            "useStateDbOnly": .bool(useStateDBOnly)
+            "useStateDbOnly": .bool(useStateDBOnly),
+            // 只有 Claude 权威首屏才显式请求历史目录重扫；默认省略以兼容旧 runtime。
+            "refreshHistory": refreshHistory ? .bool(true) : nil
         ]))
     }
 

--- a/ios/MimiRemote/Sources/Features/Inspector/SessionContextSidebarView.swift
+++ b/ios/MimiRemote/Sources/Features/Inspector/SessionContextSidebarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct OpenSubagentSessionAction {
     var handler: (SessionContextSubagent) -> Void
@@ -16,6 +17,18 @@ extension EnvironmentValues {
     var openSubagentSession: OpenSubagentSessionAction {
         get { self[OpenSubagentSessionEnvironmentKey.self] }
         set { self[OpenSubagentSessionEnvironmentKey.self] = newValue }
+    }
+}
+
+struct ClaudeSessionRecoveryCommand {
+    /// POSIX shell 的单引号包裹能阻止 cwd 或 Session ID 被解释为命令；内部单引号
+    /// 必须拆成 `'\''`，即结束引用、插入字面单引号、再开始引用。
+    static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    static func make(sessionID: String, cwd: String) -> String {
+        "cd \(shellQuote(cwd)) && claude --resume \(shellQuote(sessionID))"
     }
 }
 
@@ -40,6 +53,7 @@ struct SessionContextSidebarView: View {
             if let context {
                 List {
                     overviewSection(context, session: sessionStore.selectedSession)
+                    claudeRecoverySection(context, session: sessionStore.selectedSession)
                     goalSection(goal: sessionStore.selectedThreadGoal ?? context.goal)
                     subagentSection(context.subagents)
                     commandActionSection()
@@ -224,6 +238,68 @@ struct SessionContextSidebarView: View {
                 ContextValueRow(symbolName: "bubble.left.and.bubble.right", title: "Thread", value: threadID)
             }
         }
+    }
+
+    @ViewBuilder
+    private func claudeRecoverySection(_ context: SessionContextSnapshot, session: AgentSession?) -> some View {
+        if let details = claudeRecoveryDetails(context: context, session: session) {
+            Section(L10n.text("ui.claude_terminal_recovery")) {
+                ClaudeRecoveryValueRow(
+                    symbolName: "number",
+                    title: L10n.text("ui.claude_session_id"),
+                    value: details.sessionID
+                )
+                ClaudeRecoveryValueRow(
+                    symbolName: "folder",
+                    title: L10n.text("ui.working_directory"),
+                    value: details.cwd
+                )
+                ClaudeRecoveryValueRow(
+                    symbolName: "terminal",
+                    title: L10n.text("ui.claude_recovery_command"),
+                    value: details.command
+                )
+                Button {
+                    UIPasteboard.general.string = details.command
+                    sessionStore.setStatusMessage(L10n.text("ui.claude_recovery_command_copied"))
+                } label: {
+                    Label(L10n.text("ui.copy_claude_recovery_command"), systemImage: "doc.on.doc")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(minHeight: 44)
+                .accessibilityHint(L10n.text("ui.copy_claude_recovery_command_hint"))
+                .accessibilityIdentifier("sessionInspector.claudeRecovery.copyCommand")
+
+                Text(L10n.text("ui.claude_headless_picker_note"))
+                    .font(themeStore.uiFont(.caption))
+                    .foregroundStyle(themeStore.tokens(for: colorScheme).secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func claudeRecoveryDetails(
+        context: SessionContextSnapshot,
+        session: AgentSession?
+    ) -> (sessionID: String, cwd: String, command: String)? {
+        let runtimeProvider = nonEmpty(session?.runtimeProvider, context.environment?.runtimeProvider)
+        guard CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider) == "claude" else {
+            return nil
+        }
+        guard let sessionID = nonEmpty(
+            session?.appServerSessionID,
+            session?.resumeID,
+            context.threadID,
+            session?.id
+        ), let cwd = nonEmpty(session?.dir, context.environment?.cwd) else {
+            return nil
+        }
+        return (
+            sessionID: sessionID,
+            cwd: cwd,
+            command: ClaudeSessionRecoveryCommand.make(sessionID: sessionID, cwd: cwd)
+        )
     }
 
     @ViewBuilder
@@ -687,6 +763,43 @@ private struct ContextValueRow: View {
             .truncationMode(.middle)
             .textSelection(.enabled)
             .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ClaudeRecoveryValueRow: View {
+    @EnvironmentObject private var themeStore: ThemeStore
+    @Environment(\.colorScheme) private var colorScheme
+    let symbolName: String
+    let title: String
+    let value: String
+
+    var body: some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: symbolName)
+                .font(themeStore.uiFont(.caption, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(tokens.secondaryText)
+                .frame(width: 26, height: 26)
+                .background(tokens.elevatedSurface.opacity(0.72), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(tokens.border.opacity(0.46), lineWidth: 1)
+                }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(themeStore.uiFont(.caption, weight: .medium))
+                    .foregroundStyle(tokens.secondaryText)
+                Text(value)
+                    .font(themeStore.codeFont(.caption))
+                    .foregroundStyle(tokens.primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Inspector/SessionContextSidebarView.swift
+++ b/ios/MimiRemote/Sources/Features/Inspector/SessionContextSidebarView.swift
@@ -23,12 +23,21 @@ extension EnvironmentValues {
 struct ClaudeSessionRecoveryCommand {
     /// POSIX shell 的单引号包裹能阻止 cwd 或 Session ID 被解释为命令；内部单引号
     /// 必须拆成 `'\''`，即结束引用、插入字面单引号、再开始引用。
-    static func shellQuote(_ value: String) -> String {
+    static func posixShellQuote(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 
-    static func make(sessionID: String, cwd: String) -> String {
-        "cd \(shellQuote(cwd)) && claude --resume \(shellQuote(sessionID))"
+    /// PowerShell 单引号字符串使用两个连续单引号表达字面单引号；同时避免使用
+    /// Windows PowerShell 5.1 不支持的 `&&`。
+    static func powerShellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+    }
+
+    static func make(sessionID: String, cwd: String, hostPlatform: HostPlatform = .unknown) -> String {
+        if hostPlatform == .windows {
+            return "Set-Location -LiteralPath \(powerShellQuote(cwd)) -ErrorAction Stop; claude --resume \(powerShellQuote(sessionID))"
+        }
+        return "cd \(posixShellQuote(cwd)) && claude --resume \(posixShellQuote(sessionID))"
     }
 }
 
@@ -298,7 +307,11 @@ struct SessionContextSidebarView: View {
         return (
             sessionID: sessionID,
             cwd: cwd,
-            command: ClaudeSessionRecoveryCommand.make(sessionID: sessionID, cwd: cwd)
+            command: ClaudeSessionRecoveryCommand.make(
+                sessionID: sessionID,
+                cwd: cwd,
+                hostPlatform: sessionStore.appStore.activeConnectionProfile?.hostPlatform ?? .unknown
+            )
         )
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -591,6 +591,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(params["sortDirection"]?.stringValue, "desc")
         XCTAssertEqual(params["archived"]?.boolValue, false)
         XCTAssertEqual(params["useStateDbOnly"]?.boolValue, true)
+        XCTAssertNil(params["refreshHistory"])
     }
 
     func testControlledGlobalThreadListOmitsCWDAndCarriesOpaqueCursor() throws {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -30,6 +30,7 @@ extension ConversationDataFlowTests {
         let firstList = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
         XCTAssertEqual(firstList.params?.objectValue?["sortKey"]?.stringValue, "recency_at")
         XCTAssertEqual(firstList.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        XCTAssertNil(firstList.params?.objectValue?["refreshHistory"])
         transportResponse(
             transport,
             id: firstList.id,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
@@ -39,6 +39,95 @@ private actor FirstConfigRequestGate {
 
 @MainActor
 extension ConversationDataFlowTests {
+    func testClaudeAuthoritativeFirstPageRequestsHistoryRefresh() async throws {
+        let project = AgentProject(
+            id: "proj_claude_history_refresh",
+            name: "Claude History Refresh",
+            path: "/tmp/claude-history-refresh"
+        )
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            runtimeProvider: "claude",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "thread/list"],
+                    channels: [makeClaudeChannelMetadata()]
+                )
+            }
+        )
+
+        let pageTask = Task {
+            try await runtime.sessionsPage(
+                projectID: project.id,
+                cursor: nil,
+                limit: 20,
+                consistency: .authoritative
+            )
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-claude","platformFamily":"macos"}"#)
+        let list = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        XCTAssertEqual(list.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+        XCTAssertEqual(list.params?.objectValue?["refreshHistory"]?.boolValue, true)
+        transportResponse(transport, id: list.id, result: #"{"data":[],"nextCursor":null}"#)
+
+        let page = try await pageTask.value
+        XCTAssertTrue(page.sessions.isEmpty)
+    }
+
+    func testClaudeHistoryRefreshPolicyAndRecoveryCommand() throws {
+        let project = AgentProject(id: "repo", name: "Repo", path: "/Users/me/repo")
+        let builder = CodexAppServerRequestBuilder(allowlistedProjects: [project])
+        let request = try builder.threadList(
+            cwd: project.path,
+            useStateDBOnly: false,
+            refreshHistory: true
+        )
+        let params = try XCTUnwrap(request.params?.objectValue)
+        XCTAssertEqual(params["refreshHistory"]?.boolValue, true)
+
+        XCTAssertTrue(
+            CodexAppServerSessionRuntime.shouldRefreshHistory(
+                runtimeProvider: "claude",
+                consistency: .authoritative,
+                cursor: nil
+            )
+        )
+        XCTAssertFalse(
+            CodexAppServerSessionRuntime.shouldRefreshHistory(
+                runtimeProvider: "claude",
+                consistency: .authoritative,
+                cursor: "older"
+            )
+        )
+        XCTAssertFalse(
+            CodexAppServerSessionRuntime.shouldRefreshHistory(
+                runtimeProvider: "claude",
+                consistency: .fastIndexed,
+                cursor: nil
+            )
+        )
+        XCTAssertFalse(
+            CodexAppServerSessionRuntime.shouldRefreshHistory(
+                runtimeProvider: "codex",
+                consistency: .authoritative,
+                cursor: nil
+            )
+        )
+
+        XCTAssertEqual(
+            ClaudeSessionRecoveryCommand.make(
+                sessionID: "session'42",
+                cwd: "/Users/me/it's repo"
+            ),
+            #"cd '/Users/me/it'\''s repo' && claude --resume 'session'\''42'"#
+        )
+    }
+
     func testConnectSuspendedBeforeHydrationCannotOverrideNewerUnsubscribeLease() async throws {
         let project = AgentProject(
             id: "proj_connect_hydration_lease",

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
@@ -122,9 +122,18 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(
             ClaudeSessionRecoveryCommand.make(
                 sessionID: "session'42",
-                cwd: "/Users/me/it's repo"
+                cwd: "/Users/me/it's repo",
+                hostPlatform: .apple
             ),
             #"cd '/Users/me/it'\''s repo' && claude --resume 'session'\''42'"#
+        )
+        XCTAssertEqual(
+            ClaudeSessionRecoveryCommand.make(
+                sessionID: "session'42",
+                cwd: #"C:\Users\O'Brien Repo"#,
+                hostPlatform: .windows
+            ),
+            #"Set-Location -LiteralPath 'C:\Users\O''Brien Repo' -ErrorAction Stop; claude --resume 'session''42'"#
         )
     }
 


### PR DESCRIPTION
## 目标

解决 Claude Code 历史只能在 bridge 重启后被 Mimi 发现、且 headless 会话在原生 `/resume` picker 中不可见时缺少恢复入口的问题。

## 改动

- Claude bridge 新增显式 `thread/list.refreshHistory` 首屏刷新，运行时扫描仅补齐缺失 Session ID。
- 扫描在进程内串行并共享 2 秒冷却窗口；普通列表、分页和 State DB 快速路径不触发扫描。
- agentd 仅向 Claude runtime 透传刷新字段，Codex runtime 保持旧协议兼容。
- iOS 仅在 Claude authoritative 首屏请求历史刷新。
- Inspector 展示完整 Session ID、工作目录及安全转义的终端恢复命令，并解释 headless 会话不会出现在原生 picker。

## 用户影响

- 新增 Claude 本机历史无需重启 Mimi 即可在刷新后出现。
- 用户可以复制 `cd <cwd> && claude --resume <session-id>` 从终端精确恢复会话。
- Codex runtime 的列表与分页行为保持不变。

## 验证

- `go test ./...`
- `cargo test --locked`，包含新增 `history_refresh` 集成测试
- 固定 iPad Pro 13-inch (M5) Simulator：81 项相关回归通过；补充 4 条 MIM-94 精确回归通过
- `check-mimi-protocol-contract.sh`
- `check-ios-localization.sh`（1768 keys）
- `check-source-size.sh`
- `git diff --check`

iOS 全量套件命中的 `ConversationDataFlowTests` 数组越界已在干净 `origin/main@6153d730` 上同样复现，属于已有 MIM-106，不是本 PR 引入。

Linear: MIM-94
