### PR TITLE
MIM-145 优化工作区新建会话图标

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -1694,16 +1694,11 @@ private struct WorkspaceDetailView<StatusLine: View>: View {
     }
 
     /// 筛选器固定在列表左侧，紧接结果区域；新建会话保留在右侧。
-    /// 按容器真实宽度选择文字版或图标版，iPad mini 竖屏和窄分屏不再被 regular Size Class 误判为宽布局。
+    /// 所有尺寸统一使用图标入口；空间不足时只调整筛选器与按钮的排布，不改变按钮语义和外观。
     /// 页面已经通过筛选器说明 Runtime，卡片不再重复渲染品牌或 Runtime 文案。
     private func recentSessionsHeader(tokens: ThemeTokens) -> some View {
         ViewThatFits(in: .horizontal) {
-            // 760pt 是文字操作的内容宽度档位：iPad mini 竖屏会自然落到图标版，
-            // 宽 iPad 仍保留明确标签；旋转和窗口缩放时由 SwiftUI 自动重新选择。
-            recentSessionsHeaderLine(tokens: tokens, showsNewSessionTitle: true)
-                .frame(minWidth: 760)
-
-            recentSessionsHeaderLine(tokens: tokens, showsNewSessionTitle: false)
+            recentSessionsHeaderLine(tokens: tokens)
 
             // 窄屏或大字体时自然改为两行，筛选器仍排在结果前，新建操作靠右。
             VStack(alignment: .leading, spacing: 8) {
@@ -1711,22 +1706,19 @@ private struct WorkspaceDetailView<StatusLine: View>: View {
 
                 HStack {
                     Spacer(minLength: 0)
-                    newSessionButton(tokens: tokens, showsTitle: false)
+                    newSessionButton(tokens: tokens)
                 }
             }
         }
     }
 
-    private func recentSessionsHeaderLine(
-        tokens: ThemeTokens,
-        showsNewSessionTitle: Bool
-    ) -> some View {
+    private func recentSessionsHeaderLine(tokens: ThemeTokens) -> some View {
         HStack(spacing: 12) {
             runtimePicker
 
             Spacer(minLength: 8)
 
-            newSessionButton(tokens: tokens, showsTitle: showsNewSessionTitle)
+            newSessionButton(tokens: tokens)
         }
     }
 
@@ -1736,29 +1728,18 @@ private struct WorkspaceDetailView<StatusLine: View>: View {
             claudeChannelAvailable: claudeChannelAvailable
         )
     }
-    private func newSessionButton(tokens: ThemeTokens, showsTitle: Bool) -> some View {
+    private func newSessionButton(tokens: ThemeTokens) -> some View {
         Button {
             // thread 创建时就绑定 runtime；这里必须把当前选择一路传到 SessionStore。
             onStartSession(selectedRuntime)
         } label: {
             Group {
-                if showsTitle {
-                    Label(L10n.text("ui.new_session_3da224c4"), systemImage: "plus")
-                        .font(themeStore.uiFont(.subheadline, weight: .semibold))
-                        .imageScale(.small)
-                        .padding(.horizontal, 10)
-                        .frame(minHeight: 36)
-                } else {
-                    // 紧凑布局也使用纯加号，避免“方框＋铅笔”被误解为编辑当前内容。
-                    Image(systemName: "plus")
-                        .font(.system(size: 17, weight: .semibold))
-                        .symbolRenderingMode(.hierarchical)
-                        .frame(
-                            width: 36,
-                            height: 36
-                        )
-                        .offset(y: -0.5)
-                }
+                // iPhone 与 iPad 统一只显示纯加号，文字语义由无障碍标签完整保留。
+                Image(systemName: "plus")
+                    .font(.system(size: 17, weight: .semibold))
+                    .symbolRenderingMode(.hierarchical)
+                    .frame(width: 36, height: 36)
+                    .offset(y: -0.5)
             }
             .foregroundStyle(tokens.primaryActionForeground)
             .background(tokens.primaryAction, in: Capsule())

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -1743,18 +1743,23 @@ private struct WorkspaceDetailView<StatusLine: View>: View {
         } label: {
             Group {
                 if showsTitle {
-                    Label(L10n.text("ui.new_session_3da224c4"), systemImage: "square.and.pencil")
+                    Label(L10n.text("ui.new_session_3da224c4"), systemImage: "plus")
+                        .font(themeStore.uiFont(.subheadline, weight: .semibold))
+                        .imageScale(.small)
                         .padding(.horizontal, 10)
                         .frame(minHeight: 36)
                 } else {
-                    Image(systemName: "square.and.pencil")
+                    // 紧凑布局也使用纯加号，避免“方框＋铅笔”被误解为编辑当前内容。
+                    Image(systemName: "plus")
+                        .font(.system(size: 17, weight: .semibold))
+                        .symbolRenderingMode(.hierarchical)
                         .frame(
                             width: 36,
                             height: 36
                         )
+                        .offset(y: -0.5)
                 }
             }
-            .font(themeStore.uiFont(.subheadline, weight: .semibold)).imageScale(.small)
             .foregroundStyle(tokens.primaryActionForeground)
             .background(tokens.primaryAction, in: Capsule())
             .frame(minWidth: WorkbenchChromeIconMetrics.minimumHitTarget,

--- a/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/WorkbenchSidebarComponents.swift
@@ -499,7 +499,7 @@ struct WorkbenchSidebarFooter: View {
         Group {
             if #available(iOS 26.0, *), usesFloatingSurface, !reduceTransparency {
                 Button(action: onNewSession) {
-                    WorkbenchChromeIcon(systemName: "plus")
+                    newSessionIcon
                 }
                 // 只让系统 ButtonStyle 绘制一层主题色玻璃，不再在 label 内叠材质和白色描边。
                 .buttonStyle(.glassProminent)
@@ -515,7 +515,7 @@ struct WorkbenchSidebarFooter: View {
             } else {
                 // iOS 18–25 与 Reduce Transparency 共用清晰的实色主操作按钮。
                 Button(action: onNewSession) {
-                    WorkbenchChromeIcon(systemName: "plus")
+                    newSessionIcon
                         .frame(width: 36, height: 36)
                         .background(tokens.primaryAction, in: Circle())
                         .overlay {
@@ -531,6 +531,15 @@ struct WorkbenchSidebarFooter: View {
         }
         .accessibilityLabel(L10n.text("ui.new_session_3da224c4"))
         .accessibilityIdentifier("sidebar.newSession")
+    }
+
+    private var newSessionIcon: some View {
+        // 加号在通用 15pt 规格下实际墨迹偏小且略向下；主创建动作单独做光学校正，避免误伤其他图标。
+        Image(systemName: "plus")
+            .font(.system(size: 17, weight: .semibold))
+            .symbolRenderingMode(.hierarchical)
+            .frame(width: 20, height: 20)
+            .offset(y: -0.5)
     }
 }
 


### PR DESCRIPTION
## 改动

- 将工作区两个新建会话入口统一为纯 plus 图标，并使用 17pt semibold 与轻微上移进行光学校正。
- iPhone 和 iPad 均只显示图标，删除宽屏下的“新建会话”文字分支。
- 保留 44pt 最小点击区域、主题色背景、VoiceOver 标签与 Runtime 无障碍值。

## 原因

原有入口存在两套不一致表现：通用 15pt 加号在紫色按钮中视觉偏小且略向下，工作区标题栏则使用方框加铅笔图标并在宽屏显示文字，容易被理解为编辑操作。

## 用户影响

iPhone、iPad 与不同窗口宽度下的创建入口现在具有一致的语义、比例和视觉位置。

## 验证

- iPad Pro 13-inch (M5) Simulator 构建并运行成功；像素测量中加号质心与圆形中心纵向误差约 0.14px。
- ConversationSnapshotTests.testUnifiedWorkbenchSidebarNavigationChrome：1 test，0 failures。
- 实体 iPhone 17 Pro：Debug 构建、安装、启动成功。
- 实体 iPad mini (A17 Pro)：Debug 构建、安装、启动成功。
- git diff --check 通过。