### PR TITLE
MIM-126: 官网 CTA 在新标签页打开

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -80,7 +80,7 @@
           <h1 class="display" data-i18n="hero.title">Your agents.<br />Within reach.</h1>
           <p class="lede" data-i18n="hero.lede">A native iPhone and iPad client for Codex and Claude Code. Your Mac or Windows PC keeps running the work — Tailscale keeps the link private and fast. Android is coming soon.</p>
           <div class="cta-row cta-row--hero">
-            <a class="btn btn--solid btn--lg" href="https://testflight.apple.com/join/jhGPbSk6">
+            <a class="btn btn--solid btn--lg" href="https://testflight.apple.com/join/jhGPbSk6" target="_blank" rel="noopener noreferrer">
               <svg class="btn__icon btn__icon--testflight" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                 <g fill="none" stroke="currentColor" stroke-width="1.7">
                   <ellipse cx="12" cy="7.1" rx="2.45" ry="4.9" />
@@ -91,7 +91,7 @@
               </svg>
               <span data-i18n="hero.cta1">Join TestFlight</span>
             </a>
-            <a class="btn btn--quiet btn--lg" href="https://github.com/gaixianggeng/mimi-remote">
+            <a class="btn btn--quiet btn--lg" href="https://github.com/gaixianggeng/mimi-remote" target="_blank" rel="noopener noreferrer">
               <svg class="btn__icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
                 <path fill="currentColor" fill-rule="evenodd" d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.71 1.23 1.87.87 2.33.67.07-.52.28-.87.5-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.87.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.52.56.83 1.28.83 2.15 0 3.08-1.87 3.76-3.66 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
               </svg>


### PR DESCRIPTION
## 变更内容

- 让官网首屏 `Join TestFlight` 在新标签页打开。
- 让官网首屏 `View source` 在新标签页打开。
- 两个外部链接均增加 `rel="noopener noreferrer"`。

## 原因与影响

此前两个 CTA 会替换当前官网标签页。调整后用户可以保留 Mimi Remote 官网，同时访问 TestFlight 或 GitHub；文案、样式、目标 URL 和其他导航链接不变。

## 验证

- `git diff --check`
- 精确检查仅两个首屏 CTA 包含 `target="_blank" rel="noopener noreferrer"`
- `bash scripts/check-brand-identity.sh`

Linear: MIM-126
