### PR TITLE
MIM-115 消除会话页底部横向色差

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
@@ -121,6 +121,9 @@ struct ConversationTimelineView: View {
                 .scrollContentBackground(.hidden)
                 .scrollDismissesKeyboard(.interactively)
                 .background(tokens.background)
+                // Composer 是唯一的底部功能材质；时间线只在它后方留一层柔和渐隐，
+                // 不再在输入区外侧切出一整块与页面不同的底色。
+                .workbenchSoftBottomScrollEdge()
                 .simultaneousGesture(TapGesture().onEnded {
                     KeyboardDismissal.dismiss()
                 })

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -474,6 +474,7 @@ struct SessionListView: View {
         .listRowSpacing(0)
         .scrollContentBackground(.hidden)
         .background(tokens.background.ignoresSafeArea())
+        .workbenchSoftBottomScrollEdge()
         .contentMargins(.bottom, bottomContentMargin, for: .scrollContent)
         .focusable()
         .focused($hasListKeyboardFocus)

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -260,15 +260,8 @@ struct UnifiedWorkbenchShell: View {
             }
             .tag(CompactWorkbenchTab.me)
         }
-        // 原生 Tab 保留系统交互，并用更厚的材质遮住其后的列表文字；关闭透明度时退成等尺寸实色。
-        // 不再叠加全宽渐变：它会在浮动栏外形成水平色带，并在详情页隐藏 Tab Bar 后继续覆盖 Composer。
-        .toolbarBackground(
-            reduceTransparency
-                ? AnyShapeStyle(tokens.elevatedSurface)
-                : AnyShapeStyle(.ultraThickMaterial),
-            for: .tabBar
-        )
-        .toolbarBackground(.visible, for: .tabBar)
+        // 原生 Tab 保留系统交互；材质按系统版本交给 Chrome 层，页面只负责保持背景连续。
+        .compactTabBarChrome(tokens: tokens, reduceTransparency: reduceTransparency)
         .environment(\.workbenchBottomChromeClearance, bottomChromeClearance)
         .environment(\.workbenchHasCompactTabBar, true)
         .themedWorkbenchNavigationChrome(

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -560,6 +560,26 @@ extension View {
         toolbarBackground(tokens.background, for: .navigationBar)
             .toolbarColorScheme(colorScheme, for: .navigationBar)
     }
+
+    /// iOS 26 的 Tab Bar 已经是自带玻璃的浮动胶囊，本身就会模糊身后的内容。此时再强制一层
+    /// 可见的 toolbar 背景，等于把旧版整条实心栏重新画回浮动栏后方：顶层列表底部会出现一条
+    /// 横贯全宽的明度断层，详情页隐藏 Tab Bar 后它还会继续留在 Composer 后方。
+    /// 26 起交给系统绘制，页面背景一路连续到安全区底部；
+    /// iOS 18–25 的 Tab Bar 本来就是整条栏，仍用更厚的材质遮住其后的列表文字。
+    @ViewBuilder
+    func compactTabBarChrome(tokens: ThemeTokens, reduceTransparency: Bool) -> some View {
+        if #available(iOS 26.0, *) {
+            self
+        } else {
+            toolbarBackground(
+                reduceTransparency
+                    ? AnyShapeStyle(tokens.elevatedSurface)
+                    : AnyShapeStyle(.ultraThickMaterial),
+                for: .tabBar
+            )
+            .toolbarBackground(.visible, for: .tabBar)
+        }
+    }
 }
 
 extension ConnectionStatus {
@@ -707,6 +727,17 @@ extension View {
         )
         .background { WorkbenchChromeMaterial(shape: Circle(), tokens: tokens) }
         .contentShape(Circle())
+    }
+
+    /// 底部滚动边缘统一使用柔和渐隐：内容经过浮动 Tab Bar 或 Composer 后方时只有渐变模糊，
+    /// 不会像 `hard` 那样切出一条横贯全宽的边界线。iOS 26 之前没有该效果，保持原样。
+    @ViewBuilder
+    func workbenchSoftBottomScrollEdge() -> some View {
+        if #available(iOS 26.0, *) {
+            scrollEdgeEffectStyle(.soft, for: .bottom)
+        } else {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
iOS 26 的 Tab Bar 已经是自带玻璃的浮动胶囊，再对 .tabBar 强制
.toolbarBackground(.visible) 等于把旧版整条实心栏画回浮动栏后方：
会话列表底部出现一条横贯全宽的明暗断层，详情页隐藏 Tab Bar 后它
还会继续留在 Composer 后方。

- 新增 compactTabBarChrome：iOS 26+ 交给系统绘制，页面背景一路 连续到安全区底部；iOS 18-25 的整条 Tab Bar 保留原来的 ultraThickMaterial 与 Reduce Transparency 实色降级。
- 新增 workbenchSoftBottomScrollEdge：会话列表与会话时间线显式 使用 .soft 底部滚动边缘，避免 automatic 落到 hard 切出硬边。

Composer 自身材质、圆角与阴影不变；左上角新建入口在 b37a2ea7 已
是纯图标，本次未改动。

未做运行态验证：当前环境无法访问 CoreSimulatorService，xcodebuild
与 simctl 均不可用，仅通过 swiftc -parse 与仓库静态门禁。