### PR TITLE
MIM-131 让 Mac App 变更进入 required CI

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,0 +1,44 @@
+name: Mac App CI
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+    paths:
+      - "macos/MimiRemoteMac/**"
+      - "scripts/test-macos-app.sh"
+      - ".github/workflows/macos-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          go version
+          rustc --version
+
+      - name: Build and test Mac App
+        env:
+          MACOS_DERIVED_DATA_PATH: ${{ runner.temp }}/MimiRemoteMacDerivedData
+        run: bash ./scripts/test-macos-app.sh

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -20,6 +20,7 @@ jobs:
       go: ${{ steps.scope.outputs.go }}
       ios: ${{ steps.scope.outputs.ios }}
       rust: ${{ steps.scope.outputs.rust }}
+      macos: ${{ steps.scope.outputs.macos }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -73,6 +74,12 @@ jobs:
     if: needs.scope.outputs.rust == 'true'
     uses: ./.github/workflows/claude-bridge-ci.yml
 
+  macos:
+    name: Mac App
+    needs: scope
+    if: needs.scope.outputs.macos == 'true'
+    uses: ./.github/workflows/macos-ci.yml
+
   gate:
     name: PR Gate
     if: always()
@@ -83,6 +90,7 @@ jobs:
       - go
       - ios
       - rust
+      - macos
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -98,6 +106,8 @@ jobs:
           IOS_RESULT: ${{ needs.ios.result }}
           RUST_REQUIRED: ${{ needs.scope.outputs.rust }}
           RUST_RESULT: ${{ needs.rust.result }}
+          MACOS_REQUIRED: ${{ needs.scope.outputs.macos }}
+          MACOS_RESULT: ${{ needs.macos.result }}
         run: |
           set -euo pipefail
 
@@ -131,6 +141,7 @@ jobs:
           require_scoped_success "Go and release" "$GO_REQUIRED" "$GO_RESULT"
           require_scoped_success "iOS" "$IOS_REQUIRED" "$IOS_RESULT"
           require_scoped_success "Rust bridge" "$RUST_REQUIRED" "$RUST_RESULT"
+          require_scoped_success "Mac App" "$MACOS_REQUIRED" "$MACOS_RESULT"
 
           {
             echo "## PR Gate"
@@ -143,6 +154,7 @@ jobs:
             echo "| Go and release | \`$GO_REQUIRED\` | \`$GO_RESULT\` |"
             echo "| iOS | \`$IOS_REQUIRED\` | \`$IOS_RESULT\` |"
             echo "| Rust bridge | \`$RUST_REQUIRED\` | \`$RUST_RESULT\` |"
+            echo "| Mac App | \`$MACOS_REQUIRED\` | \`$MACOS_RESULT\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$failures" -ne 0 ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,8 @@ bash ./scripts/test-conversation-regressions.sh
 门禁并行执行以下检查：
 
 - 始终执行 Codex 协议快照、公开仓库安全和 PR Gate 配置自检；
-- Go、macOS/Windows/Linux 打包或 Release 相关路径调用现有 Go CI；
+- Go、Windows/Linux 打包或 Release 相关路径调用现有 Go CI；
+- Mac App 源码与 Xcode 工程路径调用独立 Mac App CI，使用无签名 build 运行现有 Scheme 单测；
 - iOS、App Store/TestFlight 脚本或相关文档路径调用现有 iOS CI；
 - Cargo 或 `bridges/claude` 路径调用现有 Rust bridge CI；
 - `.github/workflows`、`.github/actions` 或 Gate 分类脚本变化时执行全部语言检查。
@@ -117,7 +118,7 @@ bash ./scripts/check-packaging.sh
 ```
 
 `PR Gate` 红灯时先打开失败的子 job；最终聚合 job 只负责判断必需检查是否成功，
-真正的错误日志保留在 `Go and release`、`iOS`、`Rust bridge`、`Codex protocol`
+真正的错误日志保留在 `Go and release`、`iOS`、`Rust bridge`、`Mac App`、`Codex protocol`
 或 `Repository safety` 中。`Detect change scope` 失败时，先用下面的命令确认
 base/head 可读取且路径分类符合预期：
 

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -18,7 +18,8 @@ bash -n \
   scripts/ci-pr-scope.sh \
   scripts/check-critical-regressions.sh \
   scripts/check-nightly-release.sh \
-  scripts/check-pr-gate.sh
+  scripts/check-pr-gate.sh \
+  scripts/test-macos-app.sh
 
 bash ./scripts/check-critical-regressions.sh
 bash ./scripts/check-nightly-release.sh
@@ -31,7 +32,8 @@ assert_scope() {
   local expected_go="$2"
   local expected_ios="$3"
   local expected_rust="$4"
-  shift 4
+  local expected_macos="$5"
+  shift 5
 
   local paths_path="$test_root/${case_name}.paths"
   local output_path="$test_root/${case_name}.output"
@@ -44,28 +46,32 @@ assert_scope() {
     || fail "${case_name} 的 iOS 分类错误。"
   grep -Fqx "rust=$expected_rust" "$output_path" \
     || fail "${case_name} 的 Rust 分类错误。"
+  grep -Fqx "macos=$expected_macos" "$output_path" \
+    || fail "${case_name} 的 Mac App 分类错误。"
 }
 
-assert_scope go_only true false false internal/httpapi/router.go
-assert_scope ios_only false true false ios/MimiRemote/Sources/App/MimiRemoteApp.swift
-assert_scope rust_only false false true bridges/claude/crates/claude-bridge/src/main.rs
-assert_scope release true false false scripts/check-release-artifacts.sh
-assert_scope windows_release true false false scripts/build-windows-installer.ps1
-assert_scope ios_release false true false scripts/ios_testflight_ci.sh
-assert_scope ios_asc_pin false true false config/release/ios-asc-cli.env
-assert_scope ios_asc_test false true false scripts/test-ios-asc-cli.sh
-assert_scope mimi_contract true true false contracts/mimi-protocol/contract.json
-assert_scope mimi_contract_generator true true false internal/protocolcontract/cmd/generate/main.go
-assert_scope critical_runner true true false scripts/test-conversation-regressions.sh
-assert_scope critical_checker true true false scripts/check-critical-regressions.sh
-assert_scope nightly_checker true true false scripts/check-nightly-release.sh
-assert_scope nightly_docs true true false docs/nightly-release.md
-assert_scope ios_device_lease false true false scripts/ios-device-lease.sh
-assert_scope ios_device_management false true false scripts/test-ios-device-management.sh
-assert_scope ios_device_fixture false true false scripts/testdata/ios-device-management/simulators.json
-assert_scope docs_only false false false CONTRIBUTING.md
-assert_scope workflow true true true .github/workflows/pr-gate.yml
-assert_scope mixed true true true \
+assert_scope go_only true false false false internal/httpapi/router.go
+assert_scope ios_only false true false false ios/MimiRemote/Sources/App/MimiRemoteApp.swift
+assert_scope rust_only false false true false bridges/claude/crates/claude-bridge/src/main.rs
+assert_scope macos_only false false false true macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
+assert_scope macos_runner false false false true scripts/test-macos-app.sh
+assert_scope release true false false false scripts/check-release-artifacts.sh
+assert_scope windows_release true false false false scripts/build-windows-installer.ps1
+assert_scope ios_release false true false false scripts/ios_testflight_ci.sh
+assert_scope ios_asc_pin false true false false config/release/ios-asc-cli.env
+assert_scope ios_asc_test false true false false scripts/test-ios-asc-cli.sh
+assert_scope mimi_contract true true false false contracts/mimi-protocol/contract.json
+assert_scope mimi_contract_generator true true false false internal/protocolcontract/cmd/generate/main.go
+assert_scope critical_runner true true false false scripts/test-conversation-regressions.sh
+assert_scope critical_checker true true false false scripts/check-critical-regressions.sh
+assert_scope nightly_checker true true false false scripts/check-nightly-release.sh
+assert_scope nightly_docs true true false false docs/nightly-release.md
+assert_scope ios_device_lease false true false false scripts/ios-device-lease.sh
+assert_scope ios_device_management false true false false scripts/test-ios-device-management.sh
+assert_scope ios_device_fixture false true false false scripts/testdata/ios-device-management/simulators.json
+assert_scope docs_only false false false false CONTRIBUTING.md
+assert_scope workflow true true true true .github/workflows/pr-gate.yml
+assert_scope mixed true true true false \
   cmd/agentd/main.go \
   ios/MimiRemote/project.yml \
   Cargo.lock
@@ -106,12 +112,27 @@ expected_calls = {
   "go" => "./.github/workflows/go-ci.yml",
   "ios" => "./.github/workflows/ios-ci.yml",
   "rust" => "./.github/workflows/claude-bridge-ci.yml",
+  "macos" => "./.github/workflows/macos-ci.yml",
 }
 jobs = gate.fetch("jobs")
+scope_job = jobs.fetch("scope")
+expected_scope_outputs = %w[go ios rust macos]
+unless scope_job.fetch("outputs").keys.sort == expected_scope_outputs.sort
+  abort("PR Gate 自检失败：Change scope 输出集合不完整。")
+end
+expected_scope_outputs.each do |name|
+  unless scope_job.dig("outputs", name).to_s.include?("steps.scope.outputs.#{name}")
+    abort("PR Gate 自检失败：Change scope 没有透传 #{name} 输出。")
+  end
+end
+
 expected_calls.each do |job_id, workflow_path|
   unless jobs.dig(job_id, "uses") == workflow_path
     abort("PR Gate 自检失败：#{job_id} 没有调用 #{workflow_path}。")
   end
+end
+unless jobs.dig("macos", "if").to_s.include?("needs.scope.outputs.macos")
+  abort("PR Gate 自检失败：Mac App job 没有按 macos scope 执行。")
 end
 
 final_gate = jobs.fetch("gate")
@@ -119,9 +140,36 @@ abort("PR Gate 自检失败：最终 check 名称必须为 PR Gate。") unless f
 unless final_gate["if"].to_s.include?("always()")
   abort("PR Gate 自检失败：最终聚合 job 必须在上游失败或跳过时仍执行。")
 end
-expected_needs = %w[scope codex-protocol repository-safety go ios rust]
+expected_needs = %w[scope codex-protocol repository-safety go ios rust macos]
 unless Array(final_gate["needs"]).sort == expected_needs.sort
   abort("PR Gate 自检失败：最终聚合 job 的 needs 不完整。")
+end
+%w[MACOS_REQUIRED MACOS_RESULT].each do |name|
+  unless final_gate.to_s.include?(name)
+    abort("PR Gate 自检失败：最终聚合缺少 #{name} 判断。")
+  end
+end
+
+macos_path = ".github/workflows/macos-ci.yml"
+macos_workflow = load_workflow(macos_path)
+macos_triggers = triggers(macos_workflow, macos_path)
+macos_push_paths = Array(macos_triggers.dig("push", "paths"))
+unless macos_push_paths.include?("macos/MimiRemoteMac/**") &&
+       macos_push_paths.include?("scripts/test-macos-app.sh")
+  abort("PR Gate 自检失败：Mac App CI 的 main push paths 与 PR scope 不一致。")
+end
+macos_job = macos_workflow.fetch("jobs").fetch("build-and-test")
+unless macos_job["runs-on"] == "macos-26" && macos_job["timeout-minutes"] == 20
+  abort("PR Gate 自检失败：Mac App CI 必须使用 macOS 26 runner 和 20 分钟超时。")
+end
+unless macos_job.to_s.include?("bash ./scripts/test-macos-app.sh")
+  abort("PR Gate 自检失败：Mac App CI 没有运行统一编译测试入口。")
+end
+macos_test_script = File.read("scripts/test-macos-app.sh")
+%w[xcodebuild CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test].each do |fragment|
+  unless macos_test_script.include?(fragment)
+    abort("PR Gate 自检失败：Mac App 编译测试入口缺少 #{fragment}。")
+  end
 end
 
 expected_calls.values.each do |workflow_path|

--- a/scripts/ci-pr-scope.sh
+++ b/scripts/ci-pr-scope.sh
@@ -81,6 +81,7 @@ if [[ "$run_all" -eq 1 ]]; then
   go_scope=true
   ios_scope=true
   rust_scope=true
+  macos_scope=true
   path_count="all"
 else
   if [[ -n "$paths_file" ]]; then
@@ -101,6 +102,7 @@ else
   go_scope=false
   ios_scope=false
   rust_scope=false
+  macos_scope=false
   path_count=0
 
   while IFS= read -r -d '' changed_path; do
@@ -113,12 +115,13 @@ else
         go_scope=true
         ios_scope=true
         rust_scope=true
+        macos_scope=true
         continue
         ;;
     esac
 
     case "$changed_path" in
-      *.go|go.mod|go.sum|.goreleaser.yml|SKILL.md|packaging/*|packaging/**/*|macos/MimiRemoteMac/*|macos/MimiRemoteMac/**/*|contracts/mimi-protocol/*|contracts/mimi-protocol/**/*)
+      *.go|go.mod|go.sum|.goreleaser.yml|SKILL.md|packaging/*|packaging/**/*|contracts/mimi-protocol/*|contracts/mimi-protocol/**/*)
         go_scope=true
         ;;
       scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-nightly-release.sh|scripts/check-packaging.sh|scripts/check-source-size.sh|scripts/check-mimi-protocol-contract.sh|scripts/check-macos-*|scripts/check-release-*|scripts/build-macos-installer.sh|scripts/build-windows-installer.ps1|scripts/check-windows-installer.ps1|scripts/test-windows-install.ps1|scripts/install-linux.sh|scripts/test-install-linux.sh|scripts/package-skill.sh|scripts/sign-agentd-dev-macos.sh|scripts/restart-agentd-dev-macos.sh|scripts/restart-agentd-dev-handoff-macos.sh|scripts/verify-release.sh)
@@ -146,14 +149,21 @@ else
         rust_scope=true
         ;;
     esac
+
+    case "$changed_path" in
+      macos/MimiRemoteMac/*|macos/MimiRemoteMac/**/*|scripts/test-macos-app.sh)
+        macos_scope=true
+        ;;
+    esac
   done < "$resolved_paths_file"
 fi
 
 output="$(
-  printf 'go=%s\nios=%s\nrust=%s\n' \
+  printf 'go=%s\nios=%s\nrust=%s\nmacos=%s\n' \
     "$go_scope" \
     "$ios_scope" \
-    "$rust_scope"
+    "$rust_scope" \
+    "$macos_scope"
 )"
 printf '%s\n' "$output"
 
@@ -169,6 +179,7 @@ if [[ -n "$summary_file" ]]; then
     echo "- Go and release: \`$go_scope\`"
     echo "- iOS: \`$ios_scope\`"
     echo "- Rust bridge: \`$rust_scope\`"
+    echo "- Mac App: \`$macos_scope\`"
     echo "- Codex protocol and repository safety: \`always\`"
   } >> "$summary_file"
 fi

--- a/scripts/test-macos-app.sh
+++ b/scripts/test-macos-app.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+project_path="macos/MimiRemoteMac/MimiRemoteMac.xcodeproj"
+scheme="MimiRemoteMac"
+configuration="${MACOS_TEST_CONFIGURATION:-Debug}"
+architecture="${MACOS_TEST_ARCH:-$(uname -m)}"
+derived_data="${MACOS_DERIVED_DATA_PATH:-$ROOT_DIR/.build/MimiRemoteMacTests}"
+
+case "$architecture" in
+  arm64|x86_64) ;;
+  *)
+    echo "Mac App 测试失败：不支持架构 ${architecture}。" >&2
+    exit 1
+    ;;
+esac
+
+for command_name in xcodebuild go cargo rustc; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || { echo "Mac App 测试失败：缺少 ${command_name}。" >&2; exit 1; }
+done
+
+# 必须通过真实 Scheme 运行测试，不只做 Swift 语法检查。这会同时
+# 编译 Mac App、内嵌 agentd / Claude bridge 和现有单测，但不读取发布签名凭据。
+xcodebuild \
+  -quiet \
+  -project "$project_path" \
+  -scheme "$scheme" \
+  -configuration "$configuration" \
+  -destination "platform=macOS,arch=$architecture" \
+  -derivedDataPath "$derived_data" \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  test
+
+echo "Mac App 编译与单测通过：scheme=${scheme} configuration=${configuration} arch=${architecture}"


### PR DESCRIPTION
## 目标

让 Mac App 源码与 Xcode 工程变更真正编译并运行单测，由 required PR Gate 阻断未验证的 Mac 改动。

## 实现

- 新增独立 `Mac App CI` reusable workflow，使用 `macos-26` 和无签名 `xcodebuild test`
- Mac path 改为独立 `macos` scope，不再错误触发 Go / Windows lane
- PR Gate fail-closed 聚合 Mac job，unexpected skipped / failure / cancellation 均不能放行
- main push paths 与 Mac-owned paths 对齐
- checker 锁定 scope outputs、job condition、needs/result、runner/timeout/paths 与真实测试参数

## 验证

- `git diff --check`
- Bash syntax
- `bash scripts/check-pr-gate.sh`
- `bash scripts/check-public-repo-safety.sh`
- workflow YAML parse
- 本机真实 Mac Scheme：52 passed / 0 failed / 0 skipped
- 全新上下文只读复审：ship，无阻断项

## 边界

不包含 Mac 签名、公证、DMG、Release tag trust 或 iOS 测试分层。首次 PR runner 将验证 `macos-26` 冷缓存能否稳定低于 20 分钟。

Linear: MIM-131