### PR TITLE
MIM-54 收敛 runtime 重启后的旧 Turn

### DIFF
--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -1081,17 +1081,7 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 		},
 	)
 	apiRouter.EnableTailscaleHostMetadata()
-	if appServerWSProcess != nil {
-		apiRouter.SetCodexRuntimeIdentity(
-			httpapi.CodexRuntimeKindManagedWebSocket,
-			appServerWSProcess.StartedAt(),
-		)
-	} else if !sharedDaemonStatus.StartedAt.IsZero() {
-		apiRouter.SetCodexRuntimeIdentity(
-			httpapi.CodexRuntimeKindLocalDaemon,
-			sharedDaemonStatus.StartedAt,
-		)
-	}
+	configureServeCodexRuntimeIdentity(apiRouter, appServerWSProcess, sharedDaemonStatus)
 	server := &http.Server{
 		Addr:              cfg.Listen,
 		Handler:           apiHandler,

--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -1082,9 +1082,15 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 	)
 	apiRouter.EnableTailscaleHostMetadata()
 	if appServerWSProcess != nil {
-		apiRouter.SetCodexRuntimeStartedAt(appServerWSProcess.StartedAt())
+		apiRouter.SetCodexRuntimeIdentity(
+			httpapi.CodexRuntimeKindManagedWebSocket,
+			appServerWSProcess.StartedAt(),
+		)
 	} else if !sharedDaemonStatus.StartedAt.IsZero() {
-		apiRouter.SetCodexRuntimeStartedAt(sharedDaemonStatus.StartedAt)
+		apiRouter.SetCodexRuntimeIdentity(
+			httpapi.CodexRuntimeKindLocalDaemon,
+			sharedDaemonStatus.StartedAt,
+		)
 	}
 	server := &http.Server{
 		Addr:              cfg.Listen,

--- a/cmd/agentd/serve_runtime_identity.go
+++ b/cmd/agentd/serve_runtime_identity.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
+	"github.com/gaixianggeng/mimi-remote/internal/httpapi"
+)
+
+// configureServeCodexRuntimeIdentity 把 serve 层实际启动的 upstream 身份交给 HTTP Router。
+// 只有真实 managed WebSocket 或 shared local daemon 启动时间可作为 runtime identity，
+// 外部 upstream 不写入身份，避免把 agentd 的启动时间误报为 Codex runtime 启动时间。
+func configureServeCodexRuntimeIdentity(
+	apiRouter *httpapi.Router,
+	appServerWSProcess *appserver.ManagedWebSocketProcess,
+	sharedDaemonStatus appserver.LocalDaemonStatus,
+) {
+	if appServerWSProcess != nil {
+		apiRouter.SetCodexRuntimeIdentity(
+			httpapi.CodexRuntimeKindManagedWebSocket,
+			appServerWSProcess.StartedAt(),
+		)
+	} else if !sharedDaemonStatus.StartedAt.IsZero() {
+		apiRouter.SetCodexRuntimeIdentity(
+			httpapi.CodexRuntimeKindLocalDaemon,
+			sharedDaemonStatus.StartedAt,
+		)
+	}
+}

--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -287,7 +287,10 @@ func (t *ExternalActivityTracker) Snapshot() ([]ExternalActivity, error) {
 		if entry.metaThreadID != candidate.ThreadID ||
 			!isTopLevelExternalThreadSource(entry.threadSource) ||
 			!entry.active ||
-			entry.gatewayOwned {
+			entry.gatewayOwned ||
+			t.hasGatewayInterruptedTurn(entry.metaThreadID, entry.turnID) {
+			// runtime 重启只证明账本里的精确旧 Turn 已结束；同 Thread 后续
+			// 新 Turn 的 ID 不匹配 tombstone，仍会恢复 external 只读保护。
 			continue
 		}
 		// SQLite cwd 和 session_meta cwd 都必须落在同一个白名单项目中。

--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -79,17 +79,23 @@ type externalRolloutCacheEntry struct {
 	gatewayTurnPending             bool
 	gatewayTurnPendingAt           time.Time
 	gatewayTurnPendingRegisteredAt time.Time
+	gatewayTurnPendingRuntimeKind  string
+	gatewayTurnPendingRuntimeStart time.Time
 	gatewayOwned                   bool
 	turnStartedAt                  time.Time
 }
 
 type gatewayTurnRegistration struct {
-	registeredAt time.Time
+	registeredAt     time.Time
+	runtimeKind      string
+	runtimeStartedAt time.Time
 }
 
 type gatewayTurnEvidence struct {
-	registeredAt time.Time
-	eventAt      time.Time
+	registeredAt     time.Time
+	eventAt          time.Time
+	runtimeKind      string
+	runtimeStartedAt time.Time
 }
 
 type externalRolloutRecord struct {
@@ -124,25 +130,29 @@ type ExternalActivityTracker struct {
 	// ownedGatewayTurns 是精确的 Thread+Turn 归属证据。生产环境可为它配置
 	// 私有 claim store，使 managed app-server 被重启强杀后，新 Tracker 仍能
 	// 区分旧 iPad turn 与真正的新 Mac turn。
-	ownedGatewayTurns   map[string]gatewayOwnedTurnClaim
-	gatewayClaimStore   *gatewayTurnClaimStore
-	gatewayClaimsLoaded bool
-	gatewayClaimsDirty  bool
-	diagnostics         ExternalActivityDiagnostics
+	ownedGatewayTurns       map[string]gatewayOwnedTurnClaim
+	interruptedGatewayTurns map[string]gatewayInterruptedTurn
+	gatewayClaimStore       *gatewayTurnClaimStore
+	gatewayClaimsLoaded     bool
+	gatewayClaimsDirty      bool
+	codexRuntimeKind        string
+	codexRuntimeStartedAt   time.Time
+	diagnostics             ExternalActivityDiagnostics
 }
 
 func NewExternalActivityTracker(db string, registry *projects.Registry) *ExternalActivityTracker {
 	return &ExternalActivityTracker{
-		store:               NewThreadStore(db),
-		registry:            registry,
-		now:                 time.Now,
-		stat:                os.Stat,
-		open:                os.Open,
-		query:               sqliteQueryFunc,
-		files:               map[string]externalRolloutCacheEntry{},
-		gatewayTurns:        map[string]gatewayTurnRegistration{},
-		ownedGatewayTurns:   map[string]gatewayOwnedTurnClaim{},
-		gatewayClaimsLoaded: true,
+		store:                   NewThreadStore(db),
+		registry:                registry,
+		now:                     time.Now,
+		stat:                    os.Stat,
+		open:                    os.Open,
+		query:                   sqliteQueryFunc,
+		files:                   map[string]externalRolloutCacheEntry{},
+		gatewayTurns:            map[string]gatewayTurnRegistration{},
+		ownedGatewayTurns:       map[string]gatewayOwnedTurnClaim{},
+		interruptedGatewayTurns: map[string]gatewayInterruptedTurn{},
+		gatewayClaimsLoaded:     true,
 	}
 }
 
@@ -200,7 +210,11 @@ func (t *ExternalActivityTracker) RegisterGatewayTurnStart(threadID string, clie
 		t.gatewayTurns = map[string]gatewayTurnRegistration{}
 	}
 	key := gatewayTurnRegistrationKey(threadID, clientUserMessageID)
-	t.gatewayTurns[key] = gatewayTurnRegistration{registeredAt: now}
+	t.gatewayTurns[key] = gatewayTurnRegistration{
+		registeredAt:     now,
+		runtimeKind:      t.codexRuntimeKind,
+		runtimeStartedAt: t.codexRuntimeStartedAt,
+	}
 	t.gatewayClaimsDirty = true
 	t.trimGatewayTurnClaims()
 	t.persistGatewayTurnClaims()
@@ -526,16 +540,18 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 			if matched &&
 				entry.active &&
 				gatewayTurnEvidenceMatchesTaskStart(evidence, entry.turnStartedAt) {
-				entry.gatewayOwned = true
-				t.setGatewayOwnedTurnClaim(
+				t.recordGatewayTurnOwnership(
 					entry.metaThreadID,
 					entry.turnID,
-					evidence.eventAt,
+					evidence,
 				)
+				entry.gatewayOwned = t.hasGatewayOwnedTurnClaim(entry.metaThreadID, entry.turnID)
 			} else if matched && !entry.active {
 				entry.gatewayTurnPending = true
 				entry.gatewayTurnPendingAt = evidence.eventAt
 				entry.gatewayTurnPendingRegisteredAt = evidence.registeredAt
+				entry.gatewayTurnPendingRuntimeKind = evidence.runtimeKind
+				entry.gatewayTurnPendingRuntimeStart = evidence.runtimeStartedAt
 			}
 		case "task_started":
 			turnStartedAt, _ := parseExternalRolloutTimestamp(record.Timestamp)
@@ -545,20 +561,26 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 			pendingOwned := entry.gatewayTurnPending &&
 				gatewayTurnEvidenceMatchesTaskStart(
 					gatewayTurnEvidence{
-						registeredAt: entry.gatewayTurnPendingRegisteredAt,
-						eventAt:      entry.gatewayTurnPendingAt,
+						registeredAt:     entry.gatewayTurnPendingRegisteredAt,
+						eventAt:          entry.gatewayTurnPendingAt,
+						runtimeKind:      entry.gatewayTurnPendingRuntimeKind,
+						runtimeStartedAt: entry.gatewayTurnPendingRuntimeStart,
 					},
 					turnStartedAt,
 				)
 			if pendingOwned {
-				t.setGatewayOwnedTurnClaim(
+				t.recordGatewayTurnOwnership(
 					entry.metaThreadID,
 					turnID,
-					entry.gatewayTurnPendingAt,
+					gatewayTurnEvidence{
+						registeredAt:     entry.gatewayTurnPendingRegisteredAt,
+						eventAt:          entry.gatewayTurnPendingAt,
+						runtimeKind:      entry.gatewayTurnPendingRuntimeKind,
+						runtimeStartedAt: entry.gatewayTurnPendingRuntimeStart,
+					},
 				)
 			}
-			entry.gatewayOwned = pendingOwned ||
-				t.hasGatewayOwnedTurnClaim(entry.metaThreadID, turnID)
+			entry.gatewayOwned = t.hasGatewayOwnedTurnClaim(entry.metaThreadID, turnID)
 			// 全量重扫会先经过历史 turn，不能让历史 task_started 删除时间更晚的
 			// 持久化 claim。只有时间上不早于 claim 的不同 turn 才能证明控制边界
 			// 已前进；没有 exact claim 的新 Mac turn 仍会恢复 external 只读保护。
@@ -574,6 +596,7 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 				terminalTurnID = entry.turnID
 			}
 			t.removeGatewayOwnedTurnClaim(entry.metaThreadID, terminalTurnID)
+			t.removeGatewayInterruptedTurn(entry.metaThreadID, terminalTurnID)
 			// 旧 turn 的迟到 terminal 不能终止已经开始的新 turn。
 			if turnID == "" || entry.turnID == "" || turnID == entry.turnID {
 				entry.active = false
@@ -590,6 +613,8 @@ func clearGatewayTurnPending(entry *externalRolloutCacheEntry) {
 	entry.gatewayTurnPending = false
 	entry.gatewayTurnPendingAt = time.Time{}
 	entry.gatewayTurnPendingRegisteredAt = time.Time{}
+	entry.gatewayTurnPendingRuntimeKind = ""
+	entry.gatewayTurnPendingRuntimeStart = time.Time{}
 }
 
 func expireGatewayTurnPending(entry *externalRolloutCacheEntry, now time.Time) bool {
@@ -635,8 +660,10 @@ func (t *ExternalActivityTracker) consumeGatewayTurnRegistration(
 		return gatewayTurnEvidence{}, false
 	}
 	return gatewayTurnEvidence{
-		registeredAt: registration.registeredAt,
-		eventAt:      eventAt,
+		registeredAt:     registration.registeredAt,
+		eventAt:          eventAt,
+		runtimeKind:      registration.runtimeKind,
+		runtimeStartedAt: registration.runtimeStartedAt,
 	}, true
 }
 

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -670,6 +670,16 @@ func TestExternalActivityManagedRuntimeRestartProjectsOwnedTurnAsInterrupted(t *
 		t.Fatal(err)
 	}
 	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+	path := fixture.writeRollout(
+		"thread-restarted",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(lastEvidenceAt, "task_started", "turn-restarted"),
+	)
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-restarted", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
 
 	fixture.tracker.SetCodexRuntimeIdentity("managed_websocket", now)
 	interrupted := fixture.tracker.GatewayInterruptedTurns("thread-restarted")
@@ -678,6 +688,19 @@ func TestExternalActivityManagedRuntimeRestartProjectsOwnedTurnAsInterrupted(t *
 	}
 	if len(fixture.tracker.ownedGatewayTurns) != 0 {
 		t.Fatalf("已被上一代进程终止的 owned claim 不应继续 active：%+v", fixture.tracker.ownedGatewayTurns)
+	}
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("精确中断 Turn 不得继续投影为 external running：%+v", got)
+	}
+
+	nextTurnAt := now.Add(time.Second)
+	fixture.appendLine(path, externalEventLineAt(nextTurnAt, "task_started", "turn-mac-next"))
+	if err := os.Chtimes(path, nextTurnAt, nextTurnAt); err != nil {
+		t.Fatal(err)
+	}
+	got := fixture.snapshot(t)
+	if len(got) != 1 || got[0].TurnID != "turn-mac-next" {
+		t.Fatalf("同 Thread 后续真正的 Mac Turn 必须恢复 external 只读：%+v", got)
 	}
 	stored, err := newGatewayTurnClaimStore(claimPath).load()
 	if err != nil {

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -244,6 +244,7 @@ func TestExternalActivityExcludesExactGatewayOwnedTurn(t *testing.T) {
 	fixture := newExternalActivityTrackerFixture(t)
 	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
 	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.SetCodexRuntimeIdentity("managed_websocket", now.Add(-10*time.Minute))
 	fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
 	// 即使 originator 是 mimi_remote，精确 Thread+Turn gateway claim 仍应排除该 turn。
 	path := fixture.writeRollout("thread-ipad", "mimi_remote", fixture.projectDir,
@@ -336,6 +337,7 @@ func TestExternalActivityAlsoSupportsUserMessageBeforeTaskStarted(t *testing.T) 
 	fixture := newExternalActivityTrackerFixture(t)
 	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
 	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.SetCodexRuntimeIdentity("managed_websocket", now.Add(-10*time.Minute))
 	fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
 	path := fixture.writeRollout("thread-ipad", "Codex Desktop", fixture.projectDir,
 		externalUserMessageLine(now.Add(100*time.Millisecond), "client-ipad"),
@@ -353,6 +355,10 @@ func TestExternalActivityAlsoSupportsUserMessageBeforeTaskStarted(t *testing.T) 
 	entry := fixture.tracker.files[path]
 	if !entry.active || !entry.gatewayOwned || entry.turnID != "turn-ipad" {
 		t.Fatalf("反向落盘顺序也应保留 gateway 归属：%+v", entry)
+	}
+	claim := fixture.tracker.ownedGatewayTurns[gatewayOwnedTurnClaimKey("thread-ipad", "turn-ipad")]
+	if claim.runtimeKind != "managed_websocket" || !claim.runtimeStartedAt.Equal(now.Add(-10*time.Minute)) {
+		t.Fatalf("反向落盘顺序必须保留 runtime identity：%+v", claim)
 	}
 }
 
@@ -641,6 +647,279 @@ func TestExternalActivityPersistentClaimSurvivesTrackerRestartAndCandidateGap(t 
 	}
 	if len(storedAfterMacTurn.Owned) != 0 {
 		t.Fatalf("不同的新 turn 必须清理旧 owned claim：%+v", storedAfterMacTurn.Owned)
+	}
+}
+
+func TestExternalActivityManagedRuntimeRestartProjectsOwnedTurnAsInterrupted(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	registeredAt := now.Add(-2 * time.Minute)
+	lastEvidenceAt := now.Add(-time.Minute)
+	oldRuntimeStartedAt := now.Add(-10 * time.Minute)
+	if err := newGatewayTurnClaimStore(claimPath).save(gatewayTurnClaimStoreFile{
+		Owned: []gatewayTurnOwnedClaimStoreEntry{{
+			ThreadID:         "thread-restarted",
+			TurnID:           "turn-restarted",
+			RegisteredAt:     registeredAt,
+			LastEvidenceAt:   lastEvidenceAt,
+			RuntimeKind:      "managed_websocket",
+			RuntimeStartedAt: oldRuntimeStartedAt,
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+
+	fixture.tracker.SetCodexRuntimeIdentity("managed_websocket", now)
+	interrupted := fixture.tracker.GatewayInterruptedTurns("thread-restarted")
+	if got := interrupted["turn-restarted"]; !got.Equal(now) {
+		t.Fatalf("managed runtime 重启后应记录精确中断 Turn：%+v", interrupted)
+	}
+	if len(fixture.tracker.ownedGatewayTurns) != 0 {
+		t.Fatalf("已被上一代进程终止的 owned claim 不应继续 active：%+v", fixture.tracker.ownedGatewayTurns)
+	}
+	stored, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Version != gatewayTurnClaimStoreVersion || len(stored.Owned) != 0 || len(stored.Interrupted) != 1 {
+		t.Fatalf("重启中断账本应原子持久化为 v2：%+v", stored)
+	}
+}
+
+func TestExternalActivityGatewayOwnedClaimPersistsRuntimeIdentity(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	runtimeStartedAt := now.Add(-10 * time.Minute)
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+	fixture.tracker.SetCodexRuntimeIdentity("managed_websocket", runtimeStartedAt)
+	fixture.tracker.RegisterGatewayTurnStart("thread-runtime-identity", "client-runtime-identity")
+	path := fixture.writeRollout(
+		"thread-runtime-identity",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(now.Add(100*time.Millisecond), "task_started", "turn-runtime-identity"),
+		externalUserMessageLine(now.Add(500*time.Millisecond), "client-runtime-identity"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-runtime-identity", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("当前 runtime 的 gateway Turn 不应成为 external：%+v", got)
+	}
+	stored, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored.Owned) != 1 ||
+		stored.Owned[0].RuntimeKind != "managed_websocket" ||
+		!stored.Owned[0].RuntimeStartedAt.Equal(runtimeStartedAt) {
+		t.Fatalf("精确 claim 必须绑定产生它的 runtime 类型与代际：%+v", stored.Owned)
+	}
+}
+
+func TestExternalActivitySharedRuntimeDoesNotInterruptNewerOwnedTurn(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	sharedRuntimeStartedAt := now.Add(-time.Hour)
+	if err := newGatewayTurnClaimStore(claimPath).save(gatewayTurnClaimStoreFile{
+		Owned: []gatewayTurnOwnedClaimStoreEntry{{
+			ThreadID:         "thread-shared",
+			TurnID:           "turn-shared",
+			RegisteredAt:     now.Add(-2 * time.Minute),
+			LastEvidenceAt:   now.Add(-time.Minute),
+			RuntimeKind:      "local_daemon",
+			RuntimeStartedAt: sharedRuntimeStartedAt,
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+
+	// shared daemon 比 Turn 更早启动；agentd 自身重启不代表 runtime 里的 Turn 消失。
+	fixture.tracker.SetCodexRuntimeIdentity("local_daemon", sharedRuntimeStartedAt)
+	if got := fixture.tracker.GatewayInterruptedTurns("thread-shared"); len(got) != 0 {
+		t.Fatalf("仍存活的 shared runtime Turn 不得被误标中断：%+v", got)
+	}
+	if len(fixture.tracker.ownedGatewayTurns) != 1 {
+		t.Fatalf("shared runtime 的精确 owned claim 应保留：%+v", fixture.tracker.ownedGatewayTurns)
+	}
+}
+
+func TestExternalActivityVersionOneClaimDoesNotGuessRestartInterruption(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	if err := os.MkdirAll(filepath.Dir(claimPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	v1 := fmt.Sprintf(
+		`{"version":1,"owned":[{"thread_id":"thread-v1","turn_id":"turn-v1","last_evidence_at":%q}]}`,
+		now.Add(-time.Hour).Format(time.RFC3339Nano),
+	)
+	if err := os.WriteFile(claimPath, []byte(v1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+
+	fixture.tracker.SetCodexRuntimeIdentity("managed_websocket", now)
+	if got := fixture.tracker.GatewayInterruptedTurns("thread-v1"); len(got) != 0 {
+		t.Fatalf("v1 claim 来源未知，不得猜测为重启中断：%+v", got)
+	}
+	stored, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Version != 2 || len(stored.Owned) != 0 || len(stored.Interrupted) != 0 {
+		t.Fatalf("v1 claim 应升级并安全撤销未知写归属：%+v", stored)
+	}
+}
+
+func TestExternalActivityRuntimeKindChangeDoesNotGuessInterruption(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	if err := newGatewayTurnClaimStore(claimPath).save(gatewayTurnClaimStoreFile{
+		Owned: []gatewayTurnOwnedClaimStoreEntry{{
+			ThreadID: "thread-kind-change", TurnID: "turn-kind-change",
+			RegisteredAt: now.Add(-2 * time.Minute), LastEvidenceAt: now.Add(-time.Minute),
+			RuntimeKind: "local_daemon", RuntimeStartedAt: now.Add(-time.Hour),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+
+	fixture.tracker.SetCodexRuntimeIdentity("managed_websocket", now)
+	if got := fixture.tracker.GatewayInterruptedTurns("thread-kind-change"); len(got) != 0 {
+		t.Fatalf("runtime 类型变化时旧进程可能仍存活，不得伪造中断：%+v", got)
+	}
+	if len(fixture.tracker.ownedGatewayTurns) != 0 {
+		t.Fatalf("当前 gateway 也不能沿用其他 runtime 的写归属：%+v", fixture.tracker.ownedGatewayTurns)
+	}
+}
+
+func TestExternalActivityConflictingOwnedAndInterruptedTurnFailsClosed(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	runtimeStartedAt := now.Add(-time.Hour)
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	if err := newGatewayTurnClaimStore(claimPath).save(gatewayTurnClaimStoreFile{
+		Owned: []gatewayTurnOwnedClaimStoreEntry{{
+			ThreadID: "thread-conflict", TurnID: "turn-conflict",
+			RegisteredAt: now.Add(-2 * time.Minute), LastEvidenceAt: now.Add(-time.Minute),
+			RuntimeKind: "local_daemon", RuntimeStartedAt: runtimeStartedAt,
+		}},
+		Interrupted: []gatewayTurnInterruptedStoreEntry{{
+			ThreadID: "thread-conflict", TurnID: "turn-conflict", InterruptedAt: now.Add(-30 * time.Second),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+
+	fixture.tracker.SetCodexRuntimeIdentity("local_daemon", runtimeStartedAt)
+	if len(fixture.tracker.ownedGatewayTurns) != 0 {
+		t.Fatalf("矛盾状态不得保留写归属：%+v", fixture.tracker.ownedGatewayTurns)
+	}
+	if got := fixture.tracker.GatewayInterruptedTurns("thread-conflict"); len(got) != 0 {
+		t.Fatalf("矛盾状态不得伪造中断投影：%+v", got)
+	}
+	stored, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored.Owned) != 0 || len(stored.Interrupted) != 0 {
+		t.Fatalf("矛盾状态应从私有账本清除：%+v", stored)
+	}
+}
+
+func TestExternalActivityLateTerminalClearsRestartInterruption(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	if err := newGatewayTurnClaimStore(claimPath).save(gatewayTurnClaimStoreFile{
+		Interrupted: []gatewayTurnInterruptedStoreEntry{{
+			ThreadID: "thread-late-terminal", TurnID: "turn-late-terminal", InterruptedAt: now.Add(-time.Minute),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fixture.replaceTrackerWithClaimStore(claimPath, func() time.Time { return now })
+	path := fixture.writeRollout(
+		"thread-late-terminal",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(now.Add(-2*time.Minute), "task_started", "turn-late-terminal"),
+		externalEventLineAt(now.Add(-30*time.Second), "task_complete", "turn-late-terminal"),
+	)
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-late-terminal", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("迟到 terminal 后不应残留 external activity：%+v", got)
+	}
+	if got := fixture.tracker.GatewayInterruptedTurns("thread-late-terminal"); len(got) != 0 {
+		t.Fatalf("上游已有真实 terminal 时应清理中断投影：%+v", got)
+	}
+	stored, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored.Interrupted) != 0 {
+		t.Fatalf("迟到 terminal 应同步清理落盘账本：%+v", stored.Interrupted)
+	}
+}
+
+func TestGatewayTurnClaimStoreMaximumValidEntriesFitSizeLimit(t *testing.T) {
+	now := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	stored := gatewayTurnClaimStoreFile{
+		Owned:       make([]gatewayTurnOwnedClaimStoreEntry, 0, gatewayTurnClaimStoreLimit),
+		Interrupted: make([]gatewayTurnInterruptedStoreEntry, 0, gatewayInterruptedTurnStoreLimit),
+	}
+	for index := 0; index < gatewayTurnClaimStoreLimit; index++ {
+		threadID := strings.Repeat("t", gatewayTurnRegistrationIDMax-6) + fmt.Sprintf("%06d", index)
+		turnID := strings.Repeat("u", gatewayTurnRegistrationIDMax-6) + fmt.Sprintf("%06d", index)
+		stored.Owned = append(stored.Owned, gatewayTurnOwnedClaimStoreEntry{
+			ThreadID: threadID, TurnID: turnID, RegisteredAt: now, LastEvidenceAt: now,
+			RuntimeKind: "managed_websocket", RuntimeStartedAt: now.Add(-time.Hour),
+		})
+	}
+	for index := 0; index < gatewayInterruptedTurnStoreLimit; index++ {
+		threadID := strings.Repeat("i", gatewayTurnRegistrationIDMax-6) + fmt.Sprintf("%06d", index)
+		turnID := strings.Repeat("v", gatewayTurnRegistrationIDMax-6) + fmt.Sprintf("%06d", index)
+		stored.Interrupted = append(stored.Interrupted, gatewayTurnInterruptedStoreEntry{
+			ThreadID: threadID, TurnID: turnID, InterruptedAt: now,
+		})
+	}
+	claimPath := filepath.Join(t.TempDir(), "state", "gateway-turn-claims.json")
+	if err := newGatewayTurnClaimStore(claimPath).save(stored); err != nil {
+		t.Fatalf("全部合法容量不应超过文件大小上限：%v", err)
+	}
+	info, err := os.Stat(claimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() > gatewayTurnClaimStoreMaxBytes {
+		t.Fatalf("claim store 超过大小上限：%d", info.Size())
+	}
+	loaded, err := newGatewayTurnClaimStore(claimPath).load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Owned) != gatewayTurnClaimStoreLimit ||
+		len(loaded.Interrupted) != gatewayInterruptedTurnStoreLimit {
+		t.Fatalf("最大合法条目未完整保存：owned=%d interrupted=%d", len(loaded.Owned), len(loaded.Interrupted))
 	}
 }
 

--- a/internal/codexhistory/gateway_turn_claim_store.go
+++ b/internal/codexhistory/gateway_turn_claim_store.go
@@ -625,6 +625,11 @@ func (t *ExternalActivityTracker) hasGatewayOwnedTurnClaim(threadID string, turn
 	return ok
 }
 
+func (t *ExternalActivityTracker) hasGatewayInterruptedTurn(threadID string, turnID string) bool {
+	_, ok := t.interruptedGatewayTurns[gatewayOwnedTurnClaimKey(threadID, turnID)]
+	return ok
+}
+
 func (t *ExternalActivityTracker) removeGatewayOwnedTurnClaim(threadID string, turnID string) {
 	key := gatewayOwnedTurnClaimKey(threadID, turnID)
 	if _, ok := t.ownedGatewayTurns[key]; !ok {

--- a/internal/codexhistory/gateway_turn_claim_store.go
+++ b/internal/codexhistory/gateway_turn_claim_store.go
@@ -16,9 +16,12 @@ import (
 )
 
 const (
-	gatewayTurnClaimStoreVersion  = 1
+	gatewayTurnClaimStoreVersion  = 2
 	gatewayTurnClaimStoreMaxBytes = 512 * 1024
 	gatewayTurnClaimStoreLimit    = 512
+	// interrupted 是已经确认被同类型 runtime 新代际终止的精确 Turn 账本。
+	// 它不使用时间 TTL，避免旧会话在若干天后重新显示为“处理中”；容量独立受限。
+	gatewayInterruptedTurnStoreLimit = 256
 	// 保持现有 40 分钟的 owned claim TTL。它只限制 gateway 归属证据的保存时长，
 	// 不决定 external turn 是否仍 active；claim 过期后会安全降级为只读 external。
 	gatewayOwnedTurnClaimTTL = 40 * time.Minute
@@ -27,27 +30,48 @@ const (
 )
 
 type gatewayOwnedTurnClaim struct {
-	threadID       string
-	turnID         string
-	lastEvidenceAt time.Time
+	threadID         string
+	turnID           string
+	registeredAt     time.Time
+	lastEvidenceAt   time.Time
+	runtimeKind      string
+	runtimeStartedAt time.Time
+}
+
+type gatewayInterruptedTurn struct {
+	threadID      string
+	turnID        string
+	interruptedAt time.Time
 }
 
 type gatewayTurnClaimStoreFile struct {
-	Version int                                 `json:"version"`
-	Pending []gatewayTurnPendingClaimStoreEntry `json:"pending,omitempty"`
-	Owned   []gatewayTurnOwnedClaimStoreEntry   `json:"owned,omitempty"`
+	Version     int                                 `json:"version"`
+	Pending     []gatewayTurnPendingClaimStoreEntry `json:"pending,omitempty"`
+	Owned       []gatewayTurnOwnedClaimStoreEntry   `json:"owned,omitempty"`
+	Interrupted []gatewayTurnInterruptedStoreEntry  `json:"interrupted,omitempty"`
 }
 
 type gatewayTurnPendingClaimStoreEntry struct {
 	ThreadID            string    `json:"thread_id"`
 	ClientUserMessageID string    `json:"client_user_message_id"`
 	RegisteredAt        time.Time `json:"registered_at"`
+	RuntimeKind         string    `json:"runtime_kind,omitempty"`
+	RuntimeStartedAt    time.Time `json:"runtime_started_at,omitempty"`
 }
 
 type gatewayTurnOwnedClaimStoreEntry struct {
-	ThreadID       string    `json:"thread_id"`
-	TurnID         string    `json:"turn_id"`
-	LastEvidenceAt time.Time `json:"last_evidence_at"`
+	ThreadID         string    `json:"thread_id"`
+	TurnID           string    `json:"turn_id"`
+	RegisteredAt     time.Time `json:"registered_at,omitempty"`
+	LastEvidenceAt   time.Time `json:"last_evidence_at"`
+	RuntimeKind      string    `json:"runtime_kind,omitempty"`
+	RuntimeStartedAt time.Time `json:"runtime_started_at,omitempty"`
+}
+
+type gatewayTurnInterruptedStoreEntry struct {
+	ThreadID      string    `json:"thread_id"`
+	TurnID        string    `json:"turn_id"`
+	InterruptedAt time.Time `json:"interrupted_at"`
 }
 
 type gatewayTurnClaimStore struct {
@@ -100,11 +124,14 @@ func (s *gatewayTurnClaimStore) load() (gatewayTurnClaimStoreFile, error) {
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 包含尾随内容")
 	}
-	if stored.Version != gatewayTurnClaimStoreVersion {
+	if stored.Version != 1 && stored.Version != gatewayTurnClaimStoreVersion {
 		return gatewayTurnClaimStoreFile{}, fmt.Errorf("不支持的 gateway turn claim store 版本 %d", stored.Version)
 	}
 	if len(stored.Pending)+len(stored.Owned) > gatewayTurnClaimStoreLimit {
 		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway turn claim store 超过数量上限")
+	}
+	if len(stored.Interrupted) > gatewayInterruptedTurnStoreLimit {
+		return gatewayTurnClaimStoreFile{}, fmt.Errorf("gateway interrupted turn store 超过数量上限")
 	}
 	return stored, nil
 }
@@ -200,6 +227,9 @@ func (t *ExternalActivityTracker) ensureGatewayTurnClaimsLoaded(now time.Time) {
 	if t.ownedGatewayTurns == nil {
 		t.ownedGatewayTurns = map[string]gatewayOwnedTurnClaim{}
 	}
+	if t.interruptedGatewayTurns == nil {
+		t.interruptedGatewayTurns = map[string]gatewayInterruptedTurn{}
+	}
 	if t.gatewayClaimStore == nil {
 		return
 	}
@@ -211,15 +241,27 @@ func (t *ExternalActivityTracker) ensureGatewayTurnClaimsLoaded(now time.Time) {
 		// 文件损坏、版本不支持或权限失败时不采用任何 claim，宁可保留只读保护。
 		return
 	}
+	if stored.Version != gatewayTurnClaimStoreVersion {
+		// v1 没有 interrupted 与 runtime identity；读取兼容，未知来源只撤销写归属，
+		// 下一次保存自动升级为 v2。
+		t.gatewayClaimsDirty = true
+	}
 
 	seen := map[string]struct{}{}
+	exactStates := map[string]string{}
 	for _, pending := range stored.Pending {
 		key := gatewayTurnRegistrationKey(pending.ThreadID, pending.ClientUserMessageID)
 		registeredAt := pending.RegisteredAt.UTC()
+		runtimeKind, runtimeStartedAt, runtimeIdentityOK := gatewayRuntimeIdentity(
+			pending.RuntimeKind,
+			pending.RuntimeStartedAt,
+			now,
+		)
 		if !validGatewayClaimID(pending.ThreadID) ||
 			!validGatewayClaimID(pending.ClientUserMessageID) ||
 			registeredAt.IsZero() ||
 			registeredAt.After(now.Add(gatewayTurnEventClockSkew)) ||
+			!runtimeIdentityOK ||
 			now.After(registeredAt.Add(gatewayTurnRegistrationTTL)) {
 			t.gatewayClaimsDirty = true
 			continue
@@ -229,16 +271,25 @@ func (t *ExternalActivityTracker) ensureGatewayTurnClaimsLoaded(now time.Time) {
 			continue
 		}
 		seen["pending\x00"+key] = struct{}{}
-		t.gatewayTurns[key] = gatewayTurnRegistration{registeredAt: registeredAt}
+		t.gatewayTurns[key] = gatewayTurnRegistration{
+			registeredAt: registeredAt, runtimeKind: runtimeKind, runtimeStartedAt: runtimeStartedAt,
+		}
 	}
 	for _, owned := range stored.Owned {
 		key := gatewayOwnedTurnClaimKey(owned.ThreadID, owned.TurnID)
 		lastEvidenceAt := owned.LastEvidenceAt.UTC()
+		registeredAt := owned.RegisteredAt.UTC()
+		runtimeKind, runtimeStartedAt, runtimeIdentityOK := gatewayRuntimeIdentity(
+			owned.RuntimeKind,
+			owned.RuntimeStartedAt,
+			now,
+		)
 		if !validGatewayClaimID(owned.ThreadID) ||
 			!validGatewayClaimID(owned.TurnID) ||
 			lastEvidenceAt.IsZero() ||
 			lastEvidenceAt.After(now.Add(gatewayTurnEventClockSkew)) ||
-			now.After(lastEvidenceAt.Add(gatewayOwnedTurnClaimTTL)) {
+			(!registeredAt.IsZero() && registeredAt.After(now.Add(gatewayTurnEventClockSkew))) ||
+			!runtimeIdentityOK {
 			t.gatewayClaimsDirty = true
 			continue
 		}
@@ -247,13 +298,67 @@ func (t *ExternalActivityTracker) ensureGatewayTurnClaimsLoaded(now time.Time) {
 			continue
 		}
 		seen["owned\x00"+key] = struct{}{}
-		t.ownedGatewayTurns[key] = gatewayOwnedTurnClaim{
-			threadID:       strings.TrimSpace(owned.ThreadID),
-			turnID:         strings.TrimSpace(owned.TurnID),
-			lastEvidenceAt: lastEvidenceAt,
+		exactStates[key] = "owned"
+		claim := gatewayOwnedTurnClaim{
+			threadID:         strings.TrimSpace(owned.ThreadID),
+			turnID:           strings.TrimSpace(owned.TurnID),
+			registeredAt:     registeredAt,
+			lastEvidenceAt:   lastEvidenceAt,
+			runtimeKind:      runtimeKind,
+			runtimeStartedAt: runtimeStartedAt,
+		}
+		if t.gatewayClaimInterruptedByCurrentRuntime(claim) {
+			t.setGatewayInterruptedTurn(claim.threadID, claim.turnID, t.codexRuntimeStartedAt)
+			continue
+		}
+		if !t.gatewayClaimBelongsToCurrentRuntime(claim) {
+			// runtime 类型变化或 v1 来源未知时不能猜测旧进程已退出；撤销写权限，
+			// 让 rollout 安全降级为 external 只读，但不伪造 interrupted 终态。
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		if now.After(lastEvidenceAt.Add(gatewayOwnedTurnClaimTTL)) {
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		t.ownedGatewayTurns[key] = claim
+	}
+	for _, interrupted := range stored.Interrupted {
+		key := gatewayOwnedTurnClaimKey(interrupted.ThreadID, interrupted.TurnID)
+		interruptedAt := interrupted.InterruptedAt.UTC()
+		if !validGatewayClaimID(interrupted.ThreadID) ||
+			!validGatewayClaimID(interrupted.TurnID) ||
+			interruptedAt.IsZero() ||
+			interruptedAt.After(now.Add(gatewayTurnEventClockSkew)) {
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		if _, duplicate := seen["interrupted\x00"+key]; duplicate {
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		seen["interrupted\x00"+key] = struct{}{}
+		if _, conflict := exactStates[key]; conflict {
+			// 同一精确 Turn 同时 owned + interrupted 是矛盾私有状态。
+			// 两边都不采用，恢复 external 只读且不伪造终态。
+			delete(t.ownedGatewayTurns, key)
+			delete(t.interruptedGatewayTurns, key)
+			t.gatewayClaimsDirty = true
+			continue
+		}
+		exactStates[key] = "interrupted"
+		if existing, ok := t.interruptedGatewayTurns[key]; ok &&
+			!interruptedAt.After(existing.interruptedAt) {
+			continue
+		}
+		t.interruptedGatewayTurns[key] = gatewayInterruptedTurn{
+			threadID:      strings.TrimSpace(interrupted.ThreadID),
+			turnID:        strings.TrimSpace(interrupted.TurnID),
+			interruptedAt: interruptedAt,
 		}
 	}
 	t.trimGatewayTurnClaims()
+	t.trimGatewayInterruptedTurns()
 }
 
 func (t *ExternalActivityTracker) persistGatewayTurnClaims() {
@@ -261,9 +366,10 @@ func (t *ExternalActivityTracker) persistGatewayTurnClaims() {
 		return
 	}
 	stored := gatewayTurnClaimStoreFile{
-		Version: gatewayTurnClaimStoreVersion,
-		Pending: make([]gatewayTurnPendingClaimStoreEntry, 0, len(t.gatewayTurns)),
-		Owned:   make([]gatewayTurnOwnedClaimStoreEntry, 0, len(t.ownedGatewayTurns)),
+		Version:     gatewayTurnClaimStoreVersion,
+		Pending:     make([]gatewayTurnPendingClaimStoreEntry, 0, len(t.gatewayTurns)),
+		Owned:       make([]gatewayTurnOwnedClaimStoreEntry, 0, len(t.ownedGatewayTurns)),
+		Interrupted: make([]gatewayTurnInterruptedStoreEntry, 0, len(t.interruptedGatewayTurns)),
 	}
 	for key, registration := range t.gatewayTurns {
 		threadID, clientID, ok := splitGatewayTurnClaimKey(key)
@@ -274,13 +380,25 @@ func (t *ExternalActivityTracker) persistGatewayTurnClaims() {
 			ThreadID:            threadID,
 			ClientUserMessageID: clientID,
 			RegisteredAt:        registration.registeredAt.UTC(),
+			RuntimeKind:         registration.runtimeKind,
+			RuntimeStartedAt:    registration.runtimeStartedAt.UTC(),
 		})
 	}
 	for _, owned := range t.ownedGatewayTurns {
 		stored.Owned = append(stored.Owned, gatewayTurnOwnedClaimStoreEntry{
-			ThreadID:       owned.threadID,
-			TurnID:         owned.turnID,
-			LastEvidenceAt: owned.lastEvidenceAt.UTC(),
+			ThreadID:         owned.threadID,
+			TurnID:           owned.turnID,
+			RegisteredAt:     owned.registeredAt.UTC(),
+			LastEvidenceAt:   owned.lastEvidenceAt.UTC(),
+			RuntimeKind:      owned.runtimeKind,
+			RuntimeStartedAt: owned.runtimeStartedAt.UTC(),
+		})
+	}
+	for _, interrupted := range t.interruptedGatewayTurns {
+		stored.Interrupted = append(stored.Interrupted, gatewayTurnInterruptedStoreEntry{
+			ThreadID:      interrupted.threadID,
+			TurnID:        interrupted.turnID,
+			InterruptedAt: interrupted.interruptedAt.UTC(),
 		})
 	}
 	sort.Slice(stored.Pending, func(i, j int) bool {
@@ -301,6 +419,15 @@ func (t *ExternalActivityTracker) persistGatewayTurnClaims() {
 		}
 		return stored.Owned[i].LastEvidenceAt.Before(stored.Owned[j].LastEvidenceAt)
 	})
+	sort.Slice(stored.Interrupted, func(i, j int) bool {
+		if stored.Interrupted[i].InterruptedAt.Equal(stored.Interrupted[j].InterruptedAt) {
+			if stored.Interrupted[i].ThreadID == stored.Interrupted[j].ThreadID {
+				return stored.Interrupted[i].TurnID < stored.Interrupted[j].TurnID
+			}
+			return stored.Interrupted[i].ThreadID < stored.Interrupted[j].ThreadID
+		}
+		return stored.Interrupted[i].InterruptedAt.Before(stored.Interrupted[j].InterruptedAt)
+	})
 	if err := t.gatewayClaimStore.save(stored); err != nil {
 		t.diagnostics.ClaimStoreErrors++
 		return
@@ -309,26 +436,164 @@ func (t *ExternalActivityTracker) persistGatewayTurnClaims() {
 	t.diagnostics.ClaimStoreWrites++
 }
 
-func (t *ExternalActivityTracker) setGatewayOwnedTurnClaim(threadID string, turnID string, evidenceAt time.Time) {
+func (t *ExternalActivityTracker) recordGatewayTurnOwnership(
+	threadID string,
+	turnID string,
+	evidence gatewayTurnEvidence,
+) {
 	threadID = strings.TrimSpace(threadID)
 	turnID = strings.TrimSpace(turnID)
-	if !validGatewayClaimID(threadID) || !validGatewayClaimID(turnID) || evidenceAt.IsZero() {
+	if !validGatewayClaimID(threadID) ||
+		!validGatewayClaimID(turnID) ||
+		evidence.registeredAt.IsZero() ||
+		evidence.eventAt.IsZero() {
 		return
 	}
-	evidenceAt = evidenceAt.UTC()
+	registeredAt := evidence.registeredAt.UTC()
+	evidenceAt := evidence.eventAt.UTC()
+	claim := gatewayOwnedTurnClaim{
+		threadID:         threadID,
+		turnID:           turnID,
+		registeredAt:     registeredAt,
+		lastEvidenceAt:   evidenceAt,
+		runtimeKind:      evidence.runtimeKind,
+		runtimeStartedAt: evidence.runtimeStartedAt.UTC(),
+	}
+	if t.gatewayClaimInterruptedByCurrentRuntime(claim) {
+		// 同类型 runtime 已进入更新代际，旧进程不可能继续承载这个精确 Turn。
+		t.setGatewayInterruptedTurn(threadID, turnID, t.codexRuntimeStartedAt)
+		t.removeGatewayOwnedTurnClaim(threadID, turnID)
+		return
+	}
+	if !t.gatewayClaimBelongsToCurrentRuntime(claim) {
+		// 类型变化或旧证据没有 runtime 身份时只撤销本机写归属，不能猜成终态。
+		t.removeGatewayOwnedTurnClaim(threadID, turnID)
+		return
+	}
 	key := gatewayOwnedTurnClaimKey(threadID, turnID)
 	existing, ok := t.ownedGatewayTurns[key]
 	if ok && !evidenceAt.After(existing.lastEvidenceAt) {
 		return
 	}
-	t.ownedGatewayTurns[key] = gatewayOwnedTurnClaim{
-		threadID:       threadID,
-		turnID:         turnID,
-		lastEvidenceAt: evidenceAt,
-	}
+	t.ownedGatewayTurns[key] = claim
+	t.removeGatewayInterruptedTurn(threadID, turnID)
 	t.gatewayClaimsDirty = true
 	t.removeOtherGatewayOwnedTurnClaims(threadID, turnID)
 	t.trimGatewayTurnClaims()
+}
+
+func (t *ExternalActivityTracker) gatewayClaimInterruptedByCurrentRuntime(claim gatewayOwnedTurnClaim) bool {
+	return gatewayRuntimeIdentityKnown(t.codexRuntimeKind, t.codexRuntimeStartedAt) &&
+		gatewayRuntimeIdentityKnown(claim.runtimeKind, claim.runtimeStartedAt) &&
+		t.codexRuntimeKind == claim.runtimeKind &&
+		t.codexRuntimeStartedAt.After(claim.runtimeStartedAt)
+}
+
+func (t *ExternalActivityTracker) gatewayClaimBelongsToCurrentRuntime(claim gatewayOwnedTurnClaim) bool {
+	if !gatewayRuntimeIdentityKnown(t.codexRuntimeKind, t.codexRuntimeStartedAt) {
+		return true
+	}
+	return gatewayRuntimeIdentityKnown(claim.runtimeKind, claim.runtimeStartedAt) &&
+		t.codexRuntimeKind == claim.runtimeKind &&
+		t.codexRuntimeStartedAt.Equal(claim.runtimeStartedAt)
+}
+
+func (t *ExternalActivityTracker) setGatewayInterruptedTurn(threadID string, turnID string, interruptedAt time.Time) {
+	threadID = strings.TrimSpace(threadID)
+	turnID = strings.TrimSpace(turnID)
+	interruptedAt = interruptedAt.UTC()
+	if !validGatewayClaimID(threadID) || !validGatewayClaimID(turnID) || interruptedAt.IsZero() {
+		return
+	}
+	key := gatewayOwnedTurnClaimKey(threadID, turnID)
+	existing, ok := t.interruptedGatewayTurns[key]
+	if ok && !interruptedAt.After(existing.interruptedAt) {
+		return
+	}
+	t.interruptedGatewayTurns[key] = gatewayInterruptedTurn{
+		threadID: threadID, turnID: turnID, interruptedAt: interruptedAt,
+	}
+	t.gatewayClaimsDirty = true
+	t.trimGatewayInterruptedTurns()
+}
+
+func (t *ExternalActivityTracker) removeGatewayInterruptedTurn(threadID string, turnID string) {
+	key := gatewayOwnedTurnClaimKey(threadID, turnID)
+	if _, ok := t.interruptedGatewayTurns[key]; !ok {
+		return
+	}
+	delete(t.interruptedGatewayTurns, key)
+	t.gatewayClaimsDirty = true
+}
+
+func (t *ExternalActivityTracker) trimGatewayInterruptedTurns() {
+	for len(t.interruptedGatewayTurns) > gatewayInterruptedTurnStoreLimit {
+		var oldestKey string
+		var oldestAt time.Time
+		for key, interrupted := range t.interruptedGatewayTurns {
+			if oldestKey == "" || interrupted.interruptedAt.Before(oldestAt) ||
+				(interrupted.interruptedAt.Equal(oldestAt) && key < oldestKey) {
+				oldestKey = key
+				oldestAt = interrupted.interruptedAt
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(t.interruptedGatewayTurns, oldestKey)
+		t.gatewayClaimsDirty = true
+	}
+}
+
+// SetCodexRuntimeIdentity 在 HTTP listener 开放前绑定当前 Codex runtime 类型与代际。
+// 只有“类型相同且启动代际更新”才能证明旧 Turn 的承载进程已经消失；runtime 类型
+// 变化或 v1 未知来源都保守降级为 external 只读，不能伪造 interrupted。
+func (t *ExternalActivityTracker) SetCodexRuntimeIdentity(kind string, startedAt time.Time) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now().UTC()
+	kind, startedAt, ok := gatewayRuntimeIdentity(kind, startedAt, now)
+	if !ok || !gatewayRuntimeIdentityKnown(kind, startedAt) {
+		return
+	}
+	t.codexRuntimeKind = kind
+	t.codexRuntimeStartedAt = startedAt
+	t.ensureGatewayTurnClaimsLoaded(now)
+	for key, claim := range t.ownedGatewayTurns {
+		switch {
+		case t.gatewayClaimInterruptedByCurrentRuntime(claim):
+			delete(t.ownedGatewayTurns, key)
+			t.setGatewayInterruptedTurn(claim.threadID, claim.turnID, t.codexRuntimeStartedAt)
+			t.gatewayClaimsDirty = true
+		case !t.gatewayClaimBelongsToCurrentRuntime(claim):
+			delete(t.ownedGatewayTurns, key)
+			t.gatewayClaimsDirty = true
+		}
+	}
+	t.persistGatewayTurnClaims()
+}
+
+// GatewayInterruptedTurns 返回同一 Thread 下已经确认中断的精确 Turn 投影。
+// 返回副本，避免 gateway 响应改写持有 Tracker 锁。
+func (t *ExternalActivityTracker) GatewayInterruptedTurns(threadID string) map[string]time.Time {
+	threadID = strings.TrimSpace(threadID)
+	if t == nil || !validGatewayClaimID(threadID) {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now().UTC()
+	t.ensureGatewayTurnClaimsLoaded(now)
+	result := map[string]time.Time{}
+	for _, interrupted := range t.interruptedGatewayTurns {
+		if interrupted.threadID == threadID {
+			result[interrupted.turnID] = interrupted.interruptedAt
+		}
+	}
+	return result
 }
 
 func (t *ExternalActivityTracker) refreshGatewayOwnedTurnClaim(
@@ -451,6 +716,26 @@ func validGatewayClaimID(value string) bool {
 	return value != "" &&
 		len(value) <= gatewayTurnRegistrationIDMax &&
 		!strings.ContainsRune(value, '\x00')
+}
+
+func gatewayRuntimeIdentity(kind string, startedAt time.Time, now time.Time) (string, time.Time, bool) {
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	startedAt = startedAt.UTC()
+	now = now.UTC()
+	if kind == "" && startedAt.IsZero() {
+		return "", time.Time{}, true
+	}
+	if kind == "" || len(kind) > 64 || strings.ContainsRune(kind, '\x00') || startedAt.IsZero() {
+		return "", time.Time{}, false
+	}
+	if !now.IsZero() && startedAt.After(now.Add(gatewayTurnEventClockSkew)) {
+		return "", time.Time{}, false
+	}
+	return kind, startedAt, true
+}
+
+func gatewayRuntimeIdentityKnown(kind string, startedAt time.Time) bool {
+	return strings.TrimSpace(kind) != "" && !startedAt.IsZero()
 }
 
 func gatewayOwnedTurnClaimKey(threadID string, turnID string) string {

--- a/internal/httpapi/appserver_gateway_interrupted_turns.go
+++ b/internal/httpapi/appserver_gateway_interrupted_turns.go
@@ -40,7 +40,7 @@ func (r *Router) rewriteInterruptedGatewayHistoryResponse(
 
 	changed := false
 	switch request.method {
-	case "thread/list", "thread/search":
+	case "thread/list":
 		threads, ok := result["data"].([]any)
 		if !ok {
 			break
@@ -51,6 +51,34 @@ func (r *Router) rewriteInterruptedGatewayHistoryResponse(
 				continue
 			}
 			listedThreadID := gatewayHistoryObjectID(thread)
+			if listedThreadID == "" {
+				continue
+			}
+			listedInterrupted := source.GatewayInterruptedTurns(listedThreadID)
+			if len(listedInterrupted) > 0 && rewriteInterruptedGatewayThread(thread, listedInterrupted) {
+				changed = true
+			}
+		}
+	case "thread/search":
+		rows, ok := result["data"].([]any)
+		if !ok {
+			break
+		}
+		for _, rawRow := range rows {
+			row, ok := rawRow.(map[string]any)
+			if !ok {
+				continue
+			}
+			thread, ok := row["thread"].(map[string]any)
+			if !ok {
+				continue
+			}
+			// thread/search 的 data 行自身只有 snippet + thread，没有 thread id；
+			// 必须从嵌套 Thread 取 tombstone 对应的 turns，避免把搜索行误当成 Thread。
+			listedThreadID := gatewayHistoryObjectID(thread)
+			if listedThreadID == "" {
+				continue
+			}
 			listedInterrupted := source.GatewayInterruptedTurns(listedThreadID)
 			if len(listedInterrupted) > 0 && rewriteInterruptedGatewayThread(thread, listedInterrupted) {
 				changed = true

--- a/internal/httpapi/appserver_gateway_interrupted_turns.go
+++ b/internal/httpapi/appserver_gateway_interrupted_turns.go
@@ -1,0 +1,142 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// rewriteInterruptedGatewayHistoryResponse 只改写已经由 managed runtime 代际
+// 精确确认中断的 Thread+Turn。它不按 thread 或时间猜测，避免同一会话后续真正的
+// 新 Turn 被旧中断状态清掉。
+func (r *Router) rewriteInterruptedGatewayHistoryResponse(
+	payload []byte,
+	request appServerGatewayPendingHistoryRequest,
+) ([]byte, bool) {
+	if r == nil {
+		return payload, false
+	}
+	source, ok := r.externalActivity.(gatewayInterruptedTurnSource)
+	if !ok {
+		return payload, false
+	}
+	threadID := strings.TrimSpace(request.threadID)
+	var interrupted map[string]time.Time
+	if threadID != "" {
+		interrupted = source.GatewayInterruptedTurns(threadID)
+		if len(interrupted) == 0 {
+			return payload, false
+		}
+	}
+
+	var frame map[string]any
+	if err := json.Unmarshal(payload, &frame); err != nil {
+		return payload, false
+	}
+	result, ok := frame["result"].(map[string]any)
+	if !ok {
+		return payload, false
+	}
+
+	changed := false
+	switch request.method {
+	case "thread/list", "thread/search":
+		threads, ok := result["data"].([]any)
+		if !ok {
+			break
+		}
+		for _, rawThread := range threads {
+			thread, ok := rawThread.(map[string]any)
+			if !ok {
+				continue
+			}
+			listedThreadID := gatewayHistoryObjectID(thread)
+			listedInterrupted := source.GatewayInterruptedTurns(listedThreadID)
+			if len(listedInterrupted) > 0 && rewriteInterruptedGatewayThread(thread, listedInterrupted) {
+				changed = true
+			}
+		}
+	case "thread/turns/list":
+		turns, ok := result["data"].([]any)
+		if ok {
+			changed = rewriteInterruptedGatewayTurns(turns, interrupted)
+		}
+	case "thread/read", "thread/resume":
+		thread, ok := result["thread"].(map[string]any)
+		if ok && gatewayHistoryObjectID(thread) == threadID {
+			changed = rewriteInterruptedGatewayThread(thread, interrupted)
+		}
+	}
+	if !changed {
+		return payload, false
+	}
+	rewritten, err := json.Marshal(frame)
+	if err != nil {
+		return payload, false
+	}
+	return rewritten, true
+}
+
+func rewriteInterruptedGatewayThread(thread map[string]any, interrupted map[string]time.Time) bool {
+	turns, ok := thread["turns"].([]any)
+	if !ok {
+		return false
+	}
+	changed := rewriteInterruptedGatewayTurns(turns, interrupted)
+	if !changed {
+		return false
+	}
+	for _, rawTurn := range turns {
+		turn, ok := rawTurn.(map[string]any)
+		if !ok || !gatewayHistoryTurnTerminal(turn) {
+			// 未知或非终态可能是更新的真实 Turn；保留 active thread 状态。
+			return true
+		}
+	}
+	thread["status"] = map[string]any{"type": "idle"}
+	return true
+}
+
+func rewriteInterruptedGatewayTurns(turns []any, interrupted map[string]time.Time) bool {
+	changed := false
+	for _, rawTurn := range turns {
+		turn, ok := rawTurn.(map[string]any)
+		if !ok {
+			continue
+		}
+		turnID := gatewayHistoryObjectID(turn)
+		interruptedAt, ok := interrupted[turnID]
+		if !ok || gatewayHistoryTurnTerminal(turn) {
+			continue
+		}
+		turn["status"] = "interrupted"
+		if completedAt, exists := turn["completedAt"]; !exists || completedAt == nil {
+			turn["completedAt"] = interruptedAt.Unix()
+		}
+		changed = true
+	}
+	return changed
+}
+
+func gatewayHistoryObjectID(object map[string]any) string {
+	for _, key := range []string{"id", "turnId", "threadId", "sessionId"} {
+		if value, ok := object[key].(string); ok {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func gatewayHistoryTurnTerminal(turn map[string]any) bool {
+	status, _ := turn["status"].(string)
+	status = strings.ToLower(strings.TrimSpace(status))
+	status = strings.NewReplacer("_", "", "-", "", " ", "").Replace(status)
+	switch status {
+	case "completed", "complete", "failed", "error", "interrupted", "cancelled", "canceled", "aborted":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/httpapi/appserver_gateway_interrupted_turns_test.go
+++ b/internal/httpapi/appserver_gateway_interrupted_turns_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
+
 	"github.com/gaixianggeng/mimi-remote/internal/codexhistory"
 )
 
@@ -161,6 +163,79 @@ func TestGatewayPolicyRewritesInterruptedTurnHistoryResponse(t *testing.T) {
 	}
 	if len(response.Result.Data) != 1 || response.Result.Data[0].Status != "interrupted" {
 		t.Fatalf("gateway 输出未收敛为 interrupted：%s", forwarded)
+	}
+}
+
+func TestGatewayPolicyRewritesInterruptedSearchThreadThroughSanitize(t *testing.T) {
+	interruptedAt := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	policy, projectDir, _ := newThreadSearchPolicy(t)
+	policy.router.externalActivity = &interruptedTurnTestSource{turns: map[string]map[string]time.Time{
+		"thread-search": {"turn-search-old": interruptedAt},
+	}}
+	request := []byte(`{"id":92,"method":"thread/search","params":{"searchTerm":"reconcile","limit":1}}`)
+	if _, policyErr := policy.validateClientFrame(websocket.TextMessage, request); policyErr != nil {
+		t.Fatalf("合法 thread/search 请求不应被拒绝：%+v", policyErr)
+	}
+	response, err := json.Marshal(map[string]any{
+		"id": 92,
+		"result": map[string]any{
+			"data": []any{
+				map[string]any{
+					"snippet": "search hit",
+					"thread": map[string]any{
+						"id":      "thread-search",
+						"cwd":     projectDir,
+						"status":  map[string]any{"type": "active"},
+						"preview": "keep-me",
+						"turns": []any{
+							map[string]any{"id": "turn-search-old", "status": "inProgress"},
+							map[string]any{"id": "turn-search-new", "status": "inProgress"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	forwarded, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, response)
+	if policyErr != nil || !forward {
+		t.Fatalf("thread/search 响应应经过 gateway policy 后透传：forward=%t err=%+v", forward, policyErr)
+	}
+	var decoded struct {
+		Result struct {
+			Data []struct {
+				Snippet string `json:"snippet"`
+				Thread  struct {
+					ID      string `json:"id"`
+					Preview string `json:"preview"`
+					Status  struct {
+						Type string `json:"type"`
+					} `json:"status"`
+					Turns []struct {
+						ID     string `json:"id"`
+						Status string `json:"status"`
+					} `json:"turns"`
+				} `json:"thread"`
+			} `json:"data"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(forwarded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Result.Data) != 1 {
+		t.Fatalf("sanitize 后应保留一个合法搜索条目：%s", forwarded)
+	}
+	item := decoded.Result.Data[0]
+	if item.Snippet != "search hit" || item.Thread.ID != "thread-search" || item.Thread.Preview != "keep-me" {
+		t.Fatalf("sanitize 后应保留搜索行和嵌套 Thread 原始字段：%s", forwarded)
+	}
+	if len(item.Thread.Turns) != 2 || item.Thread.Turns[0].Status != "interrupted" {
+		t.Fatalf("嵌套 Thread 中精确命中的旧 Turn 应为 interrupted：%s", forwarded)
+	}
+	if item.Thread.Turns[1].Status != "inProgress" {
+		t.Fatalf("同 Thread 的新 active Turn 不得被旧 tombstone 改写：%s", forwarded)
 	}
 }
 

--- a/internal/httpapi/appserver_gateway_interrupted_turns_test.go
+++ b/internal/httpapi/appserver_gateway_interrupted_turns_test.go
@@ -1,0 +1,212 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/codexhistory"
+)
+
+type interruptedTurnTestSource struct {
+	turns map[string]map[string]time.Time
+}
+
+func (s *interruptedTurnTestSource) Snapshot() ([]codexhistory.ExternalActivity, error) {
+	return []codexhistory.ExternalActivity{}, nil
+}
+
+func (s *interruptedTurnTestSource) SetCodexRuntimeIdentity(string, time.Time) {}
+
+func (s *interruptedTurnTestSource) GatewayInterruptedTurns(threadID string) map[string]time.Time {
+	result := map[string]time.Time{}
+	for turnID, interruptedAt := range s.turns[threadID] {
+		result[turnID] = interruptedAt
+	}
+	return result
+}
+
+func TestRewriteInterruptedGatewayTurnsListIsExact(t *testing.T) {
+	interruptedAt := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	router := &Router{externalActivity: &interruptedTurnTestSource{turns: map[string]map[string]time.Time{
+		"thread-1": {"turn-old": interruptedAt},
+	}}}
+	payload := []byte(`{"id":1,"result":{"data":[{"id":"turn-old","status":"inProgress","completedAt":null,"items":[]},{"id":"turn-new","status":"inProgress","items":[]}],"nextCursor":null}}`)
+
+	rewritten, changed := router.rewriteInterruptedGatewayHistoryResponse(payload, appServerGatewayPendingHistoryRequest{
+		method: "thread/turns/list", threadID: "thread-1",
+	})
+	if !changed {
+		t.Fatal("精确命中的旧 Turn 应被改写")
+	}
+	var response struct {
+		Result struct {
+			Data []struct {
+				ID          string `json:"id"`
+				Status      string `json:"status"`
+				CompletedAt *int64 `json:"completedAt"`
+			} `json:"data"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(rewritten, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Result.Data[0].Status != "interrupted" ||
+		response.Result.Data[0].CompletedAt == nil ||
+		*response.Result.Data[0].CompletedAt != interruptedAt.Unix() {
+		t.Fatalf("旧 Turn 中断投影异常：%s", rewritten)
+	}
+	if response.Result.Data[1].Status != "inProgress" || response.Result.Data[1].CompletedAt != nil {
+		t.Fatalf("后续真实新 Turn 不得被旧账本误改：%s", rewritten)
+	}
+}
+
+func TestRewriteInterruptedGatewayThreadReadReturnsIdleOnlyWithoutNewActiveTurn(t *testing.T) {
+	interruptedAt := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	router := &Router{externalActivity: &interruptedTurnTestSource{turns: map[string]map[string]time.Time{
+		"thread-1": {"turn-old": interruptedAt},
+	}}}
+	tests := []struct {
+		name       string
+		turns      string
+		wantStatus string
+	}{
+		{name: "only interrupted turn", turns: `[{"id":"turn-old","status":"inProgress"}]`, wantStatus: "idle"},
+		{name: "new active turn survives", turns: `[{"id":"turn-old","status":"inProgress"},{"id":"turn-new","status":"running"}]`, wantStatus: "active"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := []byte(`{"id":2,"result":{"thread":{"id":"thread-1","status":{"type":"active"},"turns":` + tc.turns + `}}}`)
+			rewritten, changed := router.rewriteInterruptedGatewayHistoryResponse(payload, appServerGatewayPendingHistoryRequest{
+				method: "thread/read", threadID: "thread-1", includeTurns: true,
+			})
+			if !changed {
+				t.Fatal("thread/read 应投影精确中断 Turn")
+			}
+			var response struct {
+				Result struct {
+					Thread struct {
+						Status struct {
+							Type string `json:"type"`
+						} `json:"status"`
+						Turns []struct {
+							ID     string `json:"id"`
+							Status string `json:"status"`
+						} `json:"turns"`
+					} `json:"thread"`
+				} `json:"result"`
+			}
+			if err := json.Unmarshal(rewritten, &response); err != nil {
+				t.Fatal(err)
+			}
+			if response.Result.Thread.Status.Type != tc.wantStatus {
+				t.Fatalf("thread status 不符合预期：want=%s payload=%s", tc.wantStatus, rewritten)
+			}
+			if response.Result.Thread.Turns[0].Status != "interrupted" {
+				t.Fatalf("旧 Turn 应为 interrupted：%s", rewritten)
+			}
+		})
+	}
+}
+
+func TestRewriteInterruptedGatewayHistoryPreservesUpstreamTerminal(t *testing.T) {
+	router := &Router{externalActivity: &interruptedTurnTestSource{turns: map[string]map[string]time.Time{
+		"thread-1": {"turn-old": time.Now().UTC()},
+	}}}
+	payload := []byte(`{"id":3,"result":{"data":[{"id":"turn-old","status":"completed","completedAt":1786423200}]}}`)
+	rewritten, changed := router.rewriteInterruptedGatewayHistoryResponse(payload, appServerGatewayPendingHistoryRequest{
+		method: "thread/turns/list", threadID: "thread-1",
+	})
+	if changed || string(rewritten) != string(payload) {
+		t.Fatalf("上游已有真实终态时不得覆盖：%s", rewritten)
+	}
+}
+
+func TestGatewayPolicyRewritesInterruptedTurnHistoryResponse(t *testing.T) {
+	interruptedAt := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	router := &Router{externalActivity: &interruptedTurnTestSource{turns: map[string]map[string]time.Time{
+		"thread-policy": {"turn-policy": interruptedAt},
+	}}}
+	policy := &appServerGatewayPolicy{
+		router:         router,
+		runtimeID:      "codex",
+		pendingHistory: map[string]appServerGatewayPendingHistoryRequest{},
+		historyBudgets: map[string]appServerGatewayHistoryBudget{},
+	}
+	id := json.RawMessage(`91`)
+	if policyErr := policy.reserveHistoryRequest(&id, "thread/turns/list", map[string]any{
+		"threadId":  "thread-policy",
+		"limit":     json.Number("20"),
+		"itemsView": "summary",
+	}, 128); policyErr != nil {
+		t.Fatalf("登记 history 请求失败：%+v", policyErr)
+	}
+	payload := []byte(`{"id":91,"result":{"data":[{"id":"turn-policy","status":"inProgress","items":[]}]}}`)
+	forwarded, forward, policyErr := policy.observeUpstreamFrame(1, payload)
+	if policyErr != nil || !forward {
+		t.Fatalf("history 响应应成功透传：forward=%t err=%+v", forward, policyErr)
+	}
+	if string(forwarded) == string(payload) {
+		t.Fatalf("gateway 策略应调用精确中断投影：%s", forwarded)
+	}
+	var response struct {
+		Result struct {
+			Data []struct {
+				Status string `json:"status"`
+			} `json:"data"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(forwarded, &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Result.Data) != 1 || response.Result.Data[0].Status != "interrupted" {
+		t.Fatalf("gateway 输出未收敛为 interrupted：%s", forwarded)
+	}
+}
+
+func TestRewriteInterruptedGatewayThreadListOnlyChangesRowsWithTurns(t *testing.T) {
+	interruptedAt := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	router := &Router{externalActivity: &interruptedTurnTestSource{turns: map[string]map[string]time.Time{
+		"thread-with-turns": {"turn-old": interruptedAt},
+		"thread-metadata":   {"turn-metadata": interruptedAt},
+	}}}
+	payload := []byte(`{"id":4,"result":{"data":[{"id":"thread-with-turns","status":{"type":"active"},"turns":[{"id":"turn-old","status":"inProgress"}]},{"id":"thread-metadata","status":{"type":"active"}}]}}`)
+
+	rewritten, changed := router.rewriteInterruptedGatewayHistoryResponse(payload, appServerGatewayPendingHistoryRequest{
+		method: "thread/list",
+	})
+	if !changed {
+		t.Fatal("带 turns 的列表行应立即收敛")
+	}
+	var response struct {
+		Result struct {
+			Data []struct {
+				Status struct {
+					Type string `json:"type"`
+				} `json:"status"`
+			} `json:"data"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(rewritten, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Result.Data[0].Status.Type != "idle" {
+		t.Fatalf("带精确 turns 的旧列表行应 idle：%s", rewritten)
+	}
+	if response.Result.Data[1].Status.Type != "active" {
+		t.Fatalf("无 turns 的 metadata 行不能猜测状态：%s", rewritten)
+	}
+}
+
+func TestRewriteInterruptedGatewayResumeWithoutTurnsDoesNotGuess(t *testing.T) {
+	router := &Router{externalActivity: &interruptedTurnTestSource{turns: map[string]map[string]time.Time{
+		"thread-resume": {"turn-old": time.Now().UTC()},
+	}}}
+	payload := []byte(`{"id":5,"result":{"thread":{"id":"thread-resume","status":{"type":"active"}}}}`)
+	rewritten, changed := router.rewriteInterruptedGatewayHistoryResponse(payload, appServerGatewayPendingHistoryRequest{
+		method: "thread/resume", threadID: "thread-resume",
+	})
+	if changed || string(rewritten) != string(payload) {
+		t.Fatalf("resume 没有 turns 时不能按线程猜测终态：%s", rewritten)
+	}
+}

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -174,6 +174,9 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 				if redacted, changed := p.router.redactInlineHistoryImagesInGatewayResponse(payload); changed {
 					payload = redacted
 				}
+				if reconciled, changed := p.router.rewriteInterruptedGatewayHistoryResponse(payload, pending); changed {
+					payload = reconciled
+				}
 				if !pending.redactOnly &&
 					appServerGatewayHistoryResponseCapBytes > 0 &&
 					len(payload) > appServerGatewayHistoryResponseCapBytes {

--- a/internal/httpapi/external_activity.go
+++ b/internal/httpapi/external_activity.go
@@ -18,6 +18,11 @@ type gatewayTurnStartRegistrar interface {
 	RegisterGatewayTurnStart(threadID string, clientUserMessageID string)
 }
 
+type gatewayInterruptedTurnSource interface {
+	SetCodexRuntimeIdentity(kind string, startedAt time.Time)
+	GatewayInterruptedTurns(threadID string) map[string]time.Time
+}
+
 type externalActivityResponse struct {
 	Activities []codexhistory.ExternalActivity `json:"activities"`
 	ScannedAt  time.Time                       `json:"scanned_at"`

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -19,6 +19,11 @@ import (
 )
 
 const (
+	CodexRuntimeKindManagedWebSocket = "managed_websocket"
+	CodexRuntimeKindLocalDaemon      = "local_daemon"
+)
+
+const (
 	runtimeStatusRefreshTimeout = 9 * time.Second
 	runtimeStatusSuccessTTL     = 5 * time.Minute
 	runtimeStatusFailureTTL     = 15 * time.Second
@@ -301,6 +306,18 @@ func (r *Router) SetCodexRuntimeStartedAt(startedAt time.Time) {
 	r.runtimeProcessMu.Lock()
 	r.codexRuntimeStartedAt = startedAt.UTC()
 	r.runtimeProcessMu.Unlock()
+}
+
+// SetCodexRuntimeIdentity 同时记录状态接口所需的启动时间，并把稳定 runtime 类型
+// 交给精确 Turn tracker。类型不同的 runtime 可能同时存活，不能只靠时间比较。
+func (r *Router) SetCodexRuntimeIdentity(kind string, startedAt time.Time) {
+	if r == nil {
+		return
+	}
+	r.SetCodexRuntimeStartedAt(startedAt)
+	if source, ok := r.externalActivity.(gatewayInterruptedTurnSource); ok {
+		source.SetCodexRuntimeIdentity(kind, startedAt)
+	}
 }
 
 func (r *Router) codexRuntimeStartTime() *time.Time {


### PR DESCRIPTION
## 目标

修复 agentd/runtime 重启后，历史 Turn 缺少终态而导致 iOS 长期显示“处理中”的问题。

## 方案

- 持久化精确 Thread+Turn claim，并记录 runtime kind 与启动代际。
- 仅在同一种 runtime 的更新代际能够证明旧进程消失时写入 interrupted tombstone。
- managed/shared 切换、v1 未知来源和已存在 local daemon 启动时间未知时保持保守，只撤销写权限，不猜测终态。
- 仅改写 thread/turns/list、thread/read、thread/resume 以及确实携带 turns 的 thread 列表响应；不按 thread 批量清除，不覆盖上游终态。
- iOS 现有 interrupted 收敛逻辑可直接消费，无需 App 生产代码变更。

## 验证

- go test ./... -count=1
- go test -race ./internal/codexhistory -run TestExternalActivity... -count=1
- go test -race ./internal/httpapi -run TestRewriteInterruptedGateway... -count=1
- iOS ConversationDataFlowTests 两个中断恢复用例通过
- 本机安装 agentd 0.3.1+mac.14 后 process_ok/service_ok=true
- 真实会话 019fb604-f752-70e3-accc-bb1080c9c834 的目标 Turn 经 WebSocket thread/turns/list 返回 interrupted

## 已知边界

附着到已经存在的官方 local daemon 时无法安全推断其启动时间，因此重启后不会自动伪造 interrupted，只会回退到只读外部活动；这是刻意的 fail-closed 行为。

Linear: MIM-54