### PR TITLE
MIM-109 系统性降低会话处理耗时

### DIFF
--- a/internal/codexhistory/history.go
+++ b/internal/codexhistory/history.go
@@ -987,6 +987,17 @@ func messagesPageFromTail(file *os.File, endOffset int64, limit int) (MessagePag
 		if len(newestFirst) < target {
 			pending = storeTailPendingLine(pending, data[:start])
 		}
+		// 大多数分页请求都能在文件尾部的首个 128 KiB 内完成；只有仍需向前
+		// 扫描时才分级扩大下一次 ReadAt（128→256→512 KiB），避免小页快路径
+		// 常驻更大的缓冲区。512 KiB 上限可显著减少长 token_count/tool/result 行跨块时的读取次数
+		// 和 pending 拼接，同时不改变行边界、游标或超大半行丢弃语义。
+		if len(newestFirst) < target && offset > 0 && int64(len(chunk)) < tailReadChunkSize {
+			nextSize := int64(len(chunk)) * 2
+			if nextSize > tailReadChunkSize {
+				nextSize = tailReadChunkSize
+			}
+			chunk = make([]byte, nextSize)
+		}
 	}
 	if len(newestFirst) < target && len(bytes.TrimSpace(pending)) > 0 {
 		if message, ok := parseMessageLine(pending); ok {

--- a/internal/codexhistory/history_test.go
+++ b/internal/codexhistory/history_test.go
@@ -254,6 +254,53 @@ func TestIndexedMessagePageMatchesTailPagination(t *testing.T) {
 	assertMessagePageEqual(t, secondIndexed, secondTail)
 }
 
+func TestMessagesPageFromTailMatchesIndexedAcrossLargeLine(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "rollout-large-page-*.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	lines := []string{
+		`{"timestamp":"2026-06-01T10:00:00Z","type":"event_msg","payload":{"type":"user_message","message":"before one"}}`,
+		`{"timestamp":"2026-06-01T10:00:01Z","type":"event_msg","payload":{"type":"agent_message","message":"before two"}}`,
+		`{"timestamp":"2026-06-01T10:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"before three"}}`,
+		`{"timestamp":"2026-06-01T10:00:03Z","type":"event_msg","payload":{"type":"agent_message","message":"before four"}}`,
+		`{"timestamp":"2026-06-01T10:00:04Z","type":"event_msg","payload":{"type":"token_count","info":"` + strings.Repeat("x", 256*1024) + `"}}`,
+		`{"timestamp":"2026-06-01T10:00:05Z","type":"event_msg","payload":{"type":"user_message","message":"after one"}}`,
+		`{"timestamp":"2026-06-01T10:00:06Z","type":"event_msg","payload":{"type":"agent_message","message":"after two"}}`,
+	}
+	if _, err := file.WriteString(strings.Join(lines, "\n")); err != nil {
+		t.Fatal(err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	indexed, err := indexedMessagesFromFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstTail, err := messagesPageFromTail(file, info.Size(), 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstIndexed := pageFromIndexedMessages(indexed, info.Size(), 3)
+	assertMessagePageEqual(t, firstTail, firstIndexed)
+
+	offset, ok := decodeMessageCursor(firstTail.PreviousCursor)
+	if !ok {
+		t.Fatalf("大行后的 previous_cursor 应可解码：%q", firstTail.PreviousCursor)
+	}
+	secondTail, err := messagesPageFromTail(file, offset, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondIndexed := pageFromIndexedMessages(indexed, offset, 3)
+	assertMessagePageEqual(t, secondTail, secondIndexed)
+}
+
 func BenchmarkMessagesPageFromTailLargeRollout(b *testing.B) {
 	file, err := os.CreateTemp(b.TempDir(), "rollout-large-*.jsonl")
 	if err != nil {
@@ -267,6 +314,53 @@ func BenchmarkMessagesPageFromTailLargeRollout(b *testing.B) {
 			_, _ = file.WriteString(strings.Repeat("x", 256*1024))
 			_, _ = file.WriteString(`"}}` + "\n")
 		}
+		role := "user_message"
+		if i%2 == 1 {
+			role = "agent_message"
+		}
+		_, _ = file.WriteString(`{"timestamp":"2026-06-01T10:00:00Z","type":"event_msg","payload":{"type":"` + role + `","message":"message ` + strconv.Itoa(i) + `"}}` + "\n")
+	}
+	// Ensure the measured tail window crosses a 256 KiB+ non-message line:
+	// fewer than 120 messages follow this record, so collecting the 120-message
+	// page must read through it instead of stopping in the newest suffix.
+	_, _ = file.WriteString(`{"timestamp":"2026-06-01T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":"`)
+	_, _ = file.WriteString(strings.Repeat("x", 256*1024))
+	_, _ = file.WriteString(`"}}` + "\n")
+	for i := 0; i < 80; i++ {
+		role := "user_message"
+		if i%2 == 1 {
+			role = "agent_message"
+		}
+		_, _ = file.WriteString(`{"timestamp":"2026-06-01T10:00:00Z","type":"event_msg","payload":{"type":"` + role + `","message":"tail message ` + strconv.Itoa(i) + `"}}` + "\n")
+	}
+	info, err := file.Stat()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		page, err := messagesPageFromTail(file, info.Size(), 120)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(page.Messages) != 120 {
+			b.Fatalf("期望返回 120 条消息，实际 %d", len(page.Messages))
+		}
+	}
+}
+
+func BenchmarkMessagesPageFromTailSmallRollout(b *testing.B) {
+	file, err := os.CreateTemp(b.TempDir(), "rollout-small-*.jsonl")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	// The file is larger than the initial chunk, while the newest 120 messages
+	// fit comfortably inside its final 128 KiB and need no adaptive expansion.
+	for i := 0; i < 3000; i++ {
 		role := "user_message"
 		if i%2 == 1 {
 			role = "agent_message"

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -430,6 +430,13 @@ struct SessionListView: View {
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
+        // 同一轮 body 求值内复用同一份轻量索引投影，避免每个 Section 的条件和内容
+        // 访问都重新触发全量 filter / merge / sort。生命周期输入仍由当前快照驱动。
+        let visibleSessions = self.visibleSessions
+        let sessionPartition = makeSessionPartition(visibleSessions: visibleSessions)
+        let historyDateGroups = makeHistoryDateGroups(sessionPartition: sessionPartition)
+        let lifecycleInput = makeLifecycleInput(visibleSessions: visibleSessions)
+        let presentationState = makePresentationState(hasVisibleSessions: !visibleSessions.isEmpty)
 
         List {
             if hasActiveFilters {
@@ -619,7 +626,7 @@ struct SessionListView: View {
         }
     }
 
-    private var sessionPartition: SessionListPartition {
+    private func makeSessionPartition(visibleSessions: [AgentSession]) -> SessionListPartition {
         let membership = lifecycleCoordinator.hasObservedInput
             ? lifecycleCoordinator.membership
             : SessionListMembership(sessions: visibleSessions)
@@ -636,7 +643,9 @@ struct SessionListView: View {
         )
     }
 
-    private var historyDateGroups: [SessionHistoryDateGroup] {
+    private func makeHistoryDateGroups(
+        sessionPartition: SessionListPartition
+    ) -> [SessionHistoryDateGroup] {
         SessionListPresentation.historyDateGroups(
             sessions: sessionPartition.history,
             now: Date(),
@@ -651,7 +660,7 @@ struct SessionListView: View {
         )
     }
 
-    private var lifecycleInput: SessionListLifecycleInput {
+    private func makeLifecycleInput(visibleSessions: [AgentSession]) -> SessionListLifecycleInput {
         SessionListLifecycleInput(
             membership: SessionListMembership(sessions: visibleSessions),
             // Haptic 不跟随搜索和筛选结果裁剪，否则切换筛选会把同一终态误当成新事件。
@@ -683,9 +692,9 @@ struct SessionListView: View {
         }
     }
 
-    private var presentationState: SessionListPresentationState {
+    private func makePresentationState(hasVisibleSessions: Bool) -> SessionListPresentationState {
         SessionListPresentationState.resolve(
-            hasVisibleSessions: !visibleSessions.isEmpty,
+            hasVisibleSessions: hasVisibleSessions,
             // sidebarProjects 只包含 rememberWorkspace 记录的已打开目录，不包含后端候选项目。
             hasOpenedWorkspace: !sessionStore.sidebarProjects.isEmpty,
             isLoading: sessionStore.isLoading,
@@ -905,7 +914,11 @@ struct SessionListView: View {
     }
 
     private var orderedVisibleSessions: [AgentSession] {
-        sessionPartition.active + sessionPartition.pinned + historyDateGroups.flatMap(\.sessions)
+        // 键盘事件发生在 body 求值之外，按当前筛选快照重新计算一次即可；正文渲染仍复用
+        // body 内的单份投影，避免每个 Section 重复过滤和排序。
+        let partition = makeSessionPartition(visibleSessions: visibleSessions)
+        let dateGroups = makeHistoryDateGroups(sessionPartition: partition)
+        return partition.active + partition.pinned + dateGroups.flatMap(\.sessions)
     }
 
     private func handleListKeyPress(_ keyPress: KeyPress) -> KeyPress.Result {

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -25,6 +25,33 @@ struct SessionArchiveMutation: Equatable {
     let target: SessionArchivePreferenceState
 }
 
+/// `applyEventReducerOutput` 内部的会话工作副本。
+///
+/// 一个 runtime event 可能同时更新 status、active turn、审批卡和列表预览。
+/// 这些更新必须按既有分组顺序彼此可见，但不能让每一步都触发整套索引/排序。
+/// 这里只复制会话数组；lookup 仍由 Store 增量维护，避免 batch 与 Store 同时持有
+/// Dictionary 导致每个 staged mutation 都触发整表 CoW。
+final class EventReducerSessionMutationBatch {
+    var sessions: [AgentSession]
+
+    init(sessions: [AgentSession]) {
+        self.sessions = sessions
+    }
+
+    func replace(at index: Int, with session: AgentSession) -> Bool {
+        guard sessions.indices.contains(index), sessions[index] != session else {
+            return false
+        }
+        sessions[index] = session
+        return true
+    }
+
+    func insert(_ session: AgentSession) {
+        // 与 SessionStore.upsert 保持一致：新会话放在数组头部。
+        sessions.insert(session, at: 0)
+    }
+}
+
 @MainActor
 final class SessionStore: ObservableObject {
     @Published var projects: [AgentProject] = [] {
@@ -355,6 +382,14 @@ final class SessionStore: ObservableObject {
     var sidebarProjectsByID: [String: AgentProject] = [:]
     var sessionsByID: [SessionID: AgentSession] = [:]
     var sessionIndexByID: [SessionID: Int] = [:]
+    // 只在 applyEventReducerOutput 的同步作用域存在；不能跨 event 或 await。
+    // lookup 在每个 staged mutation 后同步，保证 storage-protection helper 读取到最新状态。
+    var eventReducerSessionMutationBatch: EventReducerSessionMutationBatch?
+    // @Published 在实际写入 sessions 前同步通知。通知回调若重入 reducer，不能直接从旧
+    // canonical sessions 开新批次，否则外层赋值会覆盖内层结果；先排队，待提交完成后顺序处理。
+    var isPublishingEventReducerSessions = false
+    var deferredEventReducerOutputs: [EventReducerOutput] = []
+    var isDrainingDeferredEventReducerOutputs = false
     var sortedAllSessions: [AgentSession] = []
     var sortedSessionsByProjectID: [String: [AgentSession]] = [:]
     var previewSessionsByProjectID: [String: [AgentSession]] = [:]

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -948,6 +948,11 @@ extension SessionStore {
     }
 
     func applyEventReducerOutput(_ output: EventReducerOutput) {
+        if isPublishingEventReducerSessions {
+            deferredEventReducerOutputs.append(output)
+            return
+        }
+        let ownsSessionMutationBatch = beginEventReducerSessionMutationBatch()
         for session in output.upsertSessions {
             upsert(session)
         }
@@ -1009,6 +1014,11 @@ extension SessionStore {
         for mutation in output.messageMutations {
             applyMessageMutation(mutation)
         }
+        // message mutation 可能通过 assistant preview 再次更新 session；必须等这里
+        // 完成后才提交，确保整个 reducer output 只发布一次且前序 mutation 彼此可见。
+        if ownsSessionMutationBatch {
+            commitEventReducerSessionMutationBatch()
+        }
         if let statusMessage = output.statusMessage {
             setStatusMessage(statusMessage)
         }
@@ -1017,6 +1027,54 @@ extension SessionStore {
         }
         if output.disconnectWebSocket {
             disconnectWebSocket()
+        }
+    }
+
+    private func beginEventReducerSessionMutationBatch() -> Bool {
+        // @Published 的同步订阅者可能在副作用阶段重入 applyEventReducerOutput。
+        // 内层输出复用同一 working copy，但只有最外层拥有提交权，避免提前发布并清空外层批次。
+        guard eventReducerSessionMutationBatch == nil else {
+            return false
+        }
+        eventReducerSessionMutationBatch = EventReducerSessionMutationBatch(
+            sessions: sessions
+        )
+        return true
+    }
+
+    private func commitEventReducerSessionMutationBatch() {
+        guard let batch = eventReducerSessionMutationBatch else {
+            return
+        }
+        // 先退出 batch，再赋值 canonical sessions，保证 didSet 走正常的唯一重建路径。
+        eventReducerSessionMutationBatch = nil
+        guard batch.sessions != sessions else {
+            // 中间 mutation 最终抵消时保持 no-op：不发布，也不触发昂贵索引重建。
+            return
+        }
+        isPublishingEventReducerSessions = true
+        sessions = batch.sessions
+        isPublishingEventReducerSessions = false
+        // 订阅 sessions/didSet 派生状态时到达的 output 必须紧跟本次 canonical 提交，
+        // 再继续当前 output 的 status/error/disconnect 副作用，保持同步观察顺序。
+        drainDeferredEventReducerOutputs()
+    }
+
+    private func drainDeferredEventReducerOutputs() {
+        guard !isDrainingDeferredEventReducerOutputs else {
+            return
+        }
+        isDrainingDeferredEventReducerOutputs = true
+        defer { isDrainingDeferredEventReducerOutputs = false }
+
+        // 每轮整体取出，避免 removeFirst 的 O(n) 搬移；处理过程中再次排队的 output
+        // 会在下一轮继续按到达顺序执行。
+        while !deferredEventReducerOutputs.isEmpty {
+            let outputs = deferredEventReducerOutputs
+            deferredEventReducerOutputs.removeAll(keepingCapacity: true)
+            for output in outputs {
+                applyEventReducerOutput(output)
+            }
         }
     }
 
@@ -2425,6 +2483,23 @@ extension SessionStore {
         let session = sessionPreparedForStorage(alignSessionToKnownWorkspace(session))
         syncRuntimeActivity(with: session)
         contextStore.upsert(from: session)
+        if let batch = eventReducerSessionMutationBatch {
+            if let index = sessionIndexByID[session.id] {
+                guard batch.replace(at: index, with: session) else {
+                    return
+                }
+                sessionsByID[session.id] = session
+            } else {
+                batch.insert(session)
+                sessionsByID[session.id] = session
+                // 插入头部会改变所有后续位置；这是批内唯一需要 O(n) 的 lookup 更新，
+                // 与既有 upsert 的数组语义保持一致。
+                sessionIndexByID = Dictionary(
+                    uniqueKeysWithValues: batch.sessions.enumerated().map { ($0.element.id, $0.offset) }
+                )
+            }
+            return
+        }
         if let index = sessionIndexByID[session.id] {
             guard sessions[index] != session else {
                 return
@@ -2452,6 +2527,20 @@ extension SessionStore {
     }
 
     func updateSession(_ id: String, mutate: (inout AgentSession) -> Void) {
+        if let batch = eventReducerSessionMutationBatch {
+            guard let index = sessionIndexByID[id], batch.sessions.indices.contains(index) else {
+                return
+            }
+            let oldValue = batch.sessions[index]
+            var next = oldValue
+            mutate(&next)
+            guard next != oldValue else {
+                return
+            }
+            batch.sessions[index] = next
+            sessionsByID[id] = next
+            return
+        }
         guard let index = sessionIndexByID[id] else {
             return
         }

--- a/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
@@ -458,29 +458,110 @@ extension SessionStoreAPIClient {
 
 @MainActor
 final class TerminalStreamStore {
+    /// 每个数组元素代表一个“逻辑事件”。连续文本增量只保存原始 chunk，
+    /// 不在 append 时复制已有前缀；真正交付前再一次性线性拼接，避免高频 token 造成 O(n²)。
+    private struct BufferedEvent {
+        var event: AgentEvent
+        private var textChunks: [String]?
+
+        init(_ event: AgentEvent) {
+            self.event = event
+            switch event {
+            case .assistantDelta(let delta, _):
+                textChunks = [delta.text]
+            case .logDelta(let delta, _):
+                textChunks = [delta.text]
+            default:
+                textChunks = nil
+            }
+        }
+
+        var canMergeText: Bool {
+            textChunks != nil
+        }
+
+        mutating func appendTextChunk(from next: AgentEvent) {
+            switch next {
+            case .assistantDelta(let delta, _):
+                textChunks?.append(delta.text)
+                event = next
+            case .logDelta(let delta, _):
+                textChunks?.append(delta.text)
+                event = next
+            default:
+                assertionFailure("only text events can append chunks")
+            }
+        }
+
+        mutating func replace(with next: AgentEvent) {
+            event = next
+            textChunks = nil
+        }
+
+        func materialized() -> AgentEvent {
+            guard let textChunks else {
+                return event
+            }
+            let text = textChunks.joined()
+            switch event {
+            case .assistantDelta(let delta, let metadata):
+                return .assistantDelta(
+                    AgentDelta(text: text, role: delta.role, kind: delta.kind),
+                    metadata
+                )
+            case .logDelta(let delta, let metadata):
+                return .logDelta(
+                    LogDelta(text: text, stream: delta.stream),
+                    metadata
+                )
+            default:
+                assertionFailure("text chunks must belong to a text event")
+                return event
+            }
+        }
+    }
+
+    /// 以引用类型持有单个 lease 的数组，避免从 Dictionary 取出值后每个 append 都触发数组 CoW。
+    private final class LeaseBuffer {
+        var events: [BufferedEvent] = []
+    }
+
     let maxBatchSize: Int
-    var eventsByLease: [HostSessionLease: [AgentEvent]] = [:]
+    private var eventsByLease: [HostSessionLease: LeaseBuffer] = [:]
 
     init(maxBatchSize: Int = 64) {
         self.maxBatchSize = max(1, maxBatchSize)
     }
 
     func append(_ event: AgentEvent, lease: HostSessionLease) -> Bool {
-        var events = eventsByLease[lease] ?? []
-        if let previous = events.last,
-           let merged = previous.mergingContiguous(with: event) {
-            events[events.index(before: events.endIndex)] = merged
+        let buffer: LeaseBuffer
+        if let existing = eventsByLease[lease] {
+            buffer = existing
         } else {
-            events.append(event)
+            let created = LeaseBuffer()
+            eventsByLease[lease] = created
+            buffer = created
         }
-        eventsByLease[lease] = events
-        return events.count >= maxBatchSize
+
+        if let previousIndex = buffer.events.indices.last,
+           Self.canMergeContiguous(buffer.events[previousIndex].event, with: event) {
+            if buffer.events[previousIndex].canMergeText {
+                buffer.events[previousIndex].appendTextChunk(from: event)
+            } else {
+                // messageCompleted 的 plan/reasoningSummary 是累计快照，保留最新事件。
+                buffer.events[previousIndex].replace(with: event)
+            }
+        } else {
+            buffer.events.append(BufferedEvent(event))
+        }
+        return buffer.events.count >= maxBatchSize
     }
 
     func drain(lease: HostSessionLease) -> [AgentEvent] {
-        let events = eventsByLease[lease] ?? []
-        eventsByLease.removeValue(forKey: lease)
-        return events
+        guard let buffer = eventsByLease.removeValue(forKey: lease) else {
+            return []
+        }
+        return buffer.events.map { $0.materialized() }
     }
 
     func removeAll(lease: HostSessionLease) {
@@ -489,6 +570,35 @@ final class TerminalStreamStore {
 
     func removeAll(profileID: String) {
         eventsByLease = eventsByLease.filter { $0.key.hostScope.profileID != profileID }
+    }
+
+    /// 与 AgentEvent.mergingContiguous 保持同一合并判定，但不构造拼接后的 String。
+    /// 这让 append 只追加 chunk/逻辑事件，文本复制集中到 drain 的一次性 joined()。
+    private static func canMergeContiguous(_ event: AgentEvent, with next: AgentEvent) -> Bool {
+        switch (event, next) {
+        case let (.assistantDelta(previousDelta, previousMetadata), .assistantDelta(nextDelta, nextMetadata)):
+            return sameItem(previousMetadata, nextMetadata)
+                && previousDelta.role == nextDelta.role
+                && previousDelta.kind == nextDelta.kind
+        case let (.logDelta(previousDelta, previousMetadata), .logDelta(nextDelta, nextMetadata)):
+            return sameItem(previousMetadata, nextMetadata)
+                && previousDelta.stream == nextDelta.stream
+        case let (.messageCompleted(previousMessage, previousMetadata), .messageCompleted(nextMessage, nextMetadata)):
+            return previousMessage.role == .system
+                && nextMessage.role == .system
+                && previousMessage.kind == nextMessage.kind
+                && (nextMessage.kind == .plan || nextMessage.kind == .reasoningSummary)
+                && sameItem(previousMetadata, nextMetadata)
+        default:
+            return false
+        }
+    }
+
+    private static func sameItem(_ lhs: AgentEventMetadata, _ rhs: AgentEventMetadata) -> Bool {
+        lhs.sessionID == rhs.sessionID
+            && lhs.turnID == rhs.turnID
+            && lhs.itemID == rhs.itemID
+            && lhs.messageID == rhs.messageID
     }
 
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -2019,7 +2019,7 @@ extension ConversationDataFlowTests {
     }
 
     func testSelectingLoadedSessionRetainsConversationCache() async {
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let conversationStore = ConversationStore()
         conversationStore.activate(profileID: appStore.activeHostScope.profileID)
         let retainedLimit = ConversationStore.retainedSessionLimit

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
@@ -22,7 +22,10 @@ extension ConversationDataFlowTests {
 
         let conversationStore = ConversationStore()
         let sessionStore = SessionStore(
-            appStore: AppStore(defaults: defaults),
+            appStore: AppStore(
+                defaults: defaults,
+                tokenStore: TokenStore(keychain: TestKeychainOperations())
+            ),
             conversationStore: conversationStore,
             logStore: LogStore()
         )

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -11,7 +11,7 @@ extension ConversationDataFlowTests {
         let project = makeProject(id: "proj_1")
         let session = makeSession(id: "codex_1", projectID: project.id, title: "历史", status: "history", source: "codex", resumeID: "history")
         let client = FlakyBootstrapClient(failuresBeforeSuccess: 2, projects: [project], sessions: [session])
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token" // 让 isConfigured 为真，否则 bootstrap 直接返回。
         let store = SessionStore(
             appStore: appStore,
@@ -34,7 +34,7 @@ extension ConversationDataFlowTests {
             projects: [project],
             sessions: []
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "committed-token"
         let store = SessionStore(
             appStore: appStore,
@@ -67,7 +67,7 @@ extension ConversationDataFlowTests {
             projects: [project],
             sessions: [session]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "committed-token"
         let store = SessionStore(
             appStore: appStore,
@@ -141,7 +141,7 @@ extension ConversationDataFlowTests {
 
     func testBootstrapStopsImmediatelyWhenCredentialsAreRejected() async {
         let client = CredentialRejectingBootstrapClient(status: 401)
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "expired-token"
         var requestedSleeps: [UInt64] = []
         let store = SessionStore(
@@ -169,7 +169,7 @@ extension ConversationDataFlowTests {
             status: 401,
             credentialFingerprint: connectionCredentialFingerprint(staleToken)
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = activeToken
         let store = SessionStore(
             appStore: appStore,
@@ -222,7 +222,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "expired-token"
         let conversationStore = ConversationStore()
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
@@ -266,7 +266,7 @@ extension ConversationDataFlowTests {
     }
 
     func testLateOlderNetworkPathUpdateCannotOverwriteSatisfiedState() async throws {
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let pathSource = TestNetworkPathStatusSource(initialStatus: .unsatisfied)
         let store = SessionStore(
@@ -307,7 +307,7 @@ extension ConversationDataFlowTests {
                 .success(page)
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let pathSource = TestNetworkPathStatusSource(initialStatus: .unknown)
         var now = Date(timeIntervalSince1970: 0)
@@ -353,7 +353,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_network_active"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let conversationStore = ConversationStore()
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
@@ -415,7 +415,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let pathSource = TestNetworkPathStatusSource(initialStatus: .satisfied)
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
@@ -463,7 +463,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "expired-token"
         let pathSource = TestNetworkPathStatusSource(initialStatus: .satisfied)
         var sockets: [MockWebSocketClient] = []
@@ -509,7 +509,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let delayRecorder = ReconnectDelayRecorder()
         var sockets: [MockWebSocketClient] = []
@@ -561,7 +561,7 @@ extension ConversationDataFlowTests {
             projects: [project],
             sessions: [session]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -584,7 +584,7 @@ extension ConversationDataFlowTests {
 
     func testBootstrapDoesNotRetryWhenBackendHasNoProjects() async {
         let client = FlakyBootstrapClient(failuresBeforeSuccess: 0, projects: [], sessions: [])
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -606,7 +606,7 @@ extension ConversationDataFlowTests {
         let session = makeSession(id: "thread_coalesced_list", projectID: project.id, title: "合并列表", status: "history", source: "codex")
         let client = BlockingSessionListRefreshClient(projects: [project], page: SessionsPage(sessions: [session]))
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -639,7 +639,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [session]),
             blockOnCall: 1
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -686,7 +686,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [first, second])
         )
         let socket = MockWebSocketClient()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -732,7 +732,7 @@ extension ConversationDataFlowTests {
             projects: [firstProject, secondProject],
             page: SessionsPage(sessions: [first])
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -779,7 +779,7 @@ extension ConversationDataFlowTests {
             projects: [project],
             page: SessionsPage(sessions: [first, second])
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let socket = MockWebSocketClient()
         let store = SessionStore(
@@ -815,7 +815,7 @@ extension ConversationDataFlowTests {
                 .success(SessionsPage(sessions: [session]))
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         var now = Date(timeIntervalSince1970: 1_780_000_000)
         var requestedSleeps: [UInt64] = []
@@ -855,7 +855,7 @@ extension ConversationDataFlowTests {
                 .success(SessionsPage(sessions: [refreshed]))
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         var now = Date(timeIntervalSince1970: 1_780_000_000)
         let store = SessionStore(
             appStore: appStore,
@@ -902,7 +902,7 @@ extension ConversationDataFlowTests {
                 .success(SessionsPage(sessions: [refreshed]))
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         var now = Date(timeIntervalSince1970: 1_780_000_000)
         var requestedSleeps: [UInt64] = []
         let store = SessionStore(
@@ -944,7 +944,7 @@ extension ConversationDataFlowTests {
             projects: [project],
             results: [.success(SessionsPage(sessions: [session]))]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -972,7 +972,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: []),
             blockOnCall: 1
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1029,7 +1029,7 @@ extension ConversationDataFlowTests {
             sessions: [],
             projectSessions: projectSessions
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1076,7 +1076,7 @@ extension ConversationDataFlowTests {
         }
         let client = MockSessionStoreClient(projects: [project], sessions: active + history)
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1117,7 +1117,7 @@ extension ConversationDataFlowTests {
                 backgroundProject.id: SessionsPage(sessions: [backgroundRunning])
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1166,7 +1166,7 @@ extension ConversationDataFlowTests {
             runtimeProvider: "codex"
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [session])
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1234,7 +1234,7 @@ extension ConversationDataFlowTests {
             )
         ], sessionID: session.id)
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -1272,7 +1272,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [session])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1331,7 +1331,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -1410,7 +1410,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -589,7 +589,7 @@ final class ConversationDataFlowTests: XCTestCase {
     func testConversationTimelineStartsAtTailAfterSwitchingFromScrolledSession() async throws {
         let firstSessionID = "tail-position-first"
         let secondSessionID = "tail-position-second"
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let conversationStore = ConversationStore()
         conversationStore.activate(profileID: appStore.activeHostScope.profileID)
         for index in 0..<36 {
@@ -658,7 +658,7 @@ final class ConversationDataFlowTests: XCTestCase {
 #endif
         let longSessionID = "tail-race-long"
         let shortSessionID = "tail-race-short"
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let conversationStore = ConversationStore()
         conversationStore.activate(profileID: appStore.activeHostScope.profileID)
         for index in 0..<72 {
@@ -2356,6 +2356,331 @@ final class ConversationDataFlowTests: XCTestCase {
         }
     }
 
+    func testEventReducerOutputBatchesSessionFieldsAndPublishesOnce() throws {
+        let store = makeEventReducerTestStore()
+        let sessionID = "session_batch_fields"
+        var session = makeSession(
+            id: sessionID,
+            projectID: "project_batch",
+            title: "批处理会话",
+            status: SessionStatus.waitingForApproval.rawValue,
+            source: "codex",
+            activeTurnID: "turn_batch"
+        )
+        let approval = ApprovalSummary(
+            id: "approval_batch",
+            title: "允许批处理命令",
+            kind: "command",
+            count: 1
+        )
+        let input = AgentUserInputRequest(
+            id: "input_batch",
+            threadID: sessionID,
+            turnID: "turn_batch",
+            itemID: "item_batch",
+            questions: [
+                AgentUserInputQuestion(
+                    id: "question_batch",
+                    header: "范围",
+                    question: "选择范围",
+                    isOther: false,
+                    isSecret: false,
+                    options: []
+                )
+            ]
+        )
+        session.pendingApproval = approval
+        session.pendingUserInput = input
+        store.sessions = [session]
+
+        var output = EventReducerOutput()
+        output.statusUpdates = [(sessionID, SessionStatus.completed.rawValue)]
+        output.activeTurnMutations = [.clear(sessionID, "turn_batch")]
+        output.pendingApprovalUpdates = [(sessionID, nil)]
+        output.pendingUserInputUpdates = [(sessionID, nil)]
+
+        var publishCount = 0
+        let cancellable = store.$sessions.dropFirst().sink { _ in
+            publishCount += 1
+        }
+        store.applyEventReducerOutput(output)
+        withExtendedLifetime(cancellable) {}
+
+        let finalSession = try XCTUnwrap(store.sessionsByID[sessionID])
+        XCTAssertEqual(publishCount, 1)
+        XCTAssertEqual(finalSession.status, SessionStatus.completed.rawValue)
+        XCTAssertNil(finalSession.activeTurnID)
+        XCTAssertNil(finalSession.pendingApproval)
+        XCTAssertNil(finalSession.pendingUserInput)
+        XCTAssertEqual(store.sessions.map(\.id), [sessionID])
+        XCTAssertEqual(store.sessionIndexByID[sessionID], 0)
+    }
+
+    func testEventReducerBatchMakesUpsertVisibleToLaterMutations() throws {
+        let store = makeEventReducerTestStore()
+        let sessionID = "session_batch_upsert"
+        let goal = ThreadGoal(
+            threadID: sessionID,
+            objective: "完成批处理验证",
+            status: .active,
+            tokenBudget: 1_000
+        )
+        let incoming = makeSession(
+            id: sessionID,
+            projectID: "project_batch",
+            title: "新会话",
+            status: SessionStatus.history.rawValue,
+            source: "codex"
+        )
+
+        var output = EventReducerOutput()
+        output.upsertSessions = [incoming]
+        output.statusUpdates = [(sessionID, SessionStatus.running.rawValue)]
+        output.activeTurnMutations = [.set(sessionID, "turn_after_upsert")]
+        output.goalUpdates = [(sessionID, goal)]
+
+        var publishCount = 0
+        let cancellable = store.$sessions.dropFirst().sink { _ in
+            publishCount += 1
+        }
+        store.applyEventReducerOutput(output)
+        withExtendedLifetime(cancellable) {}
+
+        let finalSession = try XCTUnwrap(store.sessionsByID[sessionID])
+        XCTAssertEqual(publishCount, 1)
+        XCTAssertEqual(store.sessions.count, 1)
+        XCTAssertEqual(finalSession.status, SessionStatus.running.rawValue)
+        XCTAssertEqual(finalSession.activeTurnID, "turn_after_upsert")
+        XCTAssertEqual(finalSession.goal, goal)
+        XCTAssertEqual(store.sessionIndexByID[sessionID], 0)
+    }
+
+    func testEventReducerBatchUsesLastMutationForDuplicateFields() throws {
+        let store = makeEventReducerTestStore()
+        let sessionID = "session_batch_last_write"
+        var session = makeSession(
+            id: sessionID,
+            projectID: "project_batch",
+            title: "覆盖顺序",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            activeTurnID: "turn_initial"
+        )
+        let firstApproval = ApprovalSummary(id: "approval_first", title: "第一次", kind: "command", count: 1)
+        let lastApproval = ApprovalSummary(id: "approval_last", title: "最后一次", kind: "command", count: 2)
+        let firstInput = AgentUserInputRequest(
+            id: "input_first",
+            threadID: sessionID,
+            turnID: "turn_initial",
+            itemID: "item_first",
+            questions: []
+        )
+        let lastInput = AgentUserInputRequest(
+            id: "input_last",
+            threadID: sessionID,
+            turnID: "turn_initial",
+            itemID: "item_last",
+            questions: []
+        )
+        session.pendingApproval = firstApproval
+        session.pendingUserInput = firstInput
+        store.sessions = [session]
+
+        var output = EventReducerOutput()
+        output.statusUpdates = [
+            (sessionID, SessionStatus.waitingForApproval.rawValue),
+            (sessionID, SessionStatus.waitingForInput.rawValue)
+        ]
+        output.activeTurnMutations = [
+            .set(sessionID, "turn_first"),
+            .set(sessionID, "turn_last")
+        ]
+        output.pendingApprovalUpdates = [(sessionID, firstApproval), (sessionID, lastApproval)]
+        output.pendingUserInputUpdates = [(sessionID, firstInput), (sessionID, lastInput)]
+
+        var publishCount = 0
+        let cancellable = store.$sessions.dropFirst().sink { _ in
+            publishCount += 1
+        }
+        store.applyEventReducerOutput(output)
+        withExtendedLifetime(cancellable) {}
+
+        let finalSession = try XCTUnwrap(store.sessionsByID[sessionID])
+        XCTAssertEqual(publishCount, 1)
+        XCTAssertEqual(finalSession.status, SessionStatus.waitingForInput.rawValue)
+        XCTAssertEqual(finalSession.activeTurnID, "turn_last")
+        XCTAssertEqual(finalSession.pendingApproval, lastApproval)
+        XCTAssertEqual(finalSession.pendingUserInput, lastInput)
+    }
+
+    func testEventReducerBatchNoOpDoesNotPublish() throws {
+        let store = makeEventReducerTestStore()
+        let sessionID = "session_batch_noop"
+        let session = makeSession(
+            id: sessionID,
+            projectID: "project_batch",
+            title: "无变化",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            activeTurnID: "turn_noop"
+        )
+        store.sessions = [session]
+
+        var output = EventReducerOutput()
+        output.statusUpdates = [(sessionID, SessionStatus.running.rawValue)]
+        output.activeTurnMutations = [
+            .clear(sessionID, "turn_noop"),
+            .set(sessionID, "turn_noop")
+        ]
+
+        var publishCount = 0
+        let cancellable = store.$sessions.dropFirst().sink { _ in
+            publishCount += 1
+        }
+        store.applyEventReducerOutput(output)
+        withExtendedLifetime(cancellable) {}
+
+        XCTAssertEqual(publishCount, 0)
+        XCTAssertEqual(store.sessions, [session])
+        XCTAssertEqual(store.sessionsByID[sessionID], session)
+        XCTAssertEqual(store.sessionIndexByID[sessionID], 0)
+    }
+
+    func testEventReducerBatchDefersNestedCommitToOutermostOutput() throws {
+        let store = makeEventReducerTestStore()
+        let sessionID = "session_batch_reentrant"
+        let session = makeSession(
+            id: sessionID,
+            projectID: "project_batch",
+            title: "同步重入",
+            status: SessionStatus.running.rawValue,
+            source: "codex"
+        )
+        let nestedApproval = ApprovalSummary(
+            id: "approval_reentrant",
+            title: "重入审批",
+            kind: "command",
+            count: 1
+        )
+        store.sessions = [session]
+
+        var nestedOutput = EventReducerOutput()
+        nestedOutput.pendingApprovalUpdates = [(sessionID, nestedApproval)]
+
+        let metadata = AgentEventMetadata(
+            seq: 1,
+            sessionID: sessionID,
+            turnID: "turn_reentrant",
+            itemID: "message_reentrant",
+            messageID: "message_reentrant",
+            clientMessageID: nil,
+            revision: 1,
+            createdAt: Date()
+        )
+        var outerOutput = EventReducerOutput()
+        outerOutput.statusUpdates = [(sessionID, SessionStatus.waitingForApproval.rawValue)]
+        // foregroundActivityBySessionID 是 @Published；订阅者会在外层批次尚未提交时同步重入。
+        outerOutput.foregroundUpdates = [(sessionID, .receivingAssistant, nil)]
+        outerOutput.messageMutations = [
+            .completed(
+                AgentMessage(
+                    id: "message_reentrant",
+                    sessionID: sessionID,
+                    turnID: "turn_reentrant",
+                    itemID: "message_reentrant",
+                    role: .assistant,
+                    content: "外层提交后的预览",
+                    revision: 1
+                ),
+                metadata,
+                sessionID
+            )
+        ]
+
+        var publishCount = 0
+        let sessionsCancellable = store.$sessions.dropFirst().sink { _ in
+            publishCount += 1
+        }
+        let reentrantCancellable = store.$foregroundActivityBySessionID
+            .dropFirst()
+            .prefix(1)
+            .sink { _ in
+                store.applyEventReducerOutput(nestedOutput)
+            }
+
+        store.applyEventReducerOutput(outerOutput)
+        withExtendedLifetime((sessionsCancellable, reentrantCancellable)) {}
+
+        let finalSession = try XCTUnwrap(store.sessionsByID[sessionID])
+        XCTAssertEqual(publishCount, 1)
+        XCTAssertEqual(finalSession.status, SessionStatus.waitingForApproval.rawValue)
+        XCTAssertEqual(finalSession.pendingApproval, nestedApproval)
+        XCTAssertEqual(finalSession.preview, "外层提交后的预览")
+        XCTAssertEqual(store.sessions, [finalSession])
+        XCTAssertEqual(store.sessionIndexByID[sessionID], 0)
+        XCTAssertNil(store.eventReducerSessionMutationBatch)
+    }
+
+    func testEventReducerDefersSessionsPublisherReentryUntilCommitCompletes() throws {
+        let store = makeEventReducerTestStore()
+        let sessionID = "session_batch_publisher_reentrant"
+        let session = makeSession(
+            id: sessionID,
+            projectID: "project_batch",
+            title: "发布期间重入",
+            status: SessionStatus.running.rawValue,
+            source: "codex"
+        )
+        let nestedApproval = ApprovalSummary(
+            id: "approval_publisher_reentrant",
+            title: "发布期间审批",
+            kind: "command",
+            count: 1
+        )
+        store.sessions = [session]
+
+        var nestedOutput = EventReducerOutput()
+        nestedOutput.pendingApprovalUpdates = [(sessionID, nestedApproval)]
+        var outerOutput = EventReducerOutput()
+        outerOutput.statusUpdates = [(sessionID, SessionStatus.waitingForApproval.rawValue)]
+
+        var publishCount = 0
+        var publishedApprovalFlags: [Bool] = []
+        let cancellable = store.$sessions.dropFirst().sink { publishedSessions in
+            publishCount += 1
+            publishedApprovalFlags.append(publishedSessions.first?.pendingApproval == nestedApproval)
+            if publishCount == 1 {
+                // @Published 在 canonical sessions 实际写入前调用这里；内层 output 必须延后，
+                // 否则外层 setter 返回时会把它覆盖。
+                store.applyEventReducerOutput(nestedOutput)
+            }
+        }
+
+        store.applyEventReducerOutput(outerOutput)
+        withExtendedLifetime(cancellable) {}
+
+        let finalSession = try XCTUnwrap(store.sessionsByID[sessionID])
+        XCTAssertEqual(publishCount, 2)
+        XCTAssertEqual(publishedApprovalFlags, [false, true])
+        XCTAssertEqual(finalSession.status, SessionStatus.waitingForApproval.rawValue)
+        XCTAssertEqual(finalSession.pendingApproval, nestedApproval)
+        XCTAssertEqual(store.sessions, [finalSession])
+        XCTAssertEqual(store.sessionIndexByID[sessionID], 0)
+        XCTAssertNil(store.eventReducerSessionMutationBatch)
+        XCTAssertFalse(store.isPublishingEventReducerSessions)
+        XCTAssertTrue(store.deferredEventReducerOutputs.isEmpty)
+        XCTAssertFalse(store.isDrainingDeferredEventReducerOutputs)
+    }
+
+    private func makeEventReducerTestStore() -> SessionStore {
+        SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
+        )
+    }
+
     func testTurnCompletedNotificationPreservesFailedAndInterruptedLifecycle() async throws {
         for (wireStatus, expectedLifecycle, expectedSessionStatus) in [
             ("failed", ConversationTurnLifecycle.failed, SessionStatus.failed.rawValue),
@@ -2673,7 +2998,7 @@ final class ConversationDataFlowTests: XCTestCase {
 
     func testSessionStoreRetainsComposerSendModeAcrossComposerRecreation() {
         let sessionStore = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore()
         )
@@ -2896,7 +3221,7 @@ final class ConversationDataFlowTests: XCTestCase {
 
     func testSessionStoreRetainsComposerDraftAcrossComposerRecreation() {
         let sessionStore = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore()
         )
@@ -2923,7 +3248,7 @@ final class ConversationDataFlowTests: XCTestCase {
 
     func testSessionStoreRetainsComposerModelSelectionAcrossComposerRecreation() throws {
         let sessionStore = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore()
         )

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1630,7 +1630,7 @@ extension ConversationDataFlowTests {
         )
         let client = CodexAppServerSessionAPIClient(runtime: runtime)
         let conversationStore = ConversationStore()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationGuidanceFallbackTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationGuidanceFallbackTests.swift
@@ -13,7 +13,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_queue_guide_now"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -73,7 +73,7 @@ extension ConversationDataFlowTests {
             source: "claude",
             activeTurnID: "turn_stale"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -125,7 +125,7 @@ extension ConversationDataFlowTests {
             source: "claude",
             activeTurnID: "turn_stale"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         var sockets: [MockWebSocketClient] = []
         let store = SessionStore(
@@ -206,7 +206,7 @@ extension ConversationDataFlowTests {
             source: "claude",
             activeTurnID: "turn_old"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -72,7 +72,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -108,7 +108,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -137,7 +137,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -187,7 +187,7 @@ extension ConversationDataFlowTests {
         let conversationStore = ConversationStore()
         let logStore = LogStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: logStore,
             clientFactory: { client }
@@ -207,7 +207,7 @@ extension ConversationDataFlowTests {
     func testStructuredAssistantMessageCreatesBubble() async throws {
         let project = makeProject(id: "proj_1")
         let running = makeSession(id: "sess_structured_assistant_live", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -267,7 +267,7 @@ extension ConversationDataFlowTests {
             ],
             messagesResult: []
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let conversationStore = ConversationStore()
         let logStore = LogStore()
         conversationStore.activate(profileID: appStore.activeHostScope.profileID)
@@ -413,11 +413,285 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.drain(lease: macBLease).count, 1)
     }
 
+    func testTerminalStreamStoreMerges1000AssistantChunksAtDrain() {
+        let store = TerminalStreamStore(maxBatchSize: 2)
+        let lease = HostSessionLease(
+            hostScope: HostScope(profileID: "mac-a", installationID: "install-a", generation: 1),
+            sessionID: "sess_1000_chunks"
+        )
+        let metadata = AgentEventMetadata(
+            seq: 1,
+            sessionID: lease.sessionID,
+            turnID: "turn_1000_chunks",
+            itemID: "item_1000_chunks",
+            messageID: "message_1000_chunks",
+            clientMessageID: nil,
+            revision: 1,
+            createdAt: nil
+        )
+        let chunks = (0..<1_000).map { "chunk-\($0)|" }
+
+        for chunk in chunks {
+            XCTAssertFalse(
+                store.append(
+                    .assistantDelta(AgentDelta(text: chunk, role: .assistant, kind: .message), metadata),
+                    lease: lease
+                ),
+                "同一逻辑事件的 chunk 不应提前触发 maxBatchSize"
+            )
+        }
+
+        let drained = store.drain(lease: lease)
+        XCTAssertEqual(drained.count, 1)
+        guard case .assistantDelta(let delta, let returnedMetadata) = drained.first else {
+            return XCTFail("1000 个 assistant chunk 应在 drain 时合并为一个事件")
+        }
+        XCTAssertEqual(delta.text, chunks.joined())
+        XCTAssertEqual(delta.role, .assistant)
+        XCTAssertEqual(delta.kind, .message)
+        XCTAssertEqual(returnedMetadata, metadata)
+    }
+
+    func testTerminalStreamStoreKeepsAssistantAndLogBoundaries() {
+        let store = TerminalStreamStore(maxBatchSize: 64)
+        let lease = HostSessionLease(
+            hostScope: HostScope(profileID: "mac-a", installationID: "install-a", generation: 1),
+            sessionID: "sess_boundaries"
+        )
+        let metadata = AgentEventMetadata(
+            seq: 1,
+            sessionID: lease.sessionID,
+            turnID: "turn_boundaries",
+            itemID: "item_boundaries",
+            messageID: "message_boundaries",
+            clientMessageID: nil,
+            revision: 1,
+            createdAt: nil
+        )
+
+        _ = store.append(
+            .assistantDelta(AgentDelta(text: "message-1", role: .assistant, kind: .message), metadata),
+            lease: lease
+        )
+        _ = store.append(
+            .assistantDelta(AgentDelta(text: "commentary", role: .assistant, kind: .commentary), metadata),
+            lease: lease
+        )
+        _ = store.append(
+            .assistantDelta(AgentDelta(text: "message-2", role: .assistant, kind: .message), metadata),
+            lease: lease
+        )
+        _ = store.append(.turnStarted(metadata), lease: lease)
+        _ = store.append(.logDelta(LogDelta(text: "stdout-1", stream: "stdout"), metadata), lease: lease)
+        _ = store.append(.logDelta(LogDelta(text: "stdout-2", stream: "stdout"), metadata), lease: lease)
+        _ = store.append(.logDelta(LogDelta(text: "stderr", stream: "stderr"), metadata), lease: lease)
+        _ = store.append(.logDelta(LogDelta(text: "stdout-after", stream: "stdout"), metadata), lease: lease)
+
+        let drained = store.drain(lease: lease)
+        XCTAssertEqual(drained.count, 7, "role/kind、控制事件和 log stream 都是合并边界")
+        guard drained.count == 7 else { return }
+        guard case .assistantDelta(let message1, _) = drained[0],
+              case .assistantDelta(let commentary, _) = drained[1],
+              case .assistantDelta(let message2, _) = drained[2],
+              case .turnStarted = drained[3],
+              case .logDelta(let stdout, _) = drained[4],
+              case .logDelta(let stderr, _) = drained[5],
+              case .logDelta(let stdoutAfter, _) = drained[6]
+        else {
+            return XCTFail("事件顺序或类型不应被跨边界合并")
+        }
+        XCTAssertEqual(message1.text, "message-1")
+        XCTAssertEqual(message1.kind, .message)
+        XCTAssertEqual(commentary.text, "commentary")
+        XCTAssertEqual(commentary.kind, .commentary)
+        XCTAssertEqual(message2.text, "message-2")
+        XCTAssertEqual(stdout.text, "stdout-1stdout-2")
+        XCTAssertEqual(stdout.stream, "stdout")
+        XCTAssertEqual(stderr.text, "stderr")
+        XCTAssertEqual(stderr.stream, "stderr")
+        XCTAssertEqual(stdoutAfter.text, "stdout-after")
+        XCTAssertEqual(stdoutAfter.stream, "stdout")
+    }
+
+    func testTerminalStreamStoreMaxBatchCountsLogicalEvents() {
+        let store = TerminalStreamStore(maxBatchSize: 2)
+        let lease = HostSessionLease(
+            hostScope: HostScope(profileID: "mac-a", installationID: "install-a", generation: 1),
+            sessionID: "sess_logical_batch"
+        )
+        let metadata = AgentEventMetadata(
+            seq: 1,
+            sessionID: lease.sessionID,
+            turnID: "turn_logical_batch",
+            itemID: "item_logical_batch",
+            messageID: "message_logical_batch",
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )
+
+        XCTAssertFalse(
+            store.append(
+                .assistantDelta(AgentDelta(text: "A", role: .assistant, kind: .message), metadata),
+                lease: lease
+            )
+        )
+        XCTAssertFalse(
+            store.append(
+                .assistantDelta(AgentDelta(text: "B", role: .assistant, kind: .message), metadata),
+                lease: lease
+            ),
+            "两个 raw chunk 仍只算一个逻辑事件"
+        )
+        XCTAssertTrue(store.append(.turnStarted(metadata), lease: lease))
+        XCTAssertTrue(
+            store.append(
+                .assistantDelta(AgentDelta(text: "C", role: .assistant, kind: .message), metadata),
+                lease: lease
+            )
+        )
+
+        let drained = store.drain(lease: lease)
+        XCTAssertEqual(drained.count, 3)
+        guard case .assistantDelta(let firstDelta, _) = drained[0],
+              case .turnStarted = drained[1],
+              case .assistantDelta(let secondDelta, _) = drained[2]
+        else {
+            return XCTFail("logical batch 应保留文本 run 与控制事件顺序")
+        }
+        XCTAssertEqual(firstDelta.text, "AB")
+        XCTAssertEqual(secondDelta.text, "C")
+    }
+
+    func testTerminalStreamStoreReplacesOnlyContiguousPlanSnapshots() {
+        let store = TerminalStreamStore(maxBatchSize: 64)
+        let lease = HostSessionLease(
+            hostScope: HostScope(profileID: "mac-a", installationID: "install-a", generation: 1),
+            sessionID: "sess_completed_snapshots"
+        )
+        let metadata = AgentEventMetadata(
+            seq: 1,
+            sessionID: lease.sessionID,
+            turnID: "turn_completed_snapshots",
+            itemID: "item_completed_snapshots",
+            messageID: "message_completed_snapshots",
+            clientMessageID: nil,
+            revision: 1,
+            createdAt: nil
+        )
+        let otherItemMetadata = AgentEventMetadata(
+            seq: 4,
+            sessionID: lease.sessionID,
+            turnID: metadata.turnID,
+            itemID: "other-item",
+            messageID: metadata.messageID,
+            clientMessageID: nil,
+            revision: 4,
+            createdAt: nil
+        )
+
+        _ = store.append(
+            .messageCompleted(
+                AgentMessage(
+                    id: "plan-old",
+                    sessionID: lease.sessionID,
+                    turnID: metadata.turnID,
+                    itemID: metadata.itemID,
+                    role: .system,
+                    kind: .plan,
+                    content: "旧计划",
+                    revision: 1
+                ),
+                metadata
+            ),
+            lease: lease
+        )
+        _ = store.append(
+            .messageCompleted(
+                AgentMessage(
+                    id: "plan-latest",
+                    sessionID: lease.sessionID,
+                    turnID: metadata.turnID,
+                    itemID: metadata.itemID,
+                    role: .system,
+                    kind: .plan,
+                    content: "最新完整计划",
+                    revision: 2
+                ),
+                metadata
+            ),
+            lease: lease
+        )
+        _ = store.append(
+            .messageCompleted(
+                AgentMessage(
+                    id: "regular-1",
+                    sessionID: lease.sessionID,
+                    turnID: metadata.turnID,
+                    itemID: metadata.itemID,
+                    role: .system,
+                    kind: .message,
+                    content: "普通消息一",
+                    revision: 3
+                ),
+                metadata
+            ),
+            lease: lease
+        )
+        _ = store.append(
+            .messageCompleted(
+                AgentMessage(
+                    id: "regular-2",
+                    sessionID: lease.sessionID,
+                    turnID: metadata.turnID,
+                    itemID: metadata.itemID,
+                    role: .system,
+                    kind: .message,
+                    content: "普通消息二",
+                    revision: 4
+                ),
+                metadata
+            ),
+            lease: lease
+        )
+        _ = store.append(
+            .messageCompleted(
+                AgentMessage(
+                    id: "plan-other-item",
+                    sessionID: lease.sessionID,
+                    turnID: metadata.turnID,
+                    itemID: otherItemMetadata.itemID,
+                    role: .system,
+                    kind: .plan,
+                    content: "另一 item 计划",
+                    revision: 5
+                ),
+                otherItemMetadata
+            ),
+            lease: lease
+        )
+
+        let drained = store.drain(lease: lease)
+        XCTAssertEqual(drained.count, 4)
+        guard case .messageCompleted(let latestPlan, _) = drained[0],
+              case .messageCompleted(let regularOne, _) = drained[1],
+              case .messageCompleted(let regularTwo, _) = drained[2],
+              case .messageCompleted(let otherItemPlan, _) = drained[3]
+        else {
+            return XCTFail("completed snapshot 的边界或顺序错误")
+        }
+        XCTAssertEqual(latestPlan.content, "最新完整计划")
+        XCTAssertEqual(latestPlan.id, "plan-latest")
+        XCTAssertEqual(regularOne.content, "普通消息一")
+        XCTAssertEqual(regularTwo.content, "普通消息二")
+        XCTAssertEqual(otherItemPlan.content, "另一 item 计划")
+    }
+
     func testDisconnectFlushesBufferedRuntimeEventsBeforeSwitchingSession() async throws {
         let project = makeProject(id: "proj_ws_disconnect_flush")
         let running = makeSession(id: "sess_ws_disconnect_flush", projectID: project.id, title: "运行中", status: "running", source: "codex")
         let history = makeSession(id: "sess_ws_disconnect_history", projectID: project.id, title: "历史", status: "history", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running, history], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -472,7 +746,7 @@ extension ConversationDataFlowTests {
     func testWebSocketFailureAutoReconnectsWithLatestReplayWatermark() async throws {
         let project = makeProject(id: "proj_ws_reconnect")
         let running = makeSession(id: "sess_ws_reconnect", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let logStore = LogStore()
         logStore.append("旧输出", sessionID: running.id, seq: 5)
@@ -515,7 +789,7 @@ extension ConversationDataFlowTests {
     func testWebSocketAutoReconnectDoesNotGiveUpWhileSessionStaysRunning() async throws {
         let project = makeProject(id: "proj_ws_persistent_reconnect")
         let running = makeSession(id: "sess_ws_persistent_reconnect", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         var sockets: [MockWebSocketClient] = []
@@ -555,7 +829,7 @@ extension ConversationDataFlowTests {
     func testStaleWebSocketStatusDoesNotRetireCurrentReconnect() async throws {
         let project = makeProject(id: "proj_ws_stale_status")
         let running = makeSession(id: "sess_ws_stale_status", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         var sockets: [MockWebSocketClient] = []
@@ -616,7 +890,7 @@ extension ConversationDataFlowTests {
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
         let conversationStore = ConversationStore()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         // 测试必须自行建立认证前置条件，不能依赖其他用例残留在 Keychain 的令牌。
         appStore.token = "test-token"
         let store = SessionStore(
@@ -671,7 +945,7 @@ extension ConversationDataFlowTests {
         let project = makeProject(id: "proj_ws_ended_reconnect")
         let running = makeSession(id: "sess_ws_ended_reconnect", projectID: project.id, title: "运行中", status: "running", source: "codex")
         let ended = makeSession(id: running.id, projectID: project.id, title: "已结束", status: "history", source: "codex", resumeID: running.id)
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(
             projects: [project],
@@ -717,7 +991,7 @@ extension ConversationDataFlowTests {
     func testWebSocketReconnectRefreshesSnapshotWithLatestEventWatermark() async throws {
         let project = makeProject(id: "proj_ws_snapshot_reconnect")
         let running = makeSession(id: "sess_ws_snapshot", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(
             projects: [project],
@@ -770,7 +1044,7 @@ extension ConversationDataFlowTests {
     func testWebSocketReconnectUsesHistorySnapshotSeqWatermark() async throws {
         let project = makeProject(id: "proj_ws_history_snapshot")
         let running = makeSession(id: "sess_ws_history_snapshot", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(
             projects: [project],
@@ -814,7 +1088,7 @@ extension ConversationDataFlowTests {
     func testReturningToSessionListCancelsQueuedWebSocketReconnect() async throws {
         let project = makeProject(id: "proj_ws_cancel")
         let running = makeSession(id: "sess_ws_cancel", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         var sockets: [MockWebSocketClient] = []
@@ -851,7 +1125,7 @@ extension ConversationDataFlowTests {
         let running = makeSession(id: "sess_running", projectID: project.id, title: "运行中", status: "running", source: "codex")
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -867,7 +1141,7 @@ extension ConversationDataFlowTests {
     func testRuntimeActivityTracksTurnEventsAndClearsOnCompletion() async throws {
         let project = makeProject(id: "proj_runtime_activity")
         let running = makeSession(id: "sess_runtime_activity", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         var sockets: [MockWebSocketClient] = []
@@ -954,7 +1228,7 @@ extension ConversationDataFlowTests {
             createSessionResponse: try makeCreateSessionResponse(session: created)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -974,7 +1248,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -1015,7 +1289,7 @@ extension ConversationDataFlowTests {
         let running = makeSession(id: "sess_goal_running", projectID: project.id, title: "运行中", status: "running", source: "codex")
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -1065,7 +1339,7 @@ extension ConversationDataFlowTests {
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -1171,7 +1445,7 @@ extension ConversationDataFlowTests {
             tokensUsed: goal.tokensUsed,
             timeUsedSeconds: goal.timeUsedSeconds
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(
             projects: [project],
@@ -1307,7 +1581,7 @@ extension ConversationDataFlowTests {
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [goalSession, plainSession], messagesResult: [])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1337,7 +1611,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1365,7 +1639,7 @@ extension ConversationDataFlowTests {
         ]
         let client = MockSessionStoreClient(projects: [], sessions: [], modelOptions: options)
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1392,7 +1666,7 @@ extension ConversationDataFlowTests {
             rateLimitsByRuntime: ["claude": claudeRateLimit]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1424,7 +1698,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1470,7 +1744,7 @@ extension ConversationDataFlowTests {
             rateLimitHandler: { _ in throw MockError.unimplemented }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1525,7 +1799,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1558,7 +1832,7 @@ extension ConversationDataFlowTests {
             rateLimitsByRuntime: ["codex": RateLimitSummary(primaryUsedPercent: 42)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1587,7 +1861,7 @@ extension ConversationDataFlowTests {
             modelOptions: options
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1620,7 +1894,7 @@ extension ConversationDataFlowTests {
             modelOptions: options
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1651,7 +1925,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1700,7 +1974,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1755,7 +2029,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1798,7 +2072,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1840,7 +2114,7 @@ extension ConversationDataFlowTests {
             createSessionResponse: try makeCreateSessionResponse(session: created)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1875,7 +2149,7 @@ extension ConversationDataFlowTests {
             modelOptionsError: MockError.timeout
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1902,7 +2176,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1930,7 +2204,7 @@ extension ConversationDataFlowTests {
         let options = [
             CodexAppServerModelOption(id: "gpt-running-default", title: "Running Default", provider: "openai", isDefault: true)
         ]
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [], modelOptions: options)
         var sockets: [MockWebSocketClient] = []
@@ -1984,7 +2258,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -2058,7 +2332,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [second])
         let conversationStore = ConversationStore()
         let socket = MockWebSocketClient()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2124,7 +2398,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [history, second])
         let conversationStore = ConversationStore()
         let socket = MockWebSocketClient()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2164,7 +2438,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -2223,7 +2497,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [history])
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2272,7 +2546,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -2324,7 +2598,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn-existing"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -2403,7 +2677,7 @@ extension ConversationDataFlowTests {
         let client = DelayedCreateSessionClient(projects: [project], sessions: [failed])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -2488,7 +2762,7 @@ extension ConversationDataFlowTests {
     func testFailedRunningMessageRetryDoesNotResumeWhenWebSocketIsConnecting() async throws {
         let project = makeProject(id: "proj_retry_connecting_guard")
         let running = makeSession(id: "sess_retry_connecting_guard", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -2525,7 +2799,7 @@ extension ConversationDataFlowTests {
     func testRetryFailedUserMessagePreservesStructuredTurnPayload() async throws {
         let project = makeProject(id: "proj_retry_payload")
         let running = makeSession(id: "sess_retry_payload", projectID: project.id, title: "Retry Payload", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -2573,7 +2847,7 @@ extension ConversationDataFlowTests {
     func testRunningSendKeepsInlineImagePayloadAfterAcceptedForPreview() async throws {
         let project = makeProject(id: "proj_keep_payload")
         let running = makeSession(id: "sess_keep_payload", projectID: project.id, title: "Keep Payload", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -2629,7 +2903,7 @@ extension ConversationDataFlowTests {
     func testRunningTurnLifecycleKeepsEchoAndFinalAssistantStable() async throws {
         let project = makeProject(id: "proj_turn_lifecycle")
         let running = makeSession(id: "sess_turn_lifecycle", projectID: project.id, title: "Lifecycle", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
@@ -5,6 +5,29 @@ import SwiftUI
 import UIKit
 @testable import MimiRemote
 
+extension XCTestCase {
+    /// 为普通单元/UI 测试提供与 App 运行态完全隔离的 AppStore。
+    ///
+    /// 生产 AppStore 默认读取 UserDefaults.standard 和系统 Keychain；测试不能依赖
+    /// 这些跨测试、跨工作区的持久状态。每次调用都创建新的 suite 和内存 Keychain，
+    /// 并通过 XCTest teardown 删除 suite，避免测试结束后留下测试专属持久域。
+    @MainActor
+    func makeIsolatedAppStore() -> AppStore {
+        let suiteName = "MimiRemoteTests.AppStore.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("无法创建隔离测试 UserDefaults suite: \(suiteName)")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        return AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
+    }
+}
+
 // 直连 app-server、连接档案与通用 fixture 支持。
 // 冷启动重试用的客户端：前 N 次 projects() 抛错模拟隧道未就绪，之后成功返回。
 final class CredentialRejectingBootstrapClient: SessionStoreAPIClient {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -60,7 +60,7 @@ extension ConversationDataFlowTests {
         externalReadOnlyRoot.canAcceptDirectInput = false
 
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
@@ -129,7 +129,7 @@ extension ConversationDataFlowTests {
         let history = makeSession(id: "codex_history", projectID: project.id, title: "历史", status: "history", source: "codex", resumeID: "history")
         let client = MockSessionStoreClient(projects: [project], sessions: [history])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -182,7 +182,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -269,7 +269,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -320,7 +320,7 @@ extension ConversationDataFlowTests {
             }
         )
         let restartedStore = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { restartedClient }
@@ -435,7 +435,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -467,7 +467,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -516,7 +516,7 @@ extension ConversationDataFlowTests {
                 SessionsPage(sessions: globalSessions)
             }
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -609,7 +609,7 @@ extension ConversationDataFlowTests {
                 SessionsPage(sessions: [external])
             }
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -649,7 +649,7 @@ extension ConversationDataFlowTests {
         child.canAcceptDirectInput = false
         let client = MockSessionStoreClient(projects: [project], sessions: [])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -695,7 +695,7 @@ extension ConversationDataFlowTests {
                 rootProject.id: SessionsPage(sessions: [childSession])
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -733,7 +733,7 @@ extension ConversationDataFlowTests {
                 workspace.path: .success(workspace)
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -791,7 +791,7 @@ extension ConversationDataFlowTests {
                 "/forbidden": .failure(AgentAPIError.server(status: 403, message: "路径不在允许范围内或不可访问"))
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -841,7 +841,7 @@ extension ConversationDataFlowTests {
                 older.id: .success(())
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let preferences = makeSessionListPreferenceStore()
         let store = SessionStore(
             appStore: appStore,
@@ -911,7 +911,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -970,7 +970,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1023,7 +1023,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1069,7 +1069,7 @@ extension ConversationDataFlowTests {
             source: "codex"
         )
         let gate = SessionArchiveResponseGate()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let preferences = makeSessionListPreferenceStore()
         let client = MockSessionStoreClient(
             projects: [project],
@@ -1128,7 +1128,7 @@ extension ConversationDataFlowTests {
             source: "codex"
         )
         let gate = SessionArchiveResponseGate()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let preferences = makeSessionListPreferenceStore()
         let client = MockSessionStoreClient(
             projects: [project],
@@ -1200,7 +1200,7 @@ extension ConversationDataFlowTests {
             source: "codex"
         )
         let gate = SessionArchiveResponseGate()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let preferences = makeSessionListPreferenceStore()
         let client = MockSessionStoreClient(
             projects: [project],
@@ -1274,7 +1274,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1338,7 +1338,7 @@ extension ConversationDataFlowTests {
             sessionArchiveResults: [session.id: .success(())]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1378,7 +1378,7 @@ extension ConversationDataFlowTests {
                 project.id: SessionsPage(sessions: [session])
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let reminderStore = makeSessionReminderStore()
         let scheduler = FakeSessionReminderScheduler()
         let store = SessionStore(
@@ -1421,7 +1421,7 @@ extension ConversationDataFlowTests {
             status: "history",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let reminderStore = makeSessionReminderStore()
         let scheduler = FakeSessionReminderScheduler(scheduleOutcome: .permissionDenied)
         let store = SessionStore(
@@ -1628,7 +1628,7 @@ extension ConversationDataFlowTests {
                 )
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -1731,7 +1731,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [target]),
             blockOnCall: 1
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -1885,7 +1885,7 @@ extension ConversationDataFlowTests {
                 ))
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1917,7 +1917,7 @@ extension ConversationDataFlowTests {
                 ))
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1950,7 +1950,7 @@ extension ConversationDataFlowTests {
                 ))
             ]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1982,7 +1982,7 @@ extension ConversationDataFlowTests {
             workspaceSessionsError: [workspace.id: AgentAPIError.server(status: 403, message: "cwd 必须来自 projects allowlist")],
             resolveResults: [workspace.path: .failure(AgentAPIError.server(status: 403, message: "路径不在允许范围内或不可访问"))]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -2013,7 +2013,7 @@ extension ConversationDataFlowTests {
             workspaceSessionsError: [workspace.id: AgentAPIError.server(status: 502, message: "连接 app-server gateway 上游失败")],
             resolveResults: [workspace.path: .success(workspace)]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -2044,7 +2044,7 @@ extension ConversationDataFlowTests {
             workspaceSessionsError: [workspace.id: AgentAPIError.server(status: 403, message: "denied")],
             resolveResults: [workspace.path: .failure(AgentAPIError.server(status: 403, message: "denied"))]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -2070,7 +2070,7 @@ extension ConversationDataFlowTests {
         let client = MockSessionStoreClient(projects: [project], sessions: [latestRunning, selectedHistory])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -2093,7 +2093,7 @@ extension ConversationDataFlowTests {
         let running = makeSession(id: "sess_auto_running", projectID: project.id, title: "运行中", status: "running", source: "codex")
         let client = MockSessionStoreClient(projects: [project], sessions: [history, running])
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -2128,7 +2128,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         var sockets: [MockWebSocketClient] = []
@@ -2174,7 +2174,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(
             projects: [project],
@@ -2230,7 +2230,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [restored]),
             blockOnCall: 1
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2454,7 +2454,7 @@ extension ConversationDataFlowTests {
             accountTokenUsageHandler: { snapshot }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2485,7 +2485,7 @@ extension ConversationDataFlowTests {
             accountTokenUsageHandler: { snapshot }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2517,7 +2517,7 @@ extension ConversationDataFlowTests {
             accountTokenUsageFetchHandler: { await cursor.next() }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2547,7 +2547,7 @@ extension ConversationDataFlowTests {
             accountTokenUsageFetchHandler: { .failed }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3037,7 +3037,7 @@ extension ConversationDataFlowTests {
             )
         ], sessionID: running.id)
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -3093,7 +3093,7 @@ extension ConversationDataFlowTests {
             pendingUserInput: request
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let conversationStore = ConversationStore()
         conversationStore.activate(profileID: appStore.activeHostScope.profileID)
@@ -3147,7 +3147,7 @@ extension ConversationDataFlowTests {
 
     func testSessionStoreReturnToListPublishesOnlyIntentWhenAlreadyCleared() {
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
@@ -3174,7 +3174,7 @@ extension ConversationDataFlowTests {
             CodexHistoryMessage(id: "rollout:1", role: "assistant", content: "已加载", createdAt: Date(timeIntervalSince1970: 1))
         ], sessionID: history.id)
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -3295,7 +3295,10 @@ extension ConversationDataFlowTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let readStateStore = SessionHistoryReadStateStore(defaults: defaults)
-        let appStore = AppStore(defaults: defaults)
+        let appStore = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
         let project = makeProject(id: "project-unread")
         let initialHistory = makeSession(
             id: "session-unread",
@@ -3425,7 +3428,10 @@ extension ConversationDataFlowTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let readStateStore = SessionHistoryReadStateStore(defaults: defaults)
-        let appStore = AppStore(defaults: defaults)
+        let appStore = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
         let project = makeProject(id: "project-mark-unread")
         let session = makeSession(
             id: "session-mark-unread",
@@ -3494,7 +3500,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3526,7 +3532,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3553,7 +3559,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3581,7 +3587,7 @@ extension ConversationDataFlowTests {
             projectSessions: [firstProject.id: [freshHistory]]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3611,7 +3617,7 @@ extension ConversationDataFlowTests {
         )
         var sockets: [MockWebSocketClient] = []
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -3656,7 +3662,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             resumeID: "browsed-session"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let recentStore = makeRecentWorkspaceStore(
             workspaces: [],
@@ -3719,7 +3725,7 @@ extension ConversationDataFlowTests {
         )
         // 旧版目录刷新会把 projects() 候选项直接写入 recent，特征是没有明确打开时间。
         let legacyAutoWorkspace = AgentWorkspace(project: legacyAutoProject)
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let recentStore = makeRecentWorkspaceStore(
             workspaces: [openedWorkspace, legacyAutoWorkspace],
             endpoint: appStore.endpoint
@@ -3830,7 +3836,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3884,7 +3890,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -3939,7 +3945,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -3987,7 +3993,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -4034,7 +4040,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -4210,7 +4216,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -4267,7 +4273,7 @@ extension ConversationDataFlowTests {
             }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -4460,7 +4466,7 @@ extension ConversationDataFlowTests {
             gitStatusResults: [session.dir: .success(gitStatus)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4581,7 +4587,7 @@ extension ConversationDataFlowTests {
             gitActionResults: [session.dir: .success(updatedStatus)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4625,7 +4631,7 @@ extension ConversationDataFlowTests {
             gitPatchActionResults: [session.dir: .success(updatedStatus)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4665,7 +4671,7 @@ extension ConversationDataFlowTests {
             gitCommitResults: [session.dir: .success(cleanStatus)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4708,7 +4714,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4742,7 +4748,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4786,7 +4792,7 @@ extension ConversationDataFlowTests {
             gitPullRequestStatusResults: [session.dir: .success(status)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4869,7 +4875,7 @@ extension ConversationDataFlowTests {
             commandActionRunResults: ["\(session.dir)#\(action.id)": .success(result)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -4946,7 +4952,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -5010,7 +5016,7 @@ extension ConversationDataFlowTests {
             capabilityResults: [session.dir: .success(response)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -5034,7 +5040,10 @@ extension ConversationDataFlowTests {
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let appStore = AppStore(defaults: defaults)
+        let appStore = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
         let legacy = AgentWorkspace(
             id: "legacy-project-id",
             name: "chat-archive",
@@ -5127,7 +5136,10 @@ extension ConversationDataFlowTests {
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let appStore = AppStore(defaults: defaults)
+        let appStore = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
         let profileID = appStore.notificationRoutingProfileID
         let legacy = AgentWorkspace(
             id: "legacy-project-id",
@@ -5181,7 +5193,7 @@ extension ConversationDataFlowTests {
     }
 
     func testOpeningSameResolvedDirectoryTwiceReusesWorkspaceAndSelection() async {
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let typedPath = "/Users/me/code/chat-archive"
         let workspace = AgentWorkspace(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
@@ -16,7 +16,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "claude"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [staleIdle], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -69,7 +69,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_active_guided"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -132,7 +132,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_queue_1"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -231,7 +231,7 @@ extension ConversationDataFlowTests {
             source: "claude",
             activeTurnID: "turn_existing"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         var sockets: [MockWebSocketClient] = []
         let store = SessionStore(
@@ -306,7 +306,7 @@ extension ConversationDataFlowTests {
             source: "claude",
             activeTurnID: "turn_existing"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         var sockets: [MockWebSocketClient] = []
         let store = SessionStore(
@@ -390,7 +390,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_before_restart"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("QueuedTurnRestartTests.\(UUID().uuidString)", isDirectory: true)
@@ -461,7 +461,14 @@ extension ConversationDataFlowTests {
             status: SessionStatus.completed.rawValue,
             source: running.source
         )
-        let appStore = AppStore()
+        let defaultsSuiteName = "ConversationTurnQueueTests.StartBarrier.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsSuiteName))
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        let appStore = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
         appStore.token = "test-token"
         let queuedTurnStore = FileQueuedTurnStore(
             directoryURL: FileManager.default.temporaryDirectory
@@ -485,13 +492,18 @@ extension ConversationDataFlowTests {
         await firstStore.refreshAll(autoAttach: false)
         firstStore.takeOverSession(running)
         await firstStore.selectSession(running)
-        firstSockets[0].emitStatus(.connected)
+        // 控制连接由异步任务创建；先等待工厂产出 socket，避免测试调度较慢时数组越界崩溃。
+        for _ in 0..<80 where firstSockets.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let firstSocket = try XCTUnwrap(firstSockets.first, "控制连接未在超时前创建")
+        firstSocket.emitStatus(.connected)
         try await waitForWebSocketStatus(.connected, store: firstStore)
         let firstQueued = await firstStore.sendTurn(CodexAppServerTurnPayload(prompt: "第一条实际派发"))
         let secondQueued = await firstStore.sendTurn(CodexAppServerTurnPayload(prompt: "第二条必须等待 started"))
         XCTAssertTrue(firstQueued)
         XCTAssertTrue(secondQueued)
-        firstSockets[0].emitEvent(.turnCompleted(AgentEventMetadata(
+        firstSocket.emitEvent(.turnCompleted(AgentEventMetadata(
             seq: 1,
             sessionID: running.id,
             turnID: "turn_before_barrier",
@@ -501,8 +513,9 @@ extension ConversationDataFlowTests {
             revision: nil,
             createdAt: nil
         )))
-        try await waitForSentTurnCount(1, socket: firstSockets[0])
-        firstSockets[0].onSendAccepted?(firstSockets[0].sentTurns[0].clientMessageID)
+        try await waitForSentTurnCount(1, socket: firstSocket)
+        let sentTurn = try XCTUnwrap(firstSocket.sentTurns.first)
+        firstSocket.onSendAccepted?(sentTurn.clientMessageID)
         try await Task.sleep(nanoseconds: 60_000_000)
         XCTAssertEqual(firstStore.selectedQueuedTurns.first?.waitsForAcceptedTurnStart, true)
         XCTAssertEqual(firstStore.selectedQueuedTurns.first?.blockedCompletionID, "turn_before_barrier")
@@ -584,7 +597,7 @@ extension ConversationDataFlowTests {
             status: SessionStatus.completed.rawValue,
             source: running.source
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("QueuedTurnRestartResumeTests.\(UUID().uuidString)", isDirectory: true)
@@ -657,7 +670,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_navigation_second"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [first, second], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -711,7 +724,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_queue_management"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -762,7 +775,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_snapshot_gap_1"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let conversationStore = ConversationStore()
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
@@ -860,7 +873,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_queue_reconnect"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -919,7 +932,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -962,7 +975,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -1001,7 +1014,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_ctrl_c"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -1055,7 +1068,7 @@ extension ConversationDataFlowTests {
     func testRunningSessionGuidedDeliveryUsesTurnStartedActiveTurn() async throws {
         let project = makeProject(id: "proj_ws_guided_event")
         let running = makeSession(id: "sess_ws_guided_event", projectID: project.id, title: "Running", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1101,7 +1114,7 @@ extension ConversationDataFlowTests {
     func testRunningSessionGuidedDeliveryBackfillsActiveTurnFromAssistantDelta() async throws {
         let project = makeProject(id: "proj_ws_guided_delta")
         let running = makeSession(id: "sess_ws_guided_delta", projectID: project.id, title: "Running", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1156,7 +1169,7 @@ extension ConversationDataFlowTests {
             source: "codex",
             activeTurnID: "turn_late"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1216,7 +1229,7 @@ extension ConversationDataFlowTests {
         // 已合并时间线后面（plan 在前、命令在后的事故路径），必须走状态级回放。
         let project = makeProject(id: "proj_takeover_replay")
         let running = makeSession(id: "sess_takeover_replay", projectID: project.id, title: "Running", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1248,7 +1261,7 @@ extension ConversationDataFlowTests {
         // loadHistoryIfNeeded 是 no-op，此时重连若要求完整回放，backlog 旧卡会破坏时间线顺序。
         let project = makeProject(id: "proj_foreground_replay")
         let running = makeSession(id: "sess_foreground_replay", projectID: project.id, title: "Running", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1290,7 +1303,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let conversationStore = ConversationStore()
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
@@ -1362,7 +1375,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         var sockets: [MockWebSocketClient] = []
@@ -1407,7 +1420,7 @@ extension ConversationDataFlowTests {
             status: "running",
             source: "codex"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let pathSource = TestNetworkPathStatusSource(initialStatus: .satisfied)
         var sockets: [MockWebSocketClient] = []
@@ -1486,7 +1499,7 @@ extension ConversationDataFlowTests {
     func testRunningSessionSendWaitsForConnectedWebSocket() async throws {
         let project = makeProject(id: "proj_ws_connecting_guard")
         let running = makeSession(id: "sess_ws_connecting_guard", projectID: project.id, title: "连接中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1529,7 +1542,7 @@ extension ConversationDataFlowTests {
     func testWebSocketFailureMarksSendingUserMessagesFailedAndIgnoresStaleAccepted() async throws {
         let project = makeProject(id: "proj_ws_sending_failed")
         let running = makeSession(id: "sess_ws_sending_failed", projectID: project.id, title: "Sending Failed", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1586,7 +1599,7 @@ extension ConversationDataFlowTests {
     func testRunningSendFailureNoRolloutFoundMarksLocalEchoFailedAndRetainsRetryPayload() async throws {
         let project = makeProject(id: "proj_no_rollout_send")
         let running = makeSession(id: "sess_no_rollout_send", projectID: project.id, title: "No Rollout", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
         let conversationStore = ConversationStore()
@@ -1655,7 +1668,7 @@ extension ConversationDataFlowTests {
             updatedAt: Date(timeIntervalSince1970: 2),
             pendingApproval: approval
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [waiting])
         let conversationStore = ConversationStore()
@@ -1722,7 +1735,7 @@ extension ConversationDataFlowTests {
     func testApprovalRequestUpdatesSelectedSessionPendingApproval() async throws {
         let project = makeProject(id: "proj_approval_event")
         let running = makeSession(id: "sess_approval_event", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         let conversationStore = ConversationStore()
@@ -1809,7 +1822,7 @@ extension ConversationDataFlowTests {
             source: "claude",
             runtimeProvider: "claude"
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let scheduler = FakeSessionReminderScheduler()
         var sockets: [MockWebSocketClient] = []
@@ -1873,7 +1886,7 @@ extension ConversationDataFlowTests {
     func testApprovalRequestSurvivesLateRunningStatusAndRefresh() async throws {
         let project = makeProject(id: "proj_approval_race")
         let running = makeSession(id: "sess_approval_race", projectID: project.id, title: "运行中", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         let conversationStore = ConversationStore()
@@ -1942,7 +1955,7 @@ extension ConversationDataFlowTests {
     func testRuntimeEventsScheduleCompletionAndFailureNotifications() async throws {
         let project = makeProject(id: "proj_runtime_notice")
         let running = makeSession(id: "sess_runtime_notice", projectID: project.id, title: "长任务", status: "running", source: "codex")
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         let conversationStore = ConversationStore()
@@ -2142,7 +2155,7 @@ extension ConversationDataFlowTests {
         let sessionID = "thr_fixture_stream"
         let project = AgentProject(id: "proj_fixture_stream", name: "Fixture Stream", path: "/tmp/fixture-stream")
         let running = makeSession(id: sessionID, projectID: project.id, title: "Fixture 直连", status: "running", source: "codex", resumeID: sessionID)
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []
@@ -2238,7 +2251,7 @@ extension ConversationDataFlowTests {
             updatedAt: Date(timeIntervalSince1970: 2),
             pendingApproval: approval
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let conversationStore = ConversationStore()
         conversationStore.activate(profileID: appStore.activeHostScope.profileID)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -130,7 +130,7 @@ extension ConversationDataFlowTests {
     func testRecentActivityProjectionSurvivesTemporaryIDAndStaleListPage() throws {
         let project = makeProject(id: "proj_recent_projection")
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: []) }
@@ -193,7 +193,7 @@ extension ConversationDataFlowTests {
             recencyAt: Date(timeIntervalSince1970: 100)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: [session]) }
@@ -257,7 +257,7 @@ extension ConversationDataFlowTests {
             worktreeBranchResults: [project.path: .success(response)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -312,7 +312,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -363,7 +363,7 @@ extension ConversationDataFlowTests {
             resolveResults: [project.path: .success(workspace)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -398,7 +398,7 @@ extension ConversationDataFlowTests {
 
     func testDuplicatedSessionTitleKeepsCopySuffixWithinUTF8Limit() {
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { throw MockError.unimplemented }
@@ -460,7 +460,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -531,7 +531,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -585,7 +585,7 @@ extension ConversationDataFlowTests {
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [running])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -644,7 +644,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -704,7 +704,7 @@ extension ConversationDataFlowTests {
             worktreeListResult: .success([item])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -750,7 +750,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -803,7 +803,7 @@ extension ConversationDataFlowTests {
             worktreePruneResult: .success(WorktreePruneResponse(prunedPaths: [workspace.path], worktrees: []))
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -858,7 +858,7 @@ extension ConversationDataFlowTests {
             ))
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -914,7 +914,7 @@ extension ConversationDataFlowTests {
             ))
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -972,7 +972,7 @@ extension ConversationDataFlowTests {
             worktreeCleanupExecutionResult: .success(executed)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1005,7 +1005,7 @@ extension ConversationDataFlowTests {
         let preview = makeWorktreeCleanupResponse(items: [blocked], candidatePaths: [])
         let client = MockSessionStoreClient(projects: [project], sessions: [])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1052,7 +1052,7 @@ extension ConversationDataFlowTests {
             worktreeCleanupExecutionResult: .success(executed)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1081,7 +1081,7 @@ extension ConversationDataFlowTests {
         let secondProject = makeProject(id: "proj_2")
         let client = MockSessionStoreClient(projects: [firstProject, secondProject], sessions: [])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1099,7 +1099,7 @@ extension ConversationDataFlowTests {
         let history = makeSession(id: "codex_history", projectID: project.id, title: "历史", status: "history", source: "codex", resumeID: "history")
         let client = MockSessionStoreClient(projects: [project], sessions: [history])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1176,7 +1176,7 @@ extension ConversationDataFlowTests {
             projectSessions: [project.id: [history]]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1203,7 +1203,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1236,7 +1236,7 @@ extension ConversationDataFlowTests {
         }
         let client = MockSessionStoreClient(projects: [project], sessions: sessions)
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1293,7 +1293,7 @@ extension ConversationDataFlowTests {
         )
         let client = MockSessionStoreClient(projects: [project], sessions: history + [active])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1324,7 +1324,7 @@ extension ConversationDataFlowTests {
         }
         let client = MockSessionStoreClient(projects: [project], sessions: sessions)
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1382,7 +1382,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1455,7 +1455,7 @@ extension ConversationDataFlowTests {
             cursorPages: ["cursor_older": SessionsPage(sessions: olderPage, hasMore: false)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1506,7 +1506,7 @@ extension ConversationDataFlowTests {
             cursorPages: ["workspace_cursor": SessionsPage(sessions: olderPage, hasMore: false)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1556,7 +1556,7 @@ extension ConversationDataFlowTests {
             cursorPages: ["workspace_background_cursor": SessionsPage(sessions: olderPage, hasMore: false)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1623,7 +1623,7 @@ extension ConversationDataFlowTests {
         )
         var now = Date(timeIntervalSince1970: 1_000)
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -1677,7 +1677,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: firstPage, nextCursor: "network_cursor", hasMore: true),
             cursorPages: ["network_cursor": SessionsPage(sessions: olderPage, hasMore: false)]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let pathSource = TestNetworkPathStatusSource(initialStatus: .satisfied)
         var now = Date(timeIntervalSince1970: 1_000)
@@ -1713,7 +1713,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1747,7 +1747,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: firstPage, nextCursor: "cursor_1", hasMore: true)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1808,7 +1808,7 @@ extension ConversationDataFlowTests {
             createSessionResponse: try makeCreateSessionResponse(session: created)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1838,7 +1838,7 @@ extension ConversationDataFlowTests {
         let conversationStore = ConversationStore()
         var sockets: [MockWebSocketClient] = []
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -2037,7 +2037,7 @@ extension ConversationDataFlowTests {
             createSessionResponse: try makeCreateSessionResponse(session: created)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2099,7 +2099,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -2130,7 +2130,7 @@ extension ConversationDataFlowTests {
         let client = MockSessionStoreClient(projects: [project], sessions: [])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -2160,7 +2160,7 @@ extension ConversationDataFlowTests {
             projectSessions: [project.id: sessions]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2195,7 +2195,7 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [history, running]))
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2259,7 +2259,7 @@ extension ConversationDataFlowTests {
             recencyAt: Date(timeIntervalSince1970: 10)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: []) }
@@ -2322,7 +2322,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: history + [running])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2369,7 +2369,7 @@ extension ConversationDataFlowTests {
             sessionResponses: [running.id: SessionResponse(session: completed)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2402,7 +2402,7 @@ extension ConversationDataFlowTests {
             source: "codex"
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: []) }
@@ -2446,7 +2446,7 @@ extension ConversationDataFlowTests {
             sessionResponses: [running.id: SessionResponse(session: running)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2488,7 +2488,7 @@ extension ConversationDataFlowTests {
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [])
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2525,7 +2525,7 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2568,7 +2568,7 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2622,7 +2622,7 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2678,7 +2678,7 @@ extension ConversationDataFlowTests {
         )
         let client = MutableSessionPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2723,7 +2723,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [running])
         )
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         // 显式配置认证，保证该测试可独立运行，不读取前序测试留下的 Keychain 状态。
         appStore.token = "test-token"
         let store = SessionStore(
@@ -2759,7 +2759,7 @@ extension ConversationDataFlowTests {
         let running = makeSession(id: "sess_observing", projectID: project.id, title: "Mac 运行中", status: "running", source: "codex")
         var sockets: [MockWebSocketClient] = []
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: []) },
@@ -2788,7 +2788,7 @@ extension ConversationDataFlowTests {
         let project = makeProject(id: "proj_takeover")
         let running = makeSession(id: "sess_takeover", projectID: project.id, title: "接管运行中", status: "running", source: "codex")
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2839,7 +2839,7 @@ extension ConversationDataFlowTests {
             createSessionResponse: try makeCreateSessionResponse(session: resumed)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2892,7 +2892,7 @@ extension ConversationDataFlowTests {
         )
         var sockets: [MockWebSocketClient] = []
         let conversationStore = ConversationStore()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -2933,7 +2933,7 @@ extension ConversationDataFlowTests {
             preview: "用户可见摘要"
         )
         var sockets: [MockWebSocketClient] = []
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -3010,7 +3010,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3032,7 +3032,7 @@ extension ConversationDataFlowTests {
         let client = MockSessionStoreClient(projects: [project], sessions: [history])
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3052,7 +3052,7 @@ extension ConversationDataFlowTests {
         let history = makeSession(id: "codex_history", projectID: project.id, title: "历史", status: "history", source: "codex", resumeID: "history")
         let client = BlockingSessionListRefreshClient(projects: [project], page: SessionsPage(sessions: [history]))
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3091,7 +3091,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [history])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3132,7 +3132,7 @@ extension ConversationDataFlowTests {
             projectSessions: [firstProject.id: [refreshed]]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3162,7 +3162,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3218,7 +3218,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [first, second])
         )
         let socket = MockWebSocketClient()
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let store = SessionStore(
             appStore: appStore,
@@ -3264,7 +3264,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [running]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -3319,7 +3319,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -3419,7 +3419,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -3496,7 +3496,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -3553,7 +3553,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client },
@@ -3617,7 +3617,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3690,7 +3690,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3728,7 +3728,7 @@ extension ConversationDataFlowTests {
 
     func testHistoryOversizePolicyFailureExposesStructuredMagnitude() {
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { OrderedHistoryPageClient(projects: [], page: SessionsPage(sessions: [])) }
@@ -3767,7 +3767,7 @@ extension ConversationDataFlowTests {
 
     func testHistoryOversizeNoticeFallsBackWhenMagnitudeMissing() {
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { OrderedHistoryPageClient(projects: [], page: SessionsPage(sessions: [])) }
@@ -3788,7 +3788,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3844,7 +3844,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -3894,7 +3894,7 @@ extension ConversationDataFlowTests {
         let history = makeSession(id: "codex_full_read_oversize", projectID: project.id, title: "老版全量读取超限", status: "history", source: "codex", resumeID: "large")
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -3944,7 +3944,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -4067,7 +4067,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -4109,7 +4109,7 @@ extension ConversationDataFlowTests {
         let client = OrderedHistoryPageClient(projects: [project], page: SessionsPage(sessions: [history]))
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -4156,7 +4156,7 @@ extension ConversationDataFlowTests {
         )
         let conversationStore = ConversationStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: conversationStore,
             logStore: LogStore(),
             clientFactory: { client }
@@ -4218,7 +4218,7 @@ extension ConversationDataFlowTests {
         )
         let contextStore = SessionContextStore()
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             contextStore: contextStore,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/PairingLinkTests.swift
@@ -1424,6 +1424,7 @@ final class PairingLinkTests: XCTestCase {
         let recorder = ConnectionRouteProbeRecorder()
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: false,
             routeProbe: { endpoint, _, _ in
@@ -1581,7 +1582,10 @@ final class PairingLinkTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set("http://100.64.0.1:8787", forKey: "agentd.endpoint")
         defaults.set("https://relay.example.com", forKey: "agentd.fallbackEndpoint")
-        let store = AppStore(defaults: defaults)
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations())
+        )
 
         XCTAssertEqual(store.endpoint, "http://100.64.0.1:8787")
         XCTAssertNil(defaults.object(forKey: "agentd.fallbackEndpoint"))
@@ -1595,6 +1599,7 @@ final class PairingLinkTests: XCTestCase {
         let recorder = ConnectionRouteProbeRecorder()
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: false,
             routeProbe: { endpoint, _, _ in
@@ -1619,6 +1624,7 @@ final class PairingLinkTests: XCTestCase {
         let recorder = ConnectionRouteProbeRecorder()
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: false,
             routeProbe: { endpoint, _, _ in
@@ -1640,7 +1646,11 @@ final class PairingLinkTests: XCTestCase {
         let suiteName = "PairingLinkTests.SettingsAutomaticConnectionTest.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let store = AppStore(defaults: defaults, prefersLocalConnection: false)
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
+            prefersLocalConnection: false
+        )
         // 使用同步失败的非法地址验证一次性门闩，测试不发出真实网络请求。
         store.endpoint = "not-a-valid-endpoint"
         store.token = "test-token"
@@ -1662,6 +1672,7 @@ final class PairingLinkTests: XCTestCase {
         defaults.set("http://100.64.0.1:8787", forKey: "agentd.endpoint")
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: false,
             routeProbe: { _, _, _ in
@@ -1685,6 +1696,7 @@ final class PairingLinkTests: XCTestCase {
         let recorder = ConnectionRouteProbeRecorder()
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: false,
             routeProbe: { endpoint, _, _ in
@@ -1709,6 +1721,7 @@ final class PairingLinkTests: XCTestCase {
         let recorder = ConnectionRouteProbeRecorder()
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: true,
             localAgentProbe: { _, _ in },
@@ -1739,6 +1752,7 @@ final class PairingLinkTests: XCTestCase {
         let recorder = ConnectionRouteProbeRecorder()
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: true,
             localAgentProbe: { _, _ in },
@@ -1813,6 +1827,7 @@ final class PairingLinkTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.1,
             prefersLocalConnection: true,
             localAgentProbe: { _, _ in },
@@ -1876,6 +1891,7 @@ final class PairingLinkTests: XCTestCase {
         let recorder = LocalAgentProbeRecorder()
         let store = AppStore(
             defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
             routeProbeTimeout: 0.2,
             prefersLocalConnection: true,
             localAgentProbe: { _, _ in

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SubagentSessionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SubagentSessionTests.swift
@@ -250,7 +250,7 @@ extension ConversationDataFlowTests {
 
     func testSessionStoreSparseMergePreservesKnownSubagentOwnership() {
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
@@ -312,7 +312,7 @@ extension ConversationDataFlowTests {
         child.parentThreadID = parent.id
         child.isSubagent = true
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [project], sessions: [parent]) }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceGitSummaryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceGitSummaryTests.swift
@@ -54,7 +54,7 @@ final class WorkspaceGitSummaryTests: XCTestCase {
             gitStatusResults: [project.path: .success(status)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -77,7 +77,7 @@ final class WorkspaceGitSummaryTests: XCTestCase {
     func testFullGitRefreshProjectsOnlyLightweightFieldsIntoCardCache() {
         let path = "/tmp/workspace-summary"
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore()
         )
@@ -159,7 +159,7 @@ final class WorkspaceGitSummaryTests: XCTestCase {
             sessions: [session],
             gitStatusResults: [project.path: .success(refreshedStatus)]
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionAuthoritativeContinuationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionAuthoritativeContinuationTests.swift
@@ -52,7 +52,7 @@ extension ConversationDataFlowTests {
             cursorPages: cursorPages
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -147,7 +147,7 @@ extension ConversationDataFlowTests {
         )
         var requestedSleeps: [UInt64] = []
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
@@ -29,7 +29,7 @@ extension ConversationDataFlowTests {
     }
 
     func testWorkspaceCatalogRefreshScopeTracksCredentialSuspensionWithoutChangingHost() {
-        let hostScope = AppStore().activeHostScope
+        let hostScope = makeIsolatedAppStore().activeHostScope
 
         XCTAssertNotEqual(
             WorkspaceCatalogRefreshScope(hostScope: hostScope, credentialsSuspended: false),
@@ -194,7 +194,7 @@ extension ConversationDataFlowTests {
             workspaceSessions: [project.id: [codexSession, claudeSession]]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -236,7 +236,7 @@ extension ConversationDataFlowTests {
                 page: SessionsPage(sessions: completePage, nextCursor: "older", hasMore: true)
             )
             let store = SessionStore(
-                appStore: AppStore(),
+                appStore: makeIsolatedAppStore(),
                 conversationStore: ConversationStore(),
                 logStore: LogStore(),
                 clientFactory: { client }
@@ -298,7 +298,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -352,7 +352,7 @@ extension ConversationDataFlowTests {
             cursorPages: ["after-sparse-children": SessionsPage(sessions: roots)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -403,7 +403,7 @@ extension ConversationDataFlowTests {
             cursorPages: cursorPages
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -523,7 +523,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -552,7 +552,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: [cachedRoot], nextCursor: nil, hasMore: true)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -605,7 +605,7 @@ extension ConversationDataFlowTests {
             cursorPages: ["external-next": SessionsPage(sessions: olderRoots)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -640,7 +640,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -714,7 +714,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -780,7 +780,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -834,7 +834,7 @@ extension ConversationDataFlowTests {
             cursorPages: cursorPages
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -928,7 +928,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -977,7 +977,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1013,7 +1013,7 @@ extension ConversationDataFlowTests {
             page: SessionsPage(sessions: completePage, nextCursor: "authoritative-older", hasMore: true)
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1088,7 +1088,7 @@ extension ConversationDataFlowTests {
         var now = Date(timeIntervalSince1970: 1_780_000_000)
         var requestedSleeps: [UInt64] = []
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client },
@@ -1135,7 +1135,7 @@ extension ConversationDataFlowTests {
             source: "codex"
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
@@ -1192,7 +1192,7 @@ extension ConversationDataFlowTests {
             )
         }
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
@@ -1256,7 +1256,7 @@ extension ConversationDataFlowTests {
             source: "codex"
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
@@ -1326,7 +1326,7 @@ extension ConversationDataFlowTests {
             )
         }
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
@@ -1405,7 +1405,7 @@ extension ConversationDataFlowTests {
                 hasMore: true
             )
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1466,7 +1466,7 @@ extension ConversationDataFlowTests {
                 hasMore: true
             )
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1536,7 +1536,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1,
             blockedError: CancellationError()
         )
-        let appStore = AppStore()
+        let appStore = makeIsolatedAppStore()
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
@@ -1578,7 +1578,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1628,7 +1628,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1678,7 +1678,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1765,7 +1765,7 @@ extension ConversationDataFlowTests {
             authoritativePage: authoritativePage
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1825,7 +1825,7 @@ extension ConversationDataFlowTests {
             authoritativePage: SessionsPage(sessions: [authoritativeSession])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1884,7 +1884,7 @@ extension ConversationDataFlowTests {
             authoritativePage: SessionsPage(sessions: [authoritativeSession])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1940,7 +1940,7 @@ extension ConversationDataFlowTests {
             authoritativePage: SessionsPage(sessions: [])
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -1987,7 +1987,7 @@ extension ConversationDataFlowTests {
             projectsHandler: { await gate.projects() }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2041,7 +2041,7 @@ extension ConversationDataFlowTests {
                 resolveResults: [path: .failure(error)]
             )
             let store = SessionStore(
-                appStore: AppStore(),
+                appStore: makeIsolatedAppStore(),
                 conversationStore: ConversationStore(),
                 logStore: LogStore(),
                 clientFactory: { client }
@@ -2062,7 +2062,7 @@ extension ConversationDataFlowTests {
             resolveResults: [path: .failure(AgentAPIError.server(status: 403, message: "forbidden"))]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2083,7 +2083,7 @@ extension ConversationDataFlowTests {
             resolveResults: [workspace.path: .success(workspace)]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2105,7 +2105,7 @@ extension ConversationDataFlowTests {
             resolveWorkspaceHandler: { _ in try await gate.resolve() }
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -2126,7 +2126,7 @@ extension ConversationDataFlowTests {
 
     func testWorkspaceSessionLoadInvocationTokensKeepOnlyLatestABAReturnEligible() {
         var tokens = WorkspaceSessionLoadInvocationTokens()
-        let hostScope = AppStore().activeHostScope
+        let hostScope = makeIsolatedAppStore().activeHostScope
         let keyA = WorkspaceSessionPresentationKey(
             hostScope: hostScope,
             workspaceID: "workspace-a",
@@ -2170,7 +2170,7 @@ extension ConversationDataFlowTests {
             blockOnCall: 1
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionPresentationTests.swift
@@ -60,7 +60,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -116,7 +116,7 @@ extension ConversationDataFlowTests {
             ]
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }
@@ -185,7 +185,7 @@ extension ConversationDataFlowTests {
             )
         )
         let store = SessionStore(
-            appStore: AppStore(),
+            appStore: makeIsolatedAppStore(),
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             clientFactory: { client }


### PR DESCRIPTION
## 目标

降低 Mimi Remote 会话流、会话状态归并、长列表投影和 Go 历史尾读的重复计算与拷贝开销，同时保持现有事件、分页与 UI 语义。

## 实现

- iOS 流式事件：批内保存 chunk，drain 时一次性物化，避免反复字符串扩容与 CoW。
- Session reducer：在 working copy 中批量归并，同一 output 只提交一次 canonical sessions，并处理发布期同步重入。
- 会话长列表：单次 body 求值复用 visible sessions、partition、lifecycle 与 presentation 投影。
- Go history：尾读块从 128 KiB 按需自适应扩到 256/512 KiB，减少大行跨块读取。
- XCTest：隔离 UserDefaults 与 Keychain 测试状态，降低本机持久状态污染。
- 已 rebase 到最新 main，并保留 MIM-104 的 sidebarMonitorSections、project anchor、overflow、状态和 project identity 行为。

## 性能证据

- 1000 chunks 流合并：51.719 ms → 1.457 ms，约 35.5x。
- Go 历史尾读：3,478,762 ns/op → 524,102 ns/op，约 6.64x；B/op 下降约 18.5%。
- 3000 sessions reducer：207.328 ms / 3 次发布 → 74.507 ms / 1 次发布，约 2.78x。

## 验证

- go test ./...：通过。
- source-size、PR gate、git diff --check：通过。
- 固定 iPad Pro 13-inch (M5) Simulator：排除 3 个仓库已知过期快照后，1257 tests / 4 skipped / 0 failures。
- 完整 iOS suite 仅上述 3 个已知快照失败，生产 UI 不在本分支改动范围。
- cargo test --workspace 当前仅 active_turn_conflict 并发顺序用例在全套中失败，单独运行通过；本分支无 Rust/Cargo diff。
- Luna 与全新上下文 Sol reviewer 最终结论均为 SHIP。

## 剩余边界

- TerminalStreamStore 与 AgentEvent 各自维护连续事件合并判定；本次已验证一致，未来修改规则时需同步。
- 真机性能、Keychain、Tailscale/弱网、通知和相机专项未在本 PR 标记为完成。

Linear: MIM-109