### PR TITLE
MIM-66 修正 Claude 登录命令与复制按钮对比度

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/lifecycle.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/lifecycle.rs
@@ -1,6 +1,6 @@
 //! `initialize` / `initialized` plus the `account/*` and `feedback/upload`
 //! shapes. The bridge does not own claude's authentication (the user runs
-//! `claude /login` themselves), so the account methods are stubs that report
+//! `claude auth login` themselves), so the account methods are stubs that report
 //! "no account, no auth required".
 
 use std::path::PathBuf;
@@ -54,7 +54,7 @@ pub fn handle_initialized(_state: &Arc<ConnectionState>) {
 
 // === account/* ============================================================
 //
-// claude's auth lives outside the bridge: the user runs `claude /login`
+// claude's auth lives outside the bridge: the user runs `claude auth login`
 // (or sets `ANTHROPIC_API_KEY`) and the spawned claude process picks it up.
 // The bridge has nothing to authenticate, so every account method synthesizes
 // the "no account, no auth required" answer codex clients tolerate.

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -4179,13 +4179,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "On the Mac running Mimi Remote, open Terminal and run claude to sign in again. Then return here and try again."
+            "value": "On the Mac running Mimi Remote, open Terminal and run claude auth login to sign in again. Then return here and try again."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "请回到运行 Mimi Remote 助手的 Mac，在终端运行 claude 并按提示重新登录，然后回到这里重试。"
+            "value": "请回到运行 Mimi Remote 助手的 Mac，在终端运行 claude auth login 重新登录，然后回到这里重试。"
           }
         }
       }
@@ -4231,13 +4231,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Copied claude. Run it in Terminal on your Mac."
+            "value": "Copied claude auth login. Run it in Terminal on your Mac."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已复制 claude，请在 Mac 的终端运行。"
+            "value": "已复制 claude auth login，请在 Mac 的终端运行。"
           }
         }
       }
@@ -6700,6 +6700,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "复制登录命令"
+          }
+        }
+      }
+    },
+    "ui.copy_login_command_hint": {
+      "comment": "VoiceOver hint for the Claude Code login command copy button.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copies claude auth login to the clipboard; it does not run the command."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 claude auth login 复制到剪贴板，不会执行命令。"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Core/Models/AgentRuntimeModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentRuntimeModels.swift
@@ -1259,7 +1259,9 @@ struct AgentErrorPayload: Codable, Hashable {
 
 enum ClaudeAuthenticationRecovery {
     static let errorCode = "claude_authentication_required"
-    static let loginCommand = "claude"
+    // 这是可直接粘贴到 Mac 终端执行的 CLI 命令；`/login` 只是在
+    // Claude Code 交互会话内部使用的 slash command，不能作为终端命令复制。
+    static let loginCommand = "claude auth login"
 
     static func matches(_ payload: AgentErrorPayload) -> Bool {
         if payload.code?.caseInsensitiveCompare(errorCode) == .orderedSame {

--- a/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageAccessories.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageAccessories.swift
@@ -226,6 +226,12 @@ struct RuntimeSummaryCard: View {
         }
         .buttonStyle(.borderedProminent)
         .controlSize(.small)
+        // 不依赖页面或系统的默认 tint：深色外观的浅色 accent 会让白色
+        // doc.on.doc 图标和按钮底色融在一起，主操作色才是可读的实色背景。
+        .tint(tokens.primaryAction)
+        .foregroundStyle(tokens.primaryActionForeground)
+        .accessibilityHint(L10n.text("ui.copy_login_command_hint"))
+        .accessibilityIdentifier("conversation.claudeAuthentication.copyLoginCommand")
     }
 
     private var retryClaudeRequestButton: some View {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -2810,6 +2810,10 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertFalse(message.content.contains(rawError))
     }
 
+    func testClaudeAuthenticationRecoveryUsesTerminalLoginCommand() {
+        XCTAssertEqual(ClaudeAuthenticationRecovery.loginCommand, "claude auth login")
+    }
+
     func testLargeDiffPanelItemsDeduplicateAndCollapseTail() throws {
         let fileChangePrefix = L10n.text("ui.file_changes_766e4292")
         let old = ConversationMessage(


### PR DESCRIPTION
## 目标

修正 Claude Code 登录过期卡片复制出的错误登录命令，并让复制图标在浅色按钮上清晰可见。

## 实现

- 登录恢复命令统一为终端实际可执行的 `claude auth login`
- 复制按钮图标改用与按钮前景一致的高对比度样式
- 保留原有中文错误提示和显式重试流程

## 验证

- `testClaudeAuthenticationRecoveryUsesTerminalLoginCommand`
- `testEventReducerPresentsClaudeAuthenticationFailureAsRecoverableChineseNotice`
- 用户已在实际界面验证通过

Linear: MIM-66
