### PR TITLE
MIM-74 显示已完成会话的历史加载进度

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
@@ -59,6 +59,12 @@ struct ConversationTimelineView: View {
             messages: messages
         )
         let isHistoryLoading = sessionStore.historyLoadProgress(sessionID: displayedSessionID) != nil
+        let shouldShowInlineHistoryLoading = Self.shouldShowInlineHistoryLoading(
+            timelineItemsAreEmpty: timelineItems.isEmpty,
+            isHistoryLoading: isHistoryLoading,
+            isLoadingEarlierHistory: sessionStore.isLoadingEarlierHistory(sessionID: displayedSessionID),
+            hasHistorySavingsNotice: explicitSessionID == nil && sessionStore.selectedHistorySavingsNotice != nil
+        )
         return ScrollViewReader { proxy in
             ZStack(alignment: .bottom) {
                 // 用 List 替代 ScrollView + LazyVStack：行高是真实测量值、
@@ -93,6 +99,12 @@ struct ConversationTimelineView: View {
                                         KeyboardDismissal.dismiss()
                                     })
                                     .id(item.id)
+                                    .listRowSeparator(.hidden)
+                                    .listRowInsets(layout.messageRowInsets)
+                                    .listRowBackground(Color.clear)
+                            }
+                            if shouldShowInlineHistoryLoading {
+                                historyLoadingRow
                                     .listRowSeparator(.hidden)
                                     .listRowInsets(layout.messageRowInsets)
                                     .listRowBackground(Color.clear)
@@ -219,6 +231,30 @@ struct ConversationTimelineView: View {
                 if !isEmpty {
                     HostSwitchSignpost.event("first_text_visible")
                 }
+            }
+            .onChange(of: isHistoryLoading) { _, isLoading in
+                guard isLoading,
+                      shouldShowInlineHistoryLoading,
+                      !isUserScrollingTimeline,
+                      (isTimelineNearBottom
+                          || isTailFollowLocked
+                          || shouldFollowMessageTail
+                          || forceNextMessageTailScroll),
+                      !isPreservingHistoryScroll
+                else {
+                    return
+                }
+                // 加载行位于尾部哨兵之前；仅在用户原本贴底时重锚，避免它插入后落到屏幕外，
+                // 同时不抢走用户已经上翻的历史阅读位置。
+                queueTailScrollAttempts(
+                    timelineItems: timelineItems,
+                    proxy: proxy,
+                    sessionID: displayedSessionID,
+                    expectedTailItemID: timelineItems.last?.id,
+                    animatedFirstAttempt: false,
+                    force: true,
+                    retriesAfterLayout: false
+                )
             }
             .onChange(of: messages.last?.id) { _, newID in
                 guard newID != nil else {
@@ -697,6 +733,18 @@ struct ConversationTimelineView: View {
             isTimelineNearBottom
     }
 
+    static func shouldShowInlineHistoryLoading(
+        timelineItemsAreEmpty: Bool,
+        isHistoryLoading: Bool,
+        isLoadingEarlierHistory: Bool,
+        hasHistorySavingsNotice: Bool
+    ) -> Bool {
+        !timelineItemsAreEmpty
+            && isHistoryLoading
+            && !isLoadingEarlierHistory
+            && !hasHistorySavingsNotice
+    }
+
     private func loadEarlierRow(proxy: ScrollViewProxy, timelineItems: [ConversationTimelineItem]) -> some View {
         HStack {
             Spacer()
@@ -726,6 +774,29 @@ struct ConversationTimelineView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var historyLoadingRow: some View {
+        HStack {
+            HStack(alignment: .center, spacing: 7) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(workbenchSecondaryText)
+                Text(L10n.text("ui.loading_session_records"))
+                    .font(themeStore.uiFont(.caption, weight: .medium))
+                    .foregroundStyle(workbenchSecondaryText)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(statusChipBackground, in: Capsule())
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("conversation.historyLoading")
+        .accessibilityLabel(L10n.text("ui.loading_session_records"))
+        .allowsHitTesting(false)
     }
 
     private func isNearBottom(_ geometry: ScrollGeometry) -> Bool {

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -337,12 +337,14 @@ extension SessionStore {
         return isStillFresh
     }
 
-    // quiet 模式用于切回已加载会话时的后台补拉：界面继续展示缓存，不出进度条，
-    // 失败也不打扰用户（下一次轮询/手动刷新仍会兜底）。
+    // quiet 模式用于切回已加载会话时的后台补拉：默认界面继续展示缓存，不出进度条，
+    // 失败也不打扰用户（下一次轮询/手动刷新仍会兜底）。选中会话可用 showsProgress
+    // 只打开轻量进度反馈，不改变 quiet 的失败和 notice 语义。
     @discardableResult
     func loadHistory(
         for session: AgentSession,
         quiet: Bool = false,
+        showsProgress: Bool? = nil,
         loadMode: HistoryMessagesPage.LoadMode = .full,
         force: Bool = false,
         reason: HistoryLoadReason = .automatic,
@@ -355,6 +357,9 @@ extension SessionStore {
         if session.isLocalDraft {
             return true
         }
+        // quiet 只控制失败、状态和 savings notice 是否打扰用户；选中的已缓存会话仍可
+        // 显示轻量历史补拉进度，避免消息区只有本地 user 气泡而看不出 assistant 仍在补齐。
+        let shouldShowProgress = showsProgress ?? !quiet
         // 普通自动/权威打开只需要 progress；savings 横幅应只在用户明确选择
         // full/summary，或策略层已经确认需要降级/重试时出现。否则每次短暂的
         // 首屏请求都会先暴露“正在加载完整历史”的决策卡片，再在成功时立即消失。
@@ -393,26 +398,47 @@ extension SessionStore {
                             successStatusMessage: successStatusMessage,
                             showSavingsNotice: shouldShowSavingsNotice
                         )
-                        setHistoryLoadProgress(
-                            sessionID: session.id,
-                            title: loadMode == .full ? L10n.text("ui.request_full_history") : L10n.text("ui.request_thumbnail_history"),
-                            fraction: 0.32
-                        )
+                        if shouldShowProgress {
+                            setHistoryLoadProgress(
+                                sessionID: session.id,
+                                title: loadMode == .full ? L10n.text("ui.request_full_history") : L10n.text("ui.request_thumbnail_history"),
+                                fraction: 0.32
+                            )
+                        }
                         let didLoad = await awaitHistoryLoadJob(
                             existing,
                             session: session,
                             quiet: false,
                             successStatusMessage: successStatusMessage
                         )
-                        clearHistoryLoadProgress(sessionID: session.id)
+                        if shouldShowProgress {
+                            clearHistoryLoadProgress(
+                                sessionID: session.id,
+                                ifCurrentHistoryLoadJobToken: existing.token
+                            )
+                        }
                         return didLoad
                     }
-                    return await awaitHistoryLoadJob(
+                    if shouldShowProgress {
+                        setHistoryLoadProgress(
+                            sessionID: session.id,
+                            title: loadMode == .full ? L10n.text("ui.request_full_history") : L10n.text("ui.request_thumbnail_history"),
+                            fraction: 0.32
+                        )
+                    }
+                    let didLoad = await awaitHistoryLoadJob(
                         existing,
                         session: session,
                         quiet: quiet,
                         successStatusMessage: successStatusMessage
                     )
+                    if shouldShowProgress {
+                        clearHistoryLoadProgress(
+                            sessionID: session.id,
+                            ifCurrentHistoryLoadJobToken: existing.token
+                        )
+                    }
+                    return didLoad
                 }
             } else {
                 switch reason {
@@ -467,16 +493,19 @@ extension SessionStore {
             )
         }
 
-        if !quiet {
+        if shouldShowProgress {
             setHistoryLoadProgress(sessionID: session.id, title: loadMode == .full ? L10n.text("ui.ready_to_load_full_history") : L10n.text("ui.prepare_to_load_abbreviated_history"), fraction: 0.08)
         }
         defer {
-            if !quiet {
-                clearHistoryLoadProgress(sessionID: session.id)
+            if shouldShowProgress {
+                clearHistoryLoadProgress(
+                    sessionID: session.id,
+                    ifCurrentHistoryLoadJobToken: jobToken
+                )
             }
         }
 
-        if !quiet {
+        if shouldShowProgress {
             setHistoryLoadProgress(sessionID: session.id, title: loadMode == .full ? L10n.text("ui.request_full_history") : L10n.text("ui.request_thumbnail_history"), fraction: 0.32)
         }
         return await awaitHistoryLoadJob(job, session: session, quiet: quiet, successStatusMessage: successStatusMessage)
@@ -506,12 +535,12 @@ extension SessionStore {
         }
     }
 
-    func scheduleQuietHistoryRefresh(for session: AgentSession) {
+    func scheduleQuietHistoryRefresh(for session: AgentSession, showsProgress: Bool = false) {
         Task { [weak self] in
             guard let self, self.selectedSessionID == session.id else {
                 return
             }
-            await self.loadHistory(for: session, quiet: true)
+            await self.loadHistory(for: session, quiet: true, showsProgress: showsProgress)
         }
     }
 
@@ -922,7 +951,22 @@ extension SessionStore {
             // best-effort 取消旧 job；即使底层请求已发出，token 校验也会阻止迟到结果覆盖当前视图。
             job.task.cancel()
             historyLoadJobsBySessionID.removeValue(forKey: sessionID)
+            // 新 job 可能继续保持 quiet；先清掉旧代可见进度，由替代 job
+            // 按自己的 showsProgress 选择是否重新写入。
+            clearHistoryLoadProgress(sessionID: sessionID)
         }
+    }
+
+    func clearHistoryLoadProgress(
+        sessionID: SessionID,
+        ifCurrentHistoryLoadJobToken token: Int
+    ) {
+        // 旧 job 被权威重开/恢复任务取代后可能才结束 await；只允许当前代清进度，
+        // 避免旧 waiter 把新 job 刚写入的加载反馈误删。
+        guard historyLoadJobTokenBySessionID[sessionID] == token else {
+            return
+        }
+        clearHistoryLoadProgress(sessionID: sessionID)
     }
 
     func setHistoryLoadNotice(sessionID: SessionID, kind: HistorySavingsNotice.Kind, message customMessage: String? = nil) {

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -391,6 +391,9 @@ extension SessionStore {
                     // 已有同模式加载时直接等待同一个 job，避免切换/刷新制造重复大包请求。
                     // 前台刷新加入 quiet job 后必须提升共享 job 的反馈级别；否则 quiet waiter
                     // 若先恢复，会先移除 job 并吞掉失败提示，手动刷新只能静默返回 false。
+                    if shouldShowProgress {
+                        promoteHistoryLoadJobForVisibleProgress(existing, sessionID: session.id)
+                    }
                     if !quiet {
                         promoteHistoryLoadJobForForegroundReporting(
                             existing,
@@ -478,6 +481,7 @@ extension SessionStore {
             allowPolicyRetry: allowPolicyRetry,
             fullTurnPageLimit: loadMode == .full ? fullTurnPageLimit : nil,
             task: task,
+            showsProgress: shouldShowProgress,
             requiresForegroundReporting: !quiet,
             foregroundSuccessStatusMessage: quiet ? nil : successStatusMessage,
             foregroundSelectionLease: quiet ? nil : currentSelectionLease()
@@ -533,6 +537,16 @@ extension SessionStore {
                 message: current.loadMode == .economy ? deferredFullHistoryNotice(sessionID: sessionID) : nil
             )
         }
+    }
+
+    func promoteHistoryLoadJobForVisibleProgress(_ job: HistoryLoadJob, sessionID: SessionID) {
+        guard var current = historyLoadJobsBySessionID[sessionID], current.token == job.token else {
+            return
+        }
+        // quiet 后台 job 被当前会话的可见 waiter 加入后，后续缩页/summary 替代任务
+        // 也必须继承这项能力，不能只靠外层 defer 清理旧 token 的进度。
+        current.showsProgress = true
+        historyLoadJobsBySessionID[sessionID] = current
     }
 
     func scheduleQuietHistoryRefresh(for session: AgentSession, showsProgress: Bool = false) {
@@ -675,6 +689,7 @@ extension SessionStore {
                     return await loadHistory(
                         for: session,
                         quiet: effectiveQuiet,
+                        showsProgress: current.showsProgress,
                         loadMode: .full,
                         force: true,
                         reason: .automatic,
@@ -695,6 +710,7 @@ extension SessionStore {
                 return await loadHistory(
                     for: session,
                     quiet: effectiveQuiet,
+                    showsProgress: current.showsProgress,
                     loadMode: .economy,
                     force: true,
                     reason: .automatic,
@@ -720,6 +736,7 @@ extension SessionStore {
                 return await loadHistory(
                     for: session,
                     quiet: effectiveQuiet,
+                    showsProgress: current.showsProgress,
                     loadMode: .economy,
                     force: true,
                     reason: .automatic,

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -278,6 +278,9 @@ struct HistoryLoadJob {
     /// 供 history_response_too_large 回退时决定下一级更小的 full 页。
     let fullTurnPageLimit: Int?
     let task: Task<HistoryFirstPageResult, Error>
+    /// 与 foreground reporting 解耦：quiet 会话也可能需要在现有消息尾部显示轻量进度。
+    /// 同一 job 被可见 waiter 加入后会提升为 true，并沿策略重试链传给替代 job。
+    var showsProgress: Bool
     var requiresForegroundReporting: Bool
     var foregroundSuccessStatusMessage: String?
     var foregroundSelectionLease: SessionSelectionLease?

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -561,7 +561,8 @@ extension SessionStore {
             disconnectWebSocket()
         } else {
             // 非运行会话有两种可能：真历史，或被瞬时 idle 误读降级的运行会话。
-            // 已有缓存时先展示缓存、后台静默补一次最新页；同时仍建立事件订阅——
+            // 已有缓存时先展示缓存、后台补一次最新页；失败和 savings notice 仍保持静默，
+            // 同时仍建立事件订阅——
             // thread/resume 的权威状态能立即纠正误判，之后的 turn 事件也能直接推进来，
             // 不再要求手动刷新。
             let didRefreshHistory: Bool
@@ -577,10 +578,12 @@ extension SessionStore {
             if needsAuthoritativeReconciliation {
                 // 列表已经把 thread 判为终态、正文却仍停在本地等待态时，updatedAt/revision/seq
                 // 可能与离开前完全相同，普通 quiet refresh 会误复用局部缓存。显式重新打开只
-                // 做一次无感权威读取，让正文、状态和列表分组在建立新监听前先收敛。
+                // 做一次权威读取；正文、状态和列表分组在建立新监听前先收敛，消息尾部用轻量进度
+                // 表达 assistant 历史仍在补齐。
                 didRefreshHistory = await loadHistory(
                     for: session,
                     quiet: true,
+                    showsProgress: true,
                     force: true,
                     reason: .authoritativeReopen
                 )
@@ -593,7 +596,7 @@ extension SessionStore {
                     clearRuntimeActivity(sessionID: session.id)
                 }
             } else if conversationStore.hasLoadedHistory(sessionID: session.id) {
-                scheduleQuietHistoryRefresh(for: session)
+                scheduleQuietHistoryRefresh(for: session, showsProgress: true)
                 didRefreshHistory = true
             } else {
                 didRefreshHistory = await loadHistoryIfNeeded(for: session)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -501,6 +501,52 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertFalse(ConversationTimelineView.shouldForceTailFollow(forNewTailMessage: processSummary))
     }
 
+    func testConversationTimelineInlineHistoryLoadingConditions() {
+        XCTAssertTrue(
+            ConversationTimelineView.shouldShowInlineHistoryLoading(
+                timelineItemsAreEmpty: false,
+                isHistoryLoading: true,
+                isLoadingEarlierHistory: false,
+                hasHistorySavingsNotice: false
+            )
+        )
+        XCTAssertFalse(
+            ConversationTimelineView.shouldShowInlineHistoryLoading(
+                timelineItemsAreEmpty: true,
+                isHistoryLoading: true,
+                isLoadingEarlierHistory: false,
+                hasHistorySavingsNotice: false
+            ),
+            "空时间线由现有空状态 ProgressView 负责"
+        )
+        XCTAssertFalse(
+            ConversationTimelineView.shouldShowInlineHistoryLoading(
+                timelineItemsAreEmpty: false,
+                isHistoryLoading: true,
+                isLoadingEarlierHistory: true,
+                hasHistorySavingsNotice: false
+            ),
+            "加载更早历史时只保留顶部按钮 spinner"
+        )
+        XCTAssertFalse(
+            ConversationTimelineView.shouldShowInlineHistoryLoading(
+                timelineItemsAreEmpty: false,
+                isHistoryLoading: true,
+                isLoadingEarlierHistory: false,
+                hasHistorySavingsNotice: true
+            ),
+            "已有 savings notice 时不重复显示 inline 状态行"
+        )
+        XCTAssertFalse(
+            ConversationTimelineView.shouldShowInlineHistoryLoading(
+                timelineItemsAreEmpty: false,
+                isHistoryLoading: false,
+                isLoadingEarlierHistory: false,
+                hasHistorySavingsNotice: false
+            )
+        )
+    }
+
     func testConversationTimelineDoesNotRescrollForEveryBatchedCommand() {
         let command = ConversationMessage(
             role: .system,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -3373,6 +3373,160 @@ extension ConversationDataFlowTests {
         XCTAssertNil(store.selectedHistorySavingsNotice)
     }
 
+    func testVisibleQuietHistoryLoadJoiningExistingJobKeepsProgressUntilCompletion() async {
+        let project = makeProject(id: "proj_visible_quiet_join")
+        let history = makeSession(
+            id: "thread_visible_quiet_join",
+            projectID: project.id,
+            title: "合并静默历史",
+            status: "history",
+            source: "codex"
+        )
+        let client = OrderedHistoryPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [history])
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.selectedSessionID = history.id
+
+        let backgroundLoad = Task {
+            await store.loadHistory(for: history, quiet: true)
+        }
+        await client.waitForHistoryRequestCount(1)
+        XCTAssertNil(store.historyLoadProgress(sessionID: history.id))
+
+        let visibleJoin = Task {
+            await store.loadHistory(for: history, quiet: true, showsProgress: true)
+        }
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(client.requestedMessageCursors, [nil], "可见 waiter 应加入已有 job，不重复请求")
+        XCTAssertNotNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "加入已有 quiet job 后，进度必须保留到共享请求完成"
+        )
+
+        client.resolveHistoryRequest(
+            at: 0,
+            with: HistoryMessagesPage(messages: [
+                CodexHistoryMessage(
+                    id: "rollout:visible-quiet-join",
+                    role: "assistant",
+                    content: "共享历史已加载",
+                    createdAt: Date(timeIntervalSince1970: 10)
+                )
+            ])
+        )
+        _ = await backgroundLoad.value
+        _ = await visibleJoin.value
+
+        XCTAssertNil(store.historyLoadProgress(sessionID: history.id))
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+    }
+
+    func testReplacedHistoryJobCannotClearReplacementProgress() async {
+        let project = makeProject(id: "proj_replaced_history_progress")
+        let history = makeSession(
+            id: "thread_replaced_history_progress",
+            projectID: project.id,
+            title: "历史进度换代",
+            status: "history",
+            source: "codex"
+        )
+        let client = OrderedHistoryPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [history])
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.selectedSessionID = history.id
+
+        let staleLoad = Task {
+            await store.loadHistory(for: history, quiet: true, showsProgress: true)
+        }
+        await client.waitForHistoryRequestCount(1)
+
+        let replacementLoad = Task {
+            await store.loadHistory(
+                for: history,
+                quiet: true,
+                showsProgress: true,
+                force: true,
+                reason: .authoritativeReopen
+            )
+        }
+        await client.waitForHistoryRequestCount(2)
+        XCTAssertNotNil(store.historyLoadProgress(sessionID: history.id))
+
+        client.resolveHistoryRequest(at: 0, with: HistoryMessagesPage(messages: []))
+        _ = await staleLoad.value
+        XCTAssertNotNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "迟到的旧 job 不得清除替代 job 的进度"
+        )
+
+        client.resolveHistoryRequest(
+            at: 1,
+            with: HistoryMessagesPage(messages: [
+                CodexHistoryMessage(
+                    id: "rollout:replacement-history",
+                    role: "assistant",
+                    content: "新一代权威历史",
+                    createdAt: Date(timeIntervalSince1970: 20)
+                )
+            ])
+        )
+        _ = await replacementLoad.value
+
+        XCTAssertNil(store.historyLoadProgress(sessionID: history.id))
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+    }
+
+    func testBackgroundQuietHistoryRefreshKeepsProgressHidden() async {
+        let project = makeProject(id: "proj_background_quiet_progress")
+        let history = makeSession(
+            id: "thread_background_quiet_progress",
+            projectID: project.id,
+            title: "后台静默历史",
+            status: "history",
+            source: "codex"
+        )
+        let client = OrderedHistoryPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [history])
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.selectedSessionID = history.id
+
+        store.scheduleQuietHistoryRefresh(for: history)
+        await client.waitForHistoryRequestCount(1)
+
+        XCTAssertNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "恢复链路的默认 quiet refresh 不应意外改成可见状态"
+        )
+        client.resolveHistoryRequest(at: 0, with: HistoryMessagesPage(messages: []))
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        XCTAssertNil(store.historyLoadProgress(sessionID: history.id))
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+    }
+
     func testReopeningTerminalSessionWithLocalWaitingForcesAuthoritativeHistoryReconciliation() async {
         let project = makeProject(id: "proj_detached_completion")
         let unchangedTimestamp = Date(timeIntervalSince1970: 100)
@@ -3440,6 +3594,16 @@ extension ConversationDataFlowTests {
             [.full, .full],
             "终态重开必须绕过相同签名的局部缓存，发出一次权威首屏读取"
         )
+        XCTAssertTrue(
+            conversationStore.messages(for: running.id).contains {
+                $0.role == .user && $0.content == "讲个笑话"
+            },
+            "权威历史补拉期间先保留可见的本地 user 消息"
+        )
+        XCTAssertNotNil(
+            store.historyLoadProgress(sessionID: running.id),
+            "已有本地 user 消息时仍应展示轻量历史加载进度"
+        )
         XCTAssertNil(store.selectedHistorySavingsNotice, "权威重开只显示 progress，不应提前展示 savings 卡片")
         client.resolveHistoryRequest(
             at: 1,
@@ -3466,6 +3630,7 @@ extension ConversationDataFlowTests {
         )
         await reopen.value
 
+        XCTAssertNil(store.historyLoadProgress(sessionID: running.id))
         XCTAssertTrue(
             conversationStore.messages(for: running.id).contains {
                 $0.role == .assistant && $0.content == "程序员去海边，发现浪都是递归的。"
@@ -3602,11 +3767,17 @@ extension ConversationDataFlowTests {
         await store.selectSession(updated)
         await client.waitForHistoryRequestCount(2)
 
-        // 后台补拉不能把“正在加载完整历史”或失败横幅盖到已有会话上。
+        // 后台补拉只显示时间线内轻量进度，不能把 savings 或失败横幅盖到已有会话上。
+        XCTAssertTrue(conversationStore.messages(for: history.id).contains { $0.content == "已缓存历史" })
+        XCTAssertNotNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "缓存消息可见时，签名变化触发的静默补拉仍需给出轻量进度"
+        )
         XCTAssertNil(store.selectedHistorySavingsNotice)
         client.failHistoryRequest(at: 1, with: MockError.timeout)
         try await Task.sleep(nanoseconds: 30_000_000)
 
+        XCTAssertNil(store.historyLoadProgress(sessionID: history.id))
         XCTAssertNil(store.selectedHistorySavingsNotice)
         XCTAssertNil(store.errorMessage)
         XCTAssertEqual(conversationStore.messages(for: history.id).map(\.content), ["已缓存历史"])

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -3527,6 +3527,134 @@ extension ConversationDataFlowTests {
         XCTAssertNil(store.selectedHistorySavingsNotice)
     }
 
+    func testVisibleQuietHistoryOversizeRetryClearsReplacementProgress() async {
+        let project = makeProject(id: "proj_visible_quiet_oversize_retry")
+        let history = makeSession(
+            id: "thread_visible_quiet_oversize_retry",
+            projectID: project.id,
+            title: "可见静默缩页",
+            status: "history",
+            source: "codex"
+        )
+        let client = OrderedHistoryPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [history])
+        )
+        let conversationStore = ConversationStore()
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.selectedSessionID = history.id
+
+        let load = Task {
+            await store.loadHistory(for: history, quiet: true, showsProgress: true)
+        }
+        await client.waitForHistoryRequestCount(1)
+        client.failHistoryRequest(
+            at: 0,
+            with: historyPolicyError(
+                reason: "history_response_too_large",
+                responseBytes: 9_000_000,
+                maxResponseBytes: 5_242_880
+            )
+        )
+        await client.waitForHistoryRequestCount(2)
+
+        XCTAssertEqual(client.requestedMessageLimits, [20, 5])
+        XCTAssertEqual(client.requestedMessageLoadModes, [.full, .full])
+        XCTAssertNotNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "可见 quiet full 缩页重试期间必须继续显示进度"
+        )
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+
+        client.resolveHistoryRequest(
+            at: 1,
+            with: HistoryMessagesPage(messages: [
+                CodexHistoryMessage(
+                    id: "rollout:visible-quiet-oversize-retry",
+                    role: "assistant",
+                    content: "缩页后的完整历史",
+                    createdAt: Date(timeIntervalSince1970: 20)
+                )
+            ])
+        )
+        _ = await load.value
+
+        XCTAssertNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "替代 full job 完成后必须清除进度，不能永久旋转"
+        )
+        XCTAssertEqual(conversationStore.messages(for: history.id).map(\.content), ["缩页后的完整历史"])
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+    }
+
+    func testVisibleQuietHistorySummaryFallbackClearsReplacementProgress() async {
+        let project = makeProject(id: "proj_visible_quiet_summary_fallback")
+        let history = makeSession(
+            id: "thread_visible_quiet_summary_fallback",
+            projectID: project.id,
+            title: "可见静默缩略降级",
+            status: "history",
+            source: "codex"
+        )
+        let client = OrderedHistoryPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [history])
+        )
+        let conversationStore = ConversationStore()
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.selectedSessionID = history.id
+
+        let load = Task {
+            await store.loadHistory(for: history, quiet: true, showsProgress: true)
+        }
+        await client.waitForHistoryRequestCount(1)
+        client.failHistoryRequest(
+            at: 0,
+            with: historyPolicyError(reason: "history_response_too_large")
+        )
+        await client.waitForHistoryRequestCount(2)
+
+        XCTAssertEqual(client.requestedMessageLoadModes, [.full, .economy])
+        XCTAssertNotNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "可见 quiet summary fallback 期间必须继续显示进度"
+        )
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+
+        client.resolveHistoryRequest(
+            at: 1,
+            with: HistoryMessagesPage(
+                messages: [
+                    CodexHistoryMessage(
+                        id: "rollout:visible-quiet-summary-fallback",
+                        role: "assistant",
+                        content: "自动缩略历史",
+                        createdAt: Date(timeIntervalSince1970: 20)
+                    )
+                ],
+                loadMode: .economy
+            )
+        )
+        _ = await load.value
+
+        XCTAssertNil(
+            store.historyLoadProgress(sessionID: history.id),
+            "替代 economy job 完成后必须清除进度，不能永久旋转"
+        )
+        XCTAssertEqual(conversationStore.messages(for: history.id).map(\.content), ["自动缩略历史"])
+        XCTAssertNil(store.selectedHistorySavingsNotice)
+    }
+
     func testReopeningTerminalSessionWithLocalWaitingForcesAuthoritativeHistoryReconciliation() async {
         let project = makeProject(id: "proj_detached_completion")
         let unchangedTimestamp = Date(timeIntervalSince1970: 100)


### PR DESCRIPTION
## 目标

修复打开已完成会话时，页面只显示用户消息、助手历史尚未补齐但界面没有任何反馈的问题。

## 方案与实现

- 在已有消息的时间线尾部显示轻量“正在加载会话记录”状态，历史补齐后自动移除。
- 将轻量加载进度与 quiet 模式的错误提示、历史缩略提示解耦，避免重新出现顶部高强调卡片。
- 对已完成会话的权威重载和显式缓存刷新开启进度反馈，后台恢复刷新继续保持静默。
- 使用历史任务 token 隔离并发任务，防止旧任务清除替代任务的进度。
- 仅在用户原本贴近时间线底部时跟随加载行，不打断已向上滚动的阅读位置。

## 根因

时间线原先只在消息列表为空时消费历史加载状态。存在缓存或本地用户消息时会直接渲染消息列表，历史进度被丢弃，因此助手消息补齐前出现数秒无反馈等待。

## 用户影响

打开已完成会话时会立即看到与历史内容相关联的低打扰加载反馈；普通加载不会再弹出“只看缩略版”卡片，真正超限历史的降级与重试能力保持不变。

## 验证

- 连接的 iPad Pro，Debug 构建通过。
- 固定 `iPad Pro 13-inch (M5)` Simulator 定向回归 13/13 通过，0 failure。
- 覆盖非空时间线状态、权威重载、静默失败、并发任务合并与替换、后台静默刷新、超大历史降级。
- `git diff --check` 通过。

Linear: MIM-74
