### PR TITLE
MIM-147: 重写 README 产品定位

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@
 
 <table>
   <tr>
-    <td width="33%" valign="top" align="center">
+    <td width="33%" valign="middle" align="center">
       <img src="web/assets/iphone-workspace-light.png" alt="Mimi Remote workspace on iPhone with projects, recent conversations, and runtime selection in a compact column" width="88%" />
     </td>
-    <td width="67%" valign="top" align="center">
-      <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote workspace on iPad with projects, recent conversations, and runtime selection visible together" width="100%" />
+    <td width="67%" valign="middle" align="center">
+      <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote workspace on iPad with projects, recent conversations, and runtime selection visible together" width="96%" />
     </td>
   </tr>
 </table>
@@ -141,53 +141,24 @@ The mobile images above are the same current assets used by the Mimi Remote webs
 
 ```mermaid
 flowchart LR
-    subgraph Mobile["Mobile device"]
-        App["Mimi Remote<br/>SwiftUI workbench"]
-        Keychain["Keychain<br/>one access token per Mac profile"]
-        Keychain -.-> App
-    end
+    Mobile["iPhone / iPad<br/>Mimi Remote"]
+    Gateway["Your Mac<br/>agentd secure gateway"]
+    Codex["Codex<br/>shared daemon or managed app-server"]
+    Claude["Claude Code<br/>experimental bridge"]
 
-    subgraph Mac["Your Mac — the only control plane"]
-        Host["Mimi Remote Mac<br/>install · pair · Doctor · service lifecycle"]
-        Agent["agentd<br/>auth · REST API · WebSocket gateway · policy"]
-        Local["Scoped host operations<br/>projects · files · Git · Worktrees · actions"]
-        Codex["Codex app-server<br/>shared local daemon or loopback fallback"]
-        Bridge["alleycat-claude-bridge<br/>resident · experimental"]
-        Claude["Claude Code headless<br/>one stdio process per thread"]
-        State["Local state<br/>workspaces · credentials · histories"]
-
-        Host -->|"starts and monitors"| Agent
-        Agent -->|"validated host API"| Local
-        Agent -->|"filtered JSON-RPC"| Codex
-        Agent -->|"stable session + cursor"| Bridge
-        Bridge -->|"stdio JSONL"| Claude
-        Local --> State
-        Codex --> State
-        Claude --> State
-    end
-
-    App -->|"Tailscale or local network<br/>Bearer token · REST + WebSocket"| Agent
+    Mobile <-->|"LAN or Tailscale<br/>live sessions and approvals"| Gateway
+    Gateway <--> Codex
+    Gateway <--> Claude
 ```
 
-Mimi Remote is a native client, not a second place where the agent runs. Every remote request terminates at `agentd` on your Mac; the iOS app never connects directly to Codex app-server, Claude Code, the local filesystem, or a hosted Mimi service.
+This repository ships the complete link: the native iPhone/iPad app, the Mac menu bar host, the Go `agentd` gateway, and the Claude Code compatibility bridge. The mobile app connects only to your own Mac, so project files, session history, and runtime credentials stay on the host.
 
-There are three paths through the system:
+- **Direct and responsive:** private-network REST and WebSocket connections carry live output, follow-up messages, task controls, and approvals without a Mimi-operated application relay.
+- **A real session handoff:** Codex can opt into the official local daemon shared with Codex Desktop, so an idle Mac thread can continue on mobile without a fork; the managed app-server remains the default and fallback.
+- **Two runtimes, one mobile experience:** Codex is the primary runtime, while the optional Claude Code bridge adapts its sessions and approvals to the same structured interface.
+- **A small, explicit trust boundary:** `agentd` handles authentication, workspace authorization, and runtime routing on the Mac. The Mac must remain awake and privately reachable.
 
-1. **Host lifecycle:** Mimi Remote Mac installs, pairs, diagnoses, starts, and monitors `agentd`. It is not in the per-request data path. Homebrew or user-systemd can run the same Go service for command-line and Linux setups.
-2. **Bounded host capabilities:** project discovery, safe file reads, Git, managed Worktrees, diagnostics, voice proxying, and configured actions use authenticated REST endpoints implemented by `agentd`. They do not pass through Codex.
-3. **Agent sessions:** the mobile app uses one external Codex-compatible JSON-RPC/WebSocket gateway. `agentd` validates the runtime, method, project-derived working directory, payload size, and connection budget before routing the request to the primary Codex app-server or the experimental Claude bridge.
-
-Codex app-server remains the primary runtime. On macOS, users can explicitly enable the official local daemon so Codex Desktop and Mimi Remote share one writer process; the compatible managed loopback WebSocket remains the rollback/default path. This lets the phone continue an idle Desktop-opened thread without forking, while an actively running Desktop turn stays read-only. The optional resident Claude bridge keeps a stable session key and replay cursor across mobile reconnects, then owns one headless Claude Code stdio process per active thread. Provider-specific differences stay behind this adapter boundary; the shared mobile UI does not imply feature parity.
-
-The security boundary is deliberately concentrated on the Mac:
-
-- A QR code carries a signed pairing ticket that can be reused only during its 10-minute lifetime; it never carries the long-lived credential. The resulting `agentd` token is stored in Keychain per Mac profile.
-- The app-server capability token and provider credentials never leave the Mac. The managed app-server endpoint listens on loopback.
-- Client-supplied project IDs are resolved through the configured project allowlist. File access is limited to project roots, `browse_roots`, and managed Worktrees.
-- Git and Worktree APIs expose fixed, validated operations. General commands must be configured as actions and use confirmation, timeouts, request limits, and bounded output.
-- Live events use sequence/cursor replay after normal reconnects; when a replay window is insufficient, the client reloads authoritative local history instead of resubmitting the turn.
-
-This shape keeps deployment small and auditable, but the tradeoff is explicit: the Mac must be awake and privately reachable, and `agentd` plus the selected runtime must be healthy. There is no maintainer-operated relay, cloud state sync, or APNs background execution path.
+For protocol details and exact capability boundaries, see [project status](docs/project-status.md), [Codex shared daemon](docs/codex-shared-daemon.md), and the [Claude bridge architecture](docs/claude-bridge-architecture.md).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 <h1 align="center">Mimi Remote</h1>
 
 <p align="center">
-  <strong>Let your Mac keep working. You do not have to stay at it.</strong>
+  <strong>Continue your Mac agent sessions on iPhone or iPad.</strong>
 </p>
 
 <p align="center">
-  A native, local-first mobile workbench for Codex sessions running on your own Mac.<br />
-  Check in from iPhone, steer from iPad, and finish review or Git work on iPad Pro.
+  An open-source, native mobile workspace for Codex and Claude Code.<br />
+  Connect directly to your Mac and pick up sessions across devices without rebuilding context—follow work live, continue conversations, and handle approvals.
 </p>
 
 <p align="center">
@@ -31,12 +31,19 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3%20%2B%20Store%20Exception-blue.svg" alt="GPLv3 with store distribution exception" /></a>
 </p>
 
-<p align="center">
-  <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote workspace on iPad with projects, recent conversations, and runtime selection visible together" width="100%" />
-</p>
+<table>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <img src="web/assets/iphone-workspace-light.png" alt="Mimi Remote workspace on iPhone with projects, recent conversations, and runtime selection in a compact column" width="88%" />
+    </td>
+    <td width="67%" valign="top" align="center">
+      <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote workspace on iPad with projects, recent conversations, and runtime selection visible together" width="100%" />
+    </td>
+  </tr>
+</table>
 
 <p align="center">
-  <sub>The current iPad workspace — the same product capture used by the Mimi Remote website.</sub>
+  <sub>The current Mimi Remote workspaces on iPhone and iPad: the same capabilities, adapted layouts.</sub>
 </p>
 
 Mimi Remote connects directly to your Mac through Tailscale or the same local network. The project does not operate a relay, account system, or hosted session service. Your Mac remains the control plane; data you intentionally send to Codex, Claude Code, GitHub, voice transcription, or MCP is still handled by those services under their own terms.
@@ -48,12 +55,12 @@ Mimi Remote is an independent third-party project. It is not affiliated with, en
 <table>
   <tr>
     <td width="50%" align="center">
-      <strong>iPhone · one column, one thumb</strong><br />
-      <sub>Search and scan every session in a compact, touch-first list.</sub>
+      <strong>iPhone · same capabilities, compact layout</strong><br />
+      <sub>Continue sessions, follow progress, handle approvals, and control tasks in one column.</sub>
     </td>
     <td width="50%" align="center">
-      <strong>iPad · sidebar and list together</strong><br />
-      <sub>Keep the active Mac, navigation, recent work, and full session history visible.</sub>
+      <strong>iPad · same capabilities, expanded layout</strong><br />
+      <sub>Open the same sessions and controls into a multi-column workspace with more context.</sub>
     </td>
   </tr>
   <tr>
@@ -66,31 +73,31 @@ Mimi Remote is an independent third-party project. It is not affiliated with, en
   </tr>
 </table>
 
-These images reuse the current capture set from [`web/assets`](web/assets), covering the workspace and session hierarchy across iPhone and iPad. They were captured from Debug-only seeded UI with demo hosts, projects, sessions, paths, and usage values—never a maintainer's live workspace or credentials. The interface uses the Simplified Chinese localization; the app also supports English. Keeping one checked-in image set prevents the website and README from drifting apart again.
+Both devices share the complete session, approval, and task-control surface; only the layout, information density, and input ergonomics change. The native SwiftUI interface tunes compact navigation, wide-screen columns, touch feedback, and transitions for each device. With Reduce Motion enabled, movement falls back to restrained fades or static feedback. These images reuse the current [`web/assets`](web/assets) capture set and come from Debug-only seeded UI with demo hosts, projects, sessions, paths, and usage values—never a maintainer's live workspace or credentials. The interface uses the Simplified Chinese localization; the app also supports English.
 
-## Leave the desk, not the flow
+## Carry the session from Mac to mobile
 
-The useful moment is rarely “open a terminal on a phone.” It is “the agent finished while I was away — let me understand what changed and decide what happens next.”
+The common need is rarely “open a terminal on a phone.” It is to leave the Mac and keep the same agent session moving without explaining the context again.
 
-- **Glance:** see whether a task is thinking, waiting, failed, or complete without reopening the Mac.
-- **Steer:** add context, queue the next instruction, change model or reasoning, answer a prompt, approve an action, or interrupt the turn.
-- **Finish:** inspect status and diffs, manage Worktrees, stage a file or hunk, commit, push, and open a draft pull request.
+- **Continue:** pick up existing sessions across Mac, iPhone, and iPad instead of starting over when you leave the desk.
+- **Follow live:** see whether a task is thinking, waiting, failed, or complete while structured replies and execution progress arrive.
+- **Stay in control:** add context, queue the next instruction, change model or reasoning, answer a prompt, approve an action, or interrupt the turn.
 
-On iPhone, the hierarchy stays compact and touch-first. On iPad, the same native SwiftUI app expands into a workbench with projects, sessions, conversation, and inspector space instead of stretching a phone layout.
+When you need to finish deeper development work, advanced tools can inspect diffs, manage Worktrees, stage a file or hunk, commit, push, and open a draft pull request. None of those tools is required to use Mimi Remote.
 
 ## More than a pocket terminal
 
-- Structured Codex output groups messages, reasoning, commands, tool calls, approvals, and work into a readable timeline.
+- Mimi Remote groups Codex and Claude Code messages, reasoning, commands, tool calls, approvals, and work into a readable timeline.
 - New Codex sessions receive a concise model-generated title from the Mac host; title generation is asynchronous and never blocks the conversation.
 - Model, reasoning level, Skill, speed, permission mode, and queued turns stay next to the composer.
 - Markdown, images, file references, voice input, and safe Quick Look reads work as mobile-native content.
-- Worktree and Git actions expose previews, confirmations, timeouts, and bounded output instead of an unrestricted remote shell.
+- Spacing, hierarchy, touch feedback, and transitions are tuned separately for iPhone and iPad; Reduce Motion keeps the same state changes clear without spatial effects.
 - Multiple Mac profiles keep separate tokens in Keychain; one active connection keeps the mental model simple.
 - Readiness checks, reconnection, diagnostics, and bounded log export help recover without returning to the desk.
 
 ## Designed around context, not screen size
 
-Mimi Remote keeps the same project and session model across devices, but each surface follows the way that device is actually used. The iPad becomes a context-preserving workbench; the Mac stays a compact operational control surface instead of duplicating the mobile app.
+Mimi Remote keeps the same project and session model across devices, but each surface follows the way that device is actually used. iPhone keeps one-handed navigation compact, iPad opens the same capabilities into a context-preserving multi-column workbench, and the Mac continues running the agents and host controls. The device changes the presentation, not the available capabilities.
 
 <table>
   <tr>
@@ -123,7 +130,7 @@ Mimi Remote keeps the same project and session model across devices, but each su
 
 The hierarchy is intentional:
 
-- **Preserve context:** the iPad sidebar keeps projects and sessions visible while the detail area changes; settings use a sheet so the workbench does not disappear.
+- **Preserve context:** iPhone keeps the current task close in a compact hierarchy; the iPad sidebar keeps projects and sessions visible while the detail area changes. Layout changes without removing session capability.
 - **Disclose complexity progressively:** common status and actions stay close to the task, while setup, pairing, diagnostics, and deeper preferences move into focused surfaces.
 - **Show state before action:** connection health, runtime readiness, remaining quota, and permission mode are visible before controls that can change or interrupt work.
 - **Use each platform natively:** compact touch hierarchy on iPhone, multi-column workbench on iPad, and a dense menu bar utility on Mac — not one layout stretched across three screens.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,12 +5,12 @@
 <h1 align="center">Mimi Remote</h1>
 
 <p align="center">
-  <strong>让 Mac 继续干活，你不必一直守在 Mac 前。</strong>
+  <strong>Mac 上的 Agent 会话，接着在 iPhone 和 iPad 上用。</strong>
 </p>
 
 <p align="center">
-  开源、原生、本地优先的 Codex 移动工作台。<br />
-  iPhone 看进度，iPad 补方向，iPad Pro 做 Review 和 Git 收尾。
+  面向 Codex 与 Claude Code 的开源原生移动工作台。<br />
+  直连你的 Mac，让会话在设备间无缝接力，实时跟进任务、继续对话和处理审批。
 </p>
 
 <p align="center">
@@ -30,12 +30,19 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3%20%2B%20Store%20Exception-blue.svg" alt="GPLv3 与商店分发例外" /></a>
 </p>
 
-<p align="center">
-  <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote 在 iPad 上同时展示项目、最近会话与 Runtime 选择的工作区" width="100%" />
-</p>
+<table>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <img src="web/assets/iphone-workspace-light.png" alt="Mimi Remote 在 iPhone 上以紧凑单列展示项目、最近会话与 Runtime 选择" width="88%" />
+    </td>
+    <td width="67%" valign="top" align="center">
+      <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote 在 iPad 上同时展示项目、最近会话与 Runtime 选择的工作区" width="100%" />
+    </td>
+  </tr>
+</table>
 
 <p align="center">
-  <sub>当前 Mimi Remote iPad 工作区，与官网使用同一张产品截图。</sub>
+  <sub>当前 Mimi Remote iPhone 与 iPad 工作区：能力一致，布局分别适配。</sub>
 </p>
 
 Mimi Remote 通过 Tailscale 或同一局域网直连用户自己的 Mac。项目不运营中转服务、云账号或会话托管服务，Mac 始终是控制平面；用户主动发送给 Codex、Claude Code、GitHub、语音转写或 MCP 的数据，仍会按对应第三方服务的处理方式与条款处理。
@@ -47,12 +54,12 @@ Mimi Remote 是独立开发的第三方项目，不隶属于 OpenAI、Anthropic 
 <table>
   <tr>
     <td width="50%" align="center">
-      <strong>iPhone · 单列呈现，单手操作</strong><br />
-      <sub>在紧凑的触屏列表中搜索和浏览所有会话。</sub>
+      <strong>iPhone · 完整能力，紧凑布局</strong><br />
+      <sub>在单列界面中继续会话、跟进进度、处理审批和控制任务。</sub>
     </td>
     <td width="50%" align="center">
-      <strong>iPad · 侧栏与列表同时可见</strong><br />
-      <sub>当前 Mac、导航、最近任务与完整会话历史保持在同一视野。</sub>
+      <strong>iPad · 完整能力，展开布局</strong><br />
+      <sub>同样的会话与控制在多栏工作台中展开，保留更多上下文。</sub>
     </td>
   </tr>
   <tr>
@@ -65,25 +72,25 @@ Mimi Remote 是独立开发的第三方项目，不隶属于 OpenAI、Anthropic 
   </tr>
 </table>
 
-这些图片直接复用 [`web/assets`](web/assets) 中的当前官网截图，覆盖 iPhone 与 iPad 的工作区和会话层级。全部图片都来自 Debug 专用种子界面，其中的主机、项目、会话、路径和用量均为演示数据，不使用维护者的真实工作区或凭据。截图展示简体中文界面，App 同时支持英文。官网与 README 共用一套仓库内图片，避免后续再次出现版本漂移。
+两端共用完整的会话、审批与任务控制能力，区别只在布局、信息密度和输入方式。原生 SwiftUI 界面分别打磨了紧凑导航、宽屏分栏、触控反馈与过渡动画；开启 Reduce Motion 后，动态效果会降级为克制的淡化或静态反馈。这些图片直接复用 [`web/assets`](web/assets) 中的当前官网截图，全部来自 Debug 专用种子界面，其中的主机、项目、会话、路径和用量均为演示数据，不使用维护者的真实工作区或凭据。截图展示简体中文界面，App 同时支持英文。
 
-## 离开工位，不离开任务
+## 从 Mac 到移动端，会话继续
 
-真正高频的需求通常不是“在手机上开一个终端”，而是“Agent 趁我离开时做完了——我想看懂它改了什么，再决定下一步”。
+真正高频的需求通常不是“在手机上开一个终端”，而是离开 Mac 后仍能接着同一段 Agent 会话，不必重新解释上下文。
 
-- **看一眼：**任务是在思考、等待、失败，还是已经完成，不用重新打开 Mac。
-- **补一句：**追加上下文、排队下一条指令、切换模型或推理强度、回答问题、批准操作或中断当前 Turn。
-- **收个尾：**检查状态和 Diff、管理 Worktree、按文件或 Hunk 暂存、Commit、Push，并创建 Draft PR。
+- **接着做：**在 Mac、iPhone 与 iPad 之间继续已有会话，离开工位也不用重新开始。
+- **实时跟进：**查看任务正在思考、等待、失败还是已经完成，并持续读取结构化回复和执行过程。
+- **随时控制：**追加上下文、排队下一条指令、切换模型或推理强度、回答问题、批准操作或中断当前 Turn。
 
-iPhone 保持紧凑、适合触屏；到了 iPad，同一套原生 SwiftUI 界面会展开成项目、会话、正文与 Inspector 工作台，而不是简单把手机页面拉宽。
+需要完成更深入的开发收尾时，进阶工具还支持检查 Diff、管理 Worktree、按文件或 Hunk 暂存、Commit、Push 和创建 Draft PR；这些能力不是使用 Mimi Remote 的前提。
 
 ## 它不是口袋里的终端
 
-- Codex 的消息、推理、命令、Tool 调用、审批和执行过程会组成结构化时间线，不是一整屏终端日志。
+- Codex 与 Claude Code 的消息、推理、命令、Tool 调用、审批和执行过程会组成结构化时间线，不是一整屏终端日志。
 - 新建 Codex 会话由 Mac 端异步生成简短标题；生成失败不会阻塞对话，可通过 `app_server.auto_title` 关闭。
 - 模型、推理强度、Skill、速度、权限模式和待发送队列都留在 Composer 附近。
 - Markdown、图片、文件引用、语音输入和安全的 Quick Look 读取都按移动端内容呈现。
-- Worktree 与 Git 操作带预览、确认、超时和输出上限，不向手机暴露不受控的任意 Shell。
+- iPhone 与 iPad 的间距、层级、触控反馈和转场动画分别调校；Reduce Motion 下仍保留清晰的静态状态反馈。
 - 多个 Mac Profile 使用独立 Keychain Token；同一时间只保持一个活动连接，心智模型更简单。
 - 就绪检查、断线恢复、Doctor 和有上限的日志导出，让多数故障不必回到电脑前处理。
 
@@ -91,7 +98,7 @@ iPhone 保持紧凑、适合触屏；到了 iPad，同一套原生 SwiftUI 界�
 
 ## 设计围绕上下文，不围绕屏幕尺寸
 
-Mimi Remote 在不同设备上沿用同一套项目与会话模型，但界面会顺着设备的真实使用方式变化：iPad 是保留上下文的工作台，Mac 是紧凑的运行控制面，不会把同一张页面机械复制到所有端。
+Mimi Remote 在不同设备上沿用同一套项目与会话模型，但界面会顺着设备的真实使用方式变化：iPhone 用紧凑层级保持单手操作，iPad 展开为保留上下文的多栏工作台，Mac 则继续运行 Agent 并提供宿主控制面。设备改变的是呈现方式，不是可用能力。
 
 <table>
   <tr>
@@ -124,7 +131,7 @@ Mimi Remote 在不同设备上沿用同一套项目与会话模型，但界面�
 
 这套层级有几个明确原则：
 
-- **保留上下文：**iPad 侧栏持续展示项目和会话，右侧内容按任务变化；设置使用 Sheet，工作台不会突然消失。
+- **保留上下文：**iPhone 用紧凑层级把当前任务放在手边；iPad 侧栏持续展示项目和会话，右侧内容按任务变化；两端切换布局但不削减会话能力。
 - **渐进披露复杂度：**高频状态和动作靠近任务，首次设置、配对、诊断和深层偏好进入独立界面。
 - **先看状态，再做动作：**连接健康度、Runtime 就绪状态、剩余额度和权限模式会先于可能改变或中断任务的控制项出现。
 - **遵循各平台习惯：**iPhone 是紧凑触屏层级，iPad 是多栏工作台，Mac 是高密度菜单栏工具，而不是把一套布局拉伸到三块屏幕。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,11 +32,11 @@
 
 <table>
   <tr>
-    <td width="33%" valign="top" align="center">
+    <td width="33%" valign="middle" align="center">
       <img src="web/assets/iphone-workspace-light.png" alt="Mimi Remote 在 iPhone 上以紧凑单列展示项目、最近会话与 Runtime 选择" width="88%" />
     </td>
-    <td width="67%" valign="top" align="center">
-      <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote 在 iPad 上同时展示项目、最近会话与 Runtime 选择的工作区" width="100%" />
+    <td width="67%" valign="middle" align="center">
+      <img src="web/assets/ipad-workspace-light.png" alt="Mimi Remote 在 iPad 上同时展示项目、最近会话与 Runtime 选择的工作区" width="96%" />
     </td>
   </tr>
 </table>
@@ -142,60 +142,24 @@ Mimi Remote 在不同设备上沿用同一套项目与会话模型，但界面�
 
 ```mermaid
 flowchart LR
-    subgraph Mobile["移动设备"]
-        App["Mimi Remote<br/>SwiftUI 工作台"]
-        Keychain["Keychain<br/>每个 Mac Profile 一份访问 Token"]
-        Keychain -.-> App
-    end
+    Mobile["iPhone / iPad<br/>Mimi Remote"]
+    Gateway["你的 Mac<br/>agentd 安全网关"]
+    Codex["Codex<br/>共享 daemon 或受管 app-server"]
+    Claude["Claude Code<br/>实验 bridge"]
 
-    subgraph Mac["你的 Mac — 唯一控制面"]
-        Host["Mimi Remote Mac<br/>安装 · 配对 · Doctor · 服务生命周期"]
-        Agent["agentd<br/>认证 · REST API · WebSocket 网关 · 权限策略"]
-        Local["受限本地操作<br/>项目 · 文件 · Git · Worktree · Action"]
-        Codex["Codex app-server<br/>受管 loopback 进程"]
-        Bridge["alleycat-claude-bridge<br/>常驻 · 实验通道"]
-        Claude["Claude Code headless<br/>每个 thread 一个 stdio 进程"]
-        State["本机状态<br/>工作区 · 凭证 · 历史"]
-
-        Host -->|"启动与监控"| Agent
-        Agent -->|"校验后的本机 API"| Local
-        Agent -->|"过滤后的 JSON-RPC"| Codex
-        Agent -->|"稳定 session + cursor"| Bridge
-        Bridge -->|"stdio JSONL"| Claude
-        Local --> State
-        Codex --> State
-        Claude --> State
-    end
-
-    App -->|"Tailscale 或同一局域网<br/>Bearer Token · REST + WebSocket"| Agent
+    Mobile <-->|"局域网或 Tailscale<br/>实时会话与审批"| Gateway
+    Gateway <--> Codex
+    Gateway <--> Claude
 ```
 
-Mimi Remote 是原生客户端，不是另一台运行 Agent 的主机。所有远程请求都终止在你 Mac 上的 `agentd`；iOS 不会直接连接 Codex app-server、Claude Code、本机文件系统或项目维护者提供的云服务。
+这个仓库包含完整链路：iPhone / iPad 原生 App、Mac 菜单栏宿主、Go `agentd` 网关，以及 Claude Code 兼容 bridge。移动端只连接你自己的 Mac，项目文件、会话历史和 Runtime 凭证都留在宿主机。
 
-系统有三条清晰的调用路径：
+- **直连、响应快：**通过私有网络上的 REST 与 WebSocket 实时传递输出、追问、任务控制和审批，不经过 Mimi 运营的应用层中转。
+- **真正的会话接力：**Codex 可选择与 Codex Desktop 共用官方 local daemon，让 Mac 上空闲的原会话无需 fork 就能在移动端继续；默认和回滚链路仍使用独立受管 app-server。
+- **双 Runtime、统一体验：**Codex 是主 Runtime；可选的 Claude Code bridge 把会话与审批适配到同一套结构化移动界面。
+- **边界小而明确：**`agentd` 在 Mac 上完成认证、工作区授权和 Runtime 路由。Mac 需要保持唤醒并能从私有网络访问。
 
-1. **宿主生命周期：**Mimi Remote Mac 负责安装、配对、诊断、启动和监控 `agentd`，不经过每一条业务请求。命令行和 Linux 场景可以由 Homebrew 或 user-systemd 运行同一个 Go 服务。
-2. **受限本机能力：**项目发现、安全文件读取、Git、受管 Worktree、诊断、语音代理和配置 Action 都通过 `agentd` 的认证 REST API 完成，不需要绕经 Codex。
-3. **Agent 会话：**移动端只连接一个对外的 Codex-compatible JSON-RPC / WebSocket 网关。`agentd` 校验 runtime、method、由项目映射得到的工作目录、Payload 大小和连接预算，再把请求路由到主通道 Codex app-server 或实验通道 Claude bridge。
-
-Codex app-server 是由 `agentd` 管理的 loopback 进程，也是默认运行时。可选的常驻 Claude bridge 使用稳定 session key 和 replay cursor 承接移动端重连，并为每个活动 thread 管理一个 Claude Code headless stdio 进程。Provider 差异被限制在适配层内；移动端共用界面不代表两条通道功能完全一致。
-
-安全边界集中在 Mac：
-
-- 二维码只携带签名配对票据，不包含长期凭据；同一票据可在生成后的 10 分钟内重复兑换，换取到的长期 `agentd` Token 按 Mac Profile 保存到 Keychain。
-- app-server capability token 与 Provider 凭证不会离开 Mac；受管 app-server 只监听 loopback。
-- 客户端提交的项目 ID 必须通过配置中的项目 allowlist 解析；文件访问限制在项目根目录、`browse_roots` 和受管 Worktree。
-- Git 与 Worktree API 只暴露固定、经过参数校验的操作；通用命令必须预先配置为 Action，并受确认、超时、请求大小和输出上限约束。
-- 正常断线后通过 sequence / cursor 回放实时事件；超出回放窗口时读取本机权威历史，不会重新提交同一个 Turn。
-- 跨网络默认推荐 Tailscale；未安装时可在同一局域网直连。两种方式都不应把 `agentd` 暴露到公网。
-
-这套架构部署简单、边界可审计，但代价也很明确：Mac 必须保持唤醒并能从私有网络访问，`agentd` 与所选 Runtime 也必须健康。当前没有维护者运营的中继、云端状态同步或 APNs 后台执行链路。
-
-### Claude Code 为什么需要单独 bridge
-
-Claude bridge 位于本仓库 [`bridges/claude`](bridges/claude)，与 iOS 和 `agentd` 共用版本、CI 和发布入口。`agentd` 监督一个常驻 bridge，通过稳定 session key 把多次移动端 WebSocket 连接附着到同一运行时；每个 Claude thread 对应一个 Claude Code headless stdio JSONL 进程。
-
-该通道默认关闭并标记为实验功能。普通断线不会重新提交 `turn/start`，重连优先回放缺失事件，超出窗口时读取本机 Claude 历史；bridge 或 Mac 重启前尚未落盘的极短窗口仍可能丢失。`goal`、`archive` 和 `fork` 尚未开放，详细生命周期、权限和失败模式见 [Claude bridge 架构](docs/claude-bridge-architecture.md)。
+协议细节与准确能力边界见[项目现状](docs/project-status.md)、[Codex 共享 daemon](docs/codex-shared-daemon.md)和 [Claude bridge 架构](docs/claude-bridge-architecture.md)。
 
 ## 开始前检查
 


### PR DESCRIPTION
## 修改内容

- 重写中英文 README 首屏定位，突出 Codex 与 Claude Code 双 Runtime。
- 将核心叙事调整为 Mac、iPhone、iPad 之间的会话接力、实时跟进、继续对话和 App 内审批。
- 首屏同时展示 iPhone 与 iPad，明确两端能力一致、布局分别适配。
- 将 iPhone / iPad 首图改为垂直居中，并为 iPad 截图保留均衡的横向留白。
- 补充原生 SwiftUI、触控反馈、过渡动画与 Reduce Motion 边界。
- 将 Diff、Worktree、Git 和 PR 收尾降为进阶能力，不再按设备划分使用深度。
- 按最新 main 简化架构说明，突出直连、Codex Desktop 会话接力、双 Runtime 和 Mac 端安全边界，细节下沉到专项文档。

## 原因

现有 README 虽未直接使用 iPad-first，但通过首图、设备分工和 Git 收尾叙事，容易让读者误解为 iPhone 只适合查看、完整能力只属于 iPad / iPad Pro。新的定位与当前产品事实一致：Mimi Remote 同时适配 iPhone 与 iPad，支持 Codex 与 Claude Code，并让 Mac 上的 Agent 会话自然接力到移动端。

原架构段落细节过多，更像实现设计文档；首图又因两张截图宽高比不同导致 iPad 图贴顶、下方留白失衡。本轮将架构收成仓库级工作原理，并修正双设备截图的视觉平衡。

## 用户影响

首次访问仓库的用户能够更快理解 Mimi Remote 的主要价值、设备范围和完整仓库链路；已经实现的 Git / Worktree 能力与 Claude Code 实验状态仍保留准确边界。

## 验证

- `bash ./scripts/check-docs-static.sh`
- `git diff --check`
- GitHub Markdown API 实际渲染保留 `valign="middle"`、双列居中与 iPad `width="96%"`
- 检查新增 iPhone / iPad 图片路径可读取
- 检查双语核心定位存在、旧设备分级措辞已移除
- 检查 README HTML table 开闭标签数量一致

本次是 docs-only 修改，未启动 iOS 构建、Simulator 或真机。

Linear: MIM-147
