### PR TITLE
MIM-117 统一会话区与工作区左上角设备入口位置

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -1694,7 +1694,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]" = Resources/MimiRemote.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Resources/MimiRemote-Catalyst.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 100068;
+				CURRENT_PROJECT_VERSION = 100070;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1825,7 +1825,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]" = Resources/MimiRemote.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Resources/MimiRemote-Catalyst.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 100068;
+				CURRENT_PROJECT_VERSION = 100070;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1872,7 +1872,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = WidgetExtension/MimiCarStatusWidget.entitlements;
-				CURRENT_PROJECT_VERSION = 100068;
+				CURRENT_PROJECT_VERSION = 100070;
 				INFOPLIST_FILE = WidgetExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1960,7 +1960,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = WidgetExtension/MimiCarStatusWidget.entitlements;
-				CURRENT_PROJECT_VERSION = 100068;
+				CURRENT_PROJECT_VERSION = 100070;
 				INFOPLIST_FILE = WidgetExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -486,15 +486,32 @@ struct WorkspaceRootView: View {
         )
     }
 
+    @ViewBuilder
     private func navigationContent(tokens: ThemeTokens) -> some View {
-        workspaceBrowser(tokens: tokens)
-            .accessibilityIdentifier("workspace.browser")
-            // 标题与底部 Tab 的“工作区”标签完全重复，白占一条 44pt 横带；
-            // 当前工作区的身份改由下方胶囊行表达。
-            // “打开目录”也从导航栏移到胶囊行末端——它和切换工作区是同一类操作，
-            // 分成上下两行只会在顶部留出一整条空白。
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar(.hidden, for: .navigationBar)
+        if let manageConnections {
+            // 会话页把设备切换器放在顶栏左侧；工作区也复用同一位置，避免切换 Tab 时垂直跳动。
+            workspaceBrowser(tokens: tokens)
+                .accessibilityIdentifier("workspace.browser")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        HostSwitcherMenu(
+                            presentation: .toolbar,
+                            manageConnections: manageConnections
+                        )
+                    }
+                    // 与会话页保持相同的顶栏分组间距，避免设备入口和其他 leading 控件粘连。
+                    if #available(iOS 26.0, *) {
+                        ToolbarSpacer(.fixed, placement: .topBarLeading)
+                    }
+                }
+        } else {
+            // 宽屏由侧栏承载设备入口，工作区内容列继续隐藏空导航栏，避免多出一条空白顶栏。
+            workspaceBrowser(tokens: tokens)
+                .accessibilityIdentifier("workspace.browser")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar(.hidden, for: .navigationBar)
+        }
     }
 
     private func openDirectoryButton(tokens: ThemeTokens) -> some View {
@@ -648,16 +665,6 @@ struct WorkspaceRootView: View {
 
     private func workspaceStrip(tokens: ThemeTokens) -> some View {
         HStack(spacing: 8) {
-            if let manageConnections {
-                // 紧凑布局不能把 Host 切换器留在随后会被隐藏的系统导航栏里；
-                // 固定在自绘控件带首端，既保留连接管理入口，也不重新占用一整条顶栏。
-                HostSwitcherMenu(
-                    presentation: .toolbar,
-                    manageConnections: manageConnections
-                )
-                .workbenchChromeCircle(tokens: tokens)
-            }
-
             ScrollViewReader { proxy in
                 // 收缩成头像是一种压缩手法：只有横向真的放不下时才该发生，
                 // 而且必须渐进——只有“全展开”和“只展开选中项”两档时，

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -89,7 +89,7 @@ targets:
         # UI 文案统一由显式 L10n key 管理，关闭编译器自动提取，避免 Xcode 把技术字符串写回目录。
         SWIFT_EMIT_LOC_STRINGS: "NO"
         # 1.1 已在 App Store Connect 关闭新构建上传，本次发布切换到 1.2 通道。
-        CURRENT_PROJECT_VERSION: "100068"
+        CURRENT_PROJECT_VERSION: "100070"
         MARKETING_VERSION: "1.2"
   MimiCarStatusWidgetExtension:
     type: app-extension
@@ -116,7 +116,7 @@ targets:
         "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]": "$(IOS_WIDGET_PROVISIONING_PROFILE_SPECIFIER)"
         SKIP_INSTALL: "YES"
         TARGETED_DEVICE_FAMILY: "1,2"
-        CURRENT_PROJECT_VERSION: "100068"
+        CURRENT_PROJECT_VERSION: "100070"
         MARKETING_VERSION: "1.2"
         SWIFT_EMIT_LOC_STRINGS: "NO"
   MimiRemoteTests:


### PR DESCRIPTION
## 变更

- iPad：将工作区设备切换器放到与会话页一致的 `.topBarLeading` 顶栏位置。
- iPhone：保留原有工作区展示，设备入口与工作区文件夹胶囊共用同一行。
- 宽屏侧栏布局保持原有设备入口和空导航栏处理。

## 根因

工作区此前把设备入口放进自绘工作区胶囊行。iPad 需要与会话页共享顶栏对齐；但 iPhone 窄屏仍应保留原有工作区行内布局，避免新增导航栏占位和改变既有信息层级。

## 验证

- `git diff --check` 通过。
- `bash ./scripts/ios-dev.sh build` 通过：MimiRemote Debug / iPad Pro 13-inch (M5) Simulator。
- 运行态截图未执行：当前 Simulator 均为 Shutdown，按仓库规范未自动启动设备。

## 范围

本 PR 只包含 `WorkspaceRootView.swift` 的本次需求调整；工作树中另外两个无关文件未提交。