### PR TITLE
MIM-108 将 agentd Token 缓存 TTL 调整为 12 小时

### DIFF
--- a/internal/httpapi/appserver_account_usage_cache.go
+++ b/internal/httpapi/appserver_account_usage_cache.go
@@ -6,12 +6,13 @@ import (
 	"time"
 )
 
-const defaultAccountTokenUsageCacheTTL = time.Hour
+const defaultAccountTokenUsageCacheTTL = 12 * time.Hour
 
 const accountTokenUsageForceRefreshParam = "mimiForceRefresh"
 
-// cachedAccountTokenUsageResult 只返回 TTL 内的成功快照。缓存属于当前 agentd
-// 进程与 Codex runtime，不落盘、不跨宿主共享，也不会影响实时额度事件。
+// cachedAccountTokenUsageResult 只返回 TTL 内的成功快照。缓存属于当前 Mac 的
+// agentd 进程，同一服务端的所有客户端连接共享；它不落盘、不跨 Mac 共享，
+// 也不会影响实时额度事件。
 func (r *Router) cachedAccountTokenUsageResult(now time.Time) (json.RawMessage, bool) {
 	if r == nil {
 		return nil, false

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -1412,15 +1412,28 @@ func TestAppServerGatewayCachesAccountTokenUsageAcrossConnections(t *testing.T) 
 		t.Fatalf("强制刷新应转发到 upstream 且剥离私有 params：%s", forcedUpstream)
 	}
 
-	// TTL 过期后恢复真实上游读取，确保缓存不会永久冻结展示数据。
+	// 12 小时以内仍由当前 Mac 的 agentd 统一返回缓存，多台设备不会各自重查上游。
 	router.accountTokenUsageMu.Lock()
-	router.accountTokenUsageCachedAt = time.Now().Add(-2 * time.Hour)
+	router.accountTokenUsageCachedAt = time.Now().Add(-defaultAccountTokenUsageCacheTTL + time.Minute)
 	router.accountTokenUsageMu.Unlock()
 	if err := second.WriteMessage(websocket.TextMessage, []byte(`{"id":4,"method":"account/usage/read"}`)); err != nil {
 		t.Fatal(err)
 	}
+	withinTTLResponse := readGatewayRaw(t, second)
+	if !bytes.Contains(withinTTLResponse, []byte(`"lifetimeTokens":123456`)) {
+		t.Fatalf("12 小时内应继续返回服务端缓存：%s", withinTTLResponse)
+	}
+	assertNoUpstreamFrame(t, received)
+
+	// 超过 12 小时后恢复真实上游读取，确保缓存不会永久冻结展示数据。
+	router.accountTokenUsageMu.Lock()
+	router.accountTokenUsageCachedAt = time.Now().Add(-defaultAccountTokenUsageCacheTTL - time.Minute)
+	router.accountTokenUsageMu.Unlock()
+	if err := second.WriteMessage(websocket.TextMessage, []byte(`{"id":5,"method":"account/usage/read"}`)); err != nil {
+		t.Fatal(err)
+	}
 	_ = readGatewayRaw(t, second)
-	if got := readUpstreamFrame(t, received); !bytes.Contains(got, []byte(`"id":4`)) {
+	if got := readUpstreamFrame(t, received); !bytes.Contains(got, []byte(`"id":5`)) {
 		t.Fatalf("过期请求应重新转发到 upstream：%s", got)
 	}
 }


### PR DESCRIPTION
## 变更内容

- 将 Mac 端 agentd 的 Token 用量成功快照 TTL 从 1 小时调整为 12 小时。
- 明确缓存按 agentd 服务实例共享，同一 Mac 的多个 iPhone/iPad 客户端复用同一份缓存。
- 增加 12 小时边界回归：TTL 内命中缓存，过期后重新读取上游；显式刷新继续绕过缓存。

## 原因

Token 活动属于低频展示数据，不应因多个设备进入「我的」页而重复等待上游读取。权威缓存已位于 Mac 端 agentd，而不是设备端。

## 验证

- go test ./internal/httpapi -count=1
- git diff --check

关联 Linear：MIM-108