### PR TITLE
MIM-141 缩短 PR 公开仓库安全门

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -55,6 +55,10 @@ jobs:
   repository-safety:
     name: Repository safety
     uses: ./.github/workflows/public-repo-safety.yml
+    with:
+      mode: pull-request
+      base_sha: ${{ github.event.pull_request.base.sha }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
 
   go:
     name: Go and release

--- a/.github/workflows/public-repo-safety.yml
+++ b/.github/workflows/public-repo-safety.yml
@@ -2,6 +2,22 @@ name: Public Repository Safety
 
 on:
   workflow_call:
+    inputs:
+      mode:
+        description: full-history 或 pull-request
+        required: false
+        default: full-history
+        type: string
+      base_sha:
+        description: pull-request 模式的 base commit
+        required: false
+        default: ""
+        type: string
+      head_sha:
+        description: pull-request 模式的 head commit
+        required: false
+        default: ""
+        type: string
   push:
     branches:
       - main
@@ -24,14 +40,70 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Plan repository safety checks
+        id: safety
+        shell: bash
+        env:
+          SAFETY_MODE: ${{ inputs.mode || 'full-history' }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+        run: |
+          case "$SAFETY_MODE" in
+            pull-request)
+              bash ./scripts/check-public-repo-safety.sh \
+                --pull-request \
+                --base "$BASE_SHA" \
+                --head "$HEAD_SHA" \
+                --plan \
+                --github-output "$GITHUB_OUTPUT"
+              ;;
+            full-history)
+              bash ./scripts/check-public-repo-safety.sh \
+                --full-history \
+                --plan \
+                --github-output "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "未知 Public Repository Safety 模式：$SAFETY_MODE" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Setup Go
+        if: steps.safety.outputs.third_party == 'true'
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Install repository safety tools
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y ripgrep
+        run: |
+          if command -v rg >/dev/null 2>&1; then
+            rg --version
+          else
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y ripgrep
+          fi
 
       - name: Check public repository safety
-        run: bash ./scripts/check-public-repo-safety.sh
+        shell: bash
+        env:
+          SAFETY_MODE: ${{ inputs.mode || 'full-history' }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+        run: |
+          case "$SAFETY_MODE" in
+            pull-request)
+              bash ./scripts/check-public-repo-safety.sh \
+                --pull-request \
+                --base "$BASE_SHA" \
+                --head "$HEAD_SHA"
+              ;;
+            full-history)
+              bash ./scripts/check-public-repo-safety.sh --full-history
+              ;;
+            *)
+              echo "未知 Public Repository Safety 模式：$SAFETY_MODE" >&2
+              exit 1
+              ;;
+          esac

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -19,6 +19,8 @@ for script_path in \
   scripts/check-critical-regressions.sh \
   scripts/check-nightly-release.sh \
   scripts/check-release-source.sh \
+  scripts/check-public-repo-safety.sh \
+  scripts/test-public-repo-safety.sh \
   scripts/check-pr-gate.sh \
   scripts/verify-change.sh \
   scripts/test-verify-change.sh \
@@ -30,6 +32,7 @@ bash ./scripts/test-verify-change.sh
 bash ./scripts/check-critical-regressions.sh
 bash ./scripts/check-nightly-release.sh
 bash ./scripts/check-release-source.sh --self-test
+bash ./scripts/test-public-repo-safety.sh
 
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-pr-gate-check.XXXXXX")"
 trap 'rm -rf "$test_root"' EXIT
@@ -140,6 +143,12 @@ expected_calls.each do |job_id, workflow_path|
     abort("PR Gate 自检失败：#{job_id} 没有调用 #{workflow_path}。")
   end
 end
+repository_safety_call = jobs.fetch("repository-safety")
+unless repository_safety_call.dig("with", "mode") == "pull-request" &&
+       repository_safety_call.dig("with", "base_sha").to_s.include?("github.event.pull_request.base.sha") &&
+       repository_safety_call.dig("with", "head_sha").to_s.include?("github.event.pull_request.head.sha")
+  abort("PR Gate 自检失败：Repository safety 必须显式传入 PR mode/base/head。")
+end
 unless jobs.dig("macos", "if").to_s.include?("needs.scope.outputs.macos")
   abort("PR Gate 自检失败：Mac App job 没有按 macos scope 执行。")
 end
@@ -179,6 +188,44 @@ macos_test_script = File.read("scripts/test-macos-app.sh")
   unless macos_test_script.include?(fragment)
     abort("PR Gate 自检失败：Mac App 编译测试入口缺少 #{fragment}。")
   end
+end
+
+safety_path = ".github/workflows/public-repo-safety.yml"
+safety_workflow = load_workflow(safety_path)
+safety_triggers = triggers(safety_workflow, safety_path)
+safety_inputs = safety_triggers.dig("workflow_call", "inputs")
+unless safety_inputs.is_a?(Hash) &&
+       safety_inputs.dig("mode", "default") == "full-history" &&
+       safety_inputs.dig("base_sha", "default") == "" &&
+       safety_inputs.dig("head_sha", "default") == ""
+  abort("PR Gate 自检失败：公开仓库安全门的 reusable inputs 必须默认 fail closed 到完整历史。")
+end
+safety_job = safety_workflow.fetch("jobs").fetch("verify")
+safety_steps = safety_job.fetch("steps")
+safety_checkout = safety_steps.find { |step| step["name"] == "Checkout" }
+unless safety_checkout&.dig("with", "fetch-depth") == 0
+  abort("PR Gate 自检失败：公开仓库安全门必须保留完整 checkout，才能扫描 PR 中间提交。")
+end
+safety_plan = safety_steps.find { |step| step["name"] == "Plan repository safety checks" }
+unless safety_plan && safety_plan["id"] == "safety" &&
+       safety_plan.to_s.include?("--pull-request") &&
+       safety_plan.to_s.include?("--base") &&
+       safety_plan.to_s.include?("--head") &&
+       safety_plan.to_s.include?("--github-output")
+  abort("PR Gate 自检失败：公开仓库安全门缺少 fail-closed 的 PR 范围规划。")
+end
+safety_go = safety_steps.find { |step| step["name"] == "Setup Go" }
+unless safety_go && safety_go["if"] == "steps.safety.outputs.third_party == 'true'"
+  abort("PR Gate 自检失败：Setup Go 必须只在第三方许可检查需要时运行。")
+end
+safety_install = safety_steps.find { |step| step["name"] == "Install repository safety tools" }
+unless safety_install.to_s.include?("command -v rg")
+  abort("PR Gate 自检失败：公开仓库安全工具安装必须优先复用 runner 已有 ripgrep。")
+end
+safety_check = safety_steps.find { |step| step["name"] == "Check public repository safety" }
+unless safety_check && safety_check.to_s.include?("--pull-request") &&
+       safety_check.to_s.include?("--full-history")
+  abort("PR Gate 自检失败：公开仓库安全门没有按 PR/main 事件选择历史范围。")
 end
 
 expected_calls.values.each do |workflow_path|

--- a/scripts/check-public-repo-safety.sh
+++ b/scripts/check-public-repo-safety.sh
@@ -4,6 +4,130 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+usage() {
+  cat <<'EOF'
+用法：
+  bash ./scripts/check-public-repo-safety.sh [--full-history] [--plan] [--github-output <path>]
+  bash ./scripts/check-public-repo-safety.sh --pull-request --base <sha> --head <sha> [--plan] [--github-output <path>]
+EOF
+}
+
+fail() {
+  echo "公开仓库门禁失败：$1" >&2
+  exit 1
+}
+
+mode="full-history"
+mode_explicit=0
+base_sha=""
+head_sha=""
+plan_only=0
+github_output=""
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --full-history)
+      [[ "$mode_explicit" -eq 0 ]] || fail "只能选择一种扫描模式。"
+      mode="full-history"
+      mode_explicit=1
+      shift
+      ;;
+    --pull-request)
+      [[ "$mode_explicit" -eq 0 ]] || fail "只能选择一种扫描模式。"
+      mode="pull-request"
+      mode_explicit=1
+      shift
+      ;;
+    --base)
+      [[ "$#" -ge 2 ]] || fail "--base 缺少 SHA。"
+      base_sha="$2"
+      shift 2
+      ;;
+    --head)
+      [[ "$#" -ge 2 ]] || fail "--head 缺少 SHA。"
+      head_sha="$2"
+      shift 2
+      ;;
+    --plan)
+      plan_only=1
+      shift
+      ;;
+    --github-output)
+      [[ "$#" -ge 2 ]] || fail "--github-output 缺少路径。"
+      github_output="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "未知参数 $1。"
+      ;;
+  esac
+done
+
+for command_name in awk git mktemp sort; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "缺少命令 ${command_name}。"
+done
+
+git rev-parse --git-dir >/dev/null 2>&1 \
+  || fail "当前目录不是 Git 仓库。"
+
+temporary_paths=""
+cleanup() {
+  [[ -z "$temporary_paths" ]] || rm -f "$temporary_paths"
+}
+trap cleanup EXIT
+
+third_party=true
+if [[ "$mode" == "pull-request" ]]; then
+  [[ -n "$base_sha" && -n "$head_sha" ]] \
+    || fail "pull-request 模式必须同时提供 --base 与 --head。"
+  [[ "$base_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] \
+    || fail "base 必须是完整 commit SHA。"
+  [[ "$head_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] \
+    || fail "head 必须是完整 commit SHA。"
+  git cat-file -e "${base_sha}^{commit}" 2>/dev/null \
+    || fail "base commit 不存在：$base_sha"
+  git cat-file -e "${head_sha}^{commit}" 2>/dev/null \
+    || fail "head commit 不存在：$head_sha"
+  merge_base="$(git merge-base "$base_sha" "$head_sha")" \
+    || fail "base 与 head 没有共同祖先。"
+
+  temporary_paths="$(mktemp "${TMPDIR:-/tmp}/mimi-public-safety-paths.XXXXXX")"
+  # 许可证证明只取决于最终依赖图和打包入口；中间提交的 secret 由下方逐 tree 扫描兜底。
+  git diff --name-only -z --no-renames "$merge_base" "$head_sha" > "$temporary_paths" \
+    || fail "无法收集 PR 变更路径。"
+  third_party=false
+  while IFS= read -r -d '' changed_path; do
+    case "$changed_path" in
+      go.mod|go.sum|THIRD_PARTY_NOTICES.md|.goreleaser.yml|scripts/check-third-party-notices.sh|ios/MimiRemote/project.yml|ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj|ios/MimiRemote/MimiRemote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)
+        third_party=true
+        break
+        ;;
+    esac
+  done < "$temporary_paths"
+elif [[ -n "$base_sha" || -n "$head_sha" ]]; then
+  fail "--base/--head 只能与 --pull-request 一起使用。"
+fi
+
+plan_output="$(printf 'mode=%s\nthird_party=%s\n' "$mode" "$third_party")"
+if [[ "$plan_only" -eq 1 ]]; then
+  printf '%s\n' "$plan_output"
+  if [[ -n "$github_output" ]]; then
+    printf '%s\n' "$plan_output" >> "$github_output"
+  fi
+  exit 0
+fi
+
+for command_name in bash rg; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "缺少命令 ${command_name}。"
+done
+
 failures=0
 
 report_matches() {
@@ -26,43 +150,45 @@ secret_matches="$(rg -l --hidden --pcre2 \
 report_matches "发现疑似私钥或访问令牌" "$secret_matches"
 
 history_findings=""
-if git rev-parse --git-dir >/dev/null 2>&1; then
-  if ! history_trees="$(git log --all --format='%T %H' | awk '!seen[$1]++')"; then
-    echo "公开仓库门禁失败：无法枚举 Git 历史 tree。" >&2
-    exit 1
-  fi
-  while read -r tree_id commit_id; do
-    [[ -n "$tree_id" && -n "$commit_id" ]] || continue
-
-    # git grep 在 tree 内部批量扫描，不使用 producer | rg -q，避免命中大 blob 时 SIGPIPE 反而漏报。
-    if tree_matches="$(git grep -I -l -E -- "$secret_pattern" "$tree_id" -- . \
-      ':(exclude)scripts/check-public-repo-safety.sh' 2>/dev/null)"; then
-      while read -r matched_path; do
-        [[ -n "$matched_path" ]] || continue
-        matched_path="${matched_path#*:}"
-        history_findings+="${commit_id} ${matched_path}"$'\n'
-      done <<<"$tree_matches"
-    else
-      grep_status=$?
-      if [[ "$grep_status" -ne 1 ]]; then
-        echo "公开仓库门禁失败：无法扫描 Git tree ${tree_id}。" >&2
-        exit 1
-      fi
-    fi
-
-    if ! tree_paths="$(git ls-tree -r --name-only "$tree_id")"; then
-      echo "公开仓库门禁失败：无法读取 Git tree $tree_id 的路径。" >&2
-      exit 1
-    fi
-    while read -r historical_path; do
-      [[ -n "$historical_path" ]] || continue
-      if [[ "$historical_path" =~ (^|/)(\.env($|\.)|\.npmrc$|\.netrc$|config\.json$|id_rsa$|id_ed25519$)|\.(key|p8|p12|mobileprovision|ipa)$ ]] \
-        && [[ ! "$historical_path" =~ (^|/)\.env\.(example|sample|template)$ ]]; then
-        history_findings+="${commit_id} ${historical_path}"$'\n'
-      fi
-    done <<<"$tree_paths"
-  done <<<"$history_trees"
+if [[ "$mode" == "pull-request" ]]; then
+  history_revision="${base_sha}..${head_sha}"
+  history_label="PR 新增提交"
+else
+  history_revision="--all"
+  history_label="完整 Git 历史"
 fi
+if ! history_trees="$(git log "$history_revision" --format='%T %H' | awk '!seen[$1]++')"; then
+  fail "无法枚举${history_label} tree。"
+fi
+while read -r tree_id commit_id; do
+  [[ -n "$tree_id" && -n "$commit_id" ]] || continue
+
+  # git grep 在 tree 内部批量扫描，不使用 producer | rg -q，避免命中大 blob 时 SIGPIPE 反而漏报。
+  if tree_matches="$(git grep -I -l -E -- "$secret_pattern" "$tree_id" -- . \
+    ':(exclude)scripts/check-public-repo-safety.sh' 2>/dev/null)"; then
+    while read -r matched_path; do
+      [[ -n "$matched_path" ]] || continue
+      matched_path="${matched_path#*:}"
+      history_findings+="${commit_id} ${matched_path}"$'\n'
+    done <<<"$tree_matches"
+  else
+    grep_status=$?
+    if [[ "$grep_status" -ne 1 ]]; then
+      fail "无法扫描 Git tree ${tree_id}。"
+    fi
+  fi
+
+  if ! tree_paths="$(git ls-tree -r --name-only "$tree_id")"; then
+    fail "无法读取 Git tree $tree_id 的路径。"
+  fi
+  while read -r historical_path; do
+    [[ -n "$historical_path" ]] || continue
+    if [[ "$historical_path" =~ (^|/)(\.env($|\.)|\.npmrc$|\.netrc$|config\.json$|id_rsa$|id_ed25519$)|\.(key|p8|p12|mobileprovision|ipa)$ ]] \
+      && [[ ! "$historical_path" =~ (^|/)\.env\.(example|sample|template)$ ]]; then
+      history_findings+="${commit_id} ${historical_path}"$'\n'
+    fi
+  done <<<"$tree_paths"
+done <<<"$history_trees"
 history_findings="${history_findings%$'\n'}"
 if [[ -n "$history_findings" ]]; then
   history_findings="$(printf '%s\n' "$history_findings" | sort -u)"
@@ -97,7 +223,11 @@ fi
 
 # 品牌身份门禁独立扫描仓库地址、商店名称和 AppExternalLinks；它不回调本安全门禁，避免递归。
 bash ./scripts/check-brand-identity.sh
-bash ./scripts/check-third-party-notices.sh
+if [[ "$third_party" == true ]]; then
+  bash ./scripts/check-third-party-notices.sh
+else
+  echo "第三方许可门禁跳过：PR 未修改依赖、许可清单或打包入口。"
+fi
 bash ./scripts/check-pr-gate.sh
 
-echo "公开仓库安全门禁通过。"
+echo "公开仓库安全门禁通过：${history_label}已扫描，third_party=${third_party}。"

--- a/scripts/test-public-repo-safety.sh
+++ b/scripts/test-public-repo-safety.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "公开仓库门禁自测失败：$1" >&2
+  exit 1
+}
+
+for command_name in bash chmod cp git grep mkdir mktemp printf rm rg; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "缺少命令 ${command_name}。"
+done
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-public-safety-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+  printf '%s\n' "$output" | grep -Fq -- "$expected" \
+    || fail "输出缺少：${expected}"
+}
+
+assert_not_contains() {
+  local output="$1"
+  local unexpected="$2"
+  if printf '%s\n' "$output" | grep -Fq -- "$unexpected"; then
+    fail "输出不应包含：${unexpected}"
+  fi
+}
+
+create_repository() {
+  local repository="$1"
+  mkdir -p "$repository/scripts" "$repository/.github/workflows" \
+    "$repository/ios/MimiRemote/MimiRemote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
+  cp scripts/check-public-repo-safety.sh "$repository/scripts/"
+  chmod +x "$repository/scripts/check-public-repo-safety.sh"
+  printf '#!/usr/bin/env bash\nset -euo pipefail\n' > "$repository/scripts/check-brand-identity.sh"
+  printf '#!/usr/bin/env bash\nset -euo pipefail\n' > "$repository/scripts/check-pr-gate.sh"
+  printf '#!/usr/bin/env bash\nset -euo pipefail\n[[ -z "${THIRD_PARTY_MARKER:-}" ]] || : > "$THIRD_PARTY_MARKER"\n' \
+    > "$repository/scripts/check-third-party-notices.sh"
+  printf '# test repository\n' > "$repository/README.md"
+  printf 'module example.invalid/test\n\ngo 1.25\n' > "$repository/go.mod"
+  printf 'name: test\non:\n  push:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5\n' \
+    > "$repository/.github/workflows/test.yml"
+  git -C "$repository" init -q
+  git -C "$repository" config user.name "Mimi Safety Test"
+  git -C "$repository" config user.email "safety-test@example.invalid"
+  git -C "$repository" add .
+  git -C "$repository" commit -q -m baseline
+}
+
+repository="$test_root/repository"
+create_repository "$repository"
+base_sha="$(git -C "$repository" rev-parse HEAD)"
+
+mkdir -p "$repository/internal/example"
+printf 'package example\n' > "$repository/internal/example/example.go"
+git -C "$repository" add internal/example/example.go
+git -C "$repository" commit -q -m ordinary-source
+ordinary_head="$(git -C "$repository" rev-parse HEAD)"
+
+plan_output="$(cd "$repository" && bash ./scripts/check-public-repo-safety.sh \
+  --pull-request --base "$base_sha" --head "$ordinary_head" --plan)"
+assert_contains "$plan_output" "mode=pull-request"
+assert_contains "$plan_output" "third_party=false"
+
+third_party_marker="$test_root/ordinary-third-party.marker"
+ordinary_output="$(cd "$repository" && THIRD_PARTY_MARKER="$third_party_marker" \
+  bash ./scripts/check-public-repo-safety.sh \
+    --pull-request --base "$base_sha" --head "$ordinary_head")"
+[[ ! -e "$third_party_marker" ]] \
+  || fail "普通源码 PR 不应执行第三方许可检查。"
+assert_contains "$ordinary_output" "PR 新增提交已扫描，third_party=false"
+
+git -C "$repository" switch -q -c intermediate-secret "$base_sha"
+printf -v fake_secret 'github_pat_%040d' 0
+printf '%s\n' "$fake_secret" > "$repository/leaked-token.txt"
+printf 'placeholder\n' > "$repository/release-signing.p8"
+git -C "$repository" add leaked-token.txt release-signing.p8
+git -C "$repository" commit -q -m add-sensitive-material
+rm "$repository/leaked-token.txt" "$repository/release-signing.p8"
+git -C "$repository" add -u
+git -C "$repository" commit -q -m remove-sensitive-material
+secret_head="$(git -C "$repository" rev-parse HEAD)"
+secret_output_path="$test_root/intermediate-secret.output"
+if (cd "$repository" && bash ./scripts/check-public-repo-safety.sh \
+  --pull-request --base "$base_sha" --head "$secret_head") \
+  >"$secret_output_path" 2>&1; then
+  fail "PR 中间提交包含 secret 或签名产物时必须失败。"
+fi
+secret_output="$(<"$secret_output_path")"
+assert_contains "$secret_output" "leaked-token.txt"
+assert_contains "$secret_output" "release-signing.p8"
+assert_not_contains "$secret_output" "$fake_secret"
+
+invalid_output_path="$test_root/invalid-sha.output"
+if (cd "$repository" && bash ./scripts/check-public-repo-safety.sh \
+  --pull-request --base deadbeef --head "$secret_head" --plan) \
+  >"$invalid_output_path" 2>&1; then
+  fail "不存在的 base SHA 必须 fail closed。"
+fi
+assert_contains "$(<"$invalid_output_path")" "base 必须是完整 commit SHA"
+
+git -C "$repository" switch -q -c dependency-change "$base_sha"
+git -C "$repository" branch -D intermediate-secret >/dev/null
+printf 'module example.invalid/test\n\ngo 1.25\n\nrequire example.invalid/dependency v1.0.0\n' \
+  > "$repository/go.mod"
+git -C "$repository" add go.mod
+git -C "$repository" commit -q -m dependency-change
+dependency_head="$(git -C "$repository" rev-parse HEAD)"
+dependency_plan="$(cd "$repository" && bash ./scripts/check-public-repo-safety.sh \
+  --pull-request --base "$base_sha" --head "$dependency_head" --plan)"
+assert_contains "$dependency_plan" "third_party=true"
+
+third_party_marker="$test_root/dependency-third-party.marker"
+(cd "$repository" && THIRD_PARTY_MARKER="$third_party_marker" \
+  bash ./scripts/check-public-repo-safety.sh \
+    --pull-request --base "$base_sha" --head "$dependency_head" >/dev/null)
+[[ -f "$third_party_marker" ]] \
+  || fail "依赖相关 PR 必须执行第三方许可检查。"
+
+rm -f "$third_party_marker"
+(cd "$repository" && THIRD_PARTY_MARKER="$third_party_marker" \
+  bash ./scripts/check-public-repo-safety.sh --full-history >/dev/null)
+[[ -f "$third_party_marker" ]] \
+  || fail "完整历史模式必须执行第三方许可检查。"
+
+old_history_repository="$test_root/old-history-repository"
+create_repository "$old_history_repository"
+printf -v old_secret 'github_pat_%040d' 1
+printf '%s\n' "$old_secret" > "$old_history_repository/old-token.txt"
+git -C "$old_history_repository" add old-token.txt
+git -C "$old_history_repository" commit -q -m old-sensitive-material
+rm "$old_history_repository/old-token.txt"
+git -C "$old_history_repository" add -u
+git -C "$old_history_repository" commit -q -m remove-old-sensitive-material
+old_base="$(git -C "$old_history_repository" rev-parse HEAD)"
+printf 'safe\n' > "$old_history_repository/source.txt"
+git -C "$old_history_repository" add source.txt
+git -C "$old_history_repository" commit -q -m pull-request-change
+old_head="$(git -C "$old_history_repository" rev-parse HEAD)"
+
+(cd "$old_history_repository" && bash ./scripts/check-public-repo-safety.sh \
+  --pull-request --base "$old_base" --head "$old_head" >/dev/null)
+old_full_output_path="$test_root/old-full-history.output"
+if (cd "$old_history_repository" && bash ./scripts/check-public-repo-safety.sh --full-history) \
+  >"$old_full_output_path" 2>&1; then
+  fail "完整历史模式必须发现 base 之前的历史 secret。"
+fi
+assert_contains "$(<"$old_full_output_path")" "old-token.txt"
+assert_not_contains "$(<"$old_full_output_path")" "$old_secret"
+
+rm -rf "$test_root"
+trap - EXIT
+
+echo "公开仓库门禁自测通过：PR 中间提交、完整历史、SHA 校验与第三方许可分流均符合预期。"

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -106,6 +106,9 @@ assert_contains "$rust_full_output" "-p alleycat-claude-bridge"
 security_output="$(assert_plan security_control scripts/check-public-repo-safety.sh)"
 assert_contains "$security_output" "bash ./scripts/check-public-repo-safety.sh"
 
+security_self_test_output="$(assert_plan security_self_test scripts/test-public-repo-safety.sh)"
+assert_contains "$security_self_test_output" "bash ./scripts/check-public-repo-safety.sh"
+
 security_workflow_output="$(assert_plan security_workflow .github/workflows/public-repo-safety.yml)"
 assert_contains "$security_workflow_output" "bash ./scripts/check-public-repo-safety.sh"
 assert_not_contains "$security_workflow_output" "bash ./scripts/check-pr-gate.sh"

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -370,7 +370,7 @@ for path in "${changed_paths[@]:-}"; do
       ;;
   esac
   case "$path" in
-    .github/workflows/public-repo-safety.yml|scripts/check-public-repo-safety.sh|scripts/check-third-party-notices.sh|NOTICE.md|THIRD_PARTY_NOTICES.md)
+    .github/workflows/public-repo-safety.yml|scripts/check-public-repo-safety.sh|scripts/test-public-repo-safety.sh|scripts/check-third-party-notices.sh|NOTICE.md|THIRD_PARTY_NOTICES.md)
       has_repository_security_control=true
       ;;
   esac


### PR DESCRIPTION
## 目标

缩短每个 PR 必跑的 Public Repository Safety，同时保留对公开敏感信息和依赖许可的 fail-closed 保护。

## 改动

- PR Gate 显式向 reusable workflow 传入 `pull-request` 模式与 base/head 完整 SHA。
- PR 只扫描 base..head 的全部新增 commit tree；即使敏感内容在中间提交加入、随后删除，仍会阻断。
- 当前合并工作树仍完整扫描；main push、手动运行和未声明模式继续扫描全部 Git 历史。
- 仅当 Go/Swift 依赖、第三方许可清单或打包入口变化时执行第三方许可证明与 Setup Go。
- runner 已有 ripgrep 时不再执行 apt update/install。
- 新增临时 Git 仓库自测并将 workflow 约束锁入 PR Gate 自检。

## 影响

- 本地普通 PR 路径：17.21 秒（首次对比 10.18 秒）。
- 本地完整历史路径：148.91 秒。
- 普通 PR 本地 wall time 减少约 89%；main 仍保留完整证明。
- 不启动 Xcode、Simulator 或真机，不改变 TestFlight/正式 Release。

## 验证

- `bash ./scripts/test-public-repo-safety.sh`
- `bash ./scripts/check-pr-gate.sh`
- `bash ./scripts/check-public-repo-safety.sh --pull-request --base <origin/main SHA> --head <HEAD SHA>`
- `bash ./scripts/check-public-repo-safety.sh --full-history`
- Shell 语法、YAML 解析和 `git diff --check`

Linear: MIM-141
