### PR TITLE
MIM-119 支持在设置中配置 Codex 与 Claude 默认模型

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -7637,40 +7637,6 @@
         }
       }
     },
-    "ui.default_model_current_value": {
-      "comment": "Footer showing the effective model used by the selected runtime.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Current effective model: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前生效模型：%@"
-          }
-        }
-      }
-    },
-    "ui.default_model_reset_description": {
-      "comment": "Explains that reset restores the product defaults for the selected runtime.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore the original default model and reasoning effort for this runtime."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恢复此运行时原本的默认模型和推理强度。"
-          }
-        }
-      }
-    },
     "ui.default_model_settings_description": {
       "comment": "Description for the default model settings page.",
       "localizations": {
@@ -7684,23 +7650,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "配置没有保存模型选择时，新会话使用的模型和推理强度。"
-          }
-        }
-      }
-    },
-    "ui.default_model_summary": {
-      "comment": "Compact summary of Codex and Claude default model settings shown in the settings list.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Codex: %@ · %@ / Claude: %@ · %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Codex：%@ · %@ / Claude：%@ · %@"
           }
         }
       }

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -7637,6 +7637,74 @@
         }
       }
     },
+    "ui.default_model_current_value": {
+      "comment": "Footer showing the effective model used by the selected runtime.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current effective model: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前生效模型：%@"
+          }
+        }
+      }
+    },
+    "ui.default_model_reset_description": {
+      "comment": "Explains that reset restores the product defaults for the selected runtime.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore the original default model and reasoning effort for this runtime."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复此运行时原本的默认模型和推理强度。"
+          }
+        }
+      }
+    },
+    "ui.default_model_settings_description": {
+      "comment": "Description for the default model settings page.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose what new conversations use when they do not have a saved model selection."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置没有保存模型选择时，新会话使用的模型和推理强度。"
+          }
+        }
+      }
+    },
+    "ui.default_model_summary": {
+      "comment": "Compact summary of Codex and Claude default model settings shown in the settings list.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex: %@ · %@ / Claude: %@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex：%@ · %@ / Claude：%@ · %@"
+          }
+        }
+      }
+    },
     "ui.default_option": {
       "comment": "Default option in a picker.",
       "localizations": {
@@ -7650,6 +7718,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "默认"
+          }
+        }
+      }
+    },
+    "ui.no_reasoning_effort_available": {
+      "comment": "Displayed when a model exposes no selectable reasoning effort.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not available for this model"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此模型不支持推理强度"
+          }
+        }
+      }
+    },
+    "ui.reset_to_built_in_default": {
+      "comment": "Button that clears a runtime's custom default model settings.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to built-in default"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复内置默认"
+          }
+        }
+      }
+    },
+    "ui.use_built_in_default": {
+      "comment": "Picker option that uses the product's built-in default model.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Built-in default"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内置默认"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
@@ -103,8 +103,8 @@ extension ComposerView {
         }
         composerState.updateTurnOptions { options in
             if runtimeChanged || unsupportedModel {
-                // 切换 runtime 或目录刷新淘汰旧模型时，使用产品约定默认值：
-                // Codex 为 GPT-5.6 Sol/xhigh，Claude 为 Opus 5/high。
+                // 切换 runtime 或目录刷新淘汰旧模型时，使用设置里的对应默认值；
+                // 没有自定义设置时仍回到 Codex Sol/xhigh、Claude Opus/high。
                 applyPreferredDefaultModel(runtimeProvider: runtimeProvider, to: &options)
             } else if unsupportedEffort {
                 options.reasoningEffort = normalizedEffort
@@ -119,34 +119,12 @@ extension ComposerView {
         runtimeProvider: String,
         to options: inout CodexAppServerTurnOptions
     ) {
-        guard let option = ModelReasoningGridCatalog.preferredDefaultOption(
-            runtimeProvider: runtimeProvider,
-            options: modelOptionsForMenu
-        ) else {
-            options.runtimeProvider = runtimeProvider == "codex" ? nil : runtimeProvider
-            options.model = nil
-            options.modelProvider = nil
-            options.reasoningEffort = nil
-            options.serviceTier = nil
-            return
-        }
-        let layout = ModelReasoningGridCatalog.layout(
-            runtimeProvider: runtimeProvider,
-            options: modelOptionsForMenu
-        )
-        let effort = ModelReasoningGridCatalog.preferredDefaultEffort(
-            runtimeProvider: runtimeProvider,
-            option: option,
-            layout: layout
-        )
-        ModelReasoningGridCatalog.applySelection(
-            option: option,
-            effort: effort,
-            preservesServerDefault: false,
-            fallbackRuntimeProvider: runtimeProvider == "codex" ? nil : runtimeProvider,
+        // 默认模型统一从本机设置读取；没有保存配置时仍沿用原来的 Sol/xhigh、Opus/high。
+        DefaultModelPreferences.applyDefault(
+            for: runtimeProvider,
+            allOptions: modelOptionsForMenu,
             to: &options
         )
-        options.serviceTier = nil
     }
 
     func supportsReasoningEffort(

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -192,6 +192,158 @@ struct ComposerModelSelectionCache {
     }
 }
 
+enum DefaultModelRuntime: String, CaseIterable, Hashable, Identifiable {
+    case codex
+    case claude
+
+    var id: String { rawValue }
+
+    var payloadRuntimeProvider: String? {
+        self == .codex ? nil : rawValue
+    }
+}
+
+struct DefaultModelSelection: Equatable {
+    let option: CodexAppServerModelOption
+    let effort: CodexAppServerReasoningEffort?
+}
+
+enum DefaultModelPreferences {
+    static let codexModelOptionIDKey = "composer.defaultModel.codex.optionID"
+    static let codexReasoningEffortKey = "composer.defaultModel.codex.reasoningEffort"
+    static let claudeModelOptionIDKey = "composer.defaultModel.claude.optionID"
+    static let claudeReasoningEffortKey = "composer.defaultModel.claude.reasoningEffort"
+
+    /// 默认值是本机偏好，不跟随 Host 或会话保存；只有“没有会话快照”时才会被 Composer 使用。
+    static func options(
+        for runtimeProvider: String,
+        allOptions: [CodexAppServerModelOption]
+    ) -> [CodexAppServerModelOption] {
+        let runtime = CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider)
+        let available = allOptions.filter {
+            !$0.hidden
+                && CodexAppServerSessionRuntime.normalizedRuntimeProvider($0.runtimeProvider) == runtime
+        }
+        guard available.isEmpty else {
+            return available
+        }
+        return runtime == "claude"
+            ? CodexAppServerModelOption.builtInClaudeFallback
+            : CodexAppServerModelOption.builtInFallback
+    }
+
+    static func modelOptionIDKey(for runtimeProvider: String) -> String {
+        CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider) == "claude"
+            ? claudeModelOptionIDKey
+            : codexModelOptionIDKey
+    }
+
+    static func reasoningEffortKey(for runtimeProvider: String) -> String {
+        CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider) == "claude"
+            ? claudeReasoningEffortKey
+            : codexReasoningEffortKey
+    }
+
+    static func storedModelOptionID(
+        for runtimeProvider: String,
+        in defaults: UserDefaults = .standard
+    ) -> String? {
+        defaults.string(forKey: modelOptionIDKey(for: runtimeProvider))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .appServerNilIfEmpty
+    }
+
+    static func storedReasoningEffort(
+        for runtimeProvider: String,
+        in defaults: UserDefaults = .standard
+    ) -> CodexAppServerReasoningEffort? {
+        guard let rawValue = defaults.string(forKey: reasoningEffortKey(for: runtimeProvider)) else {
+            return nil
+        }
+        return CodexAppServerReasoningEffort(rawValue: rawValue)
+    }
+
+    static func resolvedSelection(
+        for runtimeProvider: String,
+        allOptions: [CodexAppServerModelOption],
+        defaults: UserDefaults = .standard
+    ) -> DefaultModelSelection? {
+        let candidates = options(for: runtimeProvider, allOptions: allOptions)
+        let option = storedModelOptionID(for: runtimeProvider, in: defaults)
+            .flatMap { storedID in candidates.first { $0.id == storedID } }
+            ?? ModelReasoningGridCatalog.preferredDefaultOption(
+                runtimeProvider: runtimeProvider,
+                options: candidates
+            )
+        guard let option else {
+            return nil
+        }
+
+        let layout = ModelReasoningGridCatalog.layout(
+            runtimeProvider: runtimeProvider,
+            options: candidates
+        )
+        let visibleEfforts = ModelReasoningGridCatalog.visibleEfforts(
+            for: option,
+            layout: layout
+        )
+        let storedEffort = storedReasoningEffort(for: runtimeProvider, in: defaults)
+            .flatMap { visibleEfforts.contains($0) ? $0 : nil }
+        let effort = storedEffort
+            ?? ModelReasoningGridCatalog.preferredDefaultEffort(
+                runtimeProvider: runtimeProvider,
+                option: option,
+                layout: layout
+            )
+        return DefaultModelSelection(option: option, effort: effort)
+    }
+
+    /// 将本机默认配置转换成 turn/start 可直接使用的显式模型选择。
+    /// 目录中找不到已保存的模型或推理档位时，先解析到当前 runtime 的安全默认项。
+    static func applyDefault(
+        for runtimeProvider: String,
+        allOptions: [CodexAppServerModelOption],
+        defaults: UserDefaults = .standard,
+        to options: inout CodexAppServerTurnOptions
+    ) {
+        guard let selection = resolvedSelection(
+            for: runtimeProvider,
+            allOptions: allOptions,
+            defaults: defaults
+        ) else {
+            options.runtimeProvider = DefaultModelRuntime(rawValue: runtimeProvider)?.payloadRuntimeProvider
+            options.model = nil
+            options.modelProvider = nil
+            options.reasoningEffort = nil
+            options.serviceTier = nil
+            return
+        }
+
+        let layout = ModelReasoningGridCatalog.layout(
+            runtimeProvider: runtimeProvider,
+            options: Self.options(for: runtimeProvider, allOptions: allOptions)
+        )
+        let effort = ModelReasoningGridCatalog.normalizedVisibleEffort(
+            option: selection.option,
+            current: selection.effort,
+            layout: layout
+        )
+        ModelReasoningGridCatalog.applySelection(
+            option: selection.option,
+            effort: effort,
+            preservesServerDefault: false,
+            fallbackRuntimeProvider: DefaultModelRuntime(rawValue: runtimeProvider)?.payloadRuntimeProvider,
+            to: &options
+        )
+        options.serviceTier = nil
+    }
+
+    static func reset(for runtimeProvider: String, in defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: modelOptionIDKey(for: runtimeProvider))
+        defaults.removeObject(forKey: reasoningEffortKey(for: runtimeProvider))
+    }
+}
+
 enum ComposerPermissionMode: String, CaseIterable, Identifiable {
     case requestApproval
     case readOnly

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
@@ -1102,6 +1102,256 @@ struct PreviewBubble: View {
     }
 }
 
+struct DefaultModelSettingsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var sessionStore: SessionStore
+    @EnvironmentObject private var themeStore: ThemeStore
+
+    @AppStorage(DefaultModelPreferences.codexModelOptionIDKey)
+    private var codexModelOptionID = ""
+    @AppStorage(DefaultModelPreferences.codexReasoningEffortKey)
+    private var codexReasoningEffortRawValue = ""
+    @AppStorage(DefaultModelPreferences.claudeModelOptionIDKey)
+    private var claudeModelOptionID = ""
+    @AppStorage(DefaultModelPreferences.claudeReasoningEffortKey)
+    private var claudeReasoningEffortRawValue = ""
+    @State private var runtime: DefaultModelRuntime = .codex
+
+    var body: some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+
+        Form {
+            Section {
+                Picker(L10n.text("ui.runtime"), selection: $runtime) {
+                    Text("Codex").tag(DefaultModelRuntime.codex)
+                    Text("Claude Code").tag(DefaultModelRuntime.claude)
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("settings.defaultModels.runtime")
+            } footer: {
+                Text(L10n.text("ui.default_model_settings_description"))
+            }
+            .listRowBackground(tokens.elevatedSurface)
+
+            Section {
+                Picker(L10n.text("ui.model"), selection: modelSelectionBinding) {
+                    Text(L10n.text("ui.use_built_in_default"))
+                        .tag("")
+                    ForEach(modelOptions) { option in
+                        Text(option.menuTitle)
+                            .tag(option.id)
+                    }
+                }
+                .pickerStyle(.navigationLink)
+                .accessibilityIdentifier("settings.defaultModels.model.\(runtime.rawValue)")
+
+                if availableEfforts.isEmpty {
+                    LabeledContent(L10n.text("ui.reasoning_effort")) {
+                        Text(L10n.text("ui.no_reasoning_effort_available"))
+                            .foregroundStyle(tokens.secondaryText)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    .accessibilityIdentifier(
+                        "settings.defaultModels.reasoning.\(runtime.rawValue).unavailable"
+                    )
+                } else {
+                    Picker(L10n.text("ui.reasoning_effort"), selection: reasoningEffortSelectionBinding) {
+                        ForEach(availableEfforts) { effort in
+                            Text(ModelReasoningGridCatalog.effortTitle(effort))
+                                .tag(effort.rawValue)
+                        }
+                    }
+                    .pickerStyle(.navigationLink)
+                    .accessibilityIdentifier(
+                        "settings.defaultModels.reasoning.\(runtime.rawValue)"
+                    )
+                }
+            } header: {
+                Text(runtimeTitle)
+            } footer: {
+                Text(L10n.format("ui.default_model_current_value", selectedModelTitle))
+            }
+            .listRowBackground(tokens.elevatedSurface)
+
+            Section {
+                Button {
+                    resetCurrentRuntimeDefaults()
+                } label: {
+                    Label(
+                        L10n.text("ui.reset_to_built_in_default"),
+                        systemImage: "arrow.counterclockwise"
+                    )
+                }
+                .foregroundStyle(tokens.warning)
+                .accessibilityIdentifier("settings.defaultModels.reset.\(runtime.rawValue)")
+            } footer: {
+                Text(L10n.text("ui.default_model_reset_description"))
+            }
+            .listRowBackground(tokens.elevatedSurface)
+        }
+        .themedSettingsForm(tokens: tokens)
+        .frame(maxWidth: 720)
+        .frame(maxWidth: .infinity)
+        .background(tokens.background.ignoresSafeArea())
+        .navigationTitle(L10n.text("ui.default_model"))
+        .navigationBarTitleDisplayMode(.inline)
+        .tint(tokens.accent)
+        .onAppear {
+            normalizeStoredEffortIfKnown()
+        }
+        .onChange(of: runtime) { _, _ in
+            normalizeStoredEffortIfKnown()
+        }
+        .onChange(of: sessionStore.appServerModelOptions) { _, _ in
+            normalizeStoredEffortIfKnown()
+        }
+        .task {
+            await sessionStore.refreshAppServerModelOptions()
+            normalizeStoredEffortIfKnown()
+        }
+    }
+
+    private var runtimeTitle: String {
+        switch runtime {
+        case .codex:
+            return "Codex"
+        case .claude:
+            return "Claude Code"
+        }
+    }
+
+    private var modelOptions: [CodexAppServerModelOption] {
+        DefaultModelPreferences.options(
+            for: runtime.rawValue,
+            allOptions: sessionStore.appServerModelOptions
+        )
+    }
+
+    private var selectedModelOption: CodexAppServerModelOption? {
+        if !storedModelOptionID.isEmpty,
+           let storedOption = modelOptions.first(where: { $0.id == storedModelOptionID }) {
+            return storedOption
+        }
+        return DefaultModelPreferences.resolvedSelection(
+            for: runtime.rawValue,
+            allOptions: sessionStore.appServerModelOptions
+        )?.option
+    }
+
+    private var selectedModelTitle: String {
+        selectedModelOption?.menuTitle ?? L10n.text("ui.default_model")
+    }
+
+    private var availableEfforts: [CodexAppServerReasoningEffort] {
+        guard let selectedModelOption else {
+            return []
+        }
+        let layout = ModelReasoningGridCatalog.layout(
+            runtimeProvider: runtime.rawValue,
+            options: modelOptions
+        )
+        return ModelReasoningGridCatalog.visibleEfforts(
+            for: selectedModelOption,
+            layout: layout
+        )
+    }
+
+    private var storedModelOptionID: String {
+        switch runtime {
+        case .codex:
+            return codexModelOptionID
+        case .claude:
+            return claudeModelOptionID
+        }
+    }
+
+    private var storedReasoningEffortRawValue: String {
+        switch runtime {
+        case .codex:
+            return codexReasoningEffortRawValue
+        case .claude:
+            return claudeReasoningEffortRawValue
+        }
+    }
+
+    private func setStoredModelOptionID(_ value: String) {
+        switch runtime {
+        case .codex:
+            codexModelOptionID = value
+        case .claude:
+            claudeModelOptionID = value
+        }
+    }
+
+    private func setStoredReasoningEffortRawValue(_ value: String) {
+        switch runtime {
+        case .codex:
+            codexReasoningEffortRawValue = value
+        case .claude:
+            claudeReasoningEffortRawValue = value
+        }
+    }
+
+    private var modelSelectionBinding: Binding<String> {
+        Binding(
+            get: {
+                guard !storedModelOptionID.isEmpty,
+                      modelOptions.contains(where: { $0.id == storedModelOptionID })
+                else {
+                    return ""
+                }
+                return storedModelOptionID
+            },
+            set: { newValue in
+                setStoredModelOptionID(newValue)
+                normalizeStoredEffortIfKnown()
+            }
+        )
+    }
+
+    private var reasoningEffortSelectionBinding: Binding<String> {
+        Binding(
+            get: {
+                if let storedEffort = CodexAppServerReasoningEffort(rawValue: storedReasoningEffortRawValue),
+                   availableEfforts.contains(storedEffort) {
+                    return storedEffort.rawValue
+                }
+                let layout = ModelReasoningGridCatalog.layout(
+                    runtimeProvider: runtime.rawValue,
+                    options: modelOptions
+                )
+                return ModelReasoningGridCatalog.preferredDefaultEffort(
+                    runtimeProvider: runtime.rawValue,
+                    option: selectedModelOption,
+                    layout: layout
+                )?.rawValue ?? availableEfforts.first?.rawValue ?? ""
+            },
+            set: { setStoredReasoningEffortRawValue($0) }
+        )
+    }
+
+    private func normalizeStoredEffortIfKnown() {
+        // 模型目录为空时可能暂时只显示内置兜底；保留未知的历史模型与档位，
+        // 等 model/list 返回 canonical id 后再恢复，避免网络短暂失败覆盖用户配置。
+        guard storedModelOptionID.isEmpty
+            || modelOptions.contains(where: { $0.id == storedModelOptionID })
+        else {
+            return
+        }
+        guard let storedEffort = CodexAppServerReasoningEffort(rawValue: storedReasoningEffortRawValue) else {
+            return
+        }
+        if !availableEfforts.contains(storedEffort) {
+            setStoredReasoningEffortRawValue("")
+        }
+    }
+
+    private func resetCurrentRuntimeDefaults() {
+        setStoredModelOptionID("")
+        setStoredReasoningEffortRawValue("")
+    }
+}
+
 extension View {
     func themedSettingsForm(tokens: ThemeTokens) -> some View {
         scrollContentBackground(.hidden)

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
@@ -1107,87 +1107,23 @@ struct DefaultModelSettingsView: View {
     @EnvironmentObject private var sessionStore: SessionStore
     @EnvironmentObject private var themeStore: ThemeStore
 
-    @AppStorage(DefaultModelPreferences.codexModelOptionIDKey)
-    private var codexModelOptionID = ""
-    @AppStorage(DefaultModelPreferences.codexReasoningEffortKey)
-    private var codexReasoningEffortRawValue = ""
-    @AppStorage(DefaultModelPreferences.claudeModelOptionIDKey)
-    private var claudeModelOptionID = ""
-    @AppStorage(DefaultModelPreferences.claudeReasoningEffortKey)
-    private var claudeReasoningEffortRawValue = ""
-    @State private var runtime: DefaultModelRuntime = .codex
-
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
+        let runtimes = DefaultModelRuntime.allCases
 
         Form {
-            Section {
-                Picker(L10n.text("ui.runtime"), selection: $runtime) {
-                    Text("Codex").tag(DefaultModelRuntime.codex)
-                    Text("Claude Code").tag(DefaultModelRuntime.claude)
-                }
-                .pickerStyle(.segmented)
-                .accessibilityIdentifier("settings.defaultModels.runtime")
-            } footer: {
-                Text(L10n.text("ui.default_model_settings_description"))
+            // 两个 runtime 各自一段，不再用分段控件互相遮挡：
+            // 这一页要回答的是「现在两边分别是什么」，切换器会把一半答案藏起来。
+            ForEach(runtimes) { runtime in
+                DefaultModelRuntimeSection(
+                    runtime: runtime,
+                    allOptions: sessionStore.appServerModelOptions,
+                    tokens: tokens,
+                    footer: runtime == runtimes.last
+                        ? L10n.text("ui.default_model_settings_description")
+                        : nil
+                )
             }
-            .listRowBackground(tokens.elevatedSurface)
-
-            Section {
-                Picker(L10n.text("ui.model"), selection: modelSelectionBinding) {
-                    Text(L10n.text("ui.use_built_in_default"))
-                        .tag("")
-                    ForEach(modelOptions) { option in
-                        Text(option.menuTitle)
-                            .tag(option.id)
-                    }
-                }
-                .pickerStyle(.navigationLink)
-                .accessibilityIdentifier("settings.defaultModels.model.\(runtime.rawValue)")
-
-                if availableEfforts.isEmpty {
-                    LabeledContent(L10n.text("ui.reasoning_effort")) {
-                        Text(L10n.text("ui.no_reasoning_effort_available"))
-                            .foregroundStyle(tokens.secondaryText)
-                            .multilineTextAlignment(.trailing)
-                    }
-                    .accessibilityIdentifier(
-                        "settings.defaultModels.reasoning.\(runtime.rawValue).unavailable"
-                    )
-                } else {
-                    Picker(L10n.text("ui.reasoning_effort"), selection: reasoningEffortSelectionBinding) {
-                        ForEach(availableEfforts) { effort in
-                            Text(ModelReasoningGridCatalog.effortTitle(effort))
-                                .tag(effort.rawValue)
-                        }
-                    }
-                    .pickerStyle(.navigationLink)
-                    .accessibilityIdentifier(
-                        "settings.defaultModels.reasoning.\(runtime.rawValue)"
-                    )
-                }
-            } header: {
-                Text(runtimeTitle)
-            } footer: {
-                Text(L10n.format("ui.default_model_current_value", selectedModelTitle))
-            }
-            .listRowBackground(tokens.elevatedSurface)
-
-            Section {
-                Button {
-                    resetCurrentRuntimeDefaults()
-                } label: {
-                    Label(
-                        L10n.text("ui.reset_to_built_in_default"),
-                        systemImage: "arrow.counterclockwise"
-                    )
-                }
-                .foregroundStyle(tokens.warning)
-                .accessibilityIdentifier("settings.defaultModels.reset.\(runtime.rawValue)")
-            } footer: {
-                Text(L10n.text("ui.default_model_reset_description"))
-            }
-            .listRowBackground(tokens.elevatedSurface)
         }
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
@@ -1197,49 +1133,159 @@ struct DefaultModelSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .tint(tokens.accent)
         .onAppear {
-            normalizeStoredEffortIfKnown()
-        }
-        .onChange(of: runtime) { _, _ in
-            normalizeStoredEffortIfKnown()
+            normalizeStoredEfforts()
         }
         .onChange(of: sessionStore.appServerModelOptions) { _, _ in
-            normalizeStoredEffortIfKnown()
+            normalizeStoredEfforts()
         }
         .task {
             await sessionStore.refreshAppServerModelOptions()
-            normalizeStoredEffortIfKnown()
+            normalizeStoredEfforts()
         }
     }
 
-    private var runtimeTitle: String {
-        switch runtime {
-        case .codex:
-            return "Codex"
-        case .claude:
-            return "Claude Code"
+    private func normalizeStoredEfforts() {
+        for runtime in DefaultModelRuntime.allCases {
+            normalizeStoredEffort(for: runtime)
         }
     }
 
-    private var modelOptions: [CodexAppServerModelOption] {
-        DefaultModelPreferences.options(
+    private func normalizeStoredEffort(for runtime: DefaultModelRuntime) {
+        // 模型目录为空时可能暂时只显示内置兜底；保留未知的历史模型与档位，
+        // 等 model/list 返回 canonical id 后再恢复，避免网络短暂失败覆盖用户配置。
+        let allOptions = sessionStore.appServerModelOptions
+        let candidates = DefaultModelPreferences.options(
             for: runtime.rawValue,
-            allOptions: sessionStore.appServerModelOptions
+            allOptions: allOptions
+        )
+        let storedID = DefaultModelPreferences.storedModelOptionID(for: runtime.rawValue)
+        guard storedID == nil || candidates.contains(where: { $0.id == storedID }) else {
+            return
+        }
+        guard let storedEffort = DefaultModelPreferences.storedReasoningEffort(for: runtime.rawValue),
+              let option = DefaultModelPreferences.resolvedSelection(
+                  for: runtime.rawValue,
+                  allOptions: allOptions
+              )?.option
+        else {
+            return
+        }
+        let layout = ModelReasoningGridCatalog.layout(
+            runtimeProvider: runtime.rawValue,
+            options: candidates
+        )
+        let visibleEfforts = ModelReasoningGridCatalog.visibleEfforts(for: option, layout: layout)
+        if !visibleEfforts.contains(storedEffort) {
+            UserDefaults.standard.removeObject(
+                forKey: DefaultModelPreferences.reasoningEffortKey(for: runtime.rawValue)
+            )
+        }
+    }
+}
+
+private struct DefaultModelRuntimeSection: View {
+    let runtime: DefaultModelRuntime
+    let allOptions: [CodexAppServerModelOption]
+    let tokens: ThemeTokens
+    let footer: String?
+
+    @AppStorage private var modelOptionID: String
+    @AppStorage private var reasoningEffortRawValue: String
+
+    init(
+        runtime: DefaultModelRuntime,
+        allOptions: [CodexAppServerModelOption],
+        tokens: ThemeTokens,
+        footer: String?
+    ) {
+        self.runtime = runtime
+        self.allOptions = allOptions
+        self.tokens = tokens
+        self.footer = footer
+        _modelOptionID = AppStorage(
+            wrappedValue: "",
+            DefaultModelPreferences.modelOptionIDKey(for: runtime.rawValue)
+        )
+        _reasoningEffortRawValue = AppStorage(
+            wrappedValue: "",
+            DefaultModelPreferences.reasoningEffortKey(for: runtime.rawValue)
         )
     }
 
+    var body: some View {
+        Section {
+            Picker(L10n.text("ui.model"), selection: modelSelectionBinding) {
+                Text(L10n.text("ui.use_built_in_default"))
+                    .tag("")
+                ForEach(modelOptions) { option in
+                    Text(option.menuTitle)
+                        .tag(option.id)
+                }
+            }
+            .pickerStyle(.navigationLink)
+            .accessibilityIdentifier("settings.defaultModels.model.\(runtime.rawValue)")
+
+            if availableEfforts.isEmpty {
+                LabeledContent(L10n.text("ui.reasoning_effort")) {
+                    Text(L10n.text("ui.no_reasoning_effort_available"))
+                        .foregroundStyle(tokens.secondaryText)
+                        .multilineTextAlignment(.trailing)
+                }
+                .accessibilityIdentifier(
+                    "settings.defaultModels.reasoning.\(runtime.rawValue).unavailable"
+                )
+            } else {
+                Picker(L10n.text("ui.reasoning_effort"), selection: reasoningEffortSelectionBinding) {
+                    ForEach(availableEfforts) { effort in
+                        Text(ModelReasoningGridCatalog.effortTitle(effort))
+                            .tag(effort.rawValue)
+                    }
+                }
+                .pickerStyle(.navigationLink)
+                .accessibilityIdentifier("settings.defaultModels.reasoning.\(runtime.rawValue)")
+            }
+
+            // 没改过就没什么可恢复的，常驻一个红字按钮只是噪音。
+            if hasCustomDefault {
+                Button {
+                    modelOptionID = ""
+                    reasoningEffortRawValue = ""
+                } label: {
+                    Label(
+                        L10n.text("ui.reset_to_built_in_default"),
+                        systemImage: "arrow.counterclockwise"
+                    )
+                }
+                .foregroundStyle(tokens.warning)
+                .accessibilityIdentifier("settings.defaultModels.reset.\(runtime.rawValue)")
+            }
+        } header: {
+            Text(runtime.settingsTitle)
+        } footer: {
+            if let footer {
+                Text(footer)
+            }
+        }
+        .listRowBackground(tokens.elevatedSurface)
+    }
+
+    private var hasCustomDefault: Bool {
+        !modelOptionID.isEmpty || !reasoningEffortRawValue.isEmpty
+    }
+
+    private var modelOptions: [CodexAppServerModelOption] {
+        DefaultModelPreferences.options(for: runtime.rawValue, allOptions: allOptions)
+    }
+
     private var selectedModelOption: CodexAppServerModelOption? {
-        if !storedModelOptionID.isEmpty,
-           let storedOption = modelOptions.first(where: { $0.id == storedModelOptionID }) {
+        if !modelOptionID.isEmpty,
+           let storedOption = modelOptions.first(where: { $0.id == modelOptionID }) {
             return storedOption
         }
         return DefaultModelPreferences.resolvedSelection(
             for: runtime.rawValue,
-            allOptions: sessionStore.appServerModelOptions
+            allOptions: allOptions
         )?.option
-    }
-
-    private var selectedModelTitle: String {
-        selectedModelOption?.menuTitle ?? L10n.text("ui.default_model")
     }
 
     private var availableEfforts: [CodexAppServerReasoningEffort] {
@@ -1250,61 +1296,26 @@ struct DefaultModelSettingsView: View {
             runtimeProvider: runtime.rawValue,
             options: modelOptions
         )
-        return ModelReasoningGridCatalog.visibleEfforts(
-            for: selectedModelOption,
-            layout: layout
-        )
-    }
-
-    private var storedModelOptionID: String {
-        switch runtime {
-        case .codex:
-            return codexModelOptionID
-        case .claude:
-            return claudeModelOptionID
-        }
-    }
-
-    private var storedReasoningEffortRawValue: String {
-        switch runtime {
-        case .codex:
-            return codexReasoningEffortRawValue
-        case .claude:
-            return claudeReasoningEffortRawValue
-        }
-    }
-
-    private func setStoredModelOptionID(_ value: String) {
-        switch runtime {
-        case .codex:
-            codexModelOptionID = value
-        case .claude:
-            claudeModelOptionID = value
-        }
-    }
-
-    private func setStoredReasoningEffortRawValue(_ value: String) {
-        switch runtime {
-        case .codex:
-            codexReasoningEffortRawValue = value
-        case .claude:
-            claudeReasoningEffortRawValue = value
-        }
+        return ModelReasoningGridCatalog.visibleEfforts(for: selectedModelOption, layout: layout)
     }
 
     private var modelSelectionBinding: Binding<String> {
         Binding(
             get: {
-                guard !storedModelOptionID.isEmpty,
-                      modelOptions.contains(where: { $0.id == storedModelOptionID })
+                guard !modelOptionID.isEmpty,
+                      modelOptions.contains(where: { $0.id == modelOptionID })
                 else {
                     return ""
                 }
-                return storedModelOptionID
+                return modelOptionID
             },
             set: { newValue in
-                setStoredModelOptionID(newValue)
-                normalizeStoredEffortIfKnown()
+                modelOptionID = newValue
+                // 换模型后旧档位可能不在新模型的可见档位里，交给页面级归一化清掉。
+                if let storedEffort = CodexAppServerReasoningEffort(rawValue: reasoningEffortRawValue),
+                   !availableEfforts.contains(storedEffort) {
+                    reasoningEffortRawValue = ""
+                }
             }
         )
     }
@@ -1312,7 +1323,7 @@ struct DefaultModelSettingsView: View {
     private var reasoningEffortSelectionBinding: Binding<String> {
         Binding(
             get: {
-                if let storedEffort = CodexAppServerReasoningEffort(rawValue: storedReasoningEffortRawValue),
+                if let storedEffort = CodexAppServerReasoningEffort(rawValue: reasoningEffortRawValue),
                    availableEfforts.contains(storedEffort) {
                     return storedEffort.rawValue
                 }
@@ -1326,29 +1337,19 @@ struct DefaultModelSettingsView: View {
                     layout: layout
                 )?.rawValue ?? availableEfforts.first?.rawValue ?? ""
             },
-            set: { setStoredReasoningEffortRawValue($0) }
+            set: { reasoningEffortRawValue = $0 }
         )
     }
+}
 
-    private func normalizeStoredEffortIfKnown() {
-        // 模型目录为空时可能暂时只显示内置兜底；保留未知的历史模型与档位，
-        // 等 model/list 返回 canonical id 后再恢复，避免网络短暂失败覆盖用户配置。
-        guard storedModelOptionID.isEmpty
-            || modelOptions.contains(where: { $0.id == storedModelOptionID })
-        else {
-            return
+private extension DefaultModelRuntime {
+    var settingsTitle: String {
+        switch self {
+        case .codex:
+            return "Codex"
+        case .claude:
+            return "Claude Code"
         }
-        guard let storedEffort = CodexAppServerReasoningEffort(rawValue: storedReasoningEffortRawValue) else {
-            return
-        }
-        if !availableEfforts.contains(storedEffort) {
-            setStoredReasoningEffortRawValue("")
-        }
-    }
-
-    private func resetCurrentRuntimeDefaults() {
-        setStoredModelOptionID("")
-        setStoredReasoningEffortRawValue("")
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -323,6 +323,18 @@ struct SettingsView: View {
                 .settingsStandardListRow()
                 .accessibilityIdentifier("settings.language")
 
+                NavigationLink {
+                    DefaultModelSettingsView()
+                } label: {
+                    SettingsValueLabel(
+                        title: L10n.text("ui.default_model"),
+                        value: defaultModelSettingsSummary,
+                        systemImage: "cpu"
+                    )
+                }
+                .settingsStandardListRow()
+                .accessibilityIdentifier("settings.defaultModels")
+
                 // 四个模式各自有 detail，而且是安全相关的选择：值得整页逐条读完再选。
                 SettingsChoiceRow(
                     title: L10n.text("ui.default_permissions"),
@@ -528,6 +540,27 @@ struct SettingsView: View {
         Binding(
             get: { ComposerPermissionMode.stored(defaultPermissionModeID) },
             set: { defaultPermissionModeID = $0.rawValue }
+        )
+    }
+
+    private var defaultModelSettingsSummary: String {
+        let options = sessionStore.appServerModelOptions
+        let codex = DefaultModelPreferences.resolvedSelection(
+            for: DefaultModelRuntime.codex.rawValue,
+            allOptions: options
+        )
+        let claude = DefaultModelPreferences.resolvedSelection(
+            for: DefaultModelRuntime.claude.rawValue,
+            allOptions: options
+        )
+        return L10n.format(
+            "ui.default_model_summary",
+            codex?.option.title ?? L10n.text("ui.default_model"),
+            codex.map { ModelReasoningGridCatalog.effortTitle($0.effort ?? .medium) }
+                ?? L10n.text("ui.default_option"),
+            claude?.option.title ?? L10n.text("ui.default_model"),
+            claude.map { ModelReasoningGridCatalog.effortTitle($0.effort ?? .medium) }
+                ?? L10n.text("ui.default_option")
         )
     }
 }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -326,9 +326,10 @@ struct SettingsView: View {
                 NavigationLink {
                     DefaultModelSettingsView()
                 } label: {
+                    // 两个 runtime 的模型 + 档位拼在一行会被截断成一串噪音，
+                    // 详情页已经把它们平铺开了，这里只做入口。
                     SettingsValueLabel(
                         title: L10n.text("ui.default_model"),
-                        value: defaultModelSettingsSummary,
                         systemImage: "cpu"
                     )
                 }
@@ -540,27 +541,6 @@ struct SettingsView: View {
         Binding(
             get: { ComposerPermissionMode.stored(defaultPermissionModeID) },
             set: { defaultPermissionModeID = $0.rawValue }
-        )
-    }
-
-    private var defaultModelSettingsSummary: String {
-        let options = sessionStore.appServerModelOptions
-        let codex = DefaultModelPreferences.resolvedSelection(
-            for: DefaultModelRuntime.codex.rawValue,
-            allOptions: options
-        )
-        let claude = DefaultModelPreferences.resolvedSelection(
-            for: DefaultModelRuntime.claude.rawValue,
-            allOptions: options
-        )
-        return L10n.format(
-            "ui.default_model_summary",
-            codex?.option.title ?? L10n.text("ui.default_model"),
-            codex.map { ModelReasoningGridCatalog.effortTitle($0.effort ?? .medium) }
-                ?? L10n.text("ui.default_option"),
-            claude?.option.title ?? L10n.text("ui.default_model"),
-            claude.map { ModelReasoningGridCatalog.effortTitle($0.effort ?? .medium) }
-                ?? L10n.text("ui.default_option")
         )
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -3118,6 +3118,98 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertEqual(restored.serviceTier, "priority")
     }
 
+    func testDefaultModelPreferencesKeepCodexAndClaudeIndependent() throws {
+        let suiteName = "DefaultModelPreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let options = CodexAppServerModelOption.builtInFallback
+            + CodexAppServerModelOption.builtInClaudeFallback
+        let luna = try XCTUnwrap(
+            options.first { $0.model == "gpt-5.6-luna" }
+        )
+        let opus = try XCTUnwrap(
+            options.first { $0.model == "opus" }
+        )
+        defaults.set(luna.id, forKey: DefaultModelPreferences.codexModelOptionIDKey)
+        defaults.set(CodexAppServerReasoningEffort.max.rawValue, forKey: DefaultModelPreferences.codexReasoningEffortKey)
+        defaults.set(opus.id, forKey: DefaultModelPreferences.claudeModelOptionIDKey)
+        defaults.set(CodexAppServerReasoningEffort.xhigh.rawValue, forKey: DefaultModelPreferences.claudeReasoningEffortKey)
+
+        let codex = try XCTUnwrap(
+            DefaultModelPreferences.resolvedSelection(
+                for: DefaultModelRuntime.codex.rawValue,
+                allOptions: options,
+                defaults: defaults
+            )
+        )
+        let claude = try XCTUnwrap(
+            DefaultModelPreferences.resolvedSelection(
+                for: DefaultModelRuntime.claude.rawValue,
+                allOptions: options,
+                defaults: defaults
+            )
+        )
+
+        XCTAssertEqual(codex.option.model, "gpt-5.6-luna")
+        XCTAssertEqual(codex.effort, .max)
+        XCTAssertEqual(claude.option.model, "opus")
+        XCTAssertEqual(claude.effort, .xhigh)
+
+        var codexTurnOptions = CodexAppServerTurnOptions.default
+        DefaultModelPreferences.applyDefault(
+            for: DefaultModelRuntime.codex.rawValue,
+            allOptions: options,
+            defaults: defaults,
+            to: &codexTurnOptions
+        )
+        XCTAssertEqual(codexTurnOptions.model, "gpt-5.6-luna")
+        XCTAssertEqual(codexTurnOptions.reasoningEffort, .max)
+        XCTAssertNil(codexTurnOptions.runtimeProvider)
+
+        var claudeTurnOptions = CodexAppServerTurnOptions.default
+        DefaultModelPreferences.applyDefault(
+            for: DefaultModelRuntime.claude.rawValue,
+            allOptions: options,
+            defaults: defaults,
+            to: &claudeTurnOptions
+        )
+        XCTAssertEqual(claudeTurnOptions.model, "opus")
+        XCTAssertEqual(claudeTurnOptions.modelProvider, "anthropic")
+        XCTAssertEqual(claudeTurnOptions.reasoningEffort, .xhigh)
+        XCTAssertEqual(claudeTurnOptions.runtimeProvider, "claude")
+    }
+
+    func testDefaultModelPreferencesFallBackWhenStoredSelectionIsUnavailable() throws {
+        let suiteName = "DefaultModelPreferencesFallbackTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("removed-model", forKey: DefaultModelPreferences.codexModelOptionIDKey)
+        defaults.set(CodexAppServerReasoningEffort.ultra.rawValue, forKey: DefaultModelPreferences.codexReasoningEffortKey)
+
+        let selection = try XCTUnwrap(
+            DefaultModelPreferences.resolvedSelection(
+                for: DefaultModelRuntime.codex.rawValue,
+                allOptions: [CodexAppServerModelOption.builtInFallback[2]],
+                defaults: defaults
+            )
+        )
+
+        XCTAssertEqual(selection.option.model, "gpt-5.6-luna")
+        XCTAssertEqual(selection.effort, .xhigh)
+
+        var turnOptions = CodexAppServerTurnOptions.default
+        DefaultModelPreferences.applyDefault(
+            for: DefaultModelRuntime.codex.rawValue,
+            allOptions: [CodexAppServerModelOption.builtInFallback[2]],
+            defaults: defaults,
+            to: &turnOptions
+        )
+        XCTAssertEqual(turnOptions.model, "gpt-5.6-luna")
+        XCTAssertEqual(turnOptions.reasoningEffort, .xhigh)
+    }
+
     func testComposerDraftCacheKeepsDraftsScopedToSessionOrNewProject() {
         let sessionScope = ComposerDraftScopeKey.current(selectedSessionID: "thread-a", selectedProjectID: "project-1")
         let newProjectScope = ComposerDraftScopeKey.current(selectedSessionID: nil, selectedProjectID: "project-1")


### PR DESCRIPTION
## 变更内容

- 在设置中新增“默认模型”入口，并按 Codex / Claude Code 提供独立 Tab 配置。
- 支持分别保存默认模型和推理强度，并在新会话创建时自动应用对应运行时配置。
- 当保存的模型不在当前可用模型列表中时，自动回退到当前运行时的内置默认配置。
- 增加本地化文案和数据流单测。

## 背景

目前 Codex 和 Claude 的默认模型、推理强度由代码中的默认值决定，无法针对不同运行时分别调整。本 PR 将这组偏好下沉到设置，并保持已有显式会话选择优先级。

## 验证

- ✅ `IOS_TARGET_MODE=simulator IOS_SIMULATOR_ID=E3061D53-567E-4FE9-AE33-BA252045EE3B bash ./scripts/ios-dev.sh build`
- ✅ 定向单测 3/3：独立保存与应用、不可用配置回退、创建会话前运行时解析。
- ✅ 已在 iPad Pro 13-inch (M5) Simulator 检查设置入口、Codex / Claude Code Tab、模型与推理强度选择及重置行为。
- ✅ `git diff --cached --check`

## 测试备注

此前对包含本功能的工作区执行过全量测试：1268 tests，4 skipped；3 个既有 snapshot case 失败，本 PR 未更新这些 snapshot：

- `ConversationSnapshotTests.testEmptyConversationState`
- `ConversationSnapshotTests.testExpandedGoalTrayDarkMaterialSeparatesBackdropContent`
- `SkillModelPickerSnapshotTests.testSkillInvocationCardLightAppearance`

## 关联问题

- Linear: MIM-119
