### PR TITLE
MIM-74: 延迟完整历史提示卡片

### DIFF
--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -355,6 +355,11 @@ extension SessionStore {
         if session.isLocalDraft {
             return true
         }
+        // 普通自动/权威打开只需要 progress；savings 横幅应只在用户明确选择
+        // full/summary，或策略层已经确认需要降级/重试时出现。否则每次短暂的
+        // 首屏请求都会先暴露“正在加载完整历史”的决策卡片，再在成功时立即消失。
+        let shouldShowSavingsNotice = !quiet
+            && (noticeMessageOverride != nil || reason == .summaryChoice || reason == .manualFull)
         if !force, canReuseLoadedHistory(for: session, loadMode: loadMode) {
             return true
         }
@@ -385,7 +390,8 @@ extension SessionStore {
                         promoteHistoryLoadJobForForegroundReporting(
                             existing,
                             sessionID: session.id,
-                            successStatusMessage: successStatusMessage
+                            successStatusMessage: successStatusMessage,
+                            showSavingsNotice: shouldShowSavingsNotice
                         )
                         setHistoryLoadProgress(
                             sessionID: session.id,
@@ -451,7 +457,7 @@ extension SessionStore {
             foregroundSelectionLease: quiet ? nil : currentSelectionLease()
         )
         historyLoadJobsBySessionID[session.id] = job
-        if !quiet {
+        if shouldShowSavingsNotice {
             setHistoryLoadNotice(
                 sessionID: session.id,
                 kind: loadMode == .full ? .loadingFull : .loadingSummary,
@@ -479,7 +485,8 @@ extension SessionStore {
     func promoteHistoryLoadJobForForegroundReporting(
         _ job: HistoryLoadJob,
         sessionID: SessionID,
-        successStatusMessage: String?
+        successStatusMessage: String?,
+        showSavingsNotice: Bool
     ) {
         guard var current = historyLoadJobsBySessionID[sessionID], current.token == job.token else {
             return
@@ -490,11 +497,13 @@ extension SessionStore {
             current.foregroundSuccessStatusMessage = successStatusMessage
         }
         historyLoadJobsBySessionID[sessionID] = current
-        setHistoryLoadNotice(
-            sessionID: sessionID,
-            kind: current.loadMode == .full ? .loadingFull : .loadingSummary,
-            message: current.loadMode == .economy ? deferredFullHistoryNotice(sessionID: sessionID) : nil
-        )
+        if showSavingsNotice {
+            setHistoryLoadNotice(
+                sessionID: sessionID,
+                kind: current.loadMode == .full ? .loadingFull : .loadingSummary,
+                message: current.loadMode == .economy ? deferredFullHistoryNotice(sessionID: sessionID) : nil
+            )
+        }
     }
 
     func scheduleQuietHistoryRefresh(for session: AgentSession) {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -3229,7 +3229,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(client.requestedMessageCursors, [nil])
         XCTAssertEqual(client.requestedMessageLimits, [20])
         XCTAssertEqual(client.requestedMessageLoadModes, [.full])
-        XCTAssertEqual(store.selectedHistorySavingsNotice?.kind, .loadingFull)
+        XCTAssertNil(store.selectedHistorySavingsNotice, "自动首屏 full 加载只显示 progress，不应提前展示缩略选择卡片")
 
         client.resolveHistoryRequest(
             at: 0,
@@ -3332,7 +3332,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(client.requestedMessageCursors, [nil])
         XCTAssertEqual(client.requestedMessageLimits, [20])
         XCTAssertEqual(client.requestedMessageLoadModes, [.full])
-        XCTAssertEqual(store.selectedHistorySavingsNotice?.kind, .loadingFull)
+        XCTAssertNil(store.selectedHistorySavingsNotice, "自动首屏 full 加载只显示 progress，不应提前展示缩略选择卡片")
 
         client.resolveHistoryRequest(
             at: 0,
@@ -3417,6 +3417,7 @@ extension ConversationDataFlowTests {
             [.full, .full],
             "终态重开必须绕过相同签名的局部缓存，发出一次权威首屏读取"
         )
+        XCTAssertNil(store.selectedHistorySavingsNotice, "权威重开只显示 progress，不应提前展示 savings 卡片")
         client.resolveHistoryRequest(
             at: 1,
             with: HistoryMessagesPage(messages: [
@@ -3677,7 +3678,7 @@ extension ConversationDataFlowTests {
         await client.waitForHistoryRequestCount(1)
 
         XCTAssertEqual(client.requestedMessageLoadModes, [.full])
-        XCTAssertEqual(store.selectedHistorySavingsNotice?.kind, .loadingFull)
+        XCTAssertNil(store.selectedHistorySavingsNotice, "自动首屏 full 加载只显示 progress，不应提前展示缩略选择卡片")
 
         let firstSummaryTask = Task { await store.loadSummaryHistoryForSelectedSession() }
         await client.waitForHistoryRequestCount(2)
@@ -3719,6 +3720,7 @@ extension ConversationDataFlowTests {
         let reloadFullTask = Task { await store.loadFullHistoryForSelectedSession() }
         await client.waitForHistoryRequestCount(3)
         XCTAssertEqual(client.requestedMessageLoadModes, [.full, .economy, .full])
+        XCTAssertEqual(store.selectedHistorySavingsNotice?.kind, .loadingFull)
         client.resolveHistoryRequest(
             at: 2,
             with: HistoryMessagesPage(


### PR DESCRIPTION
## 变更

- 普通自动首屏加载和权威重开只显示轻量加载进度，不再提前展示“只看缩略版”决策卡片。
- 用户主动选择缩略历史、手动请求完整历史，以及已确认历史过大时，保留原有提示和降级流程。
- 更新会话历史加载相关回归测试，覆盖并发请求、权威重开和手动模式切换。

## 根因

历史请求刚开始时，状态层无条件写入 `loadingFull` savings notice；短历史加载成功后才清除，造成首屏提示闪现和布局跳动。

## 验证

- `git diff --check` 通过。
- 固定 `iPad Pro 13-inch (M5)` 执行全套测试并完成编译：1271 tests、4 skipped。
- 本次相关用例通过；全套测试中有既有视觉快照差异，详见 MIM-74。

Closes MIM-74
