### PR TITLE
MIM-135 按变更风险分层本地验证

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,37 +24,46 @@ Bug 请尽量包含：
 
 ## 本地验证
 
-Go 后端改动至少运行：
+开发过程中只运行当前问题需要的最小检查，不要在每次微调后重复执行全量测试、
+Simulator 回归和真机验证。准备提交或推送前，统一执行一次：
+
+```bash
+bash ./scripts/verify-change.sh --plan
+bash ./scripts/verify-change.sh
+```
+
+第一条只展示变更来源、受影响栈、执行/跳过原因和真机延后项；确认计划后，第二条执行
+quick 验证。脚本会合并 `origin/main...HEAD`、暂存区、工作区和未跟踪文件并去重：
+
+- 纯文档不启动 Go、Cargo、Xcode 或真机；
+- CI、脚本和发布控制面只运行语法检查及对应的无设备自测；
+- Go 默认只测试直接变更的 package；
+- iOS 默认固定 `iPad Pro 13-inch (M5)`，只生成一次可复用测试产物；
+- Rust、Mac App、共享契约和打包改动只进入各自的必要门禁；
+- 未映射路径会明确失败，不会被静默当作通过。
+
+只有跨模块重构、共享协议/发布链路、准备正式发布，或 quick 无法覆盖风险时才升级：
+
+```bash
+bash ./scripts/verify-change.sh --full
+```
+
+`--full` 仍只覆盖受影响语言栈，并补齐仓库级 Gate。CI 红灯时先重跑或定位失败的
+具体 job，不要为了“保险”把所有本地流程再跑一遍。
+
+日常 `build` / `run` 优先租用 available、paired、USB 连接的真机，跳过已占用设备后回退到 `iPad Pro 13-inch (M5)` Simulator。`build-for-testing`、`test`、快照与 CI 精确固定这台 M5 iPad，忙或缺失时不切换 iPad mini。使用 `bash ./scripts/ios-dev.sh leases` 查看跨 Worktree 租约和外部 `xcodebuild`；兼容性运行通过 `IOS_TARGET_MODE=simulator` 和 `IOS_SIMULATOR_NAME` 显式切换。
+
+真机只在改动涉及相机、通知、Keychain、Tailscale/弱网、性能、发布前验收，或 Issue
+明确要求时执行。Simulator 通过不代表这些专项完成；真机结果也不替代固定 M5 的回归。
+
+需要单独排障时，仍可直接运行对应命令。例如 Go 全量回归：
 
 ```bash
 go test ./... -count=1
 go vet ./...
-bash ./scripts/check-codex-protocol.sh
 ```
 
-iOS 改动至少生成工程并完成无签名构建：
-
-```bash
-xcodegen generate \
-  --spec ios/MimiRemote/project.yml \
-  --project ios/MimiRemote
-
-bash ./scripts/ios-dev.sh build-for-testing
-```
-
-日常 `build` / `run` 优先租用 available、paired、USB 连接的真机，跳过已占用设备后回退到 `iPad Pro 13-inch (M5)` Simulator。`build-for-testing`、`test`、快照与 CI 精确固定这台 M5 iPad，忙或缺失时不切换 iPad mini。使用 `bash ./scripts/ios-dev.sh leases` 查看跨 Worktree 租约和外部 `xcodebuild`；兼容性运行通过 `IOS_TARGET_MODE=simulator` 和 `IOS_SIMULATOR_NAME` 显式切换。
-
-Claude bridge 改动至少运行：
-
-```bash
-cargo fmt --all -- --check
-cargo test --locked \
-  -p alleycat-codex-proto \
-  -p alleycat-bridge-core \
-  -p alleycat-claude-bridge
-```
-
-公开仓库安全相关改动还应运行：
+公开仓库安全相关改动可单独运行：
 
 ```bash
 bash ./scripts/check-public-repo-safety.sh
@@ -103,15 +112,15 @@ bash ./scripts/test-conversation-regressions.sh
 - Cargo 或 `bridges/claude` 路径调用现有 Rust bridge CI；
 - `.github/workflows`、`.github/actions` 或 Gate 分类脚本变化时执行全部语言检查。
 
-提交前始终运行：
+本地统一入口会按变化范围选择上述门禁；不需要再手工重复一遍。要预览 PR 的语言
+scope，可运行：
 
 ```bash
-bash ./scripts/check-pr-gate.sh
-bash ./scripts/check-public-repo-safety.sh
-bash ./scripts/check-codex-protocol.sh
+bash ./scripts/verify-change.sh --plan
+bash ./scripts/ci-pr-scope.sh --base origin/main --head HEAD
 ```
 
-再按改动范围运行本文件前述 Go、iOS 或 Claude bridge 命令。Release/打包改动还需运行：
+Release/打包改动仍可用下面的专项检查定位问题：
 
 ```bash
 bash ./scripts/check-packaging.sh

--- a/README.md
+++ b/README.md
@@ -394,6 +394,12 @@ bash ./scripts/verify-change.sh --full
 
 Physical-device validation is reserved for camera, notifications, Keychain, Tailscale/poor-network behavior, performance, and release checks. See [CONTRIBUTING.md](CONTRIBUTING.md) for the tier rules and targeted troubleshooting commands.
 
+Formal release validation remains a separate step from these change tiers:
+
+```bash
+bash ./scripts/verify-release.sh
+```
+
 ## Repository layout
 
 ```text

--- a/README.md
+++ b/README.md
@@ -379,28 +379,20 @@ The app rejects public HTTP endpoints at the application layer and is designed f
 
 ## Development checks
 
-Run the checks appropriate to the area you changed:
+Preview the checks selected from committed, staged, unstaged, and untracked changes, then run the quick tier once before pushing:
 
 ```bash
-go test ./... -count=1
-go vet ./...
-bash ./scripts/check-codex-protocol.sh
-bash ./scripts/check-ios-localization.sh
-bash ./scripts/check-public-repo-safety.sh
-bash ./scripts/check-third-party-notices.sh
-bash ./scripts/check-ios-privacy-manifest.sh
-bash ./scripts/restart-agentd-dev-macos.sh --self-test
-bash ./scripts/verify-release.sh
+bash ./scripts/verify-change.sh --plan
+bash ./scripts/verify-change.sh
 ```
 
-For bridge work:
+The quick tier skips language builds for documentation and control-plane-only changes, tests only directly affected stacks, and defers broad regression to PR Gate. Use the full tier for cross-module, protocol, release, or other explicitly high-risk changes:
 
 ```bash
-cargo test --locked \
-  -p alleycat-codex-proto \
-  -p alleycat-bridge-core \
-  -p alleycat-claude-bridge
+bash ./scripts/verify-change.sh --full
 ```
+
+Physical-device validation is reserved for camera, notifications, Keychain, Tailscale/poor-network behavior, performance, and release checks. See [CONTRIBUTING.md](CONTRIBUTING.md) for the tier rules and targeted troubleshooting commands.
 
 ## Repository layout
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -425,6 +425,12 @@ PR Gate。跨模块、协议、发布或明确高风险改动再运行
 `bash ./scripts/verify-change.sh --full`。相机、通知、Keychain、Tailscale/弱网、性能和
 发布前验收才需要真机。分层规则和专项排障命令见[贡献指南](CONTRIBUTING.md)。
 
+正式发布校验仍需独立于上述分层验证执行：
+
+```bash
+bash ./scripts/verify-release.sh
+```
+
 正式 macOS Release 必须通过 Developer ID 签名和 Apple notarization；发布链路另外包含签名凭据预检、Darwin 归档身份校验、打包、Linux 安装、Git 历史凭据扫描、Action SHA 固定和协议漂移门禁，详见 [P0 / P1 发布清单](docs/p0-p1-roadmap.md)。
 
 ## 仓库说明

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -412,19 +412,18 @@ bridge 只保留 Mimi Remote 需要的三个 crate；上游来源和 GPLv3-only 
 
 ## 验证
 
-提交前至少运行：
+先预览 committed、staged、unstaged 和未跟踪变更对应的验证计划；准备推送前只执行
+一次 quick：
 
 ```bash
-go test ./... -count=1
-go vet ./...
-bash ./scripts/check-codex-protocol.sh
-bash ./scripts/check-public-repo-safety.sh
-bash ./scripts/check-third-party-notices.sh
-bash ./scripts/check-ios-privacy-manifest.sh
-bash ./scripts/restart-agentd-dev-macos.sh --self-test
-bash ./scripts/verify-release.sh
-cargo test --locked -p alleycat-claude-bridge
+bash ./scripts/verify-change.sh --plan
+bash ./scripts/verify-change.sh
 ```
+
+纯文档和控制面改动不会启动语言构建；产品代码只验证直接受影响的栈，完整回归默认交给
+PR Gate。跨模块、协议、发布或明确高风险改动再运行
+`bash ./scripts/verify-change.sh --full`。相机、通知、Keychain、Tailscale/弱网、性能和
+发布前验收才需要真机。分层规则和专项排障命令见[贡献指南](CONTRIBUTING.md)。
 
 正式 macOS Release 必须通过 Developer ID 签名和 Apple notarization；发布链路另外包含签名凭据预检、Darwin 归档身份校验、打包、Linux 安装、Git 历史凭据扫描、Action SHA 固定和协议漂移门禁，详见 [P0 / P1 发布清单](docs/p0-p1-roadmap.md)。
 

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -14,14 +14,19 @@ for command_name in bash grep mktemp ruby; do
     || fail "缺少命令 ${command_name}。"
 done
 
-bash -n \
+for script_path in \
   scripts/ci-pr-scope.sh \
   scripts/check-critical-regressions.sh \
   scripts/check-nightly-release.sh \
   scripts/check-release-source.sh \
   scripts/check-pr-gate.sh \
-  scripts/test-macos-app.sh
+  scripts/verify-change.sh \
+  scripts/test-verify-change.sh \
+  scripts/test-macos-app.sh; do
+  bash -n -- "$script_path"
+done
 
+bash ./scripts/test-verify-change.sh
 bash ./scripts/check-critical-regressions.sh
 bash ./scripts/check-nightly-release.sh
 bash ./scripts/check-release-source.sh --self-test

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -206,6 +206,17 @@ assert_contains "$collection_output" "go test ./internal/httpapi -count=1"
 assert_contains "$collection_output" "ios-dev.sh build-for-testing"
 assert_contains "$collection_output" "cargo test --locked"
 
+# base 与 HEAD 都存在但没有共同祖先时，git diff 必须显式失败；不能把退出码
+# 吞掉后误报为“没有发现需要验证的变更”。
+empty_tree="$(git -C "$repo_root" mktree </dev/null)"
+unrelated_commit="$(printf 'unrelated\n' | git -C "$repo_root" commit-tree "$empty_tree")"
+collection_failure_output="$test_root/collection-failure.output"
+if (cd "$repo_root" && bash ./scripts/verify-change.sh --plan --base "$unrelated_commit") \
+  >"$collection_failure_output" 2>&1; then
+  fail "无 merge-base 时必须传播 committed 路径收集失败。"
+fi
+assert_contains "$(<"$collection_failure_output")" "无法收集 committed 变更路径。"
+
 rm -rf "$test_root"
 trap - EXIT
 

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "分层验证自测失败：$1" >&2
+  exit 1
+}
+
+for command_name in bash chmod cp git grep mkdir mktemp printf rm; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "缺少命令 ${command_name}。"
+done
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-verify-change-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+  printf '%s\n' "$output" | grep -Fq -- "$expected" \
+    || fail "输出缺少：${expected}"
+}
+
+assert_not_contains() {
+  local output="$1"
+  local unexpected="$2"
+  if printf '%s\n' "$output" | grep -Fq -- "$unexpected"; then
+    fail "输出不应包含：${unexpected}"
+  fi
+}
+
+assert_plan() {
+  local case_name="$1"
+  shift
+  local path_file="$test_root/${case_name}.paths"
+  : > "$path_file"
+  printf '%s\0' "$@" > "$path_file"
+  bash ./scripts/verify-change.sh --plan --paths-file "$path_file"
+}
+
+assert_full_plan() {
+  local case_name="$1"
+  shift
+  local path_file="$test_root/${case_name}.paths"
+  : > "$path_file"
+  printf '%s\0' "$@" > "$path_file"
+  bash ./scripts/verify-change.sh --plan --full --paths-file "$path_file"
+}
+
+docs_output="$(assert_plan docs_only CONTRIBUTING.md docs/support.md)"
+assert_contains "$docs_output" "判定：纯文档/静态内容"
+assert_not_contains "$docs_output" "ios-dev.sh build-for-testing"
+assert_not_contains "$docs_output" "ios-dev.sh target"
+assert_not_contains "$docs_output" "ios-dev.sh leases"
+assert_not_contains "$docs_output" "go test"
+assert_not_contains "$docs_output" "cargo test"
+assert_contains "$docs_output" "Go：没有直接 Go 产品路径"
+assert_contains "$docs_output" "iOS：没有直接 iOS 产品路径"
+
+nested_docs_output="$(assert_plan nested_docs ios/MimiRemote/README.md bridges/claude/README.md)"
+assert_contains "$nested_docs_output" "判定：纯文档/静态内容"
+assert_not_contains "$nested_docs_output" "ios-dev.sh build-for-testing"
+assert_not_contains "$nested_docs_output" "cargo test"
+
+ios_output="$(assert_plan ios_only ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift)"
+assert_contains "$ios_output" "ios-dev.sh build-for-testing"
+assert_contains "$ios_output" "check-source-size.sh"
+assert_not_contains "$ios_output" "go test"
+assert_not_contains "$ios_output" "cargo test"
+
+go_output="$(assert_plan go_only internal/httpapi/router.go)"
+assert_contains "$go_output" "go test ./internal/httpapi -count=1"
+assert_not_contains "$go_output" "ios-dev.sh build-for-testing"
+
+go_fixture_output="$(assert_plan go_fixture internal/httpapi/testdata/request.json)"
+assert_contains "$go_fixture_output" "go test ./internal/httpapi -count=1"
+
+rust_leaf_output="$(assert_plan rust_leaf bridges/claude/crates/claude-bridge/src/lib.rs)"
+assert_contains "$rust_leaf_output" "-p alleycat-claude-bridge"
+assert_not_contains "$rust_leaf_output" "-p alleycat-bridge-core"
+assert_not_contains "$rust_leaf_output" "-p alleycat-codex-proto"
+
+rust_shared_output="$(assert_plan rust_shared bridges/claude/crates/codex-proto/src/lib.rs)"
+assert_contains "$rust_shared_output" "-p alleycat-codex-proto"
+assert_contains "$rust_shared_output" "-p alleycat-bridge-core"
+assert_contains "$rust_shared_output" "-p alleycat-claude-bridge"
+
+ios_full_output="$(assert_full_plan ios_full ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift)"
+assert_contains "$ios_full_output" "test-conversation-regressions.sh"
+assert_contains "$ios_full_output" "test-ios-localization-smoke.sh"
+assert_not_contains "$ios_full_output" "ios-dev.sh build-for-testing"
+
+rust_full_output="$(assert_full_plan rust_full bridges/claude/crates/claude-bridge/src/lib.rs)"
+assert_contains "$rust_full_output" "-p alleycat-codex-proto"
+assert_contains "$rust_full_output" "-p alleycat-bridge-core"
+assert_contains "$rust_full_output" "-p alleycat-claude-bridge"
+
+security_output="$(assert_plan security_control scripts/check-public-repo-safety.sh)"
+assert_contains "$security_output" "bash ./scripts/check-public-repo-safety.sh"
+
+security_workflow_output="$(assert_plan security_workflow .github/workflows/public-repo-safety.yml)"
+assert_contains "$security_workflow_output" "bash ./scripts/check-public-repo-safety.sh"
+assert_not_contains "$security_workflow_output" "bash ./scripts/check-pr-gate.sh"
+
+security_verify_output="$(assert_plan security_verify scripts/check-public-repo-safety.sh scripts/verify-change.sh)"
+assert_contains "$security_verify_output" "bash ./scripts/check-public-repo-safety.sh"
+assert_not_contains "$security_verify_output" "分层验证入口或说明变化必须通过无设备自测"
+
+privacy_output="$(assert_plan ios_privacy ios/MimiRemote/Sources/Resources/PrivacyInfo.xcprivacy)"
+assert_contains "$privacy_output" "check-ios-network-security.sh"
+assert_contains "$privacy_output" "check-ios-privacy-manifest.sh"
+
+ruby_output="$(assert_plan ruby_control scripts/distribute_internal_build.rb)"
+assert_contains "$ruby_output" "ruby -c -- scripts/distribute_internal_build.rb"
+
+python_output="$(assert_plan python_control scripts/prepare-ios-store-screenshots.py)"
+assert_contains "$python_output" "Python 脚本先做无产物语法检查"
+
+powershell_output="$(assert_plan powershell_control scripts/check-windows-installer.ps1)"
+assert_contains "$powershell_output" "延后到 Windows CI"
+
+device_control_output="$(assert_plan device_control scripts/ios-dev.sh)"
+assert_contains "$device_control_output" "test-ios-device-management.sh"
+assert_not_contains "$device_control_output" "ios-dev.sh build-for-testing"
+
+asc_control_output="$(assert_plan asc_control scripts/ios_asc_cli.sh)"
+assert_contains "$asc_control_output" "test-ios-asc-cli.sh"
+
+critical_control_output="$(assert_plan critical_control scripts/test-conversation-regressions.sh)"
+assert_contains "$critical_control_output" "check-critical-regressions.sh"
+assert_not_contains "$critical_control_output" "ios-dev.sh build-for-testing"
+
+linear_control_output="$(assert_plan linear_control config/automations/mimi-linear-issue.prompt.md)"
+assert_contains "$linear_control_output" "check-linear-polling-safety.sh"
+
+restart_control_output="$(assert_plan restart_control scripts/restart-agentd-dev-macos.sh)"
+assert_contains "$restart_control_output" "restart-agentd-dev-macos.sh --self-test"
+
+contract_output="$(assert_plan contract contracts/mimi-protocol/contract.json)"
+assert_contains "$contract_output" "check-mimi-protocol-contract.sh"
+assert_contains "$contract_output" "ios-dev.sh build-for-testing"
+assert_not_contains "$contract_output" "go test ./... -count=1"
+
+contract_full_output="$(assert_full_plan contract_full contracts/mimi-protocol/contract.json)"
+assert_contains "$contract_full_output" "go test ./... -count=1"
+
+release_output="$(assert_plan release_control .github/workflows/release.yml)"
+assert_contains "$release_output" "判定：CI/脚本/发布控制面"
+assert_contains "$release_output" "bash ./scripts/check-pr-gate.sh"
+assert_contains "$release_output" "check-nightly-release.sh --self-test"
+assert_not_contains "$release_output" "check-nightly-release.sh --check"
+assert_not_contains "$release_output" "ios-dev.sh build-for-testing"
+
+release_checker_output="$(assert_plan release_checker scripts/check-nightly-release.sh)"
+assert_contains "$release_checker_output" "check-nightly-release.sh --check"
+assert_contains "$release_checker_output" "check-nightly-release.sh --self-test"
+
+release_config_output="$(assert_plan release_config config/release/ios-asc-cli.env)"
+assert_contains "$release_config_output" "check-nightly-release.sh --check"
+
+unknown_output="$(assert_plan unknown assets/example.bin)"
+assert_contains "$unknown_output" "没有验证映射"
+unknown_paths_file="$test_root/unknown-execution.paths"
+printf '%s\0' assets/example.bin > "$unknown_paths_file"
+if bash ./scripts/verify-change.sh --paths-file "$unknown_paths_file" >/dev/null 2>&1; then
+  fail "未映射路径在执行模式下必须 fail-closed。"
+fi
+
+gate_output="$(assert_plan gate_dedup scripts/check-pr-gate.sh scripts/verify-change.sh)"
+assert_contains "$gate_output" "bash ./scripts/check-pr-gate.sh"
+assert_not_contains "$gate_output" "分层验证入口或说明变化必须通过无设备自测"
+
+# 在临时仓库同时制造 committed/staged/unstaged/untracked 四类变化，证明默认收集链路
+# 不依赖当前工作区状态，也不会启动任何编译、测试或 Simulator。
+repo_root="$test_root/repository"
+mkdir -p "$repo_root/scripts"
+cp scripts/verify-change.sh scripts/ci-pr-scope.sh "$repo_root/scripts/"
+chmod +x "$repo_root/scripts/verify-change.sh" "$repo_root/scripts/ci-pr-scope.sh"
+git -C "$repo_root" init -q
+git -C "$repo_root" config user.name "Mimi Verify Test"
+git -C "$repo_root" config user.email "verify-test@example.invalid"
+printf '# baseline\n' > "$repo_root/README.md"
+git -C "$repo_root" add .
+git -C "$repo_root" commit -q -m baseline
+
+mkdir -p "$repo_root/internal/httpapi"
+printf 'package httpapi\n' > "$repo_root/internal/httpapi/committed.go"
+git -C "$repo_root" add internal/httpapi/committed.go
+git -C "$repo_root" commit -q -m committed
+
+mkdir -p "$repo_root/ios/MimiRemote/Sources" "$repo_root/bridges/claude"
+printf 'struct Staged {}\n' > "$repo_root/ios/MimiRemote/Sources/Staged.swift"
+git -C "$repo_root" add ios/MimiRemote/Sources/Staged.swift
+printf 'unstaged\n' >> "$repo_root/README.md"
+printf 'fn main() {}\n' > "$repo_root/bridges/claude/untracked.rs"
+
+collection_output="$(cd "$repo_root" && bash ./scripts/verify-change.sh --plan --base HEAD~1)"
+assert_contains "$collection_output" "committed=1, staged=1, unstaged=1, untracked=1"
+assert_contains "$collection_output" "internal/httpapi/committed.go"
+assert_contains "$collection_output" "ios/MimiRemote/Sources/Staged.swift"
+assert_contains "$collection_output" "bridges/claude/untracked.rs"
+assert_contains "$collection_output" "go test ./internal/httpapi -count=1"
+assert_contains "$collection_output" "ios-dev.sh build-for-testing"
+assert_contains "$collection_output" "cargo test --locked"
+
+rm -rf "$test_root"
+trap - EXIT
+
+echo "分层验证自测通过：docs/iOS/Go/Rust/contract/release/unknown、Gate 去重与四类 Git 变更来源均符合预期。"

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -103,13 +103,30 @@ collect_paths() {
   done
 }
 
+collect_command_paths() {
+  local source="$1"
+  local output_file="$2"
+  shift 2
+
+  # 先把 Git 输出落到临时文件，再交给循环读取；process substitution 会吞掉
+  # 生产者的退出码，浅克隆或无 merge-base 时可能因此误报“没有变更”。
+  if ! "$@" > "$output_file"; then
+    fail "无法收集 ${source} 变更路径。"
+  fi
+  collect_paths "$source" < "$output_file"
+}
+
 if [[ -n "$paths_file" ]]; then
   collect_paths synthetic < "$paths_file"
 else
-  collect_paths committed < <(git diff --name-only -z --no-renames "${base_ref}...HEAD")
-  collect_paths staged < <(git diff --name-only -z --no-renames --cached)
-  collect_paths unstaged < <(git diff --name-only -z --no-renames)
-  collect_paths untracked < <(git ls-files --others --exclude-standard -z)
+  collect_command_paths committed "$temporary_root/committed-paths" \
+    git diff --name-only -z --no-renames "${base_ref}...HEAD"
+  collect_command_paths staged "$temporary_root/staged-paths" \
+    git diff --name-only -z --no-renames --cached
+  collect_command_paths unstaged "$temporary_root/unstaged-paths" \
+    git diff --name-only -z --no-renames
+  collect_command_paths untracked "$temporary_root/untracked-paths" \
+    git ls-files --others --exclude-standard -z
 fi
 
 for path in "${changed_paths[@]:-}"; do

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -1,0 +1,667 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'EOF'
+用法：
+  bash ./scripts/verify-change.sh [--plan] [--full] [--base <ref>]
+  bash ./scripts/verify-change.sh --plan --paths-file <NUL-separated-paths>
+
+默认执行 quick 验证：分析 origin/main...HEAD、暂存区、工作区和未跟踪文件，
+只运行受影响栈的最小检查。--plan 只打印计划；--full 升级为受影响栈的完整本地回归。
+EOF
+}
+
+fail() {
+  echo "分层验证失败：$1" >&2
+  exit 1
+}
+
+mode="quick"
+plan_only=0
+base_ref="origin/main"
+paths_file=""
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --plan)
+      plan_only=1
+      shift
+      ;;
+    --full)
+      mode="full"
+      shift
+      ;;
+    --base)
+      [[ "$#" -ge 2 ]] || fail "--base 缺少 ref。"
+      base_ref="$2"
+      shift 2
+      ;;
+    --paths-file)
+      [[ "$#" -ge 2 ]] || fail "--paths-file 缺少路径文件。"
+      paths_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "未知参数 $1。"
+      ;;
+  esac
+done
+
+for command_name in awk bash git mktemp; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "缺少命令 ${command_name}。"
+done
+
+if [[ -n "$paths_file" ]]; then
+  [[ -f "$paths_file" ]] || fail "路径文件不存在：$paths_file"
+else
+  git cat-file -e "${base_ref}^{commit}" 2>/dev/null \
+    || fail "base ref 不存在：${base_ref}。请先 git fetch origin main，或显式传 --base。"
+fi
+
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-verify-change.XXXXXX")"
+trap 'rm -rf "$temporary_root"' EXIT
+resolved_paths_file="$temporary_root/changed-paths"
+: > "$resolved_paths_file"
+
+changed_paths=()
+committed_count=0
+staged_count=0
+unstaged_count=0
+untracked_count=0
+
+add_changed_path() {
+  local path="$1"
+  local existing
+  [[ -n "$path" ]] || return 0
+  for existing in "${changed_paths[@]:-}"; do
+    [[ "$existing" == "$path" ]] && return 0
+  done
+  changed_paths+=("$path")
+}
+
+collect_paths() {
+  local source="$1"
+  local path
+  while IFS= read -r -d '' path; do
+    case "$source" in
+      committed) committed_count=$((committed_count + 1)) ;;
+      staged) staged_count=$((staged_count + 1)) ;;
+      unstaged) unstaged_count=$((unstaged_count + 1)) ;;
+      untracked) untracked_count=$((untracked_count + 1)) ;;
+    esac
+    add_changed_path "$path"
+  done
+}
+
+if [[ -n "$paths_file" ]]; then
+  collect_paths synthetic < "$paths_file"
+else
+  collect_paths committed < <(git diff --name-only -z --no-renames "${base_ref}...HEAD")
+  collect_paths staged < <(git diff --name-only -z --no-renames --cached)
+  collect_paths unstaged < <(git diff --name-only -z --no-renames)
+  collect_paths untracked < <(git ls-files --others --exclude-standard -z)
+fi
+
+for path in "${changed_paths[@]:-}"; do
+  [[ -n "$path" ]] || continue
+  printf '%s\0' "$path" >> "$resolved_paths_file"
+done
+
+scope_output="$(bash ./scripts/ci-pr-scope.sh --paths-file "$resolved_paths_file")"
+go_scope="$(printf '%s\n' "$scope_output" | awk -F= '$1 == "go" { print $2 }')"
+ios_scope="$(printf '%s\n' "$scope_output" | awk -F= '$1 == "ios" { print $2 }')"
+rust_scope="$(printf '%s\n' "$scope_output" | awk -F= '$1 == "rust" { print $2 }')"
+macos_scope="$(printf '%s\n' "$scope_output" | awk -F= '$1 == "macos" { print $2 }')"
+
+is_documentation_path() {
+  case "$1" in
+    *.md|README|README.*|CONTRIBUTING.*|AGENTS.md|SECURITY.md|LICENSE|LICENSE.*|*/LICENSE|*/LICENSE.*|docs/*|web/*|artifacts/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_control_path() {
+  case "$1" in
+    .github/*|scripts/*|packaging/*|config/*|.goreleaser.yml|.gitignore|.editorconfig|.xcodebuildmcp/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_go_source_path() {
+  case "$1" in
+    *.go|go.mod|go.sum|cmd/*|internal/*|contracts/mimi-protocol/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_ios_source_path() {
+  case "$1" in
+    ios/MimiRemote/*|contracts/mimi-protocol/*|internal/protocolcontract/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_rust_source_path() {
+  case "$1" in
+    Cargo.toml|Cargo.lock|bridges/claude/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_macos_source_path() {
+  case "$1" in
+    macos/MimiRemoteMac/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+all_docs=true
+direct_go=false
+direct_ios=false
+direct_rust=false
+direct_macos=false
+has_control=false
+has_contract=false
+has_release_control=false
+has_gate_control=false
+has_codex_control=false
+has_verify_control=false
+has_packaging_control=false
+has_source_size_control=false
+has_repository_security_control=false
+has_ios_privacy_control=false
+has_ios_device_control=false
+has_ios_asc_control=false
+has_critical_mapping_control=false
+has_linear_polling_control=false
+has_agentd_restart_control=false
+unknown_paths=()
+shell_paths=()
+yaml_paths=()
+ruby_paths=()
+python_paths=()
+powershell_paths=()
+go_packages=()
+go_requires_full=false
+rust_all=false
+rust_codex=false
+rust_core=false
+rust_claude=false
+
+add_unique_value() {
+  local value="$1"
+  shift
+  local existing
+  for existing in "$@"; do
+    [[ "$existing" == "$value" ]] && return 1
+  done
+  return 0
+}
+
+add_go_package_for_path() {
+  local source_path="$1"
+  local candidate="."
+  local go_file
+  local package_path
+
+  [[ "$source_path" == */* ]] && candidate="${source_path%/*}"
+  while true; do
+    for go_file in "$candidate"/*.go; do
+      if [[ -f "$go_file" ]]; then
+        package_path="."
+        [[ "$candidate" != "." ]] && package_path="./${candidate}"
+        if add_unique_value "$package_path" "${go_packages[@]:-}"; then
+          go_packages+=("$package_path")
+        fi
+        return 0
+      fi
+    done
+
+    [[ "$candidate" == "." ]] && break
+    if [[ "$candidate" == */* ]]; then
+      candidate="${candidate%/*}"
+    else
+      candidate="."
+    fi
+  done
+
+  # 删除整个 package、go.mod/go.sum 或无法归属 package 时，用完整 Go 回归兜底。
+  go_requires_full=true
+}
+
+classify_rust_path() {
+  case "$1" in
+    Cargo.toml|Cargo.lock)
+      rust_all=true
+      ;;
+    bridges/claude/crates/codex-proto/*)
+      rust_codex=true
+      rust_core=true
+      rust_claude=true
+      ;;
+    bridges/claude/crates/bridge-core/*)
+      rust_core=true
+      rust_claude=true
+      ;;
+    bridges/claude/crates/claude-bridge/*)
+      rust_claude=true
+      ;;
+    *)
+      rust_all=true
+      ;;
+  esac
+}
+
+for path in "${changed_paths[@]:-}"; do
+  [[ -n "$path" ]] || continue
+
+  path_is_documentation=false
+  path_is_go=false
+  path_is_ios=false
+  path_is_rust=false
+  path_is_macos=false
+
+  if is_documentation_path "$path"; then
+    path_is_documentation=true
+  else
+    all_docs=false
+    if is_go_source_path "$path"; then
+      path_is_go=true
+      direct_go=true
+      case "$path" in
+        contracts/mimi-protocol/*)
+          # 共享 fixture 由专用契约检查覆盖；quick 不再重复一次全仓 Go test。
+          ;;
+        *)
+          add_go_package_for_path "$path"
+          ;;
+      esac
+    fi
+    if is_ios_source_path "$path"; then
+      path_is_ios=true
+      direct_ios=true
+    fi
+    if is_rust_source_path "$path"; then
+      path_is_rust=true
+      direct_rust=true
+      classify_rust_path "$path"
+    fi
+    if is_macos_source_path "$path"; then
+      path_is_macos=true
+      direct_macos=true
+    fi
+  fi
+  if is_control_path "$path"; then
+    has_control=true
+  fi
+
+  case "$path" in
+    contracts/mimi-protocol/*|internal/protocolcontract/*)
+      has_contract=true
+      ;;
+  esac
+  case "$path" in
+    .github/workflows/release.yml|.github/workflows/nightly.yml|scripts/check-nightly-release.sh|scripts/check-release-source.sh|scripts/verify-release.sh|scripts/ios_testflight_*|config/release/*|docs/nightly-release.md)
+      has_release_control=true
+      ;;
+  esac
+  case "$path" in
+    .github/workflows/*|.github/actions/*|scripts/ci-pr-scope.sh|scripts/check-pr-gate.sh)
+      has_gate_control=true
+      ;;
+  esac
+  case "$path" in
+    .github/workflows/codex-protocol.yml|scripts/check-codex-protocol.sh|docs/codex-protocol-support.md)
+      has_codex_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/verify-change.sh|scripts/test-verify-change.sh|CONTRIBUTING.md|README.md|README.zh-CN.md)
+      has_verify_control=true
+      ;;
+  esac
+  case "$path" in
+    packaging/*|.goreleaser.yml|scripts/check-packaging.sh|scripts/verify-release.sh|scripts/build-*-installer.*|scripts/check-*-installer.*)
+      has_packaging_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/check-source-size.sh)
+      has_source_size_control=true
+      ;;
+  esac
+  case "$path" in
+    .github/workflows/public-repo-safety.yml|scripts/check-public-repo-safety.sh|scripts/check-third-party-notices.sh|NOTICE.md|THIRD_PARTY_NOTICES.md)
+      has_repository_security_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/check-ios-network-security.sh|scripts/check-ios-privacy-manifest.sh|*/PrivacyInfo.xcprivacy)
+      has_ios_privacy_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/ios-dev.sh|scripts/ios-device-lease.sh|scripts/test-ios-device-management.sh|scripts/testdata/ios-device-management/*)
+      has_ios_device_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/ios_asc_*|scripts/test-ios-asc-cli.sh|scripts/distribute_internal_build.rb|config/release/ios-asc-cli.env)
+      has_ios_asc_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/check-critical-regressions.sh|scripts/test-conversation-regressions.sh)
+      has_critical_mapping_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/check-linear-polling-safety.sh|scripts/install-linear-poll-guard.sh|config/automations/*)
+      has_linear_polling_control=true
+      ;;
+  esac
+  case "$path" in
+    scripts/restart-agentd-dev-macos.sh|scripts/restart-agentd-dev-handoff-macos.sh|scripts/sign-agentd-dev-macos.sh)
+      has_agentd_restart_control=true
+      ;;
+  esac
+
+  case "$path" in
+    *.sh|scripts/git-testflight-push)
+      [[ -f "$path" ]] && shell_paths+=("$path")
+      ;;
+    *.rb)
+      [[ -f "$path" ]] && ruby_paths+=("$path")
+      ;;
+    *.py)
+      [[ -f "$path" ]] && python_paths+=("$path")
+      ;;
+    *.ps1)
+      [[ -f "$path" ]] && powershell_paths+=("$path")
+      ;;
+    *.yml|*.yaml)
+      [[ -f "$path" ]] && yaml_paths+=("$path")
+      ;;
+  esac
+
+  if [[ "$path_is_documentation" == false ]] && \
+     ! is_control_path "$path" && \
+     [[ "$path_is_go" == false ]] && \
+     [[ "$path_is_ios" == false ]] && \
+     [[ "$path_is_rust" == false ]] && \
+     [[ "$path_is_macos" == false ]]; then
+    unknown_paths+=("$path")
+  fi
+done
+
+checks=()
+check_reasons=()
+
+add_check() {
+  local reason="$1"
+  local command="$2"
+  local existing
+  for existing in "${checks[@]:-}"; do
+    [[ "$existing" == "$command" ]] && return 0
+  done
+  check_reasons+=("$reason")
+  checks+=("$command")
+}
+
+shell_quote() {
+  local quoted
+  printf -v quoted '%q' "$1"
+  printf '%s' "$quoted"
+}
+
+if [[ -z "$paths_file" ]]; then
+  add_check "已提交差异的空白/冲突标记" "git diff --check $(shell_quote "$base_ref")...HEAD"
+  add_check "暂存区差异的空白/冲突标记" "git diff --cached --check"
+  add_check "工作区差异的空白/冲突标记" "git diff --check"
+fi
+
+if [[ "${#shell_paths[@]}" -gt 0 ]]; then
+  shell_command=""
+  for path in "${shell_paths[@]}"; do
+    [[ -z "$shell_command" ]] || shell_command+=" && "
+    shell_command+="bash -n -- $(shell_quote "$path")"
+  done
+  add_check "变更的 Shell 脚本先做语法检查" "$shell_command"
+fi
+
+if [[ "${#yaml_paths[@]}" -gt 0 ]]; then
+  command -v ruby >/dev/null 2>&1 || fail "YAML 语法检查需要 ruby。"
+  yaml_command="ruby -e 'require \"yaml\"; ARGV.each { |path| YAML.parse_file(path) }' --"
+  for path in "${yaml_paths[@]}"; do
+    yaml_command+=" $(shell_quote "$path")"
+  done
+  add_check "变更的 YAML 文件先做语法解析" "$yaml_command"
+fi
+
+if [[ "${#ruby_paths[@]}" -gt 0 ]]; then
+  command -v ruby >/dev/null 2>&1 || fail "Ruby 语法检查需要 ruby。"
+  ruby_command=""
+  for path in "${ruby_paths[@]}"; do
+    [[ -z "$ruby_command" ]] || ruby_command+=" && "
+    ruby_command+="ruby -c -- $(shell_quote "$path")"
+  done
+  add_check "变更的 Ruby 脚本先做语法检查" "$ruby_command"
+fi
+
+if [[ "${#python_paths[@]}" -gt 0 ]]; then
+  command -v python3 >/dev/null 2>&1 || fail "Python 语法检查需要 python3。"
+  python_command="python3 -c 'import ast, pathlib, sys; [ast.parse(pathlib.Path(path).read_text(), filename=path) for path in sys.argv[1:]]'"
+  for path in "${python_paths[@]}"; do
+    python_command+=" $(shell_quote "$path")"
+  done
+  add_check "变更的 Python 脚本先做无产物语法检查" "$python_command"
+fi
+
+if [[ "$has_gate_control" == true && "$has_repository_security_control" == false ]]; then
+  add_check "CI 编排或路径分类变化必须通过 Gate 自检" "bash ./scripts/check-pr-gate.sh"
+fi
+if [[ "$has_verify_control" == true && "$has_gate_control" == false && "$has_repository_security_control" == false ]]; then
+  # check-pr-gate.sh 已包含这项自测；同一轮不要嵌套执行两次。
+  add_check "分层验证入口或说明变化必须通过无设备自测" "bash ./scripts/test-verify-change.sh"
+fi
+if [[ "$has_release_control" == true ]]; then
+  if [[ "$has_gate_control" == false && "$has_repository_security_control" == false ]]; then
+    add_check "Release/Nightly 控制面先做信任门静态检查" "bash ./scripts/check-nightly-release.sh --check"
+  fi
+  add_check "Release/Nightly 信任门必须保持 fail-closed" "bash ./scripts/check-nightly-release.sh --self-test"
+fi
+if [[ "$has_codex_control" == true ]]; then
+  add_check "Codex 协议快照相关变化" "bash ./scripts/check-codex-protocol.sh"
+fi
+if [[ "$has_packaging_control" == true ]]; then
+  add_check "打包与 Release 来源策略变化" "bash ./scripts/check-packaging.sh"
+fi
+if [[ "$has_repository_security_control" == true ]]; then
+  add_check "公开仓库安全门自身变化必须执行完整安全检查" "bash ./scripts/check-public-repo-safety.sh"
+fi
+if [[ "$has_ios_privacy_control" == true ]]; then
+  add_check "iOS 网络与隐私边界变化必须执行专项静态检查" "bash ./scripts/check-ios-network-security.sh && bash ./scripts/check-ios-privacy-manifest.sh"
+fi
+if [[ "$has_ios_device_control" == true ]]; then
+  add_check "iOS 目标选择和设备租约变化使用 fake xcrun/xcodebuild 自测" "bash ./scripts/test-ios-device-management.sh"
+fi
+if [[ "$has_ios_asc_control" == true ]]; then
+  add_check "App Store Connect CLI 封装变化使用本地 fake ASC 自测" "bash ./scripts/test-ios-asc-cli.sh"
+fi
+if [[ "$has_critical_mapping_control" == true && "$has_gate_control" == false && "$has_repository_security_control" == false ]]; then
+  add_check "关键用户链路 selector 变化执行静态映射自检" "bash ./scripts/check-critical-regressions.sh"
+fi
+if [[ "$has_linear_polling_control" == true ]]; then
+  add_check "Linear 自动化变化保持本地 guard 和单轮调用约束" "bash ./scripts/check-linear-polling-safety.sh"
+fi
+if [[ "$has_agentd_restart_control" == true ]]; then
+  add_check "agentd 本地重启链路只执行无安装副作用的 self-test" "bash ./scripts/restart-agentd-dev-macos.sh --self-test"
+fi
+if [[ "$has_contract" == true ]]; then
+  add_check "Go/iOS 共享契约变化" "bash ./scripts/check-mimi-protocol-contract.sh"
+fi
+if [[ "$direct_go" == true || "$direct_ios" == true || "$has_source_size_control" == true ]]; then
+  # 先用秒级门禁拦住超大源文件，避免等到 Xcode/Go 构建后才失败。
+  add_check "Go/iOS 源码体积快速门禁" "bash ./scripts/check-source-size.sh"
+fi
+
+if [[ "$direct_go" == true ]]; then
+  if [[ "$mode" == "full" || "$go_requires_full" == true || "${#go_packages[@]}" -gt 8 ]]; then
+    add_check "Go 受影响范围使用完整回归" "go test ./... -count=1"
+  elif [[ "${#go_packages[@]}" -gt 0 ]]; then
+    go_test_command="go test"
+    for package_path in "${go_packages[@]}"; do
+      go_test_command+=" $(shell_quote "$package_path")"
+    done
+    go_test_command+=" -count=1"
+    add_check "Go quick 只测试直接变更的 package" "$go_test_command"
+  elif [[ "$has_contract" == false ]]; then
+    add_check "Go 受影响范围无法定位 package，使用完整回归" "go test ./... -count=1"
+  fi
+  if [[ "$mode" == "full" ]]; then
+    add_check "Go full 补充静态分析" "go vet ./..."
+  fi
+fi
+
+if [[ "$direct_ios" == true ]]; then
+  add_check "iOS 验证前只解析一次目标" "bash ./scripts/ios-dev.sh target"
+  add_check "iOS 验证前只查看一次设备占用" "bash ./scripts/ios-dev.sh leases"
+  if [[ "$mode" == "full" ]]; then
+    add_check "iOS full 执行核心关键链路回归" "bash ./scripts/test-conversation-regressions.sh"
+    add_check "iOS full 执行英文文案 smoke" "bash ./scripts/test-ios-localization-smoke.sh"
+  else
+    add_check "iOS quick 只编译一次可复用测试产物" "bash ./scripts/ios-dev.sh build-for-testing"
+  fi
+fi
+
+if [[ "$direct_rust" == true ]]; then
+  add_check "Rust 格式检查" "cargo fmt --all -- --check"
+  rust_test_command="cargo test --locked"
+  if [[ "$rust_all" == true || "$mode" == "full" ]]; then
+    rust_codex=true
+    rust_core=true
+    rust_claude=true
+  fi
+  [[ "$rust_codex" == true ]] && rust_test_command+=" -p alleycat-codex-proto"
+  [[ "$rust_core" == true ]] && rust_test_command+=" -p alleycat-bridge-core"
+  [[ "$rust_claude" == true ]] && rust_test_command+=" -p alleycat-claude-bridge"
+  add_check "Rust 只回归变更 crate 及其下游 crate" "$rust_test_command"
+fi
+
+if [[ "$direct_macos" == true ]]; then
+  add_check "Mac App 变更执行统一无签名编译测试" "bash ./scripts/test-macos-app.sh"
+fi
+
+if [[ "$mode" == "full" ]]; then
+  # public-repo-safety 末尾已经调用 check-pr-gate；full 不再提前重复执行一次。
+  add_check "full 模式补齐公开仓库安全检查（包含 PR Gate 自检）" "bash ./scripts/check-public-repo-safety.sh"
+  add_check "full 模式补齐 Codex 协议检查" "bash ./scripts/check-codex-protocol.sh"
+fi
+
+plan_suffix=""
+[[ "$plan_only" -eq 1 ]] && plan_suffix="（仅计划）"
+echo "Mimi 分层验证计划"
+echo "- 模式：${mode}${plan_suffix}"
+if [[ -n "$paths_file" ]]; then
+  echo "- 变更来源：显式 paths file"
+else
+  echo "- Base：${base_ref}"
+  echo "- 来源计数：committed=${committed_count}, staged=${staged_count}, unstaged=${unstaged_count}, untracked=${untracked_count}"
+fi
+echo "- 去重后路径：${#changed_paths[@]}"
+echo "- PR Gate scope：go=${go_scope}, ios=${ios_scope}, rust=${rust_scope}, macos=${macos_scope}"
+echo
+
+if [[ "${#changed_paths[@]}" -eq 0 ]]; then
+  echo "没有发现需要验证的变更。"
+  exit 0
+fi
+
+echo "变更路径："
+for path in "${changed_paths[@]}"; do
+  echo "- ${path}"
+done
+echo
+
+if [[ "$all_docs" == true ]]; then
+  echo "判定：纯文档/静态内容；不启动 Go、Cargo、Xcode 或真机。"
+elif [[ "$has_control" == true && "$direct_go" == false && "$direct_ios" == false && "$direct_rust" == false && "$direct_macos" == false ]]; then
+  echo "判定：CI/脚本/发布控制面；只运行语法与映射自检，不启动语言构建。"
+else
+  echo "判定：包含产品源码；只验证直接受影响的语言栈。"
+fi
+
+echo "跳过的语言栈："
+[[ "$direct_go" == false ]] && echo "- Go：没有直接 Go 产品路径。"
+[[ "$direct_ios" == false ]] && echo "- iOS：没有直接 iOS 产品路径，不启动 Xcode/Simulator/真机。"
+[[ "$direct_rust" == false ]] && echo "- Rust：没有直接 bridge 产品路径。"
+[[ "$direct_macos" == false ]] && echo "- Mac App：没有直接 Mac App 产品路径。"
+if [[ "$direct_go" == true && "$direct_ios" == true && "$direct_rust" == true && "$direct_macos" == true ]]; then
+  echo "- 无：四个产品栈均受影响。"
+fi
+
+if [[ "$direct_ios" == true ]]; then
+  echo "真机：默认延后。相机、通知、Keychain、Tailscale/弱网、性能和发布前专项仍必须单独真机验收。"
+fi
+if [[ "${#powershell_paths[@]}" -gt 0 ]]; then
+  echo "Windows：PowerShell 脚本的执行与平台语义延后到 Windows CI；本地不启动额外虚拟机。"
+fi
+if [[ "$mode" == "quick" ]]; then
+  echo "完整回归：默认延后到 --full 或 PR Gate；不要在每个微调后重复执行。"
+fi
+if [[ "${#unknown_paths[@]}" -gt 0 ]]; then
+  echo "人工确认：以下路径没有验证映射，quick 不会把它们静默视为通过："
+  for path in "${unknown_paths[@]}"; do
+    echo "- ${path}"
+  done
+fi
+echo
+
+echo "将执行 ${#checks[@]} 项："
+for index in "${!checks[@]}"; do
+  echo "$((index + 1)). ${check_reasons[$index]}"
+  echo "   ${checks[$index]}"
+done
+
+if [[ "$plan_only" -eq 1 ]]; then
+  exit 0
+fi
+
+if [[ "${#unknown_paths[@]}" -gt 0 ]]; then
+  fail "存在未映射路径；请先人工确认风险并补充映射，不要用 quick 静默跳过。"
+fi
+
+overall_started="$SECONDS"
+for index in "${!checks[@]}"; do
+  started="$SECONDS"
+  echo
+  echo "==> [$((index + 1))/${#checks[@]}] ${check_reasons[$index]}"
+  echo "    ${checks[$index]}"
+  bash -c "${checks[$index]}"
+  echo "<== 通过，用时 $((SECONDS - started))s"
+done
+
+echo
+echo "分层验证通过：${#checks[@]} 项，总用时 $((SECONDS - overall_started))s。"


### PR DESCRIPTION
## 目标

把开发收尾从手工重复执行 target/leases/build/test/run 和全仓检查，收敛为一个可解释、fail-closed 的本地入口。

## 实现

- 新增 `scripts/verify-change.sh`：默认 quick，支持 `--plan`、`--full`、`--base`。
- 合并 `origin/main...HEAD`、staged、unstaged、untracked 四类路径并去重，复用现有 PR Gate scope，同时按直接风险决定本地最小验证。
- docs/control-plane 不启动语言构建；Go 定位直接 package；iOS quick 只做 source-size + target/leases + 一次 build-for-testing；Rust quick 只跑变更 crate 及下游；未知路径执行时 fail-closed。
- Release、安全、隐私、设备管理、ASC、关键回归映射、Linear 自动化和 agentd 重启脚本接入已有静态检查/self-test，并消除 public-safety → PR Gate → 子自测的嵌套重复。
- 新增无设备自测，覆盖 quick/full、docs/iOS/Go/Rust/contract/release/security/unknown、Gate 去重和四类 Git 变更来源。
- CONTRIBUTING/README 收敛为“迭代中最小检查，push 前一次 quick，明确高风险才 full/真机”。

## 本地验证

- `bash ./scripts/verify-change.sh`：5 项通过，4s；未启动 Go/Cargo/Xcode/Simulator/真机。
- `bash ./scripts/test-verify-change.sh`：通过。
- `git diff --check`：通过。
- 代表性 `--plan` 实测：docs 0.04s；SwiftUI 0.03s；Go package 0.03s；跨语言 contract 0.03s。
- SwiftUI plan：source-size → target → leases → 一次 build-for-testing，Go/Rust/Mac 跳过，真机延后。
- Go plan：source-size → 直接 package test，iOS/Rust/Mac 跳过。
- contract plan：专用 contract check → source-size → target/leases → 一次 iOS build-for-testing；quick 不再重复全仓 Go test。

## 风险与边界

- 不降低 required `PR Gate`，不修改 CI 周期/concurrency/auto-merge。
- 规则无法识别的路径会阻止 quick，不会静默放行。
- 真机仍保留给相机、通知、Keychain、Tailscale/弱网、性能和发布前专项。
- 本 PR 修改 Gate 自检，因此本次 PR 按现有规则触发全栈 CI；这是对验证入口本身的一次性验收。

Linear: MIM-135