### PR TITLE
MIM-123: 让会话操作菜单稳定展开并收敛路径操作

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -6721,6 +6721,24 @@
         }
       }
     },
+    "ui.copy_path": {
+      "comment": "Session menu action that copies the session directory path.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy path"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制路径"
+          }
+        }
+      }
+    },
     "ui.counts_joined": {
       "comment": "Join two localized count fragments.",
       "localizations": {

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionActions.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionActions.swift
@@ -123,6 +123,7 @@ struct SessionActionMenuContent: View {
                 } label: {
                     Label(L10n.text("ui.copy_path"), systemImage: "folder")
                 }
+                .accessibilityValue(fullDirectoryPath)
 
                 Divider()
             }

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionActions.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionActions.swift
@@ -20,10 +20,6 @@ private struct SessionRowActionController {
         sessionStore.isHistorySessionUnread(session)
     }
 
-    var isCarStatusSession: Bool {
-        sessionStore.isCarStatusSession(session)
-    }
-
     var canChangePinState: Bool {
         !isArchived && !sessionStore.isSessionArchiveMutationPending(session.id)
     }
@@ -62,16 +58,6 @@ private struct SessionRowActionController {
         isArchived ? "archivebox.fill" : "archivebox"
     }
 
-    var carStatusTitle: String {
-        isCarStatusSession
-            ? L10n.text("ui.clear_car_status_session")
-            : L10n.text("ui.set_car_status_session")
-    }
-
-    var carStatusSystemImage: String {
-        isCarStatusSession ? "car.side.fill" : "car.side"
-    }
-
     func togglePinned() {
         guard canChangePinState else { return }
         sessionStore.toggleSessionPinned(session)
@@ -98,15 +84,6 @@ private struct SessionRowActionController {
         Task {
             await sessionStore.setSessionArchivedRemote(session, archived: archived)
         }
-    }
-
-    func toggleCarStatusSession() {
-        if isCarStatusSession {
-            sessionStore.clearCarStatusSession()
-        } else {
-            sessionStore.selectCarStatusSession(session)
-        }
-        MimiHaptics.fire(.commit)
     }
 }
 
@@ -144,9 +121,8 @@ struct SessionActionMenuContent: View {
                 Button {
                     UIPasteboard.general.string = fullDirectoryPath
                 } label: {
-                    Label(fullDirectoryPath, systemImage: "folder")
+                    Label(L10n.text("ui.copy_path"), systemImage: "folder")
                 }
-                .accessibilityLabel("\(fullDirectoryPath) · \(L10n.text("ui.copy"))")
 
                 Divider()
             }
@@ -256,15 +232,6 @@ struct SessionActionMenuContent: View {
                 )
             }
 
-
-#if os(iOS) && !targetEnvironment(macCatalyst)
-            Button {
-                actions.toggleCarStatusSession()
-            } label: {
-                Label(actions.carStatusTitle, systemImage: actions.carStatusSystemImage)
-            }
-#endif
-
             Button(role: actions.isArchived ? nil : .destructive) {
                 actions.toggleArchived()
             } label: {
@@ -318,13 +285,6 @@ private struct SessionActionsContextMenuModifier: ViewModifier {
                         actions.toggleReadState()
                     }
                 }
-
-
-#if os(iOS) && !targetEnvironment(macCatalyst)
-                Button(actions.carStatusTitle) {
-                    actions.toggleCarStatusSession()
-                }
-#endif
 
                 Button(actions.archiveTitle) {
                     actions.toggleArchived()


### PR DESCRIPTION
## 改动

- 将会话操作菜单顶部的动态完整路径改为固定“复制路径”按钮
- 点击按钮仍复制去除首尾空白后的完整会话目录路径
- 移除“设为状态小组件”菜单入口及对应 VoiceOver 自定义动作
- 保留底层状态小组件能力及其他会话操作行为

## 原因与影响

长路径作为 SwiftUI Menu 的动态标签时会换行并参与菜单尺寸、位置计算，导致菜单展开时出现可感知的来回跳动。固定短文案后菜单尺寸稳定，同时路径操作更明确。

## 验证

- Debug 编译通过
- Localizable.xcstrings JSON 校验通过
- git diff --check 通过
- 全量测试 1271 项：1264 通过、4 跳过、3 个现有快照基线失败
- 3 个快照失败在本分支与干净 origin/main 上以完全相同精度复现，确认不是本次回归
- 用户已确认验证无问题

Linear: https://linear.app/code89757/issue/MIM-123/让会话操作菜单稳定展开并收敛路径操作
