### PR TITLE
MIM-142 取消过时的 iOS 回归

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -73,10 +73,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ios-ci-${{ github.ref }}
-  # TestFlight 上传不能被同一 main 上的新 push 或手工运行中途取消；PR Gate
-  # 自身仍会取消过时的 PR caller，因此这里优先保证签名发布的原子性。
-  cancel-in-progress: false
+  # 普通回归与签名发布使用不同组：新提交可以取消过时的 Simulator 回归，
+  # 但不能取消或排队阻塞同一 main 上正在执行的 TestFlight 上传。
+  group: >-
+    ios-ci-${{ (inputs.publish_internal_testflight || (github.event_name == 'workflow_dispatch' && inputs.publish_app_store)) && 'release' || 'regression' }}-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ !(inputs.publish_internal_testflight || (github.event_name == 'workflow_dispatch' && inputs.publish_app_store)) }}
 
 jobs:
   conversation-regressions:

--- a/scripts/check-nightly-release.sh
+++ b/scripts/check-nightly-release.sh
@@ -202,7 +202,16 @@ trust_run = trust.fetch("run")
 ].each { |needle| fail_check("iOS trust gate 缺少 #{needle}") unless trust_run.include?(needle) }
 upload = app.dig("env", "IOS_TESTFLIGHT_UPLOAD").to_s
 fail_check("iOS upload 必须严格使用 1/0 二选一") unless upload.include?("'1'") && upload.include?("'0'") && app.dig("env", "IOS_TESTFLIGHT_VALIDATE").to_s == "0"
-fail_check("iOS CI 不得取消正在运行的 TestFlight 上传") unless ios.dig("concurrency", "cancel-in-progress") == false
+ios_concurrency = ios.fetch("concurrency")
+concurrency_group = ios_concurrency.fetch("group").to_s.gsub(/\s+/, "")
+cancel_expression = ios_concurrency.fetch("cancel-in-progress").to_s.gsub(/\s+/, "")
+expected_release_predicate = "(inputs.publish_internal_testflight||(github.event_name=='workflow_dispatch'&&inputs.publish_app_store))"
+expected_group = 'ios-ci-${{' + expected_release_predicate + "&&'release'||'regression'" + '}}-${{github.ref}}'
+expected_cancel_expression = '${{!' + expected_release_predicate + '}}'
+fail_check("iOS CI 必须把 TestFlight release 与普通 regression concurrency group 分开") unless
+  concurrency_group == expected_group
+fail_check("iOS CI 只能取消普通回归，不能取消 TestFlight 上传") unless
+  cancel_expression == expected_cancel_expression
 evidence = step(app, "Write Nightly TestFlight evidence")
 artifact = step(app, "Upload Nightly TestFlight evidence")
 fail_check("Nightly evidence 只能由显式 reusable publish input 生成") unless
@@ -331,6 +340,22 @@ self_test() {
   mutate_nightly 'value["uploaded"] == true' 'true'
   mutate_nightly 'IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64 }}' 'IOS_WIDGET_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 }}'
   mutate_nightly "needs.release-secrets-preflight.result == 'success'" "true"
+
+  mutate_ios() {
+    local old_value="$1"
+    local new_value="$2"
+    cp "$ROOT_DIR/.github/workflows/ios-ci.yml" "$test_root/.github/workflows/ios-ci.yml"
+    ruby -e '
+      path, old_value, new_value = ARGV
+      source = File.read(path)
+      abort "self-test mutation target missing: #{old_value}" unless source.include?(old_value)
+      File.write(path, source.sub(old_value, new_value))
+    ' "$test_root/.github/workflows/ios-ci.yml" "$old_value" "$new_value"
+    expect_failure
+  }
+  mutate_ios "&& 'release' || 'regression'" "&& 'regression' || 'regression'"
+  mutate_ios '${{ !(inputs.publish_internal_testflight || (github.event_name == '\''workflow_dispatch'\'' && inputs.publish_app_store)) }}' '${{ false }}'
+  mutate_ios '!(inputs.publish_internal_testflight || (github.event_name == '\''workflow_dispatch'\'' && inputs.publish_app_store))' '!inputs.publish_internal_testflight'
 
   cp "$ROOT_DIR/.github/workflows/nightly.yml" "$test_root/.github/workflows/nightly.yml"
   ruby -e 'p = ARGV.fetch(0); s = File.read(p).sub("      inputs.publish_internal_testflight", "      (github.event_name == '\''workflow_call'\'' && inputs.publish_internal_testflight)"); File.write(p, s)' "$test_root/.github/workflows/ios-ci.yml"


### PR DESCRIPTION
## 目标

缩短过时 iOS 回归占用的 CI 时间，同时保证 TestFlight/App Store 发布不会被新提交中途取消。

## 实现

- 将 iOS reusable workflow 的 concurrency 拆成 `regression` 与 `release` 两组。
- 普通 PR/main 回归允许新运行取消旧运行；Nightly 和手工发布保持不可取消。
- 扩展 Nightly/Release 静态门禁，精确锁定分组与取消条件，并加入 fail-closed 变异自测。

## 验证

- `bash ./scripts/verify-change.sh --base origin/main`（7 项通过，12 秒）
- `bash ./scripts/check-pr-gate.sh`
- `bash ./scripts/check-nightly-release.sh --self-test`
- 未启动 Xcode、Simulator 或真机；完整语言栈回归交给 PR Gate。

Linear: MIM-142
