### PR TITLE
MIM-118: 合并语言与语音输入设置入口

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -13404,6 +13404,23 @@
         }
       }
     },
+    "ui.language_settings_summary": {
+      "comment": "Short summary of the selected app language and voice input provider shown on the settings home page.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@"
+          }
+        }
+      }
+    },
     "ui.last_send_interrupted_before_confirmation": {
       "comment": "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "extractionState": "stale",

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsChoiceRow.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsChoiceRow.swift
@@ -274,3 +274,76 @@ struct SettingsOptionListView<Option: SettingsChoiceOption>: View {
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }
+
+/// 语言入口的详情页把应用语言和语音提供方放在同一层，首页只负责展示当前摘要。
+/// 两个选择器仍然绑定到设置页持有的 AppStorage，因此返回首页或重启 App 后不会出现第二份状态。
+struct LanguageSettingsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var themeStore: ThemeStore
+
+    @Binding var appLanguageRawValue: String
+    @Binding var voiceInputProviderRawValue: String
+
+    var body: some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+
+        Form {
+            Section {
+                SettingsChoiceRow(
+                    title: L10n.text("ui.language"),
+                    systemImage: "globe",
+                    options: AppLanguage.allCases,
+                    selection: appLanguageSelection
+                )
+                .detailListRow()
+                .accessibilityIdentifier("settings.language.detail.language")
+            } header: {
+                Text(L10n.text("ui.language"))
+            }
+
+            Section {
+                SettingsChoiceRow(
+                    title: L10n.text("ui.voice_input"),
+                    systemImage: "waveform",
+                    options: VoiceInputProvider.availableProviders(),
+                    selection: voiceInputProviderSelection
+                )
+                .detailListRow()
+                .accessibilityIdentifier("settings.language.detail.voiceInput")
+            }
+        }
+        .themedSettingsForm(tokens: tokens)
+        .frame(maxWidth: 720)
+        .frame(maxWidth: .infinity)
+        .background(tokens.background.ignoresSafeArea())
+        .navigationTitle(L10n.text("ui.language"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var appLanguageSelection: Binding<AppLanguage> {
+        Binding(
+            get: { AppLanguage(rawValue: appLanguageRawValue) ?? .system },
+            set: { appLanguageRawValue = $0.rawValue }
+        )
+    }
+
+    private var voiceInputProviderSelection: Binding<VoiceInputProvider> {
+        Binding(
+            get: { VoiceInputProvider.resolved(rawValue: voiceInputProviderRawValue) },
+            set: { voiceInputProviderRawValue = $0.rawValue }
+        )
+    }
+}
+
+private extension View {
+    func detailListRow() -> some View {
+        listRowInsets(
+            EdgeInsets(
+                top: 0,
+                leading: SettingsLayoutMetrics.rowHorizontalInset,
+                bottom: 0,
+                trailing: SettingsLayoutMetrics.rowHorizontalInset
+            )
+        )
+    }
+}

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -308,23 +308,20 @@ struct SettingsView: View {
                 .settingsStandardListRow()
                 .accessibilityIdentifier("settings.appearance")
 
-                SettingsChoiceRow(
-                    title: L10n.text("ui.language"),
-                    systemImage: "globe",
-                    options: AppLanguage.allCases,
-                    selection: appLanguageSelection
-                )
+                NavigationLink {
+                    LanguageSettingsView(
+                        appLanguageRawValue: $appLanguageRawValue,
+                        voiceInputProviderRawValue: $voiceInputProviderRawValue
+                    )
+                } label: {
+                    SettingsValueLabel(
+                        title: L10n.text("ui.language"),
+                        value: languageSettingsSummary,
+                        systemImage: "globe"
+                    )
+                }
                 .settingsStandardListRow()
                 .accessibilityIdentifier("settings.language")
-
-                SettingsChoiceRow(
-                    title: L10n.text("ui.voice_input"),
-                    systemImage: "waveform",
-                    options: VoiceInputProvider.availableProviders(),
-                    selection: voiceInputProviderSelection
-                )
-                .settingsStandardListRow()
-                .accessibilityIdentifier("settings.voiceInput")
 
                 // 四个模式各自有 detail，而且是安全相关的选择：值得整页逐条读完再选。
                 SettingsChoiceRow(
@@ -516,6 +513,14 @@ struct SettingsView: View {
                 VoiceInputProvider.resolved(rawValue: voiceInputProviderRawValue)
             },
             set: { voiceInputProviderRawValue = $0.rawValue }
+        )
+    }
+
+    private var languageSettingsSummary: String {
+        L10n.format(
+            "ui.language_settings_summary",
+            appLanguageSelection.wrappedValue.displayName,
+            voiceInputProviderSelection.wrappedValue.title
         )
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
@@ -365,4 +365,21 @@ final class LocalizationTests: XCTestCase {
             "Uses Codex built-in voice capability · Transcribes after recording"
         )
     }
+
+    func testLanguageSettingsSummaryKeepsBothSelectionsVisible() {
+        XCTAssertEqual(
+            L10n.formatTemplate(
+                L10n.text("ui.language_settings_summary", language: .english),
+                arguments: ["System Default", "Codex"]
+            ),
+            "System Default · Codex"
+        )
+        XCTAssertEqual(
+            L10n.formatTemplate(
+                L10n.text("ui.language_settings_summary", language: .simplifiedChinese),
+                arguments: ["跟随系统", "设备端"]
+            ),
+            "跟随系统 · 设备端"
+        )
+    }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -337,33 +337,39 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         add(screenshot)
     }
 
-    func testVoiceProviderInlineSelectionSurvivesRotation() throws {
+    func testLanguageSettingsCombinesVoiceProviderAndSurvivesRotation() throws {
         try enterWorkbenchIfNeeded()
         try openSettings()
 
-        let voiceInput = app.descendant(identifier: "settings.voiceInput")
-        XCTAssertTrue(scrollUntilHittable(voiceInput), "设置页应提供语音输入入口")
-        let originalValue = "\(voiceInput.value ?? "")"
+        let language = app.descendant(identifier: "settings.language")
+        XCTAssertTrue(scrollUntilHittable(language), "设置页应提供语言统一入口")
+        let originalValue = "\(language.value ?? "")"
         let originalProviderWasOnDevice =
             originalValue.contains("On-device") || originalValue.contains("设备端")
 
-        voiceInput.tap()
+        language.tap()
+
+        let detailVoiceInput = app.descendant(identifier: "settings.language.detail.voiceInput")
+        XCTAssertTrue(
+            detailVoiceInput.waitForExistence(timeout: 5),
+            "语言详情页应同时展示语音输入选择"
+        )
 
         guard let codex = firstExistingButton(labels: ["Codex"], timeout: 5) else {
-            XCTFail("语音输入行应直接弹出提供方选择菜单")
+            XCTFail("语言详情页应提供 Codex 语音输入选项")
             return
         }
         codex.tap()
         XCTAssertTrue(
-            waitForControlValue(voiceInput, containing: ["Codex"]),
-            "在弹出菜单选择 Codex 后应立即保存设备级偏好"
+            waitForControlValue(detailVoiceInput, containing: ["Codex"]),
+            "在语言详情页选择 Codex 后应立即保存设备级偏好"
         )
 
         rotate(to: .landscapeLeft)
-        let landscapeVoiceInput = app.descendant(identifier: "settings.voiceInput")
+        let landscapeVoiceInput = app.descendant(identifier: "settings.language.detail.voiceInput")
         XCTAssertTrue(
             scrollUntilHittable(landscapeVoiceInput),
-            "横屏后应仍能找到语音输入选择组件"
+            "横屏后语言详情页应仍能找到语音输入选择组件"
         )
         XCTAssertTrue(
             waitForControlValue(landscapeVoiceInput, containing: ["Codex"]),
@@ -371,10 +377,10 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         )
 
         rotate(to: .portrait)
-        let portraitVoiceInput = app.descendant(identifier: "settings.voiceInput")
+        let portraitVoiceInput = app.descendant(identifier: "settings.language.detail.voiceInput")
         XCTAssertTrue(
             scrollUntilHittable(portraitVoiceInput),
-            "竖屏后应仍能找到语音输入选择组件"
+            "竖屏后语言详情页应仍能找到语音输入选择组件"
         )
         XCTAssertTrue(
             waitForControlValue(portraitVoiceInput, containing: ["Codex"]),
@@ -382,12 +388,11 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         )
 
         if originalProviderWasOnDevice {
-            portraitVoiceInput.tap()
             guard let onDevice = firstExistingButton(
                 labels: ["On-device", "设备端"],
                 timeout: 5
             ) else {
-                XCTFail("测试结束时应能从同一弹出菜单恢复设备端语音")
+                XCTFail("测试结束时应能从语言详情页恢复设备端语音")
                 return
             }
             onDevice.tap()
@@ -399,6 +404,17 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
                 "测试结束时应恢复原语音提供方"
             )
         }
+
+        let back = app.navigationBars.buttons.firstMatch
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "语言详情页应提供返回路径")
+        back.tap()
+        XCTAssertTrue(
+            waitForControlValue(
+                language,
+                containing: originalProviderWasOnDevice ? ["On-device", "设备端"] : ["Codex"]
+            ),
+            "返回设置首页后应保留合并入口及最新选择摘要"
+        )
     }
 
     func testMePageCombinesQuotaActivityPreferencesAndMore() throws {
@@ -413,7 +429,6 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         let macDevices = app.descendant(identifier: "settings.connectionManagement")
         let appearance = app.descendant(identifier: "settings.appearance")
         let language = app.descendant(identifier: "settings.language")
-        let voiceInput = app.descendant(identifier: "settings.voiceInput")
         let defaultPermissions = app.descendant(identifier: "settings.defaultPermissions")
         let diagnostics = app.descendant(identifier: "settings.diagnostics")
         let advanced = app.descendant(identifier: "settings.advancedDevelopment")
@@ -452,8 +467,8 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
             scrollUntilHittable(defaultPermissions, maximumSwipes: 6),
             "设置页应能滚动到默认权限行内选择器"
         )
-        XCTAssertTrue(voiceInput.exists, "设置页应展示语音行内选择器")
-        XCTAssertEqual(voiceInput.frame.height, 52, accuracy: 1, "语音输入行应保持标准行高")
+        XCTAssertTrue(language.exists, "设置页应展示合并后的语言入口")
+        XCTAssertEqual(language.frame.height, 52, accuracy: 1, "语言入口应保持标准行高")
         XCTAssertEqual(defaultPermissions.frame.height, 52, accuracy: 1, "默认权限行应保持标准行高")
 
         XCTAssertTrue(scrollUntilHittable(aboutLegal), "我的页面应能滚动到“更多”分区")


### PR DESCRIPTION
## 变更

- 将「我的」页的语言与语音输入合并为单一「语言」导航行。
- 首页摘要展示当前应用语言和语音 Provider。
- 新增语言详情页，分别展示语言选择和语音输入选择。
- 继续复用现有 AppStorage、Provider 可用性判断、能力说明和本地化逻辑。
- 更新本地化单测、设置组件快照测试和旋转场景 UI 测试。

## 用户影响

设置首页更简洁，用户可从一个统一入口管理语言与语音输入，并在返回首页后立即看到当前选择摘要。

## 验证

- `bash ./scripts/ios-dev.sh build`
- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/LocalizationTests`：22 个通过，1 个按设计跳过。
- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/SettingsChoiceRowSnapshotTests`：3 个通过。
- iPad Pro 13-inch (M5) Simulator 运行态验证：首页摘要与详情页选择均正常。
- `MimiRemoteUITests` 未执行：当前 `MimiRemote` scheme/test plan 未包含该测试目标，Xcode 在启动前返回 test plan membership 错误。

## 关联

- Linear：MIM-118
