### PR TITLE
MIM-120 防止重连陈旧响应污染会话列表

### DIFF
--- a/bridges/claude/crates/bridge-core/src/notify.rs
+++ b/bridges/claude/crates/bridge-core/src/notify.rs
@@ -50,6 +50,22 @@ impl NotificationSender {
         Ok(())
     }
 
+    /// Answer a client request that arrived on attachment `generation`.
+    /// Returns whether the response was accepted for the attachment that asked
+    /// for it. `false` means that stream has since been replaced and the answer
+    /// was dropped rather than handed to its successor.
+    pub fn send_response(
+        &self,
+        response: JsonRpcResponse,
+        generation: u64,
+    ) -> anyhow::Result<bool> {
+        let frame = serde_json::to_value(JsonRpcMessage::Response(response))?;
+        Ok(self
+            .session
+            .enqueue_for_generation(frame, generation)
+            .is_some())
+    }
+
     /// Issue a server→client request and await the response, with a per-call
     /// timeout. The request id is minted by the session, the pending oneshot
     /// is parked in the session's pending table, and the params are stored in

--- a/bridges/claude/crates/bridge-core/src/server.rs
+++ b/bridges/claude/crates/bridge-core/src/server.rs
@@ -11,13 +11,9 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 #[cfg(unix)]
 use tokio::net::UnixListener;
 use tokio::net::{TcpListener, TcpStream};
-#[cfg(unix)]
-use tracing::debug;
-use tracing::warn;
+use tracing::{debug, warn};
 
-use crate::envelope::{
-    InboundMessage, JsonRpcError, JsonRpcMessage, JsonRpcResponse, JsonRpcVersion, error_codes,
-};
+use crate::envelope::{InboundMessage, JsonRpcError, JsonRpcResponse, JsonRpcVersion, error_codes};
 use crate::framing::{read_json_line, write_json_line};
 use crate::notify::NotificationSender;
 use crate::session::{
@@ -517,9 +513,9 @@ where
     let writer_task = tokio::spawn(drain_attachment(writer, attach, Arc::clone(&session)));
 
     if let Some(value) = pending {
-        dispatch_inbound(&bridge, &conn, value).await;
+        dispatch_inbound(&bridge, &conn, value, generation).await;
     }
-    let result = run_reader(bridge, &conn, &mut reader).await;
+    let result = run_reader(bridge, &conn, &mut reader, generation).await;
     session.drop_attachment(generation);
     let _ = writer_task.await;
     result
@@ -573,18 +569,21 @@ async fn run_reader<B, R>(
     bridge: Arc<B>,
     conn: &Conn,
     reader: &mut BufReader<R>,
+    generation: u64,
 ) -> anyhow::Result<()>
 where
     B: Bridge + ?Sized,
     R: AsyncRead + Unpin + Send,
 {
     while let Some(value) = read_json_line::<Value, _>(reader).await? {
-        dispatch_inbound(&bridge, conn, value).await;
+        dispatch_inbound(&bridge, conn, value, generation).await;
     }
     Ok(())
 }
 
-async fn dispatch_inbound<B>(bridge: &Arc<B>, conn: &Conn, value: Value)
+/// `generation` is the attachment the frame arrived on. A response is only
+/// ever written back while that attachment is still the installed one.
+async fn dispatch_inbound<B>(bridge: &Arc<B>, conn: &Conn, value: Value, generation: u64)
 where
     B: Bridge + ?Sized,
 {
@@ -624,9 +623,20 @@ where
                         error: Some(error),
                     },
                 };
-                let _ = conn
-                    .notifier()
-                    .send_message(JsonRpcMessage::Response(response));
+                // The client that asked is gone once its attachment has been
+                // replaced, and the successor numbers its requests from
+                // scratch: handing it this response answers whatever request
+                // happens to reuse the id. `model/list` and `thread/list` both
+                // return `{data, nextCursor}`, so the model catalogue lands in
+                // the recent-thread list looking like real sessions (MIM-120).
+                // Nothing downstream can tell the frames apart, so a response
+                // that outlived its stream is dropped instead.
+                if matches!(
+                    conn.notifier().send_response(response, generation),
+                    Ok(false)
+                ) {
+                    debug!(method = %method, "dropped response whose client stream was replaced");
+                }
             });
         }
         InboundMessage::Notification(notification) => {

--- a/bridges/claude/crates/bridge-core/src/session/mod.rs
+++ b/bridges/claude/crates/bridge-core/src/session/mod.rs
@@ -231,7 +231,46 @@ impl Session {
     /// read it off the wire. Codex's JSON-RPC envelopes use serde without
     /// `deny_unknown_fields`, so existing litter-side parsers ignore it.
     /// Non-object payloads are passed through unstamped.
-    pub fn enqueue(&self, mut payload: Value) -> u64 {
+    pub fn enqueue(&self, payload: Value) -> u64 {
+        self.enqueue_inner(payload)
+    }
+
+    /// Enqueue a frame that is only meaningful to one attachment — a response
+    /// to a request that arrived on it. Returns `None` without touching the
+    /// ring when that attachment has already been replaced.
+    ///
+    /// Dropping is the whole point: the successor stream numbers its requests
+    /// from scratch, so delivering a response minted for the previous one
+    /// answers whatever request reused the id.
+    pub fn enqueue_for_generation(&self, mut payload: Value, generation: u64) -> Option<u64> {
+        // generation 校验、序号分配和 live 投递必须以 attachment 锁作为同一个
+        // 临界区。否则连接可能在校验后、ring 写入前被替换，旧响应仍会占用
+        // replay 容量，极端情况下还会挤掉真正需要重放的通知。
+        //
+        // 锁顺序与 install_attachment / publish_server_request 一致：
+        // attachment → ring，避免引入反向等待。
+        let attachment = self.attachment.lock().unwrap();
+        let current = attachment
+            .as_ref()
+            .filter(|attachment| attachment.generation == generation)?;
+
+        let seq = {
+            let mut ring = self.ring.lock().unwrap();
+            let next = ring.next_seq_peek();
+            stamp_alleycat_seq(&mut payload, next);
+            let assigned = ring.push(payload.clone());
+            debug_assert_eq!(assigned, next, "ring assigned a different seq than peeked");
+            assigned
+        };
+        let _ = current.live_tx.send(Sequenced {
+            seq,
+            payload,
+            bytes: 0,
+        });
+        Some(seq)
+    }
+
+    fn enqueue_inner(&self, mut payload: Value) -> u64 {
         let seq = {
             let mut ring = self.ring.lock().unwrap();
             let next = ring.next_seq_peek();
@@ -420,6 +459,15 @@ impl Session {
         let backlog: Vec<Sequenced> = backlog
             .into_iter()
             .filter(|frame| !is_unanswered_server_request(&frame.payload, &outstanding))
+            // A response belongs to exactly one request on exactly one
+            // attachment, and that attachment is gone by definition here. The
+            // client that reattaches numbers its requests from scratch, so a
+            // replayed response can land on a live request that merely reuses
+            // the old id — `model/list` and `thread/list` both answer
+            // `{data, nextCursor}`, so the model catalogue silently becomes
+            // the recent-thread list. Nothing downstream can tell the two
+            // apart, so the frame must not be replayed at all.
+            .filter(|frame| !is_client_request_response(&frame.payload))
             .collect();
         // Whatever we could or couldn't replay, a prompt still waiting on the
         // user is state the client has to be told about — it is the whole
@@ -630,6 +678,23 @@ fn is_unanswered_server_request(
     outstanding.contains_key(&key)
 }
 
+/// True when `payload` is a response to a client→server request: it carries an
+/// id and a `result`/`error`, and no `method` of its own. Server→client
+/// requests also carry an id but always name a `method`, and they stay
+/// replayable — the client still has to answer them.
+fn is_client_request_response(payload: &Value) -> bool {
+    let Some(object) = payload.as_object() else {
+        return false;
+    };
+    if object.contains_key("method") {
+        return false;
+    }
+    if !matches!(object.get("id"), Some(Value::String(_) | Value::Number(_))) {
+        return false;
+    }
+    object.contains_key("result") || object.contains_key("error")
+}
+
 fn outstanding_replay_message(outstanding: &HashMap<String, OutstandingRequest>) -> Option<Value> {
     if outstanding.is_empty() {
         return None;
@@ -704,6 +769,64 @@ mod tests {
         assert_eq!(handle.outcome, AttachOutcome::Resumed);
         let seqs: Vec<_> = handle.backlog.iter().map(|f| f.seq).collect();
         assert_eq!(seqs, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn response_for_a_replaced_attachment_is_dropped_not_handed_to_its_successor() {
+        let session = Session::new("pi", "node-abc".into(), 16, 1 << 20);
+        let first = session.install_attachment(None);
+        let mut second = session.install_attachment(None);
+
+        // The first stream's request finishes after its client was replaced.
+        let dropped = session.enqueue_for_generation(
+            serde_json::json!({"jsonrpc": "2.0", "id": 3, "result": {"data": []}}),
+            first.generation,
+        );
+        assert_eq!(dropped, None, "陈旧响应不能进环，更不能投给继任连接");
+        assert!(
+            session
+                .enqueue_for_generation(
+                    serde_json::json!({"jsonrpc": "2.0", "id": 1, "result": {"data": []}}),
+                    second.generation,
+                )
+                .is_some()
+        );
+
+        let delivered = second.live_rx.recv().await.expect("当前连接的响应仍要送达");
+        assert_eq!(delivered.seq, 1, "陈旧响应不能消耗 replay 序号");
+        assert_eq!(delivered.payload["id"], 1);
+    }
+
+    #[test]
+    fn resumed_attach_never_replays_client_request_responses() {
+        let session = Session::new("pi", "node-abc".into(), 16, 1 << 20);
+        session.enqueue(notif("a"));
+        // The reattaching client restarts its request ids at 1, so replaying
+        // this would answer its next request with a model catalogue.
+        session.enqueue(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "result": {"data": [{"id": "sonnet"}], "nextCursor": null},
+        }));
+        session.enqueue(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "error": {"code": -32600, "message": "nope"},
+        }));
+        // Server→client requests carry an id too, but the client still owes
+        // them an answer, so they stay in the backlog.
+        session.enqueue(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "applyPatchApproval",
+            "params": {},
+        }));
+        session.enqueue(notif("b"));
+
+        let handle = session.install_attachment(Some(1));
+        assert_eq!(handle.outcome, AttachOutcome::Resumed);
+        let seqs: Vec<_> = handle.backlog.iter().map(|f| f.seq).collect();
+        assert_eq!(seqs, vec![4, 5]);
     }
 
     #[test]

--- a/bridges/claude/crates/bridge-core/tests/socket_attach.rs
+++ b/bridges/claude/crates/bridge-core/tests/socket_attach.rs
@@ -142,20 +142,32 @@ async fn reattach_replays_frames_produced_while_disconnected() {
     let (mut read, _write, ack) = attach(&registry, "device-A", Some(cursor)).await;
     assert_eq!(ack["kind"], "resumed");
 
-    // Everything after the cursor comes back, contiguously and in order —
-    // including the response frame the client never got to read. Replay is
-    // over the whole outbound stream, not just notifications.
+    // Everything after the cursor comes back in order, except responses to the
+    // vanished client's own requests: those belong to continuations that died
+    // with the old stream, and the reattaching client numbers its requests from
+    // scratch, so replaying one answers whatever request happens to reuse that
+    // id. Seqs stay strictly increasing but may skip the dropped responses.
     let mut seqs = Vec::new();
     let replayed = loop {
         let frame: Value = read_json_line(&mut read).await.unwrap().unwrap();
+        assert!(
+            frame["method"].is_string(),
+            "a response frame must never be replayed: {frame}"
+        );
         seqs.push(frame["_alleycat_seq"].as_u64().unwrap());
         if frame["params"]["from"] == "while-detached" {
             break frame;
         }
     };
     assert_eq!(replayed["method"], "event");
-    let expected: Vec<u64> = (cursor + 1..=cursor + seqs.len() as u64).collect();
-    assert_eq!(seqs, expected, "replay must have no gaps after the cursor");
+    assert!(
+        seqs.first().is_some_and(|first| *first > cursor),
+        "replay must start after the cursor: {seqs:?}"
+    );
+    assert!(
+        seqs.windows(2).all(|pair| pair[0] < pair[1]),
+        "replay must stay in order: {seqs:?}"
+    );
 }
 
 #[tokio::test]

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -517,9 +517,10 @@ extension CodexAppServerSessionRuntime {
         let projectName = project?.name ?? fallbackProject?.name ?? cwd
         let status = sessionStatus(from: thread["status"], forceRunning: forceRunning)
         let preview = thread["preview"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let title = thread["name"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-            ?? preview?.split(separator: "\n").first.map(String.init)
-            ?? "Thread \(id.prefix(8))"
+        let name = thread["name"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let previewTitle = preview?.split(separator: "\n").first.map(String.init)
+        // id 是协议字段，缺 name/preview 时只给稳定占位标题，不能把 id 伪装成会话名。
+        let title = [name, previewTitle].compactMap { $0 }.first(where: { !$0.isEmpty }) ?? ""
         let cached = contextsBySessionID[id]?.session
         // thread/list 可能不带 turns，此时沿用本地 activeTurnID；但 thread/read/resume 一旦带回
         // turns，就以服务端 turns 为准。即使 turns 里没有 inProgress，也要清掉旧缓存，避免引导发到旧 turn。

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1240,7 +1240,9 @@ actor CodexAppServerSessionRuntime {
             "id": .string(sessionID),
             "sessionId": .string(sessionID),
             "cwd": cwd,
-            "name": .string("Thread \(sessionID.prefix(8))"),
+            // 这层壳只是拿不到 thread 元数据时的占位；名字留空由投影统一填占位标题，
+            // 不要把 thread id 当成会话名写进去。
+            "name": .null,
             "status": .object(["type": .string("notLoaded")]),
             "modelProvider": .string("openai")
         ]

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
@@ -215,12 +215,35 @@ private struct PendingCodexAppServerResponse {
     let timeoutTask: Task<Void, Never>
 }
 
+/// JSON-RPC 请求 id 的全进程分配器：每条连接都从上一条连接用完的地方继续，
+/// 绝不从 1 重来。
+///
+/// Claude 常驻 bridge 的回放环里可能还留着上一条连接未被消费的响应帧。id 一旦
+/// 被复用，那条陈旧响应就会兑现新连接里编号相同的请求——而 `model/list` 与
+/// `thread/list` 的结果都是 `{data, nextCursor}`，模型目录会被原样投影成最近
+/// 会话列表（MIM-120）。响应帧里没有 method，客户端事后无从分辨，只能靠 id 不
+/// 复用来根除。
+///
+/// 起点按进程随机：App 重启后 bridge 那边仍是同一个常驻会话，固定起点同样会撞。
+private enum CodexAppServerRequestIDAllocator {
+    private static let lock = NSLock()
+    // 上界留足余量，保证 id 始终落在 JSON number 的精确整数区间内。
+    nonisolated(unsafe) private static var next: Int64 = .random(in: 1...(1 << 40))
+
+    static func allocate() -> Int64 {
+        lock.lock()
+        defer { lock.unlock() }
+        let id = next
+        next &+= 1
+        return id
+    }
+}
+
 actor CodexAppServerConnection {
     private let transport: CodexAppServerTransport
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
     private let requestTimeoutNanoseconds: UInt64
-    private var nextRequestNumber: Int64 = 1
     private var pendingResponses: [CodexAppServerRequestID: PendingCodexAppServerResponse] = [:]
     private var receiveTask: Task<Void, Never>?
     private var isConnected = false
@@ -519,9 +542,6 @@ actor CodexAppServerConnection {
     }
 
     private func nextRequestID() -> CodexAppServerRequestID {
-        defer {
-            nextRequestNumber += 1
-        }
-        return .int(nextRequestNumber)
+        .int(CodexAppServerRequestIDAllocator.allocate())
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationAppServerProjectorTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationAppServerProjectorTests.swift
@@ -40,4 +40,77 @@ extension ConversationDataFlowTests {
             XCTAssertNotEqual(message.activityPayload?.displayTitle, L10n.text("ui.call_tool"))
         }
     }
+
+    // MIM-120：缺 name/preview 的会话只能拿到稳定占位标题，不能暴露 thread id。
+    func testThreadListPlaceholderTitleNeverEmbedsThreadID() async throws {
+        let runtime = CodexAppServerSessionRuntime(endpoint: "http://127.0.0.1:8787", token: "test")
+        let project = AgentProject(id: "repo", name: "Repo", path: "/Users/me/repo")
+        let placeholder = L10n.text("ui.unnamed_session")
+        let threads: [[String: CodexAppServerJSONValue]] = [
+            [
+                "id": .string("019f36d2-0000-7000-8000-000000000001"),
+                "cwd": .string(project.path),
+                "status": .object(["type": .string("idle")]),
+            ],
+            [
+                "id": .string("019f36d2-0000-7000-8000-000000000002"),
+                "cwd": .string(project.path),
+                "name": .string("   "),
+                "preview": .string("  \n "),
+                "status": .object(["type": .string("idle")]),
+            ],
+            [
+                "id": .string("sonnet"),
+                "cwd": .string(project.path),
+                "status": .object(["type": .string("idle")]),
+            ],
+        ]
+
+        for thread in threads {
+            let session = try await runtime.agentSession(
+                from: thread,
+                projects: [project],
+                fallbackProject: project
+            )
+            let id = try XCTUnwrap(thread["id"]?.stringValue)
+            XCTAssertEqual(session.title, placeholder, "缺标题信息时必须使用稳定占位标题")
+            XCTAssertFalse(session.title.contains(id), "占位标题不能内嵌 thread id")
+            XCTAssertEqual(session.id, id, "占位标题不得改写真实 thread id")
+            XCTAssertEqual(session.resumeID, id, "恢复仍要走真实 thread id")
+        }
+    }
+
+    // 有名称或首条用户消息时不能被占位标题顶掉，空白 name 也必须回退到 preview。
+    func testThreadListKeepsRealNameAndPreviewFirstLine() async throws {
+        let runtime = CodexAppServerSessionRuntime(endpoint: "http://127.0.0.1:8787", token: "test")
+        let project = AgentProject(id: "repo", name: "Repo", path: "/Users/me/repo")
+        let cases: [([String: CodexAppServerJSONValue], String)] = [
+            ([
+                "id": .string("thread-named"),
+                "cwd": .string(project.path),
+                "name": .string("  重构会话列表  "),
+                "preview": .string("忽略我"),
+            ], "重构会话列表"),
+            ([
+                "id": .string("thread-preview"),
+                "cwd": .string(project.path),
+                "preview": .string("修一下底部色差\n第二行不要"),
+            ], "修一下底部色差"),
+            ([
+                "id": .string("thread-blank-name"),
+                "cwd": .string(project.path),
+                "name": .string("   "),
+                "preview": .string("保留这条真实首消息\n第二行不要"),
+            ], "保留这条真实首消息"),
+        ]
+
+        for (thread, expectedTitle) in cases {
+            let session = try await runtime.agentSession(
+                from: thread,
+                projects: [project],
+                fallbackProject: project
+            )
+            XCTAssertEqual(session.title, expectedTitle)
+        }
+    }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -1854,4 +1854,34 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(closedContext?.session.status, "closed")
         XCTAssertNil(closedContext?.activeTurnID)
     }
+
+    // MIM-120 根因侧：Claude 常驻 bridge 的回放环里可能还留着上一条连接的响应帧。
+    // 只要新连接的请求 id 从 1 重来，旧 model/list 响应就可能兑现新的 thread/list。
+    func testRequestIDsNeverRepeatAcrossConnections() async throws {
+        let firstTransport = FakeCodexAppServerTransport()
+        let firstConnection = CodexAppServerConnection(transport: firstTransport)
+        try await connectFakeAppServer(firstConnection, transport: firstTransport)
+        let firstTask = Task { try await firstConnection.send(CodexAppServerRequestSpec(method: "thread/list")) }
+        let firstRequest = try await waitForFakeAppServerRequest(firstTransport, method: "thread/list")
+        await firstConnection.disconnect()
+        _ = try? await firstTask.value
+
+        let secondTransport = FakeCodexAppServerTransport()
+        let secondConnection = CodexAppServerConnection(transport: secondTransport)
+        try await connectFakeAppServer(secondConnection, transport: secondTransport)
+        let secondTask = Task { try await secondConnection.send(CodexAppServerRequestSpec(method: "thread/list")) }
+        let secondRequest = try await waitForFakeAppServerRequest(secondTransport, method: "thread/list")
+
+        XCTAssertNotEqual(firstRequest.id, secondRequest.id, "重连后的请求 id 不能复用上一条连接的编号")
+
+        // 回放过来的陈旧 model/list 响应带着旧连接的 id，必须无人认领地落地。
+        await secondConnection.ingestTextForTesting(
+            #"{"id":\#(try jsonFragment(for: firstRequest.id)),"result":{"data":[{"id":"sonnet"}],"nextCursor":null}}"#
+        )
+        transportResponse(secondTransport, id: secondRequest.id, result: #"{"data":[],"nextCursor":null}"#)
+
+        let page = try await secondTask.value
+        XCTAssertEqual(page?.objectValue?["data"]?.arrayValue?.count, 0, "thread/list 只能被自己的响应兑现")
+        await secondConnection.disconnect()
+    }
 }


### PR DESCRIPTION
## 目标

修复 Claude 重连后旧 JSON-RPC 响应被新请求误接收，导致最近会话出现 `Thread sonnet`、`Thread opus` 等模型别名的问题。

## 根因

- Claude bridge 会把上一条连接的 client response 留在 replay ring
- iOS 旧实现每条连接都从 request ID 1 重新编号
- 重连后旧 `model/list` 响应可能与新 `thread/list` 请求撞 ID；两者结果结构都为 `{data, nextCursor}`，因此模型条目会被误投影成会话

## 实现

- bridge 将 client response 绑定到接收请求时的 attachment generation
- generation 校验、ring 序号分配与 live 投递放在同一 attachment 临界区，关闭连接切换 TOCTOU
- 重连 replay 过滤 client response，同时保留 server-to-client request 的恢复语义
- iOS request ID 改为全进程唯一递增并使用随机安全起点，作为纵深防御
- 缺少 name/preview 时不再把 thread ID 拼成标题；空白 name 会正确回退到 preview 首行

## 验证

- `cargo test -p alleycat-bridge-core`：107 项通过
- Go Claude gateway 相关测试：3 项通过
- iOS `CodexAppServerProtocolTests` 针对性测试：3 项通过
- `cargo fmt --all -- --check`
- `git diff --check`
- Luna 独立审查发现 TOCTOU 后已修正；最终 fresh-context Sol reviewer 结论 `ship`、无 blocker
- 用户已完成实际界面验证

Linear: MIM-120
