### PR TITLE
MIM-108 缓存 Token 用量并降低刷新频率

### DIFF
--- a/internal/httpapi/appserver_account_usage_cache.go
+++ b/internal/httpapi/appserver_account_usage_cache.go
@@ -1,0 +1,83 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"time"
+)
+
+const defaultAccountTokenUsageCacheTTL = time.Hour
+
+// cachedAccountTokenUsageResult 只返回 TTL 内的成功快照。缓存属于当前 agentd
+// 进程与 Codex runtime，不落盘、不跨宿主共享，也不会影响实时额度事件。
+func (r *Router) cachedAccountTokenUsageResult(now time.Time) (json.RawMessage, bool) {
+	if r == nil {
+		return nil, false
+	}
+	r.accountTokenUsageMu.RLock()
+	defer r.accountTokenUsageMu.RUnlock()
+	if r.accountTokenUsageCacheTTL <= 0 ||
+		r.accountTokenUsageCachedAt.IsZero() ||
+		now.Sub(r.accountTokenUsageCachedAt) >= r.accountTokenUsageCacheTTL ||
+		len(r.accountTokenUsageResult) == 0 {
+		return nil, false
+	}
+	return append(json.RawMessage(nil), r.accountTokenUsageResult...), true
+}
+
+func (r *Router) storeAccountTokenUsageResult(result json.RawMessage, now time.Time) {
+	if r == nil || len(result) == 0 || !json.Valid(result) || bytes.Equal(bytes.TrimSpace(result), []byte("null")) {
+		return
+	}
+	r.accountTokenUsageMu.Lock()
+	r.accountTokenUsageResult = append(r.accountTokenUsageResult[:0], result...)
+	r.accountTokenUsageCachedAt = now
+	r.accountTokenUsageMu.Unlock()
+}
+
+// cachedAccountTokenUsageResponse 用当前请求 id 重建 JSON-RPC 响应。只复用 result，
+// 不缓存上游 request id，避免不同连接之间串响应。
+func (p *appServerGatewayPolicy) cachedAccountTokenUsageResponse(requestPayload []byte, now time.Time) ([]byte, bool) {
+	if p == nil || normalizeAppServerRuntimeID(p.runtimeID) != "codex" {
+		return nil, false
+	}
+	var frame appServerGatewayFrame
+	if err := json.Unmarshal(requestPayload, &frame); err != nil ||
+		frame.ID == nil ||
+		frame.Method != "account/usage/read" {
+		return nil, false
+	}
+	result, ok := p.router.cachedAccountTokenUsageResult(now)
+	if !ok {
+		return nil, false
+	}
+
+	// validateClientFrame 已登记 pending；缓存命中不再等上游响应，立即释放这一项。
+	p.consumePendingClientRequest(frame.ID)
+	response := map[string]json.RawMessage{
+		"id":     append(json.RawMessage(nil), (*frame.ID)...),
+		"result": result,
+	}
+	var envelope map[string]json.RawMessage
+	if json.Unmarshal(requestPayload, &envelope) == nil {
+		if version := envelope["jsonrpc"]; len(version) > 0 {
+			response["jsonrpc"] = version
+		}
+	}
+	payload, err := json.Marshal(response)
+	if err != nil {
+		return nil, false
+	}
+	return payload, true
+}
+
+func (p *appServerGatewayPolicy) rememberAccountTokenUsageResponse(frame *appServerGatewayFrame, now time.Time) {
+	if p == nil || frame == nil || !gatewayFrameIsResponse(frame) {
+		return
+	}
+	pending, ok := p.consumePendingClientRequest(frame.ID)
+	if !ok || pending.method != "account/usage/read" || len(frame.Error) > 0 || len(frame.Result) == 0 {
+		return
+	}
+	p.router.storeAccountTokenUsageResult(frame.Result, now)
+}

--- a/internal/httpapi/appserver_account_usage_cache.go
+++ b/internal/httpapi/appserver_account_usage_cache.go
@@ -72,7 +72,10 @@ func (p *appServerGatewayPolicy) cachedAccountTokenUsageResponse(requestPayload 
 }
 
 func (p *appServerGatewayPolicy) rememberAccountTokenUsageResponse(frame *appServerGatewayFrame, now time.Time) {
-	if p == nil || frame == nil || !gatewayFrameIsResponse(frame) {
+	if p == nil ||
+		normalizeAppServerRuntimeID(p.runtimeID) != "codex" ||
+		frame == nil ||
+		!gatewayFrameIsResponse(frame) {
 		return
 	}
 	pending, ok := p.consumePendingClientRequest(frame.ID)

--- a/internal/httpapi/appserver_account_usage_cache.go
+++ b/internal/httpapi/appserver_account_usage_cache.go
@@ -8,6 +8,8 @@ import (
 
 const defaultAccountTokenUsageCacheTTL = time.Hour
 
+const accountTokenUsageForceRefreshParam = "mimiForceRefresh"
+
 // cachedAccountTokenUsageResult 只返回 TTL 内的成功快照。缓存属于当前 agentd
 // 进程与 Codex runtime，不落盘、不跨宿主共享，也不会影响实时额度事件。
 func (r *Router) cachedAccountTokenUsageResult(now time.Time) (json.RawMessage, bool) {
@@ -45,6 +47,14 @@ func (p *appServerGatewayPolicy) cachedAccountTokenUsageResponse(requestPayload 
 	if err := json.Unmarshal(requestPayload, &frame); err != nil ||
 		frame.ID == nil ||
 		frame.Method != "account/usage/read" {
+		return nil, false
+	}
+	params, err := decodeGatewayParams(frame.Params)
+	if err != nil {
+		return nil, false
+	}
+	// 设置页的显式刷新必须读取最新数据；该标记只供 agentd 判断，转发前会被安全参数重写剥离。
+	if forceRefresh, ok := gatewayBoolParam(params, accountTokenUsageForceRefreshParam); ok && forceRefresh {
 		return nil, false
 	}
 	result, ok := p.router.cachedAccountTokenUsageResult(now)

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -69,7 +69,10 @@ func (p *appServerGatewayPolicy) validateClientFrame(messageType int, payload []
 		p.forgetPending(frame.ID)
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
 	}
-	if frame.ID != nil && normalizeAppServerRuntimeID(p.runtimeID) == "claude" && method == "model/list" {
+	runtimeID := normalizeAppServerRuntimeID(p.runtimeID)
+	tracksClientResponse := (runtimeID == "claude" && method == "model/list") ||
+		(runtimeID == "codex" && method == "account/usage/read")
+	if frame.ID != nil && tracksClientResponse {
 		if err := p.rememberPendingClientRequest(frame.ID, method); err != nil {
 			return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
 		}

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -419,7 +419,12 @@ func rewriteGatewaySafeDefaults(payload []byte, runtimeID string, method string,
 	if err := decoder.Decode(&frame); err != nil {
 		return nil, fmt.Errorf("JSON-RPC frame 无效")
 	}
-	frame["params"] = sanitized
+	if method == "account/usage/read" {
+		// mimiForceRefresh 是移动端与 agentd 的私有提示；上游 schema 没有 params，必须完整剥离。
+		delete(frame, "params")
+	} else {
+		frame["params"] = sanitized
+	}
 	rewritten, err := json.Marshal(frame)
 	if err != nil {
 		return nil, fmt.Errorf("重写 app-server 安全参数失败：%w", err)

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -904,7 +904,6 @@ func TestAppServerGatewaySanitizesParamsForAllAllowedMethods(t *testing.T) {
 		`{"method":"initialized","params":{` + dangerousTail + `}}`,
 		`{"id":61,"method":"model/list","params":{` + dangerousTail + `}}`,
 		`{"id":62,"method":"account/rateLimits/read","params":{` + dangerousTail + `}}`,
-		`{"id":63,"method":"account/usage/read","params":{` + dangerousTail + `}}`,
 	}
 	for _, frame := range emptyParamFrames {
 		if err := conn.WriteMessage(websocket.TextMessage, []byte(frame)); err != nil {
@@ -912,6 +911,17 @@ func TestAppServerGatewaySanitizesParamsForAllAllowedMethods(t *testing.T) {
 		}
 		params := decodeGatewayParamsForTest(t, readUpstreamFrame(t, received))
 		assertGatewayParamsOnly(t, params)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"id":63,"method":"account/usage/read","params":{`+dangerousTail+`}}`)); err != nil {
+		t.Fatal(err)
+	}
+	accountUsageFrame := readUpstreamFrame(t, received)
+	var accountUsageEnvelope map[string]json.RawMessage
+	if err := json.Unmarshal(accountUsageFrame, &accountUsageEnvelope); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := accountUsageEnvelope["params"]; ok {
+		t.Fatalf("account/usage/read 转发前应完整移除 params：%s", accountUsageFrame)
 	}
 
 	pluginList := []byte(fmt.Sprintf(`{"id":621,"method":"plugin/installed","params":{"cwds":[%q],"unknown":"drop"}}`, projectDir))

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -1395,15 +1395,32 @@ func TestAppServerGatewayCachesAccountTokenUsageAcrossConnections(t *testing.T) 
 	}
 	assertNoUpstreamFrame(t, received)
 
+	// 用户点击刷新时必须绕过仍在 TTL 内的快照；私有提示不能泄露给严格校验的上游 schema。
+	if err := second.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":3,"method":"account/usage/read","params":{"mimiForceRefresh":true}}`)); err != nil {
+		t.Fatal(err)
+	}
+	forcedResponse := readGatewayRaw(t, second)
+	if !bytes.Contains(forcedResponse, []byte(`"lifetimeTokens":123456`)) {
+		t.Fatalf("强制刷新应返回真实上游快照：%s", forcedResponse)
+	}
+	forcedUpstream := readUpstreamFrame(t, received)
+	var forwarded map[string]json.RawMessage
+	if err := json.Unmarshal(forcedUpstream, &forwarded); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := forwarded["params"]; ok || !bytes.Contains(forcedUpstream, []byte(`"id":3`)) {
+		t.Fatalf("强制刷新应转发到 upstream 且剥离私有 params：%s", forcedUpstream)
+	}
+
 	// TTL 过期后恢复真实上游读取，确保缓存不会永久冻结展示数据。
 	router.accountTokenUsageMu.Lock()
 	router.accountTokenUsageCachedAt = time.Now().Add(-2 * time.Hour)
 	router.accountTokenUsageMu.Unlock()
-	if err := second.WriteMessage(websocket.TextMessage, []byte(`{"id":3,"method":"account/usage/read"}`)); err != nil {
+	if err := second.WriteMessage(websocket.TextMessage, []byte(`{"id":4,"method":"account/usage/read"}`)); err != nil {
 		t.Fatal(err)
 	}
 	_ = readGatewayRaw(t, second)
-	if got := readUpstreamFrame(t, received); !bytes.Contains(got, []byte(`"id":3`)) {
+	if got := readUpstreamFrame(t, received); !bytes.Contains(got, []byte(`"id":4`)) {
 		t.Fatalf("过期请求应重新转发到 upstream：%s", got)
 	}
 }

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -1341,6 +1341,112 @@ func TestAppServerGatewayRejectsUnsafeMethodWithoutForwarding(t *testing.T) {
 	assertNoUpstreamFrame(t, received)
 }
 
+func TestAppServerGatewayCachesAccountTokenUsageAcrossConnections(t *testing.T) {
+	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var request appServerGatewayFrame
+		if json.Unmarshal(payload, &request) != nil || request.Method != "account/usage/read" {
+			return
+		}
+		response, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"result": map[string]any{
+				"summary": map[string]any{"lifetimeTokens": 123456},
+				"dailyUsageBuckets": []map[string]any{{
+					"startDate": "2026-08-06",
+					"tokens":    789,
+				}},
+			},
+		})
+		_ = conn.WriteMessage(messageType, response)
+	})
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	first := dialAuthedGateway(t, server.URL)
+	if err := first.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"method":"account/usage/read"}`)); err != nil {
+		t.Fatal(err)
+	}
+	firstResponse := readGatewayRaw(t, first)
+	if !bytes.Contains(firstResponse, []byte(`"lifetimeTokens":123456`)) {
+		t.Fatalf("首次上游响应应返回 Token 快照：%s", firstResponse)
+	}
+	if got := readUpstreamFrame(t, received); !bytes.Contains(got, []byte(`"method":"account/usage/read"`)) {
+		t.Fatalf("首次请求应转发到 upstream：%s", got)
+	}
+	_ = first.Close()
+
+	second := dialAuthedGateway(t, server.URL)
+	defer second.Close()
+	if err := second.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":2,"method":"account/usage/read"}`)); err != nil {
+		t.Fatal(err)
+	}
+	secondResponse := readGatewayRaw(t, second)
+	var cached struct {
+		ID     json.RawMessage `json:"id"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(secondResponse, &cached); err != nil {
+		t.Fatal(err)
+	}
+	if string(cached.ID) != "2" || !bytes.Contains(cached.Result, []byte(`"lifetimeTokens":123456`)) {
+		t.Fatalf("缓存响应必须替换为当前请求 id 并保留快照：%s", secondResponse)
+	}
+	assertNoUpstreamFrame(t, received)
+
+	// TTL 过期后恢复真实上游读取，确保缓存不会永久冻结展示数据。
+	router.accountTokenUsageMu.Lock()
+	router.accountTokenUsageCachedAt = time.Now().Add(-2 * time.Hour)
+	router.accountTokenUsageMu.Unlock()
+	if err := second.WriteMessage(websocket.TextMessage, []byte(`{"id":3,"method":"account/usage/read"}`)); err != nil {
+		t.Fatal(err)
+	}
+	_ = readGatewayRaw(t, second)
+	if got := readUpstreamFrame(t, received); !bytes.Contains(got, []byte(`"id":3`)) {
+		t.Fatalf("过期请求应重新转发到 upstream：%s", got)
+	}
+}
+
+func TestAppServerGatewayDoesNotCacheFailedAccountTokenUsage(t *testing.T) {
+	var requests atomic.Int64
+	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var request appServerGatewayFrame
+		if json.Unmarshal(payload, &request) != nil || request.Method != "account/usage/read" {
+			return
+		}
+		requests.Add(1)
+		response, _ := json.Marshal(map[string]any{
+			"id": request.ID,
+			"error": map[string]any{
+				"code":    -32000,
+				"message": "usage unavailable",
+			},
+		})
+		_ = conn.WriteMessage(messageType, response)
+	})
+	handler, _ := appServerGatewayRouterFixture(t, upstreamURL)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	conn := dialAuthedGateway(t, server.URL)
+	defer conn.Close()
+	for _, id := range []int{10, 11} {
+		request := fmt.Sprintf(`{"id":%d,"method":"account/usage/read"}`, id)
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(request)); err != nil {
+			t.Fatal(err)
+		}
+		response := readGatewayRaw(t, conn)
+		if !bytes.Contains(response, []byte(`"usage unavailable"`)) {
+			t.Fatalf("失败响应应原样返回：%s", response)
+		}
+		_ = readUpstreamFrame(t, received)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("失败响应不能进入缓存，upstream requests=%d", requests.Load())
+	}
+}
+
 func TestAppServerGatewayRejectsUnauthorizedThreadIDWithoutForwarding(t *testing.T) {
 	upstreamURL, received, _ := fakeAppServerUpstream(t, nil)
 	handler, projectDir := appServerGatewayRouterFixture(t, upstreamURL)

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -160,6 +160,7 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 		return payload, true, nil
 	}
 	if gatewayFrameIsResponse(&frame) {
+		p.rememberAccountTokenUsageResponse(&frame, time.Now())
 		if pending, ok := p.consumePendingHistoryRequest(frame.ID); ok {
 			if len(frame.Error) == 0 && len(frame.Result) > 0 {
 				if redacted, changed := p.router.redactInlineHistoryImagesInGatewayResponse(payload); changed {

--- a/internal/httpapi/appserver_gateway_websocket.go
+++ b/internal/httpapi/appserver_gateway_websocket.go
@@ -94,6 +94,14 @@ func (r *Router) copyClientFramesToAppServer(client *websocket.Conn, upstream *w
 			}
 			continue
 		}
+		if cachedPayload, ok := policy.cachedAccountTokenUsageResponse(payload, time.Now()); ok {
+			writeStart := time.Now()
+			if err := writeWebSocketFrame(client, clientWriteMu, websocket.TextMessage, cachedPayload); err != nil {
+				return gatewayCloseReason("client_cache_write", err)
+			}
+			monitor.recordForward("upstream_to_client", len(cachedPayload), len(cachedPayload), policyDuration, time.Since(writeStart), cachedPayload)
+			continue
+		}
 		requestID := monitor.beginRPCRequest(forwardPayload, len(forwardPayload))
 		writeStart := time.Now()
 		if err := writeWebSocketFrame(upstream, upstreamWriteMu, messageType, forwardPayload); err != nil {

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -78,6 +78,12 @@ type Router struct {
 	claudeRuntimeQuotaMu        sync.RWMutex
 	claudeRuntimeQuota          *runtimeRateLimits
 	claudeRuntimeQuotaCheckedAt time.Time
+	// Token 活动只是低频展示数据。缓存成功响应可以让 iOS 重进「我的」页或重连后
+	// 立即拿到最近快照，避免每次都等待 account/usage/read 的慢查询。
+	accountTokenUsageMu       sync.RWMutex
+	accountTokenUsageResult   json.RawMessage
+	accountTokenUsageCachedAt time.Time
+	accountTokenUsageCacheTTL time.Duration
 
 	gatewayThreadsMu              sync.Mutex
 	gatewayThreads                map[string]appServerGatewayAllowedThread
@@ -188,6 +194,7 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 		managedWorktreeCleanupPlans: map[string]worktreeCleanupPlan{},
 		managedWorktreePendingUses:  map[string]int{},
 		gitTestFlightJobs:           map[string]*gitTestFlightReleaseJob{},
+		accountTokenUsageCacheTTL:   defaultAccountTokenUsageCacheTTL,
 		claudeBridge:                newClaudeBridgeSupervisor(),
 	}
 	r.refreshClaudeBridgeProbe(false)

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -433,9 +433,7 @@ extension CodexAppServerSessionRuntime {
             return await accountTokenUsageRefreshTask.value
         }
 
-        let task = Task { [self] in
-            await performAccountTokenUsageRefresh(forceRefresh: forceRefresh)
-        }
+        let task = Task { [self] in await performAccountTokenUsageRefresh(forceRefresh: forceRefresh) }
         accountTokenUsageRefreshTask = task
         let fetch = await task.value
         accountTokenUsageRefreshTask = nil
@@ -461,9 +459,8 @@ extension CodexAppServerSessionRuntime {
 
         do {
             let result = try await sendRecoveringFromStaleInitialization(
-                CodexAppServerRequestBuilder(allowlistedProjects: config.projects).accountUsageRead(
-                    forceRefresh: forceRefresh
-                ),
+                CodexAppServerRequestBuilder(allowlistedProjects: config.projects)
+                    .accountUsageRead(forceRefresh: forceRefresh),
                 timeout: min(requestTimeout, 10)
             )
             guard let snapshot = accountTokenUsageSnapshot(fromPayload: result) else {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -428,13 +428,13 @@ extension CodexAppServerSessionRuntime {
         _ = await refreshRateLimitIfAvailable()
     }
 
-    func refreshAccountTokenUsage() async -> AccountTokenUsageFetch {
+    func refreshAccountTokenUsage(forceRefresh: Bool = false) async -> AccountTokenUsageFetch {
         if let accountTokenUsageRefreshTask {
             return await accountTokenUsageRefreshTask.value
         }
 
         let task = Task { [self] in
-            await performAccountTokenUsageRefresh()
+            await performAccountTokenUsageRefresh(forceRefresh: forceRefresh)
         }
         accountTokenUsageRefreshTask = task
         let fetch = await task.value
@@ -442,7 +442,7 @@ extension CodexAppServerSessionRuntime {
         return fetch
     }
 
-    func performAccountTokenUsageRefresh() async -> AccountTokenUsageFetch {
+    func performAccountTokenUsageRefresh(forceRefresh: Bool = false) async -> AccountTokenUsageFetch {
         // 账号活动是 Codex/ChatGPT 专属能力；Claude bridge 没有同构数据，必须 fail closed。
         guard runtimeProvider == "codex" else {
             return .unsupported
@@ -461,7 +461,9 @@ extension CodexAppServerSessionRuntime {
 
         do {
             let result = try await sendRecoveringFromStaleInitialization(
-                CodexAppServerRequestBuilder(allowlistedProjects: config.projects).accountUsageRead(),
+                CodexAppServerRequestBuilder(allowlistedProjects: config.projects).accountUsageRead(
+                    forceRefresh: forceRefresh
+                ),
                 timeout: min(requestTimeout, 10)
             )
             guard let snapshot = accountTokenUsageSnapshot(fromPayload: result) else {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
@@ -181,6 +181,10 @@ final class CodexAppServerSessionAPIClient: SessionStoreAPIClient {
         await runtime.refreshAccountTokenUsage()
     }
 
+    func refreshAccountTokenUsage(forceRefresh: Bool) async throws -> AccountTokenUsageFetch {
+        await runtime.refreshAccountTokenUsage(forceRefresh: forceRefresh)
+    }
+
     func threadGoal(threadID: String) async throws -> ThreadGoal? {
         try await runtime.threadGoal(threadID: threadID)
     }
@@ -527,6 +531,11 @@ final class CodexAppServerRuntimeRoutingSessionAPIClient: SessionStoreAPIClient 
     func refreshAccountTokenUsage() async throws -> AccountTokenUsageFetch {
         // Token 活动来自 ChatGPT 账号，只允许走 Codex channel。
         await bundle.codex.refreshAccountTokenUsage()
+    }
+
+    func refreshAccountTokenUsage(forceRefresh: Bool) async throws -> AccountTokenUsageFetch {
+        // Token 活动来自 ChatGPT 账号，只允许走 Codex channel。
+        await bundle.codex.refreshAccountTokenUsage(forceRefresh: forceRefresh)
     }
 
     func threadGoal(threadID: String) async throws -> ThreadGoal? {

--- a/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
@@ -474,9 +474,12 @@ struct CodexAppServerRequestBuilder {
         CodexAppServerRequestSpec(method: "account/rateLimits/read")
     }
 
-    func accountUsageRead() -> CodexAppServerRequestSpec {
-        // 该方法在 app-server schema 中没有 params；省略字段可兼容严格校验版本。
-        CodexAppServerRequestSpec(method: "account/usage/read", params: nil)
+    func accountUsageRead(forceRefresh: Bool = false) -> CodexAppServerRequestSpec {
+        // 强制刷新提示只在 iOS 到 agentd 的 gateway 内生效；agentd 会在转发前剥离它。
+        let params: CodexAppServerJSONValue? = forceRefresh
+            ? .object(["mimiForceRefresh": .bool(true)])
+            : nil
+        return CodexAppServerRequestSpec(method: "account/usage/read", params: params)
     }
 
     func threadStart(projectID: String, model: String? = nil, options: CodexAppServerTurnOptions = .default) throws -> CodexAppServerRequestSpec {

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -444,7 +444,7 @@ struct SettingsView: View {
 
     private func refreshAccountUsage() async {
         async let codexQuota: Void = sessionStore.refreshCodexUsage()
-        async let tokenActivity: Void = sessionStore.refreshAccountTokenUsage()
+        async let tokenActivity: Void = sessionStore.refreshAccountTokenUsage(forceRefresh: true)
         if sessionStore.hasClaudeRuntimeChannel {
             await sessionStore.refreshClaudeUsage()
         }

--- a/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
@@ -167,6 +167,7 @@ protocol SessionStoreAPIClient {
     func refreshRateLimit(sessionID: String?) async throws -> RateLimitSummary?
     func refreshRateLimit(runtimeProvider: String) async throws -> RateLimitSummary?
     func refreshAccountTokenUsage() async throws -> AccountTokenUsageFetch
+    func refreshAccountTokenUsage(forceRefresh: Bool) async throws -> AccountTokenUsageFetch
 }
 
 extension SessionStoreAPIClient {
@@ -224,6 +225,10 @@ extension SessionStoreAPIClient {
     func refreshAccountTokenUsage() async throws -> AccountTokenUsageFetch {
         // 没有实现该能力的客户端是“不提供”，不是“请求失败”。
         .unsupported
+    }
+    func refreshAccountTokenUsage(forceRefresh: Bool) async throws -> AccountTokenUsageFetch {
+        // 兼容旧客户端与测试替身；生产客户端会覆盖该方法并把强制刷新提示传到 agentd。
+        try await refreshAccountTokenUsage()
     }
     func modelOptions() async throws -> [CodexAppServerModelOption] {
         []

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -3,7 +3,7 @@ import os
 import UserNotifications
 
 extension SessionStore {
-    func refreshAccountTokenUsage() async {
+    func refreshAccountTokenUsage(forceRefresh: Bool = false) async {
         let hostScope = appStore.activeHostScope
         guard accountTokenUsageRefreshHostScope != hostScope else {
             return
@@ -26,7 +26,7 @@ extension SessionStore {
         guard !Task.isCancelled else { return }
         let fetch: AccountTokenUsageFetch
         do {
-            fetch = try await clientFactory().refreshAccountTokenUsage()
+            fetch = try await clientFactory().refreshAccountTokenUsage(forceRefresh: forceRefresh)
         } catch is CancellationError {
             return
         } catch {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -460,6 +460,10 @@ final class CodexAppServerProtocolTests: XCTestCase {
         let builder = CodexAppServerRequestBuilder(allowlistedProjects: [])
         XCTAssertEqual(builder.accountUsageRead().method, "account/usage/read")
         XCTAssertNil(builder.accountUsageRead().params)
+        XCTAssertEqual(
+            builder.accountUsageRead(forceRefresh: true).params?.objectValue?["mimiForceRefresh"]?.boolValue,
+            true
+        )
 
         let runtime = CodexAppServerSessionRuntime(
             endpoint: "http://127.0.0.1:8787",


### PR DESCRIPTION
## 改动

- 在 agentd 的 Codex gateway 中缓存成功的 `account/usage/read` result，默认 TTL 为 1 小时。
- 缓存命中时使用当前 JSON-RPC request id 重建响应，可跨 iOS WebSocket 重连复用。
- 失败结果不缓存；TTL 过期后恢复真实上游读取。
- 不缓存实时额度接口或事件，不改变 iOS 协议和 Token 统计口径。

## 原因

「我的」页 Token 活动属于低频展示数据，但此前每次进入或重连都会重新等待上游慢查询，导致反复出现长时间加载态。

## 验证

- `go test ./...`
- `go test ./internal/httpapi -count=1`
- `go test -race ./internal/httpapi -run 'TestAppServerGateway(CachesAccountTokenUsageAcrossConnections|DoesNotCacheFailedAccountTokenUsage)$' -count=1`
- `go vet ./...`
- `go build ./cmd/agentd`

Linear: MIM-108
