### PR TITLE
MIM-125 修正侧边栏完成状态与项目头像

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -13439,7 +13439,7 @@
       }
     },
     "ui.just_completed": {
-      "comment": "Sidebar section for unread sessions that have just reached a terminal state.",
+      "comment": "Sidebar section for sessions whose terminal transition was observed inside the short just-completed window.",
       "extractionState": "manual",
       "localizations": {
         "en": {

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
@@ -214,6 +214,22 @@ enum SessionListPresentation {
         directoryTail(for: session)
     }
 
+    /// 仅在运行中和刚完成分区合并相邻的同项目头像：第一行保留项目标识，
+    /// 后续行只保留对齐占位。缺少项目 ID 时不合并，避免把不同的未知项目误当成一组。
+    static func shouldShowProjectIcon(
+        for session: AgentSession,
+        previousSession: AgentSession?,
+        in kind: SessionSidebarSectionKind
+    ) -> Bool {
+        guard kind == .running || kind == .justCompleted,
+              let previousSession,
+              !session.projectID.isEmpty else {
+            return true
+        }
+
+        return session.projectID != previousSession.projectID
+    }
+
     /// 按“需要你 → 运行中 → 刚完成 → 置顶 → 最近”建立扁平侧边栏列表。
     /// 先恢复纯活动时间顺序，避免 Store 的置顶投影改变各动态分区内部顺序；重复 ID 只保留第一次出现的会话。
     ///

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
@@ -53,7 +53,7 @@ enum SessionSidebarSectionKind: String, CaseIterable, Equatable, Hashable, Ident
 struct SessionSidebarSection: Equatable, Hashable, Identifiable {
     let kind: SessionSidebarSectionKind
     let sessions: [AgentSession]
-    /// 目前只有 justCompleted 会产生溢出数量；其它组固定为 0。
+    /// 保留统一的扩展入口；当前侧边栏分组不会隐藏溢出会话。
     let overflowCount: Int
 
     init(
@@ -74,6 +74,8 @@ struct SessionSidebarSection: Equatable, Hashable, Identifiable {
 
 /// 会话列表需要的纯展示计算，避免 SwiftUI View 同时承担日期和字符串规则。
 enum SessionListPresentation {
+    static let sidebarJustCompletedWindow: TimeInterval = 2 * 60 * 60
+
     /// 按历史时间将会话放入固定日期桶；空桶不返回，桶内保持输入顺序。
     static func historyGroups(
         _ sessions: [AgentSession],
@@ -214,10 +216,16 @@ enum SessionListPresentation {
 
     /// 按“需要你 → 运行中 → 刚完成 → 置顶 → 最近”建立扁平侧边栏列表。
     /// 先恢复纯活动时间顺序，避免 Store 的置顶投影改变各动态分区内部顺序；重复 ID 只保留第一次出现的会话。
+    ///
+    /// “刚完成”只读取 Store 观察到终态转换的本地时间，并限制时间窗口和条数。它与
+    /// Mimi 本地未读水位无关：Codex Desktop 没有向当前协议回传已读回执，不能让
+    /// 本地未读冒充跨 App 完成状态。超过条数上限的完成会话继续参与置顶/最近，不会被静默丢弃。
     static func sidebarSections(
         _ sessions: [AgentSession],
         pinnedIDs: Set<SessionID> = [],
-        unreadIDs: Set<SessionID> = [],
+        completionObservedAtByID: [SessionID: Date] = [:],
+        now: Date = Date(),
+        justCompletedWindow: TimeInterval = SessionListPresentation.sidebarJustCompletedWindow,
         justCompletedLimit: Int = 5,
         recentLimit: Int = 8
     ) -> [SessionSidebarSection] {
@@ -246,11 +254,23 @@ enum SessionListPresentation {
         }
         // 本地草稿代表尚未发送首条消息的新会话，也应固定留在“进行中”，不能被 recent 上限截掉。
         let running = consume { $0.isRunning || $0.isLocalDraft }
-        let unread = consume { session in
-            !session.isLocalDraft && unreadIDs.contains(session.id)
+        let completionCandidates = unclaimed.enumerated().compactMap { index, session -> (AgentSession, Date, Int)? in
+            guard let completionDate = completionObservedAtByID[session.id] else { return nil }
+            let age = now.timeIntervalSince(completionDate)
+            guard age >= 0 && age <= max(0, justCompletedWindow) else { return nil }
+            return (session, completionDate, index)
         }
-        let visibleJustCompleted = Array(unread.prefix(max(0, justCompletedLimit)))
-        let justCompletedOverflow = max(0, unread.count - visibleJustCompleted.count)
+        .sorted { lhs, rhs in
+            if lhs.1 == rhs.1 {
+                return lhs.2 < rhs.2
+            }
+            return lhs.1 > rhs.1
+        }
+        let justCompleted = completionCandidates
+            .prefix(max(0, justCompletedLimit))
+            .map { $0.0 }
+        let justCompletedIDs = Set(justCompleted.map(\.id))
+        unclaimed.removeAll { justCompletedIDs.contains($0.id) }
         let pinned = consume { pinnedIDs.contains($0.id) }
         let recent = Array(unclaimed.prefix(max(0, recentLimit)))
 
@@ -258,12 +278,7 @@ enum SessionListPresentation {
         sections.reserveCapacity(SessionSidebarSectionKind.displayOrder.count)
         appendSection(.needYou, sessions: needYou, to: &sections)
         appendSection(.running, sessions: running, to: &sections)
-        appendSection(
-            .justCompleted,
-            sessions: visibleJustCompleted,
-            overflowCount: justCompletedOverflow,
-            to: &sections
-        )
+        appendSection(.justCompleted, sessions: justCompleted, to: &sections)
         appendSection(.pinned, sessions: pinned, to: &sections)
 
         // recent 不依赖其它分组存在；因此前组全空时仍会展示第一批最近会话。
@@ -275,36 +290,20 @@ enum SessionListPresentation {
     static func sidebarSections(
         sessions: [AgentSession],
         pinnedIDs: Set<SessionID> = [],
-        unreadIDs: Set<SessionID> = [],
+        completionObservedAtByID: [SessionID: Date] = [:],
+        now: Date = Date(),
+        justCompletedWindow: TimeInterval = SessionListPresentation.sidebarJustCompletedWindow,
         justCompletedLimit: Int = 5,
         recentLimit: Int = 8
     ) -> [SessionSidebarSection] {
         sidebarSections(
             sessions,
             pinnedIDs: pinnedIDs,
-            unreadIDs: unreadIDs,
+            completionObservedAtByID: completionObservedAtByID,
+            now: now,
+            justCompletedWindow: justCompletedWindow,
             justCompletedLimit: justCompletedLimit,
             recentLimit: recentLimit
-        )
-    }
-
-    /// 多项目侧栏只给每个项目的第一条可见会话一个身份锚点。
-    ///
-    /// 必须跨 section 去重：点击“刚完成”会立即把会话迁入“最近”，如果每个
-    /// section 独立判断首行，同一项目就会在点击前后反复出现或消失头像。
-    static func sidebarProjectAnchorSessionIDs(
-        in sections: [SessionSidebarSection]
-    ) -> Set<SessionID> {
-        let visibleSessions = stableUniqueSessions(sections.flatMap(\.sessions))
-        guard Set(visibleSessions.map(\.projectID)).count > 1 else {
-            return []
-        }
-
-        var seenProjectIDs: Set<String> = []
-        return Set(
-            visibleSessions.compactMap { session in
-                seenProjectIDs.insert(session.projectID).inserted ? session.id : nil
-            }
         )
     }
 

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
@@ -214,9 +214,9 @@ enum SessionListPresentation {
         directoryTail(for: session)
     }
 
-    /// 仅在运行中和刚完成分区合并相邻的同项目头像：第一行保留项目标识，
-    /// 后续行只保留对齐占位。缺少项目 ID 时不合并，避免把不同的未知项目误当成一组。
-    static func shouldShowProjectIcon(
+    /// 仅在运行中和刚完成分区将相邻的同项目视为一组；返回 true 代表当前行是组头。
+    /// 缺少项目 ID 时不合并，避免把不同的未知项目误当成一组。
+    static func startsSidebarProjectGroup(
         for session: AgentSession,
         previousSession: AgentSession?,
         in kind: SessionSidebarSectionKind

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -702,7 +702,7 @@ struct UnifiedWorkbenchShell: View {
                         sidebarSessionLink(
                             session,
                             kind: section.kind,
-                            showsProjectIcon: SessionListPresentation.shouldShowProjectIcon(
+                            startsProjectGroup: SessionListPresentation.startsSidebarProjectGroup(
                                 for: session,
                                 previousSession: index > 0 ? section.sessions[index - 1] : nil,
                                 in: section.kind
@@ -783,7 +783,7 @@ struct UnifiedWorkbenchShell: View {
     private func sidebarSessionLink(
         _ session: AgentSession,
         kind: SessionSidebarSectionKind,
-        showsProjectIcon: Bool,
+        startsProjectGroup: Bool,
         layout: WorkbenchLayout
     ) -> some View {
         Group {
@@ -794,7 +794,7 @@ struct UnifiedWorkbenchShell: View {
                     sidebarSessionRow(
                         session,
                         kind: kind,
-                        showsProjectIcon: showsProjectIcon
+                        startsProjectGroup: startsProjectGroup
                     )
                         .contentShape(Rectangle())
                 }
@@ -809,7 +809,7 @@ struct UnifiedWorkbenchShell: View {
                     sidebarSessionRow(
                         session,
                         kind: kind,
-                        showsProjectIcon: showsProjectIcon
+                        startsProjectGroup: startsProjectGroup
                     )
                 }
             }
@@ -824,7 +824,7 @@ struct UnifiedWorkbenchShell: View {
     private func sidebarSessionRow(
         _ session: AgentSession,
         kind: SessionSidebarSectionKind,
-        showsProjectIcon: Bool
+        startsProjectGroup: Bool
     ) -> some View {
         SessionSidebarMonitorRow(
             session: session,
@@ -832,8 +832,10 @@ struct UnifiedWorkbenchShell: View {
             isSelected: navigationState.selection == .session(session.id),
             isRecentlyCompleted: sidebarHighlightCoordinator.highlightedSessionID == session.id,
             completionObservedAt: sessionStore.historyCompletionObservedAtBySessionID[session.id],
-            // 同项目连续行只在首行画头像；Row 内的固定宽度占位保持标题对齐。
-            projectIcon: showsProjectIcon
+            // 运行组头同时承担状态和项目身份；后续同项目行隐藏两个标记，
+            // Row 内的固定宽度占位保持标题对齐。
+            showsStateMarker: kind != .running || startsProjectGroup,
+            projectIcon: startsProjectGroup
                 ? sidebarProjectIcons[session.projectID]
                     ?? workspaceAppearanceStore.projectIconContent(
                         profileID: appStore.activeHostScope.profileID,

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -669,11 +669,7 @@ struct UnifiedWorkbenchShell: View {
         }
     }
 
-    private func sidebarListContent(
-        tokens: ThemeTokens,
-        layout: WorkbenchLayout,
-        now: Date
-    ) -> some View {
+    private func sidebarListContent(tokens: ThemeTokens, layout: WorkbenchLayout, now: Date) -> some View {
         let sections = sidebarMonitorSections(now: now)
 
         return List(selection: selectionBinding(layout: layout)) {
@@ -696,8 +692,7 @@ struct UnifiedWorkbenchShell: View {
 
             ForEach(sections) { section in
                 Section {
-                    // 仍以 session.id 作为行身份；index 只用来判断相邻项目，
-                    // 避免列表刷新时因下标变化而重建已选中行。
+                    // index 只判断相邻项目，行身份仍用 session.id，避免刷新时重建已选中行。
                     ForEach(Array(section.sessions.enumerated()), id: \.element.id) { index, session in
                         sidebarSessionLink(
                             session,
@@ -832,8 +827,7 @@ struct UnifiedWorkbenchShell: View {
             isSelected: navigationState.selection == .session(session.id),
             isRecentlyCompleted: sidebarHighlightCoordinator.highlightedSessionID == session.id,
             completionObservedAt: sessionStore.historyCompletionObservedAtBySessionID[session.id],
-            // 运行组头同时承担状态和项目身份；后续同项目行隐藏两个标记，
-            // Row 内的固定宽度占位保持标题对齐。
+            // 运行组头承担状态和项目身份；后续同项目行隐藏标记，Row 固定占位保持标题对齐。
             showsStateMarker: kind != .running || startsProjectGroup,
             projectIcon: startsProjectGroup
                 ? sidebarProjectIcons[session.projectID]

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -664,10 +664,17 @@ struct UnifiedWorkbenchShell: View {
     }
 
     private func sidebarList(tokens: ThemeTokens, layout: WorkbenchLayout) -> some View {
-        let sections = sidebarMonitorSections
-        let projectAnchorSessionIDs = SessionListPresentation.sidebarProjectAnchorSessionIDs(
-            in: sections
-        )
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            sidebarListContent(tokens: tokens, layout: layout, now: context.date)
+        }
+    }
+
+    private func sidebarListContent(
+        tokens: ThemeTokens,
+        layout: WorkbenchLayout,
+        now: Date
+    ) -> some View {
+        let sections = sidebarMonitorSections(now: now)
 
         return List(selection: selectionBinding(layout: layout)) {
             Section {
@@ -693,7 +700,6 @@ struct UnifiedWorkbenchShell: View {
                         sidebarSessionLink(
                             session,
                             kind: section.kind,
-                            showsProjectAnchor: projectAnchorSessionIDs.contains(session.id),
                             layout: layout
                         )
                     }
@@ -770,7 +776,6 @@ struct UnifiedWorkbenchShell: View {
     private func sidebarSessionLink(
         _ session: AgentSession,
         kind: SessionSidebarSectionKind,
-        showsProjectAnchor: Bool,
         layout: WorkbenchLayout
     ) -> some View {
         Group {
@@ -780,8 +785,7 @@ struct UnifiedWorkbenchShell: View {
                 } label: {
                     sidebarSessionRow(
                         session,
-                        kind: kind,
-                        showsProjectAnchor: showsProjectAnchor
+                        kind: kind
                     )
                         .contentShape(Rectangle())
                 }
@@ -795,17 +799,11 @@ struct UnifiedWorkbenchShell: View {
                 NavigationLink(value: AppDestination.session(session.id)) {
                     sidebarSessionRow(
                         session,
-                        kind: kind,
-                        showsProjectAnchor: showsProjectAnchor
+                        kind: kind
                     )
                 }
             }
         }
-        .accessibilityValue(
-            sessionStore.isHistorySessionUnread(session)
-                ? L10n.text("ui.unread_result")
-                : ""
-        )
         .sessionRowActions(session)
         .sessionRowSwipeActions(session)
         .listRowInsets(.init(top: 0, leading: 8, bottom: 0, trailing: 8))
@@ -815,33 +813,33 @@ struct UnifiedWorkbenchShell: View {
 
     private func sidebarSessionRow(
         _ session: AgentSession,
-        kind: SessionSidebarSectionKind,
-        showsProjectAnchor: Bool
+        kind: SessionSidebarSectionKind
     ) -> some View {
         SessionSidebarMonitorRow(
             session: session,
             kind: kind,
             isSelected: navigationState.selection == .session(session.id),
             isRecentlyCompleted: sidebarHighlightCoordinator.highlightedSessionID == session.id,
-            projectIcon: showsProjectAnchor
-                ? sidebarProjectIcons[session.projectID]
-                    ?? workspaceAppearanceStore.projectIconContent(
-                        profileID: appStore.activeHostScope.profileID,
-                        projectID: session.projectID
-                    )
-                : nil,
+            completionObservedAt: sessionStore.historyCompletionObservedAtBySessionID[session.id],
+            // 监视器没有按项目成组，头像若只出现一次会像随机缺失；每行稳定展示项目身份。
+            projectIcon: sidebarProjectIcons[session.projectID]
+                ?? workspaceAppearanceStore.projectIconContent(
+                    profileID: appStore.activeHostScope.profileID,
+                    projectID: session.projectID
+                ),
             runtimeActivitySnapshot: sessionStore.runtimeActivitySnapshot(for: session.id)
         )
     }
 
-    private var sidebarMonitorSections: [SessionSidebarSection] {
+    private func sidebarMonitorSections(now: Date) -> [SessionSidebarSection] {
         let chronologicallySortedSessions = sessionStore.sortedAllSessions.isEmpty
             ? SessionStore.sortedSessions(sessionStore.sessionLibrarySessions)
             : sessionStore.sortedAllSessions
         return SessionListPresentation.sidebarSections(
             sessions: chronologicallySortedSessions,
             pinnedIDs: sessionStore.pinnedSessionIDs,
-            unreadIDs: sessionStore.unreadHistorySessionIDs
+            completionObservedAtByID: sessionStore.historyCompletionObservedAtBySessionID,
+            now: now
         )
     }
 

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -696,10 +696,17 @@ struct UnifiedWorkbenchShell: View {
 
             ForEach(sections) { section in
                 Section {
-                    ForEach(section.sessions) { session in
+                    // 仍以 session.id 作为行身份；index 只用来判断相邻项目，
+                    // 避免列表刷新时因下标变化而重建已选中行。
+                    ForEach(Array(section.sessions.enumerated()), id: \.element.id) { index, session in
                         sidebarSessionLink(
                             session,
                             kind: section.kind,
+                            showsProjectIcon: SessionListPresentation.shouldShowProjectIcon(
+                                for: session,
+                                previousSession: index > 0 ? section.sessions[index - 1] : nil,
+                                in: section.kind
+                            ),
                             layout: layout
                         )
                     }
@@ -776,6 +783,7 @@ struct UnifiedWorkbenchShell: View {
     private func sidebarSessionLink(
         _ session: AgentSession,
         kind: SessionSidebarSectionKind,
+        showsProjectIcon: Bool,
         layout: WorkbenchLayout
     ) -> some View {
         Group {
@@ -785,7 +793,8 @@ struct UnifiedWorkbenchShell: View {
                 } label: {
                     sidebarSessionRow(
                         session,
-                        kind: kind
+                        kind: kind,
+                        showsProjectIcon: showsProjectIcon
                     )
                         .contentShape(Rectangle())
                 }
@@ -799,7 +808,8 @@ struct UnifiedWorkbenchShell: View {
                 NavigationLink(value: AppDestination.session(session.id)) {
                     sidebarSessionRow(
                         session,
-                        kind: kind
+                        kind: kind,
+                        showsProjectIcon: showsProjectIcon
                     )
                 }
             }
@@ -813,7 +823,8 @@ struct UnifiedWorkbenchShell: View {
 
     private func sidebarSessionRow(
         _ session: AgentSession,
-        kind: SessionSidebarSectionKind
+        kind: SessionSidebarSectionKind,
+        showsProjectIcon: Bool
     ) -> some View {
         SessionSidebarMonitorRow(
             session: session,
@@ -821,12 +832,14 @@ struct UnifiedWorkbenchShell: View {
             isSelected: navigationState.selection == .session(session.id),
             isRecentlyCompleted: sidebarHighlightCoordinator.highlightedSessionID == session.id,
             completionObservedAt: sessionStore.historyCompletionObservedAtBySessionID[session.id],
-            // 监视器没有按项目成组，头像若只出现一次会像随机缺失；每行稳定展示项目身份。
-            projectIcon: sidebarProjectIcons[session.projectID]
-                ?? workspaceAppearanceStore.projectIconContent(
-                    profileID: appStore.activeHostScope.profileID,
-                    projectID: session.projectID
-                ),
+            // 同项目连续行只在首行画头像；Row 内的固定宽度占位保持标题对齐。
+            projectIcon: showsProjectIcon
+                ? sidebarProjectIcons[session.projectID]
+                    ?? workspaceAppearanceStore.projectIconContent(
+                        profileID: appStore.activeHostScope.profileID,
+                        projectID: session.projectID
+                    )
+                : nil,
             runtimeActivitySnapshot: sessionStore.runtimeActivitySnapshot(for: session.id)
         )
     }

--- a/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
@@ -546,7 +546,7 @@ struct SessionSidebarMonitorRow: View {
     let isSelected: Bool
     let isRecentlyCompleted: Bool
     let completionObservedAt: Date?
-    let showsStateMarker: Bool
+    var showsStateMarker: Bool = true
     let projectIcon: WorkspaceProjectIconContent?
     let runtimeActivitySnapshot: RuntimeActivitySnapshot?
 

--- a/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
@@ -545,6 +545,7 @@ struct SessionSidebarMonitorRow: View {
     let kind: SessionSidebarSectionKind
     let isSelected: Bool
     let isRecentlyCompleted: Bool
+    let completionObservedAt: Date?
     let projectIcon: WorkspaceProjectIconContent?
     let runtimeActivitySnapshot: RuntimeActivitySnapshot?
 
@@ -552,15 +553,19 @@ struct SessionSidebarMonitorRow: View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         HStack(spacing: 6) {
-            if kind == .needYou || kind == .running {
-                // 等待与运行是需要立即扫到的进行态，继续占据 leading 状态槽。
-                stateMarker(tokens: tokens)
-                    .frame(width: 12, height: 12)
-            }
+            // 所有状态共用固定 leading 槽，终态用透明占位，刷新分组时标题不会横向跳动。
+            stateMarker(tokens: tokens)
+                .frame(width: 12, height: 12)
 
-            if let projectIcon {
-                WorkspaceProjectIconTile(content: projectIcon, size: 18, tokens: tokens)
+            Group {
+                if let projectIcon {
+                    WorkspaceProjectIconTile(content: projectIcon, size: 18, tokens: tokens)
+                } else {
+                    Color.clear
+                        .accessibilityHidden(true)
+                }
             }
+            .frame(width: 18, height: 18)
 
             Text(SessionListPresentation.titleDisplayText(for: session))
                 .font(themeStore.uiFont(size: 13, weight: isSelected ? .semibold : .medium))
@@ -571,13 +576,6 @@ struct SessionSidebarMonitorRow: View {
 
             Spacer(minLength: 4)
             detail(tokens: tokens)
-
-            if kind == .justCompleted {
-                // 完成未读属于“待查看结果”，跟随相对时间放在整行 trailing，
-                // 不再与需要处理 / 正在运行的 leading 状态混在一起。
-                SessionUnreadIndicator()
-                    .frame(width: 12, height: 12)
-            }
         }
         .padding(.horizontal, 8)
         .frame(maxWidth: .infinity, minHeight: 34, alignment: .leading)
@@ -640,7 +638,13 @@ struct SessionSidebarMonitorRow: View {
                 TimelineView(.periodic(from: .now, by: 30)) { context in
                     Text(runningDuration(at: context.date))
                 }
-            case .justCompleted, .pinned, .recent:
+            case .justCompleted:
+                if let date = completionObservedAt {
+                    TimelineView(.periodic(from: .now, by: 30)) { context in
+                        Text(compactRelativeDuration(from: date, to: context.date))
+                    }
+                }
+            case .pinned, .recent:
                 if let date = session.recencyAt ?? session.updatedAt ?? session.createdAt {
                     TimelineView(.periodic(from: .now, by: 30)) { context in
                         Text(compactRelativeDuration(from: date, to: context.date))

--- a/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
@@ -546,6 +546,7 @@ struct SessionSidebarMonitorRow: View {
     let isSelected: Bool
     let isRecentlyCompleted: Bool
     let completionObservedAt: Date?
+    let showsStateMarker: Bool
     let projectIcon: WorkspaceProjectIconContent?
     let runtimeActivitySnapshot: RuntimeActivitySnapshot?
 
@@ -553,8 +554,19 @@ struct SessionSidebarMonitorRow: View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         HStack(spacing: 6) {
-            // 所有状态共用固定 leading 槽，终态用透明占位，刷新分组时标题不会横向跳动。
-            stateMarker(tokens: tokens)
+            // 所有状态共用固定 leading 槽；同项目后续行只隐藏视觉菊花，
+            // 仍保留“进行中”无障碍语义，同时避免标题横向跳动。
+            Group {
+                if showsStateMarker {
+                    stateMarker(tokens: tokens)
+                } else if kind == .running {
+                    Color.clear
+                        .accessibilityLabel(L10n.text("ui.in_progress"))
+                } else {
+                    Color.clear
+                        .accessibilityHidden(true)
+                }
+            }
                 .frame(width: 12, height: 12)
 
             Group {

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -96,6 +96,8 @@ final class SessionStore: ObservableObject {
     /// 避免两台 Mac 上碰巧相同的 Session ID 互相禁用操作。
     @Published private(set) var pendingSessionArchiveMutationKeys: Set<ScopedSessionID> = []
     @Published private(set) var unreadHistorySessionIDs: Set<SessionID> = []
+    /// 真实观察到 running → terminal 的本地时间，独立于已读水位，供侧边栏展示短时完成结果。
+    @Published private(set) var historyCompletionObservedAtBySessionID: [SessionID: Date] = [:]
     @Published var sessionWorkspaceIDs: Set<String>? = nil
     @Published var sessionRemindersByID: [SessionID: SessionReminder] = [:]
     @Published var selectedProjectID: String?
@@ -219,6 +221,13 @@ final class SessionStore: ObservableObject {
             return
         }
         unreadHistorySessionIDs = value
+    }
+
+    func setHistoryCompletionObservedAtBySessionID(_ value: [SessionID: Date]) {
+        guard historyCompletionObservedAtBySessionID != value else {
+            return
+        }
+        historyCompletionObservedAtBySessionID = value
     }
 
     func insertPendingSessionArchiveMutationKey(_ key: ScopedSessionID) {

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -1636,6 +1636,8 @@ extension SessionStore {
     func synchronizeHistoryReadStates() {
         var next = historyReadStateBySessionID
         var didChange = false
+        // 同一份 sessions 快照里的完成共享观察时间，避免循环顺序制造虚假的先后关系。
+        lazy var snapshotCompletionObservedAt = sessionListNow()
 
         for session in sessions where !session.isLocalDraft {
             var state = next[session.id] ?? SessionHistoryReadState()
@@ -1674,14 +1676,16 @@ extension SessionStore {
                         if completedAfterObservedRunning {
                             // running → terminal 本身就是可靠完成事件；即使轻量快照尚未推进版本字段，
                             // 也只在这次转换上记录一次，不让后续普通轮询刷新时间。
-                            state.completionObservedAt = sessionListNow()
+                            state.completionObservedAt = snapshotCompletionObservedAt
                         }
                     } else {
                         state.latestCompletion = version
                         state.manualUnreadCompletion = nil
                         // 冷启动或离线期间只能确认“版本不同”，无法确认它刚刚完成；
                         // 没观察到运行态就明确清空，避免把旧结果放进刚完成。
-                        state.completionObservedAt = completedAfterObservedRunning ? sessionListNow() : nil
+                        state.completionObservedAt = completedAfterObservedRunning
+                            ? snapshotCompletionObservedAt
+                            : nil
                         if selectedSessionID == session.id {
                             state.readCompletion = version
                         }
@@ -1690,7 +1694,9 @@ extension SessionStore {
                     state.latestCompletion = version
                     state.manualUnreadCompletion = nil
                     // 旧历史首次进入索引时视为已读；从已观察运行态进入终态才是新结果。
-                    state.completionObservedAt = completedAfterObservedRunning ? sessionListNow() : nil
+                    state.completionObservedAt = completedAfterObservedRunning
+                        ? snapshotCompletionObservedAt
+                        : nil
                     if !completedAfterObservedRunning || selectedSessionID == session.id {
                         state.readCompletion = version
                     }

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -1643,13 +1643,16 @@ extension SessionStore {
 
             if session.isRunning {
                 state.observedRunning = true
+                // 新一轮运行开始后，上一轮“刚完成”立即失效；终态快照不完整时也不能让旧时间重新泄漏。
+                state.completionObservedAt = nil
                 if let activeTurnID = normalizedCompletionTurnID(session.activeTurnID) {
                     state.pendingTurnID = activeTurnID
                 }
             } else {
+                let completedAfterObservedRunning = state.observedRunning
                 let version = SessionCompletionVersion(
                     session: session,
-                    completedTurnID: state.observedRunning ? state.pendingTurnID : nil
+                    completedTurnID: completedAfterObservedRunning ? state.pendingTurnID : nil
                 )
                 guard version.hasStableSignal else {
                     continue
@@ -1668,9 +1671,17 @@ extension SessionStore {
                         } else if selectedSessionID == session.id || wasRead {
                             state.readCompletion = merged
                         }
+                        if completedAfterObservedRunning {
+                            // running → terminal 本身就是可靠完成事件；即使轻量快照尚未推进版本字段，
+                            // 也只在这次转换上记录一次，不让后续普通轮询刷新时间。
+                            state.completionObservedAt = sessionListNow()
+                        }
                     } else {
                         state.latestCompletion = version
                         state.manualUnreadCompletion = nil
+                        // 冷启动或离线期间只能确认“版本不同”，无法确认它刚刚完成；
+                        // 没观察到运行态就明确清空，避免把旧结果放进刚完成。
+                        state.completionObservedAt = completedAfterObservedRunning ? sessionListNow() : nil
                         if selectedSessionID == session.id {
                             state.readCompletion = version
                         }
@@ -1679,7 +1690,8 @@ extension SessionStore {
                     state.latestCompletion = version
                     state.manualUnreadCompletion = nil
                     // 旧历史首次进入索引时视为已读；从已观察运行态进入终态才是新结果。
-                    if !state.observedRunning || selectedSessionID == session.id {
+                    state.completionObservedAt = completedAfterObservedRunning ? sessionListNow() : nil
+                    if !completedAfterObservedRunning || selectedSessionID == session.id {
                         state.readCompletion = version
                     }
                 }
@@ -1701,6 +1713,7 @@ extension SessionStore {
             )
         }
         publishUnreadHistorySessionIDs(from: next)
+        publishHistoryCompletionObservedAtBySessionID(from: next)
     }
 
     func isHistorySessionUnread(_ session: AgentSession) -> Bool {
@@ -1773,6 +1786,23 @@ extension SessionStore {
             return session.id
         })
         setUnreadHistorySessionIDs(visibleUnreadIDs)
+    }
+
+    private func publishHistoryCompletionObservedAtBySessionID(
+        from states: [SessionID: SessionHistoryReadState]
+    ) {
+        var visibleCompletionDates: [SessionID: Date] = [:]
+        visibleCompletionDates.reserveCapacity(sessions.count)
+        for session in sessions {
+            guard !session.isRunning,
+                  !session.isLocalDraft,
+                  let observedAt = states[session.id]?.completionObservedAt else {
+                continue
+            }
+            // 数据合并层理论上已按 ID 去重；这里仍使用下标覆盖，避免异常重复快照触发字典构造崩溃。
+            visibleCompletionDates[session.id] = observedAt
+        }
+        setHistoryCompletionObservedAtBySessionID(visibleCompletionDates)
     }
 
     private func normalizedCompletionTurnID(_ value: TurnID?) -> TurnID? {

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -471,6 +471,9 @@ struct SessionHistoryReadState: Codable, Equatable {
     var readCompletion: SessionCompletionVersion?
     /// 区分用户显式“标为未读”和新完成自然产生的未读，避免选中态同步把前者覆盖。
     var manualUnreadCompletion: SessionCompletionVersion?
+    /// Mimi 首次确认当前完成版本进入终态的本地时间。它不表示跨 App 已读状态，
+    /// 只让“刚完成”在重启后仍能维持一个短而稳定的展示窗口。
+    var completionObservedAt: Date?
     var observedRunning = false
     var pendingTurnID: TurnID?
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -3412,6 +3412,15 @@ extension ConversationDataFlowTests {
             firstCompletionObservationDate,
             "running → terminal 才记录本地完成观察时间"
         )
+        let sectionsBeforeOpening = SessionListPresentation.sidebarSections(
+            sessions: [firstCompletion],
+            completionObservedAtByID: store.historyCompletionObservedAtBySessionID,
+            now: firstCompletionObservationDate.addingTimeInterval(1)
+        )
+        XCTAssertEqual(
+            sectionsBeforeOpening.first { $0.kind == .justCompleted }?.sessions.map(\.id),
+            [firstCompletion.id]
+        )
 
         await store.selectSession(firstCompletion)
         XCTAssertFalse(store.isHistorySessionUnread(firstCompletion), "打开历史会话后应立即标记已读")
@@ -3419,6 +3428,16 @@ extension ConversationDataFlowTests {
             store.historyCompletionObservedAtBySessionID[firstCompletion.id],
             firstCompletionObservationDate,
             "Mimi 标记已读不能清除完成观察时间"
+        )
+        let sectionsAfterOpening = SessionListPresentation.sidebarSections(
+            sessions: [firstCompletion],
+            completionObservedAtByID: store.historyCompletionObservedAtBySessionID,
+            now: firstCompletionObservationDate.addingTimeInterval(1)
+        )
+        XCTAssertEqual(
+            sectionsAfterOpening.first { $0.kind == .justCompleted }?.sessions.map(\.id),
+            [firstCompletion.id],
+            "点击只改变已读水位，刚完成行在时间窗内必须保留原分组，避免视觉跳动"
         )
 
         let persisted = readStateStore.load(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -3326,8 +3326,8 @@ extension ConversationDataFlowTests {
         )
     }
 
-    func testHistoryUnreadPersistsReadAndReopensForNextCompletion() async {
-        let suiteName = "ConversationSessionStoreTests.HistoryUnread.\(UUID().uuidString)"
+    func testHistoryCompletionObservationPersistsAcrossReadAndRestart() async throws {
+        let suiteName = "ConversationSessionStoreTests.HistoryCompletionObservation.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -3358,17 +3358,26 @@ extension ConversationDataFlowTests {
             )
         ], sessionID: initialHistory.id)
         let client = MockSessionStoreClient(projects: [project], sessions: [initialHistory])
+        let initialObservationDate = Date(timeIntervalSince1970: 100)
+        let firstCompletionObservationDate = Date(timeIntervalSince1970: 120)
+        let secondCompletionObservationDate = Date(timeIntervalSince1970: 140)
+        var sessionListNow = initialObservationDate
         let store = SessionStore(
             appStore: appStore,
             conversationStore: conversationStore,
             logStore: LogStore(),
             sessionHistoryReadStateStore: readStateStore,
             clientFactory: { client },
-            webSocketFactory: { MockWebSocketClient() }
+            webSocketFactory: { MockWebSocketClient() },
+            sessionListNow: { sessionListNow }
         )
 
         store.sessions = [initialHistory]
         XCTAssertFalse(store.isHistorySessionUnread(initialHistory), "升级后首次见到的旧历史应建立已读基线")
+        XCTAssertNil(
+            store.historyCompletionObservedAtBySessionID[initialHistory.id],
+            "旧历史首次进入索引没有观察到运行态，不应伪装成刚完成"
+        )
 
         let running = makeSession(
             id: initialHistory.id,
@@ -3383,7 +3392,9 @@ extension ConversationDataFlowTests {
         )
         store.sessions = [running]
         XCTAssertFalse(store.isHistorySessionUnread(running), "进行中会话不能显示历史未读")
+        XCTAssertTrue(store.historyCompletionObservedAtBySessionID.isEmpty)
 
+        sessionListNow = firstCompletionObservationDate
         let firstCompletion = makeSession(
             id: initialHistory.id,
             projectID: project.id,
@@ -3396,9 +3407,19 @@ extension ConversationDataFlowTests {
         )
         store.sessions = [firstCompletion]
         XCTAssertTrue(store.isHistorySessionUnread(firstCompletion))
+        XCTAssertEqual(
+            store.historyCompletionObservedAtBySessionID[firstCompletion.id],
+            firstCompletionObservationDate,
+            "running → terminal 才记录本地完成观察时间"
+        )
 
         await store.selectSession(firstCompletion)
         XCTAssertFalse(store.isHistorySessionUnread(firstCompletion), "打开历史会话后应立即标记已读")
+        XCTAssertEqual(
+            store.historyCompletionObservedAtBySessionID[firstCompletion.id],
+            firstCompletionObservationDate,
+            "Mimi 标记已读不能清除完成观察时间"
+        )
 
         let persisted = readStateStore.load(
             profileID: appStore.notificationRoutingProfileID,
@@ -3406,6 +3427,10 @@ extension ConversationDataFlowTests {
             profiles: appStore.connectionProfiles
         )
         XCTAssertFalse(try XCTUnwrap(persisted[firstCompletion.id]).isUnread)
+        XCTAssertEqual(
+            try XCTUnwrap(persisted[firstCompletion.id]).completionObservedAt,
+            firstCompletionObservationDate
+        )
 
         let restartedStore = SessionStore(
             appStore: appStore,
@@ -3413,15 +3438,39 @@ extension ConversationDataFlowTests {
             logStore: LogStore(),
             sessionHistoryReadStateStore: readStateStore,
             clientFactory: { client },
-            webSocketFactory: { MockWebSocketClient() }
+            webSocketFactory: { MockWebSocketClient() },
+            sessionListNow: { sessionListNow }
         )
         restartedStore.sessions = [firstCompletion]
         XCTAssertFalse(
             restartedStore.isHistorySessionUnread(firstCompletion),
             "App 重启和列表重新加载后不能把已读状态回退"
         )
+        XCTAssertEqual(
+            restartedStore.historyCompletionObservedAtBySessionID[firstCompletion.id],
+            firstCompletionObservationDate,
+            "完成观察时间应随持久化读状态在重启后恢复"
+        )
 
         restartedStore.returnToSessionList()
+        // 离线期间直接发现了新 completion version，但没有观察到 running；这不是可靠的
+        // 完成转换证据，不能写入或复用“刚完成”时间。
+        let offlineCompletion = makeSession(
+            id: firstCompletion.id,
+            projectID: project.id,
+            title: "离线期间完成",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            resumeID: firstCompletion.resumeID,
+            updatedAt: Date(timeIntervalSince1970: 25),
+            recencyAt: Date(timeIntervalSince1970: 25)
+        )
+        restartedStore.sessions = [offlineCompletion]
+        XCTAssertNil(
+            restartedStore.historyCompletionObservedAtBySessionID[offlineCompletion.id],
+            "冷启动/离线只知道版本变化时不应标记为刚完成"
+        )
+
         let secondRunning = makeSession(
             id: firstCompletion.id,
             projectID: project.id,
@@ -3435,7 +3484,9 @@ extension ConversationDataFlowTests {
         )
         restartedStore.sessions = [secondRunning]
         XCTAssertFalse(restartedStore.isHistorySessionUnread(secondRunning))
+        XCTAssertTrue(restartedStore.historyCompletionObservedAtBySessionID.isEmpty)
 
+        sessionListNow = secondCompletionObservationDate
         let secondCompletion = makeSession(
             id: firstCompletion.id,
             projectID: project.id,
@@ -3451,15 +3502,24 @@ extension ConversationDataFlowTests {
             restartedStore.isHistorySessionUnread(secondCompletion),
             "同一会话产生新的完成结果后应重新进入未读"
         )
+        XCTAssertEqual(
+            restartedStore.historyCompletionObservedAtBySessionID[secondCompletion.id],
+            secondCompletionObservationDate
+        )
 
         restartedStore.sessions = [secondCompletion]
         XCTAssertTrue(
             restartedStore.isHistorySessionUnread(secondCompletion),
             "相同完成版本的重复刷新不能改变未读判定"
         )
+        XCTAssertEqual(
+            restartedStore.historyCompletionObservedAtBySessionID[secondCompletion.id],
+            secondCompletionObservationDate,
+            "相同完成版本重复快照不能刷新观察时间"
+        )
     }
 
-    func testMarkHistorySessionUnreadPersistsCompletionWatermark() throws {
+    func testMarkHistorySessionUnreadKeepsCompletionObservationPersisted() throws {
         let suiteName = "ConversationSessionStoreTests.MarkUnread.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
@@ -3481,19 +3541,42 @@ extension ConversationDataFlowTests {
             recencyAt: Date(timeIntervalSince1970: 40)
         )
         let client = MockSessionStoreClient(projects: [project], sessions: [session])
+        let completionObservedAt = Date(timeIntervalSince1970: 60)
+        let nextCompletionObservedAt = Date(timeIntervalSince1970: 80)
+        var sessionListNow = completionObservedAt
         let store = SessionStore(
             appStore: appStore,
             conversationStore: ConversationStore(),
             logStore: LogStore(),
             sessionHistoryReadStateStore: readStateStore,
-            clientFactory: { client }
+            clientFactory: { client },
+            sessionListNow: { sessionListNow }
         )
         store.sessions = [session]
         XCTAssertFalse(store.isHistorySessionUnread(session))
+        XCTAssertNil(store.historyCompletionObservedAtBySessionID[session.id])
 
+        var running = session
+        running.status = SessionStatus.running.rawValue
+        running.activeTurnID = "turn-mark-unread"
+        running.updatedAt = Date(timeIntervalSince1970: 50)
+        running.recencyAt = Date(timeIntervalSince1970: 50)
+        store.sessions = [running]
+        XCTAssertTrue(store.historyCompletionObservedAtBySessionID.isEmpty)
+
+        var completed = session
+        completed.updatedAt = Date(timeIntervalSince1970: 51)
+        completed.recencyAt = Date(timeIntervalSince1970: 51)
+        store.sessions = [completed]
+        XCTAssertEqual(store.historyCompletionObservedAtBySessionID[session.id], completionObservedAt)
+
+        // 先确认自然完成已读，再回退为手动未读，才能验证两条水位彼此独立。
+        store.markHistorySessionRead(session.id)
+        XCTAssertFalse(store.isHistorySessionUnread(completed))
         store.markHistorySessionUnread(session.id)
 
-        XCTAssertTrue(store.isHistorySessionUnread(session))
+        XCTAssertTrue(store.isHistorySessionUnread(completed))
+        XCTAssertEqual(store.historyCompletionObservedAtBySessionID[session.id], completionObservedAt)
         XCTAssertNil(try XCTUnwrap(store.historyReadStateBySessionID[session.id]).readCompletion)
         let persisted = readStateStore.load(
             profileID: appStore.notificationRoutingProfileID,
@@ -3501,28 +3584,44 @@ extension ConversationDataFlowTests {
             profiles: appStore.connectionProfiles
         )
         XCTAssertTrue(try XCTUnwrap(persisted[session.id]).isUnread)
+        XCTAssertEqual(
+            try XCTUnwrap(persisted[session.id]).completionObservedAt,
+            completionObservedAt
+        )
 
-        store.selectedSessionID = session.id
+        store.selectedSessionID = completed.id
         store.synchronizeHistoryReadStates()
         XCTAssertTrue(
-            store.isHistorySessionUnread(session),
+            store.isHistorySessionUnread(completed),
             "当前选中会话的手动未读不能被普通快照同步覆盖"
         )
+        XCTAssertEqual(store.historyCompletionObservedAtBySessionID[completed.id], completionObservedAt)
 
         // Published Set 只是派生结果；即使被清空，重新同步也必须从 completion 水位恢复。
         store.setUnreadHistorySessionIDs([])
-        XCTAssertFalse(store.isHistorySessionUnread(session))
+        XCTAssertFalse(store.isHistorySessionUnread(completed))
         store.synchronizeHistoryReadStates()
-        XCTAssertTrue(store.isHistorySessionUnread(session))
+        XCTAssertTrue(store.isHistorySessionUnread(completed))
+        XCTAssertEqual(store.historyCompletionObservedAtBySessionID[completed.id], completionObservedAt)
 
-        var nextCompletion = session
-        nextCompletion.updatedAt = Date(timeIntervalSince1970: 41)
-        nextCompletion.recencyAt = Date(timeIntervalSince1970: 41)
+        var nextRunning = completed
+        nextRunning.status = SessionStatus.running.rawValue
+        nextRunning.activeTurnID = "turn-next-completion"
+        nextRunning.updatedAt = Date(timeIntervalSince1970: 70)
+        nextRunning.recencyAt = Date(timeIntervalSince1970: 70)
+        store.sessions = [nextRunning]
+        XCTAssertTrue(store.historyCompletionObservedAtBySessionID.isEmpty)
+
+        sessionListNow = nextCompletionObservedAt
+        var nextCompletion = completed
+        nextCompletion.updatedAt = Date(timeIntervalSince1970: 71)
+        nextCompletion.recencyAt = Date(timeIntervalSince1970: 71)
         store.sessions = [nextCompletion]
         XCTAssertFalse(
             store.isHistorySessionUnread(nextCompletion),
             "当前可见的新完成结果应视为已读，不能继承上一完成版本的手动未读"
         )
+        XCTAssertEqual(store.historyCompletionObservedAtBySessionID[nextCompletion.id], nextCompletionObservedAt)
         XCTAssertNil(
             try XCTUnwrap(store.historyReadStateBySessionID[session.id]).manualUnreadCompletion
         )

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -3538,6 +3538,74 @@ extension ConversationDataFlowTests {
         )
     }
 
+    func testBatchCompletionSharesObservationTimeAndKeepsStableOrder() throws {
+        let suiteName = "ConversationSessionStoreTests.BatchCompletionObservation.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let project = makeProject(id: "project-batch-completion")
+        let running = (0..<7).map { index in
+            makeSession(
+                id: "batch-completion-\(index)",
+                projectID: project.id,
+                title: "批量完成 \(index)",
+                status: SessionStatus.running.rawValue,
+                source: "codex",
+                resumeID: "batch-completion-\(index)",
+                activeTurnID: "turn-batch-\(index)",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index)),
+                recencyAt: Date(timeIntervalSince1970: TimeInterval(100 - index))
+            )
+        }
+        let completed = running.enumerated().map { index, session in
+            let activityDate = Date(timeIntervalSince1970: TimeInterval(100 - index))
+            return makeSession(
+                id: session.id,
+                projectID: project.id,
+                title: session.title,
+                status: SessionStatus.history.rawValue,
+                source: "codex",
+                resumeID: session.resumeID,
+                updatedAt: activityDate,
+                recencyAt: activityDate
+            )
+        }
+        var clockTick: TimeInterval = 1_000
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            sessionHistoryReadStateStore: SessionHistoryReadStateStore(defaults: defaults),
+            clientFactory: { MockSessionStoreClient(projects: [project], sessions: completed) },
+            sessionListNow: {
+                defer { clockTick += 1 }
+                return Date(timeIntervalSince1970: clockTick)
+            }
+        )
+
+        store.sessions = running
+        store.sessions = completed
+
+        let observations = completed.compactMap {
+            store.historyCompletionObservedAtBySessionID[$0.id]
+        }
+        XCTAssertEqual(observations.count, completed.count)
+        XCTAssertEqual(Set(observations).count, 1, "同一份终态快照只能生成一个完成观察时间")
+
+        let observationDate = try XCTUnwrap(observations.first)
+        let sections = SessionListPresentation.sidebarSections(
+            sessions: completed,
+            completionObservedAtByID: store.historyCompletionObservedAtBySessionID,
+            now: observationDate.addingTimeInterval(1)
+        )
+        XCTAssertEqual(
+            sections.first { $0.kind == .justCompleted }?.sessions.map(\.id),
+            Array(completed.prefix(5)).map(\.id),
+            "批量完成时间相同时应保留原活动顺序，不能按循环中的取时顺序反转"
+        )
+    }
+
     func testMarkHistorySessionUnreadKeepsCompletionObservationPersisted() throws {
         let suiteName = "ConversationSessionStoreTests.MarkUnread.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
@@ -1908,6 +1908,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         isSelected: false,
                         isRecentlyCompleted: false,
                         completionObservedAt: nil,
+                        showsStateMarker: true,
                         projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: nil
                     )
@@ -1922,6 +1923,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         isSelected: true,
                         isRecentlyCompleted: false,
                         completionObservedAt: nil,
+                        showsStateMarker: true,
                         projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: RuntimeActivitySnapshot(
                             turnStartedAt: Date().addingTimeInterval(-12 * 60),
@@ -1939,6 +1941,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         isSelected: false,
                         isRecentlyCompleted: true,
                         completionObservedAt: completedObservedAt,
+                        showsStateMarker: true,
                         projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: nil
                     )

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
@@ -1908,7 +1908,6 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         isSelected: false,
                         isRecentlyCompleted: false,
                         completionObservedAt: nil,
-                        showsStateMarker: true,
                         projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: nil
                     )
@@ -1923,7 +1922,6 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         isSelected: true,
                         isRecentlyCompleted: false,
                         completionObservedAt: nil,
-                        showsStateMarker: true,
                         projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: RuntimeActivitySnapshot(
                             turnStartedAt: Date().addingTimeInterval(-12 * 60),
@@ -1941,7 +1939,6 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         isSelected: false,
                         isRecentlyCompleted: true,
                         completionObservedAt: completedObservedAt,
-                        showsStateMarker: true,
                         projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: nil
                     )
@@ -2186,8 +2183,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
         sessionStore.sidebarProjects = [project, secondProject]
         sessionStore.sessions = [active, pinned] + historyRows
         sessionStore.pinnedSessionIDs = [pinned.id]
-        // 这是主会话列表快照，继续验证 Mimi 自己维护的未读标记；
-        // 浮动侧栏的“刚完成”已改用独立的完成观察时间，不影响这里的语义。
+        // 主列表继续验证 Mimi 本地未读；浮动侧栏的“刚完成”使用独立的完成观察时间。
         sessionStore.setUnreadHistorySessionIDs([historyRows[1].id, historyRows[5].id])
         sessionStore.selectedSessionID = historyRows[0].id
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
@@ -1880,6 +1880,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
             preview: "",
             recencyAt: Date().addingTimeInterval(-3 * 60)
         )
+        let completedObservedAt = Date().addingTimeInterval(-3 * 60)
 
         let view = VStack(spacing: 0) {
             List {
@@ -1906,6 +1907,7 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         kind: .needYou,
                         isSelected: false,
                         isRecentlyCompleted: false,
+                        completionObservedAt: nil,
                         projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: nil
                     )
@@ -1919,7 +1921,8 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         kind: .running,
                         isSelected: true,
                         isRecentlyCompleted: false,
-                        projectIcon: nil,
+                        completionObservedAt: nil,
+                        projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: RuntimeActivitySnapshot(
                             turnStartedAt: Date().addingTimeInterval(-12 * 60),
                             lastActivityAt: Date()
@@ -1935,7 +1938,8 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
                         kind: .justCompleted,
                         isSelected: false,
                         isRecentlyCompleted: true,
-                        projectIcon: nil,
+                        completionObservedAt: completedObservedAt,
+                        projectIcon: .emoji("🐱"),
                         runtimeActivitySnapshot: nil
                     )
                     .listRowInsets(.init(top: 0, leading: 8, bottom: 0, trailing: 8))
@@ -2179,6 +2183,8 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
         sessionStore.sidebarProjects = [project, secondProject]
         sessionStore.sessions = [active, pinned] + historyRows
         sessionStore.pinnedSessionIDs = [pinned.id]
+        // 这是主会话列表快照，继续验证 Mimi 自己维护的未读标记；
+        // 浮动侧栏的“刚完成”已改用独立的完成观察时间，不影响这里的语义。
         sessionStore.setUnreadHistorySessionIDs([historyRows[1].id, historyRows[5].id])
         sessionStore.selectedSessionID = historyRows[0].id
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
@@ -296,6 +296,75 @@ final class SessionListPresentationTests: XCTestCase {
         XCTAssertEqual(sections[0].overflowCount, 0)
     }
 
+    func testSidebarCollapsesOnlyAdjacentProjectIconsInRunningAndJustCompleted() {
+        let first = makeSession(id: "project-a-first", projectID: "project-a")
+        let adjacentSameProject = makeSession(id: "project-a-second", projectID: "project-a")
+        let differentProject = makeSession(id: "project-b", projectID: "project-b")
+        let separatedSameProject = makeSession(id: "project-a-third", projectID: "project-a")
+        let missingProject = makeSession(id: "missing-project", projectID: "")
+
+        XCTAssertTrue(
+            SessionListPresentation.shouldShowProjectIcon(
+                for: first,
+                previousSession: nil,
+                in: .running
+            )
+        )
+        XCTAssertFalse(
+            SessionListPresentation.shouldShowProjectIcon(
+                for: adjacentSameProject,
+                previousSession: first,
+                in: .running
+            ),
+            "运行中的相邻同项目只展示第一个头像"
+        )
+        XCTAssertFalse(
+            SessionListPresentation.shouldShowProjectIcon(
+                for: adjacentSameProject,
+                previousSession: first,
+                in: .justCompleted
+            ),
+            "刚完成的相邻同项目也应合并头像"
+        )
+        XCTAssertTrue(
+            SessionListPresentation.shouldShowProjectIcon(
+                for: differentProject,
+                previousSession: adjacentSameProject,
+                in: .running
+            )
+        )
+        XCTAssertTrue(
+            SessionListPresentation.shouldShowProjectIcon(
+                for: separatedSameProject,
+                previousSession: differentProject,
+                in: .running
+            ),
+            "同项目被其他项目隔开后要重新展示头像"
+        )
+        for kind in [
+            SessionSidebarSectionKind.needYou,
+            .pinned,
+            .recent,
+        ] {
+            XCTAssertTrue(
+                SessionListPresentation.shouldShowProjectIcon(
+                    for: adjacentSameProject,
+                    previousSession: first,
+                    in: kind
+                ),
+                "\(kind.rawValue) 不在本次合并范围，仍应逐行展示项目身份"
+            )
+        }
+        XCTAssertTrue(
+            SessionListPresentation.shouldShowProjectIcon(
+                for: missingProject,
+                previousSession: missingProject,
+                in: .running
+            ),
+            "缺少项目 ID 时不能把未知会话误合并"
+        )
+    }
+
     func testSidebarKeepsLocalDraftInRunningSection() throws {
         let localDraft = makeSession(
             id: "local-draft",

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
@@ -163,11 +163,13 @@ final class SessionListPresentationTests: XCTestCase {
         let pinned = makeSession(id: "pinned")
         let recent = makeSession(id: "recent")
         let duplicatePinned = makeSession(id: "pinned", status: SessionStatus.running.rawValue)
+        let now = Date(timeIntervalSince1970: 10_000)
 
         let sections = SessionListPresentation.sidebarSections(
             sessions: [needApproval, needInput, running, waitingWithoutPayload, justCompleted, pinned, recent, duplicatePinned],
             pinnedIDs: Set(["need-approval", "pinned"]),
-            unreadIDs: Set(["completed", "running"])
+            completionObservedAtByID: [justCompleted.id: now.addingTimeInterval(-60)],
+            now: now
         )
 
         XCTAssertEqual(
@@ -186,18 +188,103 @@ final class SessionListPresentationTests: XCTestCase {
         ])
     }
 
-    func testSidebarJustCompletedKeepsFiveAndReturnsOverflowAfterDeduplication() throws {
-        let completed = (0..<7).map { makeSession(id: "completed-\($0)") }
+    func testSidebarJustCompletedKeepsFiveAndLetsOverflowContinueIntoPinnedAndRecent() throws {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let completed = (0..<7).map { index in
+            makeSession(
+                id: "completed-\(index)",
+                recencyAt: now.addingTimeInterval(-Double(index))
+            )
+        }
+        // 输入重复 ID 后仍只占一个槽；第 6、7 个完成候选不能被静默吞掉。
         let sessions = completed + [completed[2]]
         let sections = SessionListPresentation.sidebarSections(
             sessions,
-            unreadIDs: Set(completed.map(\.id))
+            pinnedIDs: [completed[5].id],
+            completionObservedAtByID: Dictionary(
+                uniqueKeysWithValues: completed.map { ($0.id, now.addingTimeInterval(-60)) }
+            ),
+            now: now
         )
 
-        let section = try XCTUnwrap(sections.first { $0.kind == .justCompleted })
-        XCTAssertEqual(section.sessions.map(\.id), (0..<5).map { "completed-\($0)" })
-        XCTAssertEqual(section.overflowCount, 2)
-        XCTAssertEqual(section.overflow, 2)
+        let justCompleted = try XCTUnwrap(sections.first { $0.kind == .justCompleted })
+        let pinned = try XCTUnwrap(sections.first { $0.kind == .pinned })
+        let recent = try XCTUnwrap(sections.first { $0.kind == .recent })
+        XCTAssertEqual(justCompleted.sessions.map(\.id), (0..<5).map { "completed-\($0)" })
+        XCTAssertEqual(justCompleted.overflowCount, 0)
+        XCTAssertEqual(pinned.sessions.map(\.id), ["completed-5"])
+        XCTAssertEqual(recent.sessions.map(\.id), ["completed-6"])
+        XCTAssertTrue(sections.allSatisfy { $0.overflowCount == 0 })
+    }
+
+    func testSidebarJustCompletedUsesTwoHourWindowBoundaryAndOldTasksBecomeRecent() throws {
+        let now = Date(timeIntervalSince1970: 20_000)
+        let inside = makeSession(
+            id: "inside-window",
+            recencyAt: now.addingTimeInterval(-60)
+        )
+        let atBoundary = makeSession(
+            id: "at-boundary",
+            recencyAt: now.addingTimeInterval(-120)
+        )
+        let outside = makeSession(
+            id: "outside-window",
+            recencyAt: now.addingTimeInterval(-180)
+        )
+        let completionObservedAtByID: [SessionID: Date] = [
+            inside.id: now.addingTimeInterval(-60 * 60),
+            atBoundary.id: now.addingTimeInterval(-2 * 60 * 60),
+            outside.id: now.addingTimeInterval(-(2 * 60 * 60 + 1)),
+        ]
+
+        let sections = SessionListPresentation.sidebarSections(
+            [inside, atBoundary, outside],
+            completionObservedAtByID: completionObservedAtByID,
+            now: now,
+            justCompletedWindow: 2 * 60 * 60
+        )
+
+        let justCompleted = try XCTUnwrap(sections.first { $0.kind == .justCompleted })
+        let recent = try XCTUnwrap(sections.first { $0.kind == .recent })
+        XCTAssertEqual(justCompleted.sessions.map(\.id), [inside.id, atBoundary.id])
+        XCTAssertEqual(recent.sessions.map(\.id), [outside.id])
+    }
+
+    func testSidebarJustCompletedRanksByObservedCompletionTimeNotSessionRecency() throws {
+        let now = Date(timeIntervalSince1970: 30_000)
+        // 活动时间故意反向：较新的完成观察对应较旧的会话 recency，避免排序规则被混淆。
+        let olderSession = makeSession(
+            id: "older-session",
+            recencyAt: now.addingTimeInterval(-60)
+        )
+        let newerCompletion = makeSession(
+            id: "newer-completion",
+            recencyAt: now.addingTimeInterval(-600)
+        )
+        let oldestCompletion = makeSession(
+            id: "oldest-completion",
+            recencyAt: now.addingTimeInterval(-1)
+        )
+
+        let sections = SessionListPresentation.sidebarSections(
+            [olderSession, newerCompletion, oldestCompletion],
+            completionObservedAtByID: [
+                olderSession.id: now.addingTimeInterval(-30 * 60),
+                newerCompletion.id: now.addingTimeInterval(-5 * 60),
+                oldestCompletion.id: now.addingTimeInterval(-60 * 60),
+            ],
+            now: now,
+            justCompletedLimit: 2
+        )
+
+        let justCompleted = try XCTUnwrap(sections.first { $0.kind == .justCompleted })
+        XCTAssertEqual(
+            justCompleted.sessions.map(\.id),
+            [newerCompletion.id, olderSession.id],
+            "刚完成候选和输出都应按本地观察时间倒序，而不是复用会话活动时间排序"
+        )
+        let recent = try XCTUnwrap(sections.first { $0.kind == .recent })
+        XCTAssertEqual(recent.sessions.map(\.id), [oldestCompletion.id])
     }
 
     func testSidebarRecentIsFallbackWhenAllEarlierGroupsAreEmpty() {
@@ -245,67 +332,6 @@ final class SessionListPresentationTests: XCTestCase {
         let running = try XCTUnwrap(sections.first { $0.kind == .running })
 
         XCTAssertEqual(running.sessions.map(\.id), [newer.id, olderPinned.id])
-    }
-
-    func testSidebarProjectAnchorsAppearOnceAcrossSectionsAndInterleavedRows() {
-        let sections = [
-            SessionSidebarSection(
-                kind: .needYou,
-                sessions: [makeSession(id: "a-need", projectID: "project-a")]
-            ),
-            SessionSidebarSection(
-                kind: .running,
-                sessions: [
-                    makeSession(id: "b-running", projectID: "project-b"),
-                    makeSession(id: "a-running", projectID: "project-a"),
-                ]
-            ),
-            SessionSidebarSection(
-                kind: .recent,
-                sessions: [
-                    makeSession(id: "a-recent", projectID: "project-a"),
-                    makeSession(id: "b-recent", projectID: "project-b"),
-                ]
-            ),
-        ]
-
-        XCTAssertEqual(
-            SessionListPresentation.sidebarProjectAnchorSessionIDs(in: sections),
-            Set(["a-need", "b-running"])
-        )
-    }
-
-    func testSidebarProjectAnchorFollowsSameSessionWhenUnreadMovesToRecent() {
-        let completed = makeSession(id: "a-completed", projectID: "project-a")
-        let olderSameProject = makeSession(id: "a-older", projectID: "project-a")
-        let otherProject = makeSession(id: "b-recent", projectID: "project-b")
-        let orderedSessions = [completed, olderSameProject, otherProject]
-
-        let beforeOpening = SessionListPresentation.sidebarSections(
-            orderedSessions,
-            unreadIDs: [completed.id]
-        )
-        let afterOpening = SessionListPresentation.sidebarSections(orderedSessions)
-
-        XCTAssertEqual(
-            SessionListPresentation.sidebarProjectAnchorSessionIDs(in: beforeOpening),
-            Set([completed.id, otherProject.id])
-        )
-        XCTAssertEqual(
-            SessionListPresentation.sidebarProjectAnchorSessionIDs(in: afterOpening),
-            Set([completed.id, otherProject.id])
-        )
-    }
-
-    func testSingleProjectSidebarDoesNotAddRedundantProjectAnchor() {
-        let sections = SessionListPresentation.sidebarSections([
-            makeSession(id: "first", projectID: "project-a"),
-            makeSession(id: "second", projectID: "project-a"),
-        ])
-
-        XCTAssertTrue(
-            SessionListPresentation.sidebarProjectAnchorSessionIDs(in: sections).isEmpty
-        )
     }
 
     func testDirectoryTailPrefersDirFallsBackToProjectAndHandlesTrailingSlashes() {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
@@ -296,7 +296,7 @@ final class SessionListPresentationTests: XCTestCase {
         XCTAssertEqual(sections[0].overflowCount, 0)
     }
 
-    func testSidebarCollapsesOnlyAdjacentProjectIconsInRunningAndJustCompleted() {
+    func testSidebarUsesOneGroupHeaderForAdjacentProjectsInRunningAndJustCompleted() {
         let first = makeSession(id: "project-a-first", projectID: "project-a")
         let adjacentSameProject = makeSession(id: "project-a-second", projectID: "project-a")
         let differentProject = makeSession(id: "project-b", projectID: "project-b")
@@ -304,22 +304,22 @@ final class SessionListPresentationTests: XCTestCase {
         let missingProject = makeSession(id: "missing-project", projectID: "")
 
         XCTAssertTrue(
-            SessionListPresentation.shouldShowProjectIcon(
+            SessionListPresentation.startsSidebarProjectGroup(
                 for: first,
                 previousSession: nil,
                 in: .running
             )
         )
         XCTAssertFalse(
-            SessionListPresentation.shouldShowProjectIcon(
+            SessionListPresentation.startsSidebarProjectGroup(
                 for: adjacentSameProject,
                 previousSession: first,
                 in: .running
             ),
-            "运行中的相邻同项目只展示第一个头像"
+            "运行中的相邻同项目只在第一行展示菊花和头像"
         )
         XCTAssertFalse(
-            SessionListPresentation.shouldShowProjectIcon(
+            SessionListPresentation.startsSidebarProjectGroup(
                 for: adjacentSameProject,
                 previousSession: first,
                 in: .justCompleted
@@ -327,14 +327,14 @@ final class SessionListPresentationTests: XCTestCase {
             "刚完成的相邻同项目也应合并头像"
         )
         XCTAssertTrue(
-            SessionListPresentation.shouldShowProjectIcon(
+            SessionListPresentation.startsSidebarProjectGroup(
                 for: differentProject,
                 previousSession: adjacentSameProject,
                 in: .running
             )
         )
         XCTAssertTrue(
-            SessionListPresentation.shouldShowProjectIcon(
+            SessionListPresentation.startsSidebarProjectGroup(
                 for: separatedSameProject,
                 previousSession: differentProject,
                 in: .running
@@ -347,7 +347,7 @@ final class SessionListPresentationTests: XCTestCase {
             .recent,
         ] {
             XCTAssertTrue(
-                SessionListPresentation.shouldShowProjectIcon(
+                SessionListPresentation.startsSidebarProjectGroup(
                     for: adjacentSameProject,
                     previousSession: first,
                     in: kind
@@ -356,7 +356,7 @@ final class SessionListPresentationTests: XCTestCase {
             )
         }
         XCTAssertTrue(
-            SessionListPresentation.shouldShowProjectIcon(
+            SessionListPresentation.startsSidebarProjectGroup(
                 for: missingProject,
                 previousSession: missingProject,
                 in: .running


### PR DESCRIPTION
## 目标

修正 iPad 浮动侧边栏中“刚完成 / 最近”分组与本地未读水位耦合造成的状态误导，并统一项目头像与运行状态标记。

Linear：[MIM-125](https://linear.app/code89757/issue/MIM-125/修正浮动侧边栏的完成最近分组跨-app-未读与头像展示)

## 根因

- “刚完成”原先直接由 Mimi 本地未读集合派生；Codex Desktop 已读不会写入 Mimi 的 UserDefaults，因此会话可能长期保留在“刚完成”并显示紫点。
- 点击会话会立即更新本地已读水位，导致同一行瞬间从“刚完成”移动到“最近”。
- 侧边栏项目头像缺少稳定的逐行解析与相邻项目视觉规则；头像合并后，后续同项目行仍重复显示运行菊花，组头语义不一致。

## 改动

- 以 Mimi 实际观察到的 running → terminal 转换记录 `completionObservedAt`，按 2 小时时间窗生成“刚完成”，不再把本地未读冒充跨 App 完成状态。
- 打开会话只更新已读水位，保留完成观察时间，避免选中行立即跨分组跳动。
- 冷启动或离线首次发现的终态不会伪装成刚完成；完成观察时间按 profile 持久化。
- “刚完成”按实际完成观察时间排序，最多 5 条；其余继续参与置顶和最近分组。
- 恢复侧边栏项目头像；“进行中”内连续相邻的同项目仅首行显示“运行菊花 + 项目头像”，后续行两个固定槽位均留空，项目切换后重新显示。
- “刚完成”内连续相邻的同项目仅首行显示项目头像，后续行保留固定占位。
- 隐藏后续运行菊花时仍保留 VoiceOver 的“进行中”语义。
- 补充状态迁移、持久化、分组边界、点击稳定性与相邻项目组头规则测试。

## 用户影响

- Codex Desktop 已读但 Mimi 无跨 App 回执时，不再因为本地未读而长期占据“刚完成”。
- 点开刚完成会话后列表保持稳定，不再瞬间跳到“最近”。
- 相邻同项目任务只显示一个明确组头，标题列保持对齐，状态提示不再重复。

## 验证

- `IOS_TARGET_MODE=device bash ./scripts/ios-dev.sh build`：USB 实体 iPad Pro，rebase 最新 main 后构建成功。
- `IOS_TARGET_MODE=device bash ./scripts/ios-dev.sh run`：实体 iPad Pro 构建、安装、启动成功。
- 真机截图确认：同项目首行显示菊花与头像，后续行两个槽位留空；项目切换后重新显示。
- `git diff --check` 通过。
- 相关测试源码 `swiftc -frontend -parse` 通过。

未运行 Simulator 单测与视觉快照；本次按用户要求采用实体设备验证，PR CI 负责 iOS conversation regressions。
