### PR TITLE
MIM-122: 让 iPad 会话输入框可收起为单行

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -208,13 +208,29 @@ extension ComposerView {
     // 宽屏设备直接平铺发送上下文。横向滚动只为大字号与极窄分屏兜底，
     // 不改变“无需先点开开关即可操作”的默认形态。
     var composerContextControlsRow: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: 8) {
-                skillPickerButton
-                permissionMenu
+        HStack(spacing: 8) {
+            ScrollView(.horizontal) {
+                HStack(spacing: 8) {
+                    skillPickerButton
+                    permissionMenu
+                }
+            }
+            .scrollIndicators(.hidden)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if canCollapseIPadComposer {
+                Button(action: collapseIPadComposer) {
+                    Image(systemName: "chevron.down")
+                        .font(themeStore.uiFont(.caption, weight: .bold))
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                        .accessibilityHidden(true)
+                }
+                .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
+                .accessibilityLabel(L10n.text("ui.collapse_input_box"))
+                .accessibilityIdentifier("composer.collapse")
             }
         }
-        .scrollIndicators(.hidden)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -224,6 +240,14 @@ extension ComposerView {
 
     var isPhoneComposer: Bool {
         UIDevice.current.userInterfaceIdiom == .phone
+    }
+
+    var isIPadComposer: Bool {
+#if targetEnvironment(macCatalyst)
+        false
+#else
+        UIDevice.current.userInterfaceIdiom == .pad
+#endif
     }
 
     var canCollapsePhoneComposer: Bool {
@@ -237,18 +261,43 @@ extension ComposerView {
             activeSkillQuery == nil
     }
 
-    var usesCollapsedPhoneComposer: Bool {
-        isPhoneComposerCollapsed && canCollapsePhoneComposer
+    /// iPad 可保留附件并收起；正在录音、转写、等待语音确认或 Skill 自动完成时，
+    /// 必须继续展示完整编辑器，避免移除 UITextView 破坏进行中的输入上下文。
+    var canCollapseIPadComposer: Bool {
+        isIPadComposer &&
+            !composerState.voiceDraftNeedsReview &&
+            !isVoicePressActive &&
+            !voiceInput.isPreparing &&
+            !voiceInput.isRecording &&
+            !isVoiceTranscribing &&
+            activeSkillQuery == nil
     }
 
-    var collapsedPhoneComposerText: String {
+    var usesCollapsedPhoneComposer: Bool {
+        isComposerCollapsed && canCollapsePhoneComposer
+    }
+
+    var usesCollapsedIPadComposer: Bool {
+        isComposerCollapsed && canCollapseIPadComposer
+    }
+
+    var collapsedComposerText: String {
         let text = composerState.draft.trimmingCharacters(in: .whitespacesAndNewlines)
         return text.isEmpty ? composerPlaceholderText : text
     }
 
     func expandPhoneComposer() {
         guard isPhoneComposer else { return }
-        isPhoneComposerCollapsed = false
+        expandComposer()
+    }
+
+    func expandIPadComposer() {
+        guard isIPadComposer else { return }
+        expandComposer()
+    }
+
+    func expandComposer() {
+        isComposerCollapsed = false
         // 焦点请求只服务于这一次“点开输入框”；UITextView 消费后会清空 token，
         // 后续因附件或语音状态重建完整输入框时不会再次误弹键盘。
         composerTextFocusRequestID = UUID()
@@ -256,12 +305,21 @@ extension ComposerView {
 
     func collapsePhoneComposer() {
         guard canCollapsePhoneComposer else { return }
+        collapseComposer()
+    }
+
+    func collapseIPadComposer() {
+        guard canCollapseIPadComposer else { return }
+        collapseComposer()
+    }
+
+    func collapseComposer() {
         // 先让输入法提交 marked text，再把最终文本同步回草稿；折叠只改变展示，不丢编辑状态。
         composerTextSubmitBridge.resignFirstResponder()
         synchronizeComposerTextBeforeDraftScopeChange()
         composerTextSubmitBridge.prepareForRemoval(text: composerState.draft)
         activeSkillQuery = nil
-        isPhoneComposerCollapsed = true
+        isComposerCollapsed = true
     }
 
     func collapsePhoneComposerAfterSubmit() {
@@ -270,7 +328,7 @@ extension ComposerView {
         composerTextExternalRevision += 1
         composerTextSubmitBridge.prepareForRemoval(text: composerState.draft)
         activeSkillQuery = nil
-        isPhoneComposerCollapsed = true
+        isComposerCollapsed = true
     }
 
     @ViewBuilder

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -234,6 +234,44 @@ extension ComposerView {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    /// iPad 收起态是独立的一行卡片，不保留 iPad 完整 Composer 的工具栏。
+    /// 附件条位于外层 `body`，因此这里仅替换输入卡本身，不会清理附件状态。
+    func collapsedIPadComposerCard(tokens: ThemeTokens) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
+
+        return Button(action: expandIPadComposer) {
+            HStack(spacing: 8) {
+                Text(collapsedComposerText)
+                    .font(themeStore.uiFont(.body))
+                    .foregroundStyle(composerState.draft.isEmpty ? tokens.tertiaryText : tokens.primaryText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.up")
+                    .font(themeStore.uiFont(.caption2, weight: .bold))
+                    .foregroundStyle(tokens.tertiaryText)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
+        .padding(8)
+        .frame(maxWidth: .infinity)
+        .background {
+            composerContainerBackground(shape: shape, tokens: tokens)
+        }
+        .overlay {
+            shape.strokeBorder(composerCardBorderColor(tokens), lineWidth: composerCardBorderWidth)
+        }
+        .tint(tokens.accent)
+        .accessibilityLabel(L10n.text("ui.expand_input_box"))
+        .accessibilityValue(collapsedComposerText)
+        .accessibilityIdentifier("composer.expand")
+    }
+
     var selectedVoiceInputProvider: VoiceInputProvider {
         VoiceInputProvider.resolved(rawValue: voiceInputProviderRawValue)
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -55,7 +55,8 @@ struct ComposerView: View {
     @State var isComposerTextComposing = false
     @State var composerTextSubmitBridge = ComposerTextSubmitBridge()
     @State var composerTextFocusRequestID: UUID?
-    @State var isPhoneComposerCollapsed: Bool
+    // iPhone 默认收起；iPad 默认保持展开，只有用户点击收起按钮才会置为 true。
+    @State var isComposerCollapsed: Bool
     @State var activeSkillQuery: ComposerSkillQuery?
     @State var selectedSkillSuggestionIndex = 0
     @AppStorage("agentd.developerMode") var developerModeEnabled = false
@@ -68,11 +69,17 @@ struct ComposerView: View {
 
     var availableWidth: CGFloat?
 
-    init(availableWidth: CGFloat? = nil, initialGoalStatusExpanded: Bool = false) {
+    init(
+        availableWidth: CGFloat? = nil,
+        initialGoalStatusExpanded: Bool = false,
+        initialComposerCollapsed: Bool? = nil
+    ) {
         self.availableWidth = availableWidth
         _isGoalStatusExpanded = State(initialValue: initialGoalStatusExpanded)
         // iPhone 首屏优先让出回复阅读空间；iPad 继续保留完整输入画布。
-        _isPhoneComposerCollapsed = State(initialValue: UIDevice.current.userInterfaceIdiom == .phone)
+        _isComposerCollapsed = State(
+            initialValue: initialComposerCollapsed ?? (UIDevice.current.userInterfaceIdiom == .phone)
+        )
     }
 
     static let minimumUsableVoiceDuration: TimeInterval = 0.35
@@ -467,8 +474,10 @@ struct ComposerView: View {
         guidedFollowUpEnabled = false
         measuredComposerTextHeight = 0
         isComposerTextComposing = false
+        // iPad 的收起是用户对当前会话输入画布的显式选择；切会话时不自动收起，
+        // 发送后也不走 phone-only 的 collapsePhoneComposerAfterSubmit，避免输入区突然消失。
         if isPhoneComposer {
-            isPhoneComposerCollapsed = true
+            isComposerCollapsed = true
         }
     }
 
@@ -880,12 +889,17 @@ struct ComposerView: View {
         Group {
             if isPhoneComposer {
                 phoneComposerCard(tokens: tokens)
+            } else if usesCollapsedIPadComposer {
+                collapsedIPadComposerCard(tokens: tokens)
             } else {
                 composerCard(tokens: tokens)
             }
         }
         .layoutPriority(1)
-        .animation(composerMotionAnimation, value: usesCollapsedPhoneComposer)
+        .animation(
+            composerMotionAnimation,
+            value: usesCollapsedPhoneComposer || usesCollapsedIPadComposer
+        )
     }
 
     /// iPhone 的收起态和编辑态共用同一个卡片与工具栏。过去在两棵完整 View 树之间
@@ -923,7 +937,7 @@ struct ComposerView: View {
     func collapsedPhoneComposerContent(tokens: ThemeTokens) -> some View {
         Button(action: expandPhoneComposer) {
             HStack(spacing: 8) {
-                Text(collapsedPhoneComposerText)
+                Text(collapsedComposerText)
                     .font(themeStore.uiFont(.body))
                     .foregroundStyle(composerState.draft.isEmpty ? tokens.tertiaryText : tokens.primaryText)
                     .lineLimit(1)
@@ -940,7 +954,45 @@ struct ComposerView: View {
         }
         .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.expand_input_box"))
-        .accessibilityValue(collapsedPhoneComposerText)
+        .accessibilityValue(collapsedComposerText)
+        .accessibilityIdentifier("composer.expand")
+    }
+
+    /// iPad 收起态是独立的一行卡片，不保留 iPad 完整 Composer 的工具栏。
+    /// 附件条位于外层 `body`，因此这里仅替换输入卡本身，不会清理附件状态。
+    func collapsedIPadComposerCard(tokens: ThemeTokens) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
+
+        return Button(action: expandIPadComposer) {
+            HStack(spacing: 8) {
+                Text(collapsedComposerText)
+                    .font(themeStore.uiFont(.body))
+                    .foregroundStyle(composerState.draft.isEmpty ? tokens.tertiaryText : tokens.primaryText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.up")
+                    .font(themeStore.uiFont(.caption2, weight: .bold))
+                    .foregroundStyle(tokens.tertiaryText)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
+        .padding(8)
+        .frame(maxWidth: .infinity)
+        .background {
+            composerContainerBackground(shape: shape, tokens: tokens)
+        }
+        .overlay {
+            shape.strokeBorder(composerCardBorderColor(tokens), lineWidth: composerCardBorderWidth)
+        }
+        .tint(tokens.accent)
+        .accessibilityLabel(L10n.text("ui.expand_input_box"))
+        .accessibilityValue(collapsedComposerText)
         .accessibilityIdentifier("composer.expand")
     }
 

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -958,44 +958,6 @@ struct ComposerView: View {
         .accessibilityIdentifier("composer.expand")
     }
 
-    /// iPad 收起态是独立的一行卡片，不保留 iPad 完整 Composer 的工具栏。
-    /// 附件条位于外层 `body`，因此这里仅替换输入卡本身，不会清理附件状态。
-    func collapsedIPadComposerCard(tokens: ThemeTokens) -> some View {
-        let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
-
-        return Button(action: expandIPadComposer) {
-            HStack(spacing: 8) {
-                Text(collapsedComposerText)
-                    .font(themeStore.uiFont(.body))
-                    .foregroundStyle(composerState.draft.isEmpty ? tokens.tertiaryText : tokens.primaryText)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Image(systemName: "chevron.up")
-                    .font(themeStore.uiFont(.caption2, weight: .bold))
-                    .foregroundStyle(tokens.tertiaryText)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, 12)
-            .frame(maxWidth: .infinity, minHeight: 44)
-            .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        }
-        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
-        .padding(8)
-        .frame(maxWidth: .infinity)
-        .background {
-            composerContainerBackground(shape: shape, tokens: tokens)
-        }
-        .overlay {
-            shape.strokeBorder(composerCardBorderColor(tokens), lineWidth: composerCardBorderWidth)
-        }
-        .tint(tokens.accent)
-        .accessibilityLabel(L10n.text("ui.expand_input_box"))
-        .accessibilityValue(collapsedComposerText)
-        .accessibilityIdentifier("composer.expand")
-    }
-
     func expandedPhoneComposerContent(tokens: ThemeTokens) -> some View {
         let skillSuggestions = filteredSkillSuggestions
         return VStack(alignment: .leading, spacing: composerCardSpacing) {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
@@ -84,6 +84,68 @@ extension ConversationDataFlowTests {
         XCTAssertGreaterThan(host.view.bounds.width, 0)
     }
 
+    func testIPadComposerDefaultsExpandedAndExplicitCollapseUsesSingleRow() throws {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            throw XCTSkip("该布局回归仅在 iPad 目标上验证")
+        }
+
+        let defaultsSuite = "IPadComposerCollapseTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsSuite))
+        defaults.removePersistentDomain(forName: defaultsSuite)
+        defer {
+            defaults.removePersistentDomain(forName: defaultsSuite)
+        }
+
+        let conversationStore = ConversationStore()
+        let sessionStore = SessionStore(
+            appStore: AppStore(
+                defaults: defaults,
+                tokenStore: TokenStore(keychain: TestKeychainOperations())
+            ),
+            conversationStore: conversationStore,
+            logStore: LogStore()
+        )
+        let session = makeSession(
+            id: "ipad-composer-collapse",
+            projectID: "ipad-composer-project",
+            title: "iPad Composer 收起回归",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        sessionStore.sessionsByID[session.id] = session
+        sessionStore.selectedSessionID = session.id
+        let themeStore = ThemeStore(defaults: defaults)
+
+        let measuredHeight: (Bool?) -> CGFloat = { initiallyCollapsed in
+            let host = UIHostingController(
+                rootView: AnyView(
+                    ComposerView(
+                        availableWidth: 900,
+                        initialComposerCollapsed: initiallyCollapsed
+                    )
+                    .environmentObject(sessionStore)
+                    .environmentObject(themeStore)
+                    .environment(\.horizontalSizeClass, .regular)
+                    .defaultAppStorage(defaults)
+                    .frame(width: 900)
+                )
+            )
+            host.view.frame = CGRect(x: 0, y: 0, width: 900, height: 1_000)
+            host.view.setNeedsLayout()
+            host.view.layoutIfNeeded()
+            return host.sizeThatFits(in: CGSize(width: 900, height: 1_000)).height
+        }
+
+        // 两个独立 Host 避免 SwiftUI 在替换同类型根视图时复用上一棵树的 @State，
+        // 同时用 nil 覆盖生产默认值，确认 iPad 首次进入仍然保持展开。
+        let expandedHeight = measuredHeight(nil)
+        let collapsedHeight = measuredHeight(true)
+
+        XCTAssertGreaterThan(expandedHeight, collapsedHeight)
+        XCTAssertGreaterThanOrEqual(collapsedHeight, 60, "收起态必须保留 44pt 触控行和卡片内边距")
+        XCTAssertLessThanOrEqual(collapsedHeight, 72, "收起态加上 Composer 既有固定间距后仍只能占一行")
+    }
+
     func testComposerRetiredTextViewDropsLateInputMethodCallbacks() {
         var boundText = ""
         var focusRequestID: UUID?


### PR DESCRIPTION
## 目标

让 iPad 会话输入框支持手动收起，只保留一行输入位置，并可恢复完整编辑。

## 改动

- iPad 使用独立的单行收起卡，保留草稿和附件状态。
- 在完整输入框右侧增加收起按钮，收起态增加展开按钮。
- 收起前先同步输入法 marked text，展开后恢复焦点。
- iPhone 既有收起行为保持不变；Catalyst 不走 iPad 分支。
- 增加 iPad 布局回归测试，确认默认展开且收起态只占单行高度。

## 验证

- git diff --check
- 相关 Composer 单测通过（固定 iPad Pro 13-inch (M5) Simulator）。
- XcodeBuildMCP iPad 运行态验证：展开/收起目标、焦点恢复和草稿保留均通过。

## Linear

MIM-122: https://linear.app/code89757/issue/MIM-122/让-ipad-会话输入框可收起为单行
