### PR TITLE
MIM-132 阻止非 main tag 进入正式 Release

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/test-conversation-regressions.sh"
       - "scripts/check-macos-release-signing.sh"
       - "scripts/check-release-artifacts.sh"
+      - "scripts/check-release-source.sh"
       - "scripts/check-source-size.sh"
       - "scripts/check-mimi-protocol-contract.sh"
       - "scripts/install-linux.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
           args: release --snapshot --clean --skip=publish
         env:
           GOTOOLCHAIN: local
+          GORELEASER_CURRENT_TAG: ${{ env.RELEASE_TAG }}
           TAP_DEPLOY_KEY: snapshot-only-not-used
 
       - name: Check release artifacts
@@ -243,6 +244,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ env.RELEASE_TAG }}
           TAP_DEPLOY_KEY: ${{ secrets.TAP_DEPLOY_KEY }}
           GOTOOLCHAIN: local
           MIMI_MACOS_SIGNING: required

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  repository_dispatch:
+    types:
+      - release
 
 permissions:
   contents: read
@@ -12,15 +12,40 @@ concurrency:
   group: mimi-remote-release
   cancel-in-progress: false
 
+env:
+  RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+
 jobs:
+  source-trust:
+    name: Verify release source
+    if: github.repository == 'gaixianggeng/mimi-remote'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      tag_sha: ${{ steps.source.outputs.tag_sha }}
+    steps:
+      - name: Checkout trusted main source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      # 这个 job 不读取任何 Secret；来源不可信时，签名与写 Release 的 job 都不会启动。
+      - name: Trust gate before release secrets
+        id: source
+        run: bash ./scripts/check-release-source.sh --check
+
   verify:
+    needs: source-trust
     if: github.repository == 'gaixianggeng/mimi-remote'
     runs-on: macos-26
     timeout-minutes: 30
+    environment: production-release
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ needs.source-trust.outputs.tag_sha }}
           fetch-depth: 0
 
       - name: Setup Go
@@ -73,7 +98,7 @@ jobs:
         run: |
           bash ./scripts/build-macos-installer.sh \
             --snapshot \
-            --version "${GITHUB_REF_NAME#v}" \
+            --version "${RELEASE_TAG#v}" \
             --build-number "$GITHUB_RUN_NUMBER" \
             --output-dir dist-macos
 
@@ -94,12 +119,16 @@ jobs:
         run: bash ./scripts/check-release-artifacts.sh
 
   verify-windows:
+    needs: source-trust
     if: github.repository == 'gaixianggeng/mimi-remote'
     runs-on: windows-latest
     timeout-minutes: 35
+    environment: production-release
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.source-trust.outputs.tag_sha }}
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -128,14 +157,14 @@ jobs:
               $pfx = Join-Path $env:RUNNER_TEMP 'mimi-remote-signing.pfx'
               [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_SIGN_PFX))
               ./scripts/build-windows-installer.ps1 `
-                -Version ($env:GITHUB_REF_NAME).TrimStart('v') `
+                -Version ($env:RELEASE_TAG).TrimStart('v') `
                 -OutputDirectory dist-windows `
                 -PfxPath $pfx `
                 -PfxPassword $env:WINDOWS_SIGN_PFX_PASSWORD
             } else {
               Write-Warning 'Windows signing secrets are absent. Publishing an unsigned installer that may trigger Microsoft Defender SmartScreen.'
               ./scripts/build-windows-installer.ps1 `
-                -Version ($env:GITHUB_REF_NAME).TrimStart('v') `
+                -Version ($env:RELEASE_TAG).TrimStart('v') `
                 -OutputDirectory dist-windows `
                 -AllowUnsignedRelease
             }
@@ -162,17 +191,20 @@ jobs:
 
   release:
     needs:
+      - source-trust
       - verify
       - verify-windows
     if: github.repository == 'gaixianggeng/mimi-remote'
     runs-on: macos-26
     timeout-minutes: 45
+    environment: production-release
     permissions:
       contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ needs.source-trust.outputs.tag_sha }}
           fetch-depth: 0
 
       - name: Setup Go
@@ -196,7 +228,7 @@ jobs:
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
         run: |
           bash ./scripts/build-macos-installer.sh \
-            --version "${GITHUB_REF_NAME#v}" \
+            --version "${RELEASE_TAG#v}" \
             --build-number "$GITHUB_RUN_NUMBER" \
             --output-dir dist-macos
 
@@ -224,7 +256,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "$GITHUB_REF_NAME" \
+          gh release upload "$RELEASE_TAG" \
             dist-macos/Mimi-Remote-Mac.dmg \
             dist-macos/Mimi-Remote-Mac.dmg.sha256 \
             dist-skill/install-mimi-remote.zip \
@@ -239,11 +271,13 @@ jobs:
 
   publish-windows:
     needs:
+      - source-trust
       - release
       - verify-windows
     if: github.repository == 'gaixianggeng/mimi-remote'
     runs-on: windows-latest
     timeout-minutes: 10
+    environment: production-release
     permissions:
       contents: write
     steps:
@@ -259,4 +293,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           $files = Get-ChildItem -LiteralPath dist-windows -File
-          gh release upload $env:GITHUB_REF_NAME $files.FullName --clobber --repo $env:GITHUB_REPOSITORY
+          gh release upload $env:RELEASE_TAG $files.FullName --clobber --repo $env:GITHUB_REPOSITORY

--- a/docs/install-upgrade-rollback.md
+++ b/docs/install-upgrade-rollback.md
@@ -363,6 +363,8 @@ rm -rf -- "$HOME/.config/mimi-remote"
 
 正式 tag 依赖 GitHub、Homebrew Tap 和 Apple Developer 三组外部资源：canonical 主仓库必须是 PUBLIC 的 `gaixianggeng/mimi-remote`，`gaixianggeng/homebrew-tap` 也必须是 PUBLIC，并且主仓库 Secret `TAP_DEPLOY_KEY` 对应的公钥必须作为可写 Deploy Key 安装在 Tap。仓库删除与改名是独立于代码合并的短维护窗口人工操作，具体顺序见[中文仓库改名 runbook](operations/github-repository-rename-runbook.zh-CN.md)。Deploy Key 只授权这一个仓库，避免把维护者账号的广域 PAT 放进公开仓库 Actions。
 
+正式发布只接受官方仓库的 `vX.Y.Z` tag，而且 tag 指向的 commit 必须已经进入当前 `origin/main`。为避免非 main tag 携带并执行它自己的高权限 workflow，单纯 push tag 不再触发正式发布；维护者通过 `repository_dispatch:release` 传入 tag，GitHub 固定从默认分支加载 workflow。workflow 会先 checkout 受信的 main SHA 并运行不读取任何 Secret 的 `source-trust` job，确认 checker 自身、workflow SHA 和当前 `origin/main` 一致，再用 `git merge-base --is-ancestor` 验证目标 tag 来源；后续 macOS / Windows 签名及 `contents:write` job 全部依赖该结果并绑定只允许 `main` 的 `production-release` Environment。仓库 ruleset 另外禁止删除或改写 `v*` tag；部分失败只允许在同一个 tag、同一个 commit 上重跑。
+
 macOS 产物还必须配置以下 GitHub Actions Secrets：
 
 | Secret | 内容 | 权限边界 |
@@ -398,6 +400,18 @@ bash ./scripts/restart-agentd-dev-macos.sh --self-test
 
 ```bash
 bash ./scripts/verify-release.sh
+```
+
+校验通过后创建并推送 tag，再发送只能从默认分支加载 workflow 的 Release 事件：
+
+```bash
+release_tag="v0.3.1"
+git tag "$release_tag"
+git push origin "$release_tag"
+gh api --method POST \
+  repos/gaixianggeng/mimi-remote/dispatches \
+  -f event_type=release \
+  -f "client_payload[release_tag]=$release_tag"
 ```
 
 该入口固定校验 GoReleaser `v2.15.3` 官方预编译包的 SHA-256，并拒绝当前 Go 版本偏离 `go.mod`。它会验证四个平台二进制的 Go 版本、GOOS/GOARCH、CGO 状态、可执行权限、许可证文件、systemd 模板和 Homebrew service；还会逐一核对 Formula 下载 URL 必须指向 `gaixianggeng/mimi-remote`，其中 SHA-256 必须与实际归档一致。普通安装用户不需要运行这个脚本。

--- a/docs/nightly-release.md
+++ b/docs/nightly-release.md
@@ -10,7 +10,7 @@
 - 同一 SHA 已有成功 Nightly 时，普通定时或手工触发只做成功的 skip；需要重发时手工选择 `force_publish`。
 - 确定需要发布后，先在轻量 Ubuntu job 中只检查 ASC、主 App / Widget profile、分发证书与临时 Keychain Secrets 是否齐全；缺失配置会在启动 macOS Simulator 回归前失败。profile 内容、App Group、Team、Bundle ID、证书和签名身份仍由后续发布 job 完整校验。
 - 发布 job 复用 iOS CI 的归档、签名和 `ios_testflight_ci.sh`，成功后保存 `nightly-testflight-<SHA>` evidence artifact 30 天。
-- 正式 iOS 候选通过 iOS CI 的 `workflow_dispatch` 和 `publish_app_store` 手工触发；正式 Mac、agentd、Windows 仍由维护者在当前 `main` 上创建并推送 `v*` tag，沿用现有 Release workflow。
+- 正式 iOS 候选通过 iOS CI 的 `workflow_dispatch` 和 `publish_app_store` 手工触发。正式 Mac、agentd、Windows 由维护者从已经进入 `main` 的 commit 创建并推送 `vX.Y.Z` tag，再发送 `repository_dispatch:release` 并传入该 tag；tag push 本身不读取发布 Secret。GitHub 固定从默认分支加载 Release workflow，workflow 再在不读取 Secret 的轻量 job 中核对官方仓库、受信 main SHA、目标 tag 与 `origin/main` 可达性，最后才允许签名和发布 job 进入 `production-release` Environment。
 
 ## 实现
 

--- a/scripts/check-nightly-release.sh
+++ b/scripts/check-nightly-release.sh
@@ -266,6 +266,12 @@ end
   fail_check("Release #{job_name} 没有 checkout source-trust 验证的 immutable SHA") unless
     checkout && checkout.dig("with", "ref").to_s.include?("needs.source-trust.outputs.tag_sha")
 end
+%w[verify release].each do |job_name|
+  goreleaser_step_name = job_name == "verify" ? "Build release snapshot" : "Release"
+  goreleaser_step = step(release_jobs.fetch(job_name), goreleaser_step_name)
+  fail_check("Release #{job_name} 的 GoReleaser 没有绑定 source-trust 校验的 RELEASE_TAG") unless
+    goreleaser_step.dig("env", "GORELEASER_CURRENT_TAG") == "${{ env.RELEASE_TAG }}"
+end
 fail_check("Release workflow 不得从 dispatch 的 main ref 推导发布版本") if
   release.to_s.include?("GITHUB_REF_NAME")
 distributor = File.read(distributor_path)
@@ -352,6 +358,7 @@ self_test() {
   mutate_release 'needs: source-trust' 'needs: []'
   mutate_release 'environment: production-release' 'environment: bypass-release'
   mutate_release 'fetch-depth: 0' 'fetch-depth: 1'
+  mutate_release 'GORELEASER_CURRENT_TAG: ${{ env.RELEASE_TAG }}' 'GORELEASER_CURRENT_TAG: v0.0.0'
   mutate_release 'permissions:
   contents: read' 'permissions:
   contents: write'

--- a/scripts/check-nightly-release.sh
+++ b/scripts/check-nightly-release.sh
@@ -211,9 +211,63 @@ fail_check("Nightly evidence JSON 字段不完整") unless %w[source_sha run_id 
 fail_check("Nightly evidence artifact 配置错误") unless artifact["uses"].to_s.match?(/@[0-9a-f]{40}\z/) && artifact.dig("with", "name").to_s.include?("nightly-testflight-") && artifact.dig("with", "retention-days") == 30
 
 release_triggers = triggers(release, release_path)
-fail_check("Release 只能由 v* tag push 触发") unless
-  release_triggers.keys == ["push"] && release_triggers.dig("push", "tags") == ["v*"]
+release_dispatch = release_triggers["repository_dispatch"]
+fail_check("Release 只能由默认分支 repository_dispatch:release 触发") unless
+  release_triggers.keys == ["repository_dispatch"] &&
+  release_dispatch == { "types" => ["release"] }
+fail_check("Release 顶层权限必须严格保持 contents:read") unless
+  release["permissions"] == { "contents" => "read" }
+fail_check("Release RELEASE_TAG 必须只来自 dispatch input") unless
+  release.dig("env", "RELEASE_TAG").to_s.include?("github.event.client_payload.release_tag") &&
+  release.fetch("env").keys == ["RELEASE_TAG"]
 fail_check("release.yml 不得依赖 release-validation/readiness/attestation") if release.to_s.match?(/release-validation|readiness|attestation/i)
+release_jobs = release.fetch("jobs")
+expected_release_jobs = %w[source-trust verify verify-windows release publish-windows]
+fail_check("Release jobs 集合存在未受 source-trust 约束的旁路") unless
+  release_jobs.keys.sort == expected_release_jobs.sort
+release_trust = release_jobs.fetch("source-trust")
+expected_trust_keys = %w[name if runs-on timeout-minutes outputs steps]
+fail_check("Release source-trust 含未允许的权限、Environment 或控制字段") unless
+  release_trust.keys.sort == expected_trust_keys.sort
+fail_check("Release source-trust 必须只输出 checker 验证的 tag_sha") unless
+  release_trust.fetch("outputs").keys == ["tag_sha"] &&
+  release_trust.dig("outputs", "tag_sha").to_s.include?("steps.source.outputs.tag_sha")
+fail_check("Release source-trust 仓库条件不可放宽") unless
+  release_trust["if"] == "github.repository == 'gaixianggeng/mimi-remote'"
+fail_check("Release source-trust 必须使用轻量 Ubuntu runner 和短超时") unless
+  release_trust["runs-on"] == "ubuntu-latest" && release_trust["timeout-minutes"] == 3
+fail_check("Release source-trust 必须且只能包含 checkout 与 trust 两步") unless
+  steps(release_trust).length == 2
+release_trust_checkout = steps(release_trust).fetch(0)
+fail_check("Release source-trust checkout 含可跳过或忽略失败的字段") unless
+  release_trust_checkout.keys.sort == %w[name uses with]
+fail_check("Release source-trust 必须完整 checkout tag 与 main 历史") unless
+  release_trust_checkout["uses"].to_s.start_with?("actions/checkout@") &&
+  release_trust_checkout.dig("with", "fetch-depth") == 0 &&
+  release_trust_checkout.dig("with", "ref").to_s.include?("github.sha")
+release_trust_step = step(release_trust, "Trust gate before release secrets")
+fail_check("Release source-trust 不得读取 Secrets") if release_trust.to_s.include?("secrets.")
+fail_check("Release trust step 含 continue-on-error、if 或其他旁路字段") unless
+  release_trust_step.keys.sort == %w[id name run] && release_trust_step["id"] == "source"
+fail_check("Release source-trust 没有调用统一来源校验入口") unless
+  release_trust_step["run"] == "bash ./scripts/check-release-source.sh --check"
+
+%w[verify verify-windows release publish-windows].each do |job_name|
+  job = release_jobs.fetch(job_name)
+  fail_check("Release #{job_name} 仓库条件不可放宽") unless
+    job["if"] == "github.repository == 'gaixianggeng/mimi-remote'"
+  fail_check("Release #{job_name} 没有显式依赖 source-trust") unless
+    Array(job["needs"]).include?("source-trust")
+  fail_check("Release #{job_name} 没有绑定 production-release Environment") unless
+    job["environment"] == "production-release"
+end
+%w[verify verify-windows release].each do |job_name|
+  checkout = steps(release_jobs.fetch(job_name)).find { |item| item["uses"].to_s.start_with?("actions/checkout@") }
+  fail_check("Release #{job_name} 没有 checkout source-trust 验证的 immutable SHA") unless
+    checkout && checkout.dig("with", "ref").to_s.include?("needs.source-trust.outputs.tag_sha")
+end
+fail_check("Release workflow 不得从 dispatch 的 main ref 推导发布版本") if
+  release.to_s.include?("GITHUB_REF_NAME")
 distributor = File.read(distributor_path)
 fail_check("Internal TestFlight 组校验必须 fail-closed") unless distributor.include?('unless group.dig("attributes", "isInternalGroup") == true')
 
@@ -281,7 +335,47 @@ self_test() {
   cp "$ROOT_DIR/.github/workflows/release.yml" "$test_root/.github/workflows/release.yml"
   ruby -e 'p = ARGV.fetch(0); s = File.read(p).sub("name: Release", "name: attestation drift"); File.write(p, s)' "$test_root/.github/workflows/release.yml"
   expect_failure
-  echo "Nightly/Release checker self-test 通过：schedule、权限、trust gate、发布凭据预检、evidence 绑定与 Release validation/attestation 漂移均能失败。"
+  mutate_release() {
+    local old_value="$1"
+    local new_value="$2"
+    cp "$ROOT_DIR/.github/workflows/release.yml" "$test_root/.github/workflows/release.yml"
+    ruby -e '
+      path, old_value, new_value = ARGV
+      source = File.read(path)
+      abort "self-test mutation target missing: #{old_value}" unless source.include?(old_value)
+      File.write(path, source.sub(old_value, new_value))
+    ' "$test_root/.github/workflows/release.yml" "$old_value" "$new_value"
+    expect_failure
+  }
+  mutate_release 'repository_dispatch:' 'push:'
+  mutate_release 'run: bash ./scripts/check-release-source.sh --check' 'run: echo bypassed'
+  mutate_release 'needs: source-trust' 'needs: []'
+  mutate_release 'environment: production-release' 'environment: bypass-release'
+  mutate_release 'fetch-depth: 0' 'fetch-depth: 1'
+  mutate_release 'permissions:
+  contents: read' 'permissions:
+  contents: write'
+  mutate_release '    name: Verify release source' '    name: Verify release source
+    permissions:
+      contents: write'
+  mutate_release '      - name: Trust gate before release secrets
+        id: source
+        run:' '      - name: Trust gate before release secrets
+        id: source
+        continue-on-error: true
+        run:'
+  mutate_release '  verify:' '  bypass-release-trust:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment: production-release
+    steps:
+      - run: echo "$STOLEN"
+        env:
+          STOLEN: ${{ secrets.TAP_DEPLOY_KEY }}
+
+  verify:'
+  echo "Nightly/Release checker self-test 通过：schedule、权限、trust gate、发布凭据预检、evidence 绑定、Release default-branch source-trust、旁路 job 与 validation/attestation 漂移均能失败。"
 }
 
 case "${1:---check}" in

--- a/scripts/check-packaging.sh
+++ b/scripts/check-packaging.sh
@@ -179,7 +179,7 @@ grep -Fq 'find "$APP_PATH" -type f -print0' scripts/check-macos-installer.sh \
   || fail "Mac 安装包门禁没有枚举 App 内全部 Mach-O。"
 grep -Fq 'xcrun vtool -arch' scripts/check-macos-installer.sh \
   || fail "Mac 安装包门禁没有逐架构检查 macOS 构建元数据。"
-grep -Fq 'gh release upload "$GITHUB_REF_NAME"' .github/workflows/release.yml \
+grep -Fq 'gh release upload "$RELEASE_TAG"' .github/workflows/release.yml \
   || fail "Release workflow 没有上传 Mac DMG 到 GitHub Release。"
 grep -Fq 'scripts/package-skill.sh' .github/workflows/release.yml \
   || fail "Release workflow 没有构建 Codex Skill 发布包。"

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -18,11 +18,13 @@ bash -n \
   scripts/ci-pr-scope.sh \
   scripts/check-critical-regressions.sh \
   scripts/check-nightly-release.sh \
+  scripts/check-release-source.sh \
   scripts/check-pr-gate.sh \
   scripts/test-macos-app.sh
 
 bash ./scripts/check-critical-regressions.sh
 bash ./scripts/check-nightly-release.sh
+bash ./scripts/check-release-source.sh --self-test
 
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-pr-gate-check.XXXXXX")"
 trap 'rm -rf "$test_root"' EXIT
@@ -56,6 +58,7 @@ assert_scope rust_only false false true false bridges/claude/crates/claude-bridg
 assert_scope macos_only false false false true macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
 assert_scope macos_runner false false false true scripts/test-macos-app.sh
 assert_scope release true false false false scripts/check-release-artifacts.sh
+assert_scope release_source true false false false scripts/check-release-source.sh
 assert_scope windows_release true false false false scripts/build-windows-installer.ps1
 assert_scope ios_release false true false false scripts/ios_testflight_ci.sh
 assert_scope ios_asc_pin false true false false config/release/ios-asc-cli.env

--- a/scripts/check-release-source.sh
+++ b/scripts/check-release-source.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_REPOSITORY="gaixianggeng/mimi-remote"
+readonly SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+readonly REPOSITORY_ROOT="${MIMI_RELEASE_SOURCE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+fail() {
+  echo "Release 来源信任门失败：$1" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "缺少命令 $1。"
+}
+
+verify_source() {
+  require_command git
+
+  cd "$REPOSITORY_ROOT"
+
+  [[ "${GITHUB_REPOSITORY:-}" == "$EXPECTED_REPOSITORY" ]] \
+    || fail "只能在官方仓库 ${EXPECTED_REPOSITORY} 运行。"
+  [[ "${GITHUB_EVENT_NAME:-}" == "repository_dispatch" ]] \
+    || fail "只能通过默认分支上的受信 repository_dispatch 入口发布。"
+  [[ "${GITHUB_REF:-}" == "refs/heads/main" && "${GITHUB_REF_NAME:-}" == "main" ]] \
+    || fail "发布工作流必须固定从 main 分支加载。"
+  [[ "${RELEASE_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || fail "tag 必须使用 vX.Y.Z 格式。"
+  [[ "${GITHUB_SHA:-}" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "workflow SHA 不是完整的小写 commit SHA。"
+
+  local head_sha
+  local workflow_sha
+  local tag_sha
+  local main_sha
+  head_sha="$(git rev-parse --verify 'HEAD^{commit}')" \
+    || fail "无法解析 checkout commit。"
+  workflow_sha="$(git rev-parse --verify "${GITHUB_SHA}^{commit}")" \
+    || fail "无法把 workflow SHA 解析为 commit。"
+  tag_sha="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")" \
+    || fail "无法把发布 tag 解析为 commit。"
+
+  [[ "$head_sha" == "$workflow_sha" ]] \
+    || fail "trust job 没有 checkout 受信 workflow commit。"
+
+  # 核心边界：只从官方 origin 读取 main，不信任 runner 上可能陈旧的本地引用。
+  git fetch --quiet --no-tags origin \
+    +refs/heads/main:refs/remotes/origin/main \
+    || fail "无法读取官方 origin/main。"
+  main_sha="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')" \
+    || fail "无法解析 origin/main。"
+  [[ "$workflow_sha" == "$main_sha" ]] \
+    || fail "workflow 不是从当前 origin/main 加载；请从 main 重新触发。"
+  git merge-base --is-ancestor "$tag_sha" "$main_sha" \
+    || fail "tag commit 尚未进入 origin/main。"
+
+  # 下游只 checkout 已验证的不可变 SHA，避免 tag 在 job 之间发生 TOCTOU 漂移。
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf 'tag_sha=%s\n' "$tag_sha" >> "$GITHUB_OUTPUT"
+  fi
+
+  echo "Release 来源信任门通过：受信 workflow ${workflow_sha} 从 main 加载；${RELEASE_TAG} -> ${tag_sha} 已包含于 origin/main。"
+}
+
+run_self_test() {
+  require_command git
+  require_command mktemp
+
+  local test_root
+  local origin_path
+  local seed_path
+  local checkout_path
+  local release_sha
+  local previous_main_sha
+  test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-release-source-self-test.XXXXXX")"
+  origin_path="$test_root/origin.git"
+  seed_path="$test_root/seed"
+  checkout_path="$test_root/checkout"
+  trap 'rm -rf "$test_root"' RETURN
+
+  git init --quiet --bare "$origin_path"
+  git init --quiet "$seed_path"
+  git -C "$seed_path" config user.name "Mimi Release Self Test"
+  git -C "$seed_path" config user.email "release-self-test@example.invalid"
+  git -C "$seed_path" checkout --quiet -b main
+  printf 'main-1\n' > "$seed_path/source.txt"
+  git -C "$seed_path" add source.txt
+  git -C "$seed_path" commit --quiet -m "main one"
+  previous_main_sha="$(git -C "$seed_path" rev-parse HEAD)"
+  printf 'main-2\n' >> "$seed_path/source.txt"
+  git -C "$seed_path" commit --quiet -am "main two"
+  release_sha="$(git -C "$seed_path" rev-parse HEAD)"
+  git -C "$seed_path" tag v1.2.3
+  git -C "$seed_path" remote add origin "$origin_path"
+  git -C "$seed_path" push --quiet origin main refs/tags/v1.2.3
+
+  git -C "$seed_path" checkout --quiet -b off-main
+  printf 'off-main\n' >> "$seed_path/source.txt"
+  git -C "$seed_path" commit --quiet -am "off main"
+  git -C "$seed_path" tag v9.9.9
+  git -C "$seed_path" push --quiet origin refs/tags/v9.9.9
+
+  git clone --quiet "$origin_path" "$checkout_path"
+  git -C "$checkout_path" checkout --quiet main
+  MIMI_RELEASE_SOURCE_ROOT="$checkout_path" \
+    GITHUB_REPOSITORY="$EXPECTED_REPOSITORY" \
+    GITHUB_EVENT_NAME="repository_dispatch" \
+    GITHUB_REF="refs/heads/main" \
+    GITHUB_REF_NAME="main" \
+    GITHUB_SHA="$release_sha" \
+    RELEASE_TAG="v1.2.3" \
+    "$SCRIPT_PATH" --check >/dev/null
+
+  expect_failure() {
+    local case_name="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+      fail "self-test ${case_name} 本应失败但通过。"
+    fi
+  }
+
+  expect_failure wrong-repository \
+    env MIMI_RELEASE_SOURCE_ROOT="$checkout_path" \
+      GITHUB_REPOSITORY="someone/fork" \
+      GITHUB_EVENT_NAME="repository_dispatch" \
+      GITHUB_REF="refs/heads/main" \
+      GITHUB_REF_NAME="main" \
+      GITHUB_SHA="$release_sha" \
+      RELEASE_TAG="v1.2.3" \
+      "$SCRIPT_PATH" --check
+  expect_failure malformed-tag \
+    env MIMI_RELEASE_SOURCE_ROOT="$checkout_path" \
+      GITHUB_REPOSITORY="$EXPECTED_REPOSITORY" \
+      GITHUB_EVENT_NAME="repository_dispatch" \
+      GITHUB_REF="refs/heads/main" \
+      GITHUB_REF_NAME="main" \
+      GITHUB_SHA="$release_sha" \
+      RELEASE_TAG="v1" \
+      "$SCRIPT_PATH" --check
+  expect_failure stale-workflow-sha \
+    env MIMI_RELEASE_SOURCE_ROOT="$checkout_path" \
+      GITHUB_REPOSITORY="$EXPECTED_REPOSITORY" \
+      GITHUB_EVENT_NAME="repository_dispatch" \
+      GITHUB_REF="refs/heads/main" \
+      GITHUB_REF_NAME="main" \
+      GITHUB_SHA="$previous_main_sha" \
+      RELEASE_TAG="v1.2.3" \
+      "$SCRIPT_PATH" --check
+  expect_failure untrusted-workflow-ref \
+    env MIMI_RELEASE_SOURCE_ROOT="$checkout_path" \
+      GITHUB_REPOSITORY="$EXPECTED_REPOSITORY" \
+      GITHUB_EVENT_NAME="repository_dispatch" \
+      GITHUB_REF="refs/tags/v1.2.3" \
+      GITHUB_REF_NAME="v1.2.3" \
+      GITHUB_SHA="$release_sha" \
+      RELEASE_TAG="v1.2.3" \
+      "$SCRIPT_PATH" --check
+
+  expect_failure off-main-tag \
+    env MIMI_RELEASE_SOURCE_ROOT="$checkout_path" \
+      GITHUB_REPOSITORY="$EXPECTED_REPOSITORY" \
+      GITHUB_EVENT_NAME="repository_dispatch" \
+      GITHUB_REF="refs/heads/main" \
+      GITHUB_REF_NAME="main" \
+      GITHUB_SHA="$release_sha" \
+      RELEASE_TAG="v9.9.9" \
+      "$SCRIPT_PATH" --check
+
+  echo "Release 来源信任门自测通过：default-branch dispatch + main tag 通过，错误仓库、非法 tag、非 main workflow ref、SHA/checkout 漂移与非 main tag 均被拒绝。"
+}
+
+case "${1:---check}" in
+  --check)
+    verify_source
+    ;;
+  --self-test)
+    run_self_test
+    ;;
+  *)
+    fail "用法：bash ./scripts/check-release-source.sh [--check|--self-test]"
+    ;;
+esac


### PR DESCRIPTION
## 目标

把正式桌面 Release 的信任根从 tag 自身 workflow 移到 GitHub 默认分支，阻止 off-main tag 携带旁路 workflow 读取签名 Secret 或申请 contents:write。

## 实现

- `release.yml` 改为 `repository_dispatch:release`，tag push 不再自动接触发布权限。
- source-trust 只 checkout 默认分支 `github.sha`，验证 `HEAD = workflow SHA = 当前 origin/main`。
- 严格校验 `vX.Y.Z` tag 已进入 main，并输出 verified `tag_sha`；下游只按该 SHA checkout，关闭 TOCTOU。
- 所有签名/发布 job 显式依赖 source-trust 并绑定 `production-release`。
- checker 锁定只读顶层权限、精确 job 集、无 continue-on-error/权限提升/旁路 job，并加入反例 self-test。
- 更新中文发布命令与恢复文档。

仓库设置已预先落地：

- `production-release` Environment 仅允许 `main`，无 reviewer / wait timer。
- active ruleset `Immutable release tags` 覆盖 `refs/tags/v*`，禁止 update / deletion。

## 验证

- `bash ./scripts/check-release-source.sh --self-test`
- `bash ./scripts/check-nightly-release.sh --check`
- `bash ./scripts/check-nightly-release.sh --self-test`
- `bash ./scripts/check-packaging.sh`
- `bash ./scripts/check-pr-gate.sh`
- `bash ./scripts/check-public-repo-safety.sh`
- workflow YAML safe parse
- `git diff --check`
- 三轮独立复审：前两轮发现并关闭 tag-workflow / tag-checker 信任根 blocker，最终结论 ship。

本 PR 不创建真实 tag、不运行签名/公证、不发布 Release。

Linear: MIM-132