### PR TITLE
MIM-31 Nightly 发布前快速校验签名 Secret

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,10 +175,52 @@ jobs:
             echo "what_to_test=$what_to_test"
           } >> "$GITHUB_OUTPUT"
 
-  publish:
-    name: Upload Nightly Internal TestFlight
+  release-secrets-preflight:
+    name: Verify Nightly release secrets
     needs: plan
     if: needs.plan.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      # plan 已先确认 official repo、最新 main 与 immutable SHA；这里只检查
+      # 发布配置是否齐全，避免缺失 Secret 时仍启动昂贵的 macOS 回归。
+      - name: Require App Store signing secrets
+        shell: bash
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+          IOS_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 }}
+          IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for secret_name in \
+            ASC_KEY_ID \
+            ASC_ISSUER_ID \
+            ASC_PRIVATE_KEY \
+            IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 \
+            IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64 \
+            IOS_DISTRIBUTION_CERTIFICATE_BASE64 \
+            IOS_DISTRIBUTION_CERTIFICATE_PASSWORD \
+            IOS_KEYCHAIN_PASSWORD; do
+            [[ -n "${!secret_name}" ]] || {
+              echo "Required GitHub Actions secret is empty: $secret_name" >&2
+              exit 1
+            }
+          done
+          echo "Nightly release secrets are configured."
+
+  publish:
+    name: Upload Nightly Internal TestFlight
+    needs:
+      - plan
+      - release-secrets-preflight
+    if: >-
+      needs.plan.outputs.should_publish == 'true' &&
+      needs.release-secrets-preflight.result == 'success'
     uses: ./.github/workflows/ios-ci.yml
     with:
       source_ref: ${{ needs.plan.outputs.source_sha }}
@@ -191,6 +233,7 @@ jobs:
     if: always()
     needs:
       - plan
+      - release-secrets-preflight
       - publish
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -199,6 +242,7 @@ jobs:
         shell: bash
         env:
           PLAN_RESULT: ${{ needs.plan.result }}
+          RELEASE_SECRETS_RESULT: ${{ needs.release-secrets-preflight.result }}
           PUBLISH_RESULT: ${{ needs.publish.result }}
           SHOULD_PUBLISH: ${{ needs.plan.outputs.should_publish }}
         run: |
@@ -207,9 +251,13 @@ jobs:
           [[ "$PLAN_RESULT" == "success" ]] \
             || { echo "Nightly plan 失败，拒绝标记成功。" >&2; exit 1; }
           if [[ "$SHOULD_PUBLISH" == "true" ]]; then
+            [[ "$RELEASE_SECRETS_RESULT" == "success" ]] \
+              || { echo "Nightly 发布凭据预检失败，拒绝启动 iOS 回归与上传。" >&2; exit 1; }
             [[ "$PUBLISH_RESULT" == "success" ]] \
               || { echo "Nightly 应发布但 Internal TestFlight 未成功。" >&2; exit 1; }
           else
+            [[ "$RELEASE_SECRETS_RESULT" == "skipped" ]] \
+              || { echo "Nightly 去重分支不得执行发布凭据预检。" >&2; exit 1; }
             [[ "$PUBLISH_RESULT" == "skipped" ]] \
               || { echo "Nightly 去重分支必须保持成功且 publish skipped。" >&2; exit 1; }
           fi

--- a/docs/nightly-release.md
+++ b/docs/nightly-release.md
@@ -8,6 +8,7 @@
 
 - Nightly workflow 先在无签名凭证的步骤中确认官方仓库、`refs/heads/main`、事件 SHA、checkout 的 `HEAD` 与最新 `origin/main` 完全一致。
 - 同一 SHA 已有成功 Nightly 时，普通定时或手工触发只做成功的 skip；需要重发时手工选择 `force_publish`。
+- 确定需要发布后，先在轻量 Ubuntu job 中只检查 ASC、主 App / Widget profile、分发证书与临时 Keychain Secrets 是否齐全；缺失配置会在启动 macOS Simulator 回归前失败。profile 内容、App Group、Team、Bundle ID、证书和签名身份仍由后续发布 job 完整校验。
 - 发布 job 复用 iOS CI 的归档、签名和 `ios_testflight_ci.sh`，成功后保存 `nightly-testflight-<SHA>` evidence artifact 30 天。
 - 正式 iOS 候选通过 iOS CI 的 `workflow_dispatch` 和 `publish_app_store` 手工触发；正式 Mac、agentd、Windows 仍由维护者在当前 `main` 上创建并推送 `v*` tag，沿用现有 Release workflow。
 
@@ -17,6 +18,6 @@ Nightly 的 What to Test 只包含北京时间日期、短 SHA 和清洗后的 c
 
 ## 风险与优化
 
-- 同一 SHA 的并发运行由固定 concurrency 串行化；已有成功 Nightly run 时默认跳过。如果上传完成后 caller 的最终汇总因基础设施故障失败，也只接受同时绑定原 Nightly workflow run、head SHA 和 evidence JSON 的 artifact，不能仅凭同名 artifact 跳过。Apple 处理或签名凭证失败时，由维护者检查日志后选择 `force_publish` 重试。
+- 同一 SHA 的并发运行由固定 concurrency 串行化；已有成功 Nightly run 时默认跳过。如果上传完成后 caller 的最终汇总因基础设施故障失败，也只接受同时绑定原 Nightly workflow run、head SHA 和 evidence JSON 的 artifact，不能仅凭同名 artifact 跳过。发布 Secret 缺失时只会输出缺失的变量名，不输出内容，也不会启动昂贵 iOS 回归；Apple 处理、profile 内容或签名凭证校验失败时，由维护者检查日志后选择 `force_publish` 重试。
 - Nightly 不会替代本地恢复入口；需要指定 commit 或离线排查时，继续使用 [`git testflight-push`](local-testflight.md)。
 - 当前不包含 App Store 审核、公开上架、rollback attestation 或额外 ASC 编排；真实需求出现后再单独评估。

--- a/scripts/check-nightly-release.sh
+++ b/scripts/check-nightly-release.sh
@@ -84,6 +84,7 @@ fail_check("Nightly 必须保留 cancel-in-progress:false") unless concurrency["
 
 nightly_jobs = nightly.fetch("jobs")
 plan = nightly_jobs.fetch("plan")
+release_secrets = nightly_jobs.fetch("release-secrets-preflight")
 publish = nightly_jobs.fetch("publish")
 final = nightly_jobs.fetch("final")
 trust_index = step_index(plan, "Trust gate before deduplication API")
@@ -120,18 +121,52 @@ dedup_run = steps(plan).fetch(dedup_index).fetch("run")
 fail_check("Nightly plan 必须输出 source_sha/what_to_test/should_publish") unless
   %w[source_sha what_to_test should_publish].all? { |key| plan.dig("outputs", key).to_s.include?("steps.plan.outputs") }
 
+fail_check("Nightly 发布凭据预检必须在 plan 成功且确定需要发布后运行") unless
+  Array(release_secrets["needs"]) == ["plan"] &&
+  release_secrets["if"].to_s.include?("needs.plan.outputs.should_publish")
+fail_check("Nightly 发布凭据预检必须使用轻量 Ubuntu runner 和短超时") unless
+  release_secrets["runs-on"] == "ubuntu-latest" && release_secrets["timeout-minutes"] == 2
+secrets_step = step(release_secrets, "Require App Store signing secrets")
+required_release_secrets = %w[
+  ASC_KEY_ID
+  ASC_ISSUER_ID
+  ASC_PRIVATE_KEY
+  IOS_APPSTORE_PROVISIONING_PROFILE_BASE64
+  IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64
+  IOS_DISTRIBUTION_CERTIFICATE_BASE64
+  IOS_DISTRIBUTION_CERTIFICATE_PASSWORD
+  IOS_KEYCHAIN_PASSWORD
+]
+fail_check("Nightly 发布凭据预检的 Secret 集合不完整") unless
+  secrets_step.fetch("env").keys.sort == required_release_secrets.sort
+required_release_secrets.each do |name|
+  fail_check("Nightly 发布凭据预检没有读取 #{name}") unless
+    secrets_step.dig("env", name).to_s.include?("secrets.#{name}") &&
+    secrets_step.fetch("run").include?(name)
+end
+fail_check("Nightly 轻量预检不得解码或写出签名材料") if
+  secrets_step.fetch("run").match?(/\bsecurity\b|profileContent|\.p12|\.mobileprovision|\bbase64\s+(?:--decode|-d|-D|<)/i)
+fail_check("Nightly 发布凭据预检必须 fail-closed") unless
+  secrets_step.fetch("run").include?('[[ -n "${!secret_name}" ]]') &&
+  secrets_step.fetch("run").include?("exit 1")
+
 fail_check("Nightly publish 必须复用 ios-ci reusable workflow") unless
   publish["uses"] == "./.github/workflows/ios-ci.yml"
-fail_check("Nightly publish 必须等待 plan 且按 should_publish 条件执行") unless
-  Array(publish["needs"]) == ["plan"] && publish["if"].to_s.include?("needs.plan.outputs.should_publish")
+fail_check("Nightly publish 必须等待 plan 与发布凭据预检") unless
+  Array(publish["needs"]).sort == %w[plan release-secrets-preflight].sort
+fail_check("Nightly publish 必须只在需要发布且凭据预检成功时执行") unless
+  publish["if"].to_s.include?("needs.plan.outputs.should_publish") &&
+  publish["if"].to_s.include?("needs.release-secrets-preflight.result") &&
+  publish["if"].to_s.include?("success")
 publish_with = publish.fetch("with")
 fail_check("Nightly publish source_ref 必须来自 plan SHA") unless publish_with["source_ref"].to_s.include?("needs.plan.outputs.source_sha")
 fail_check("Nightly publish 必须显式启用 reusable TestFlight") unless publish_with["publish_internal_testflight"] == true
 fail_check("Nightly publish What to Test 必须来自 plan") unless publish_with["what_to_test"].to_s.include?("needs.plan.outputs.what_to_test")
 fail_check("Nightly publish 必须使用 secrets: inherit") unless publish["secrets"] == "inherit"
-fail_check("Nightly final 必须 always 聚合 plan 和 publish") unless
-  final["if"].to_s.include?("always()") && Array(final["needs"]).sort == %w[plan publish]
-%w[PLAN_RESULT PUBLISH_RESULT SHOULD_PUBLISH].each do |name|
+fail_check("Nightly final 必须 always 聚合 plan、发布凭据预检和 publish") unless
+  final["if"].to_s.include?("always()") &&
+  Array(final["needs"]).sort == %w[plan publish release-secrets-preflight].sort
+%w[PLAN_RESULT RELEASE_SECRETS_RESULT PUBLISH_RESULT SHOULD_PUBLISH].each do |name|
   fail_check("Nightly final 缺少 #{name} 结果判断") unless final.to_s.include?(name)
 end
 fail_check("Nightly skip 必须按成功结果收敛") unless final.to_s.include?("PUBLISH_RESULT" ) && final.to_s.include?("skipped")
@@ -234,6 +269,8 @@ self_test() {
   mutate_nightly 'value["workflow"] == "Nightly Internal TestFlight" &&' 'true &&'
   mutate_nightly '%w[schedule workflow_dispatch].include?(value["event"]) &&' 'true &&'
   mutate_nightly 'value["uploaded"] == true' 'true'
+  mutate_nightly 'IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64 }}' 'IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 }}'
+  mutate_nightly "needs.release-secrets-preflight.result == 'success'" "true"
 
   cp "$ROOT_DIR/.github/workflows/nightly.yml" "$test_root/.github/workflows/nightly.yml"
   ruby -e 'p = ARGV.fetch(0); s = File.read(p).sub("      inputs.publish_internal_testflight", "      (github.event_name == '\''workflow_call'\'' && inputs.publish_internal_testflight)"); File.write(p, s)' "$test_root/.github/workflows/ios-ci.yml"
@@ -244,7 +281,7 @@ self_test() {
   cp "$ROOT_DIR/.github/workflows/release.yml" "$test_root/.github/workflows/release.yml"
   ruby -e 'p = ARGV.fetch(0); s = File.read(p).sub("name: Release", "name: attestation drift"); File.write(p, s)' "$test_root/.github/workflows/release.yml"
   expect_failure
-  echo "Nightly/Release checker self-test 通过：schedule、权限、trust gate、evidence 绑定与 Release validation/attestation 漂移均能失败。"
+  echo "Nightly/Release checker self-test 通过：schedule、权限、trust gate、发布凭据预检、evidence 绑定与 Release validation/attestation 漂移均能失败。"
 }
 
 case "${1:---check}" in


### PR DESCRIPTION
## 目标

恢复 Internal TestFlight Nightly，并在发布 Secret 缺失时于昂贵的 macOS/iOS 回归前失败。

## 实现

- 补充轻量 Ubuntu Secret 存在性预检，仅在计划确定需要发布时运行
- 发布 job 必须等待预检成功，去重路径保持全部 skipped
- 正式 profile、证书、Team、Bundle ID、App Group 和签名身份校验继续由原发布 job 执行
- 增加 checker、变异自测和中文发布说明

## 验证

- `git diff --check`
- `bash -n scripts/check-nightly-release.sh`
- `bash scripts/check-nightly-release.sh --check`
- `bash scripts/check-nightly-release.sh --self-test`
- `bash scripts/check-pr-gate.sh`
- Nightly YAML 安全解析
- 全新上下文只读复审：ship，无阻断项

## 外部配置

已恢复缺失的 `IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64` 仓库 Secret；未读取或输出 Secret 内容。

Linear: MIM-31