### PR TITLE
MIM-154 修复切换设备后的会话列表冲突

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		154000000000000000000001 /* SessionStoreWorkspaceRuntimePagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154000000000000000000002 /* SessionStoreWorkspaceRuntimePagination.swift */; };
+		154000000000000000000003 /* WorkspaceSessionSingleFlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154000000000000000000004 /* WorkspaceSessionSingleFlightTests.swift */; };
 		0209F743D168F03B03894AB0 /* FileAttachmentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55F20982430C816BB70A7F5 /* FileAttachmentModelsTests.swift */; };
 		038DE2248E14CF16EC1AAB30 /* SessionContextModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E033E7A8267D3C3494835305 /* SessionContextModels.swift */; };
 		03E7996441667D59DF2F9E3A /* CameraAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AAB784C642D2B0234E48BA /* CameraAttachmentTests.swift */; };
@@ -324,6 +326,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		154000000000000000000002 /* SessionStoreWorkspaceRuntimePagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreWorkspaceRuntimePagination.swift; sourceTree = "<group>"; };
+		154000000000000000000004 /* WorkspaceSessionSingleFlightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionSingleFlightTests.swift; sourceTree = "<group>"; };
 		00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCrowdedCompactWidth.1.png; sourceTree = "<group>"; };
 		025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeTests.swift; sourceTree = "<group>"; };
 		02BA631A94730FC521FE15F6 /* AssistantTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantTextNormalizer.swift; sourceTree = "<group>"; };
@@ -782,6 +786,7 @@
 				85879EDF3D64609C3C6BA873 /* WorkspaceGitSummaryTests.swift */,
 				B75153DC244B9C9543B87E2E /* WorkspaceSessionAuthoritativeContinuationTests.swift */,
 				C896DA13C5A44DA224A17CAB /* WorkspaceSessionLoadingTests.swift */,
+				154000000000000000000004 /* WorkspaceSessionSingleFlightTests.swift */,
 				E9BCF1B2E13945C6F706C8BD /* WorkspaceSessionPresentationTests.swift */,
 				327AF69020E348B4AE9F7BBE /* WorkspaceVisualSnapshotTests.swift */,
 				7DD567ECF6024FEEF09274D5 /* __Snapshots__ */,
@@ -1181,6 +1186,7 @@
 				D78D8C49C36228C60EF5D096 /* SessionStoreLifecycleWorkspaces.swift */,
 				DC7DA3118F7DF5B276A9BE1D /* SessionStoreNetworking.swift */,
 				C5A44E24BB7F5E7F9FD31191 /* SessionStoreProjectsGit.swift */,
+				154000000000000000000002 /* SessionStoreWorkspaceRuntimePagination.swift */,
 				3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */,
 				A38A8CE5A8F1D7EE3889F078 /* SessionStoreTurns.swift */,
 				1F63FE197E70AD192F429877 /* ThemeStore.swift */,
@@ -1514,6 +1520,7 @@
 				951475AE3120CB42A905E3B3 /* WorkspaceGitSummaryTests.swift in Sources */,
 				B7D06C05B900E3DC9336891D /* WorkspaceSessionAuthoritativeContinuationTests.swift in Sources */,
 				EA70EC72EE3F9B6B81CF4E71 /* WorkspaceSessionLoadingTests.swift in Sources */,
+				154000000000000000000003 /* WorkspaceSessionSingleFlightTests.swift in Sources */,
 				5B378569754B50364C872318 /* WorkspaceSessionPresentationTests.swift in Sources */,
 				626E053AFAE30F345EEFC01D /* WorkspaceVisualSnapshotTests.swift in Sources */,
 			);
@@ -1639,6 +1646,7 @@
 				5B092289C5F40E2A9B3622B9 /* SessionStoreLifecycleWorkspaces.swift in Sources */,
 				509445C02B3E5D545DB2808B /* SessionStoreNetworking.swift in Sources */,
 				A71327B3931B9947D3A58A5E /* SessionStoreProjectsGit.swift in Sources */,
+				154000000000000000000001 /* SessionStoreWorkspaceRuntimePagination.swift in Sources */,
 				5CD51AE13B5D23F8FBE444C5 /* SessionStoreSupport.swift in Sources */,
 				D4B700AC9DF628887258F469 /* SessionStoreTurns.swift in Sources */,
 				FE5964208A6DD5D8EF26BAC8 /* SettingsChoiceRow.swift in Sources */,

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 /// Projects/Git 请求必须把主机身份和 client 一起冻结；endpoint 切换后不能重新从全局工厂取 client。
-private struct ProjectsGitHostLease {
+struct ProjectsGitHostLease {
     let scope: HostScope
     let client: any SessionStoreAPIClient
 }
 
 // 文件预览、命令动作、Git、项目列表与网络恢复按工作区能力集中。
 extension SessionStore {
-    private func captureProjectsGitHostLease() throws -> ProjectsGitHostLease {
+    func captureProjectsGitHostLease() throws -> ProjectsGitHostLease {
         let scope = appStore.activeHostScope
         let client = try clientFactory()
         return ProjectsGitHostLease(scope: scope, client: client)
@@ -22,7 +22,7 @@ extension SessionStore {
         !Task.isCancelled && isProjectsGitHostCurrent(lease)
     }
 
-    private func requireCurrentProjectsGitHost(_ lease: ProjectsGitHostLease) throws {
+    func requireCurrentProjectsGitHost(_ lease: ProjectsGitHostLease) throws {
         guard canApplyProjectsGitResult(lease) else {
             throw CancellationError()
         }
@@ -1562,49 +1562,6 @@ extension SessionStore {
             }
             setErrorMessage(error.localizedDescription)
         }
-    }
-
-    /// 工作区详情按 Runtime 独立分页。opaque cursor 原样归属于当前 Runtime，View 只缓存展示窗口；
-    /// canonical Store 仍吸收 raw rows，保证打开会话时已有正确的路由和上下文。
-    func workspaceRuntimeSessionsPage(
-        projectID: String,
-        runtimeProvider: String,
-        cursor: String?,
-        limit: Int,
-        excludingListableSessionIDs: Set<SessionID> = []
-    ) async throws -> SessionsPage {
-        guard let workspace = ensureWorkspaceForKnownProjectID(projectID) else {
-            throw CancellationError()
-        }
-        let lease = try captureProjectsGitHostLease()
-        let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
-        let page = try await sessionListPageFillingPresentationWindow(
-            client: lease.client,
-            workspace: workspace,
-            runtimeProvider: normalizedRuntime,
-            cursor: cursor,
-            limit: max(1, limit),
-            consistency: .authoritative,
-            source: cursor == nil ? .workspaceForeground : .workspaceLoadMore,
-            expectedHostScope: lease.scope,
-            excludingListableSessionIDs: excludingListableSessionIDs
-        )
-        try requireCurrentProjectsGitHost(lease)
-
-        let prepared = sessions(page.sessions, in: workspace).map(sessionPreparedForStorage)
-        mergeSessionPage(prepared)
-        clearWorkspaceUnavailable(workspace.id)
-
-        let listable = prepared.filter { session in
-            isListableSession(session)
-                && !excludingListableSessionIDs.contains(session.id)
-                && Self.normalizedRuntimeProvider(session.runtimeProvider ?? session.source) == normalizedRuntime
-        }
-        return SessionsPage(
-            sessions: SessionIndexStore.sortedSessions(listable),
-            nextCursor: page.nextCursor,
-            hasMore: page.hasMore
-        )
     }
 
     func refreshSelectedProjectSessions(showLoading: Bool = true) async {

--- a/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+extension SessionStore {
+    /// 工作区详情按 Runtime 独立分页。Codex 首屏复用 canonical single-flight，
+    /// opaque cursor 和 Claude 请求仍独立归属于当前 Runtime。
+    func workspaceRuntimeSessionsPage(
+        projectID: String,
+        runtimeProvider: String,
+        cursor: String?,
+        limit: Int,
+        excludingListableSessionIDs: Set<SessionID> = []
+    ) async throws -> SessionsPage {
+        guard let workspace = ensureWorkspaceForKnownProjectID(projectID) else {
+            throw CancellationError()
+        }
+        let lease = try captureProjectsGitHostLease()
+        let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
+        let requestedLimit = max(1, limit)
+        let page: SessionsPage
+        var canonicalFirstPageResult: SessionListFirstPageResult?
+        if normalizedRuntime == "codex",
+           cursor == nil,
+           excludingListableSessionIDs.isEmpty {
+            // Host 切换后的 refreshAll 与工作区 View 会同时请求 Codex 首屏。直接调用
+            // client 会让后发 thread/list 被 app-server 以 -32080 拒绝。
+            let result = try await sessionListFirstPage(
+                workspace: workspace,
+                limit: requestedLimit,
+                reuseRecent: false,
+                consistency: .authoritative,
+                source: .workspaceForeground,
+                client: lease.client,
+                hostScope: lease.scope
+            )
+            canonicalFirstPageResult = result
+            page = result.page
+        } else {
+            page = try await sessionListPageFillingPresentationWindow(
+                client: lease.client,
+                workspace: workspace,
+                runtimeProvider: normalizedRuntime,
+                cursor: cursor,
+                limit: requestedLimit,
+                consistency: .authoritative,
+                source: cursor == nil ? .workspaceForeground : .workspaceLoadMore,
+                expectedHostScope: lease.scope,
+                excludingListableSessionIDs: excludingListableSessionIDs
+            )
+        }
+        try requireCurrentProjectsGitHost(lease)
+
+        let prepared = sessions(page.sessions, in: workspace).map(sessionPreparedForStorage)
+        if let canonicalFirstPageResult {
+            // 复用 canonical 请求也必须提交同一条 authoritative cursor 的推进结果；
+            // 否则 child-dense 首屏会反复从旧 continuation 重拉，View 与 Store 看到两套进度。
+            _ = applyWorkspaceSessionFirstPage(
+                workspace: workspace,
+                page: page,
+                consistency: .authoritative,
+                requestedCursor: canonicalFirstPageResult.requestedCursor,
+                // Runtime 页面只拿到 Codex rows，不能整页替换并误删同工作区已缓存的
+                // Claude 会话或旧分页；沿用该入口原先的 merge-only 展示语义。
+                preserveAllLoaded: true
+            )
+        } else {
+            mergeSessionPage(prepared)
+            clearWorkspaceUnavailable(workspace.id)
+        }
+
+        let listable = prepared.filter { session in
+            isListableSession(session)
+                && !excludingListableSessionIDs.contains(session.id)
+                && Self.normalizedRuntimeProvider(session.runtimeProvider ?? session.source) == normalizedRuntime
+        }
+        return SessionsPage(
+            sessions: SessionIndexStore.sortedSessions(listable),
+            nextCursor: page.nextCursor,
+            hasMore: page.hasMore
+        )
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionSingleFlightTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionSingleFlightTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testWorkspaceRuntimeCodexFirstPageWaitsForHostBootstrapFastRequest() async throws {
+        let project = makeProject(id: "workspace_runtime_fast_then_foreground")
+        let workspace = AgentWorkspace(
+            project: project,
+            lastOpenedAt: Date(timeIntervalSince1970: 100)
+        )
+        let sparseSession = makeSession(
+            id: "thread_runtime_fast",
+            projectID: project.id,
+            title: "快速索引结果",
+            status: "history",
+            source: "codex",
+            runtimeProvider: "codex"
+        )
+        let authoritativeSession = makeSession(
+            id: "thread_runtime_authoritative",
+            projectID: project.id,
+            title: "切换设备后首次可见",
+            status: "history",
+            source: "codex",
+            runtimeProvider: "codex"
+        )
+        let client = WorkspaceRuntimeFastThenAuthoritativeClient(
+            projects: [project],
+            fastPage: SessionsPage(sessions: [sparseSession]),
+            authoritativePage: SessionsPage(sessions: [authoritativeSession])
+        )
+        let appStore = makeIsolatedAppStore()
+        let suiteName = "WorkspaceRuntimeSingleFlight.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let recentWorkspaceStore = RecentWorkspaceStore(defaults: defaults)
+        recentWorkspaceStore.save(
+            [workspace],
+            profileID: appStore.notificationRoutingProfileID
+        )
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: recentWorkspaceStore,
+            clientFactory: { client }
+        )
+
+        let connectionRefresh = Task { @MainActor in
+            await store.refreshAll(autoAttach: true)
+        }
+        await client.waitForBlockedFastRequest()
+        var workspaceForegroundStarted = false
+        let workspaceForeground = Task { @MainActor in
+            workspaceForegroundStarted = true
+            return try await store.workspaceRuntimeSessionsPage(
+                projectID: project.id,
+                runtimeProvider: "codex",
+                cursor: nil,
+                limit: SessionStore.initialSessionPageLimit
+            )
+        }
+        while !workspaceForegroundStarted {
+            await Task.yield()
+        }
+
+        var snapshot = await client.snapshot()
+        XCTAssertEqual(snapshot.callCount, 1, "fastIndexed 未结束前不能并发启动前台 thread/list")
+        XCTAssertEqual(snapshot.maximumConcurrentRequestCount, 1)
+
+        await client.releaseFastRequest()
+        let page = try await workspaceForeground.value
+        await connectionRefresh.value
+
+        snapshot = await client.snapshot()
+        XCTAssertEqual(snapshot.callCount, 2)
+        XCTAssertEqual(snapshot.consistencies, [.fastIndexed, .authoritative])
+        XCTAssertEqual(snapshot.maximumConcurrentRequestCount, 1)
+        XCTAssertEqual(page.sessions.map(\.id), [authoritativeSession.id])
+        XCTAssertEqual(store.workspaceSessionFirstPageConsistency(projectID: project.id), .authoritative)
+        XCTAssertTrue(store.sessionListFirstPageInFlightByKey.isEmpty)
+    }
+
+    func testWorkspaceRuntimeCodexFirstPageCommitsAuthoritativeContinuation() async throws {
+        let project = makeProject(id: "workspace_runtime_continuation")
+        let seed = makeSession(
+            id: "thread_runtime_seed",
+            projectID: project.id,
+            title: "已扫描会话",
+            status: "history",
+            source: "codex",
+            runtimeProvider: "codex"
+        )
+        let continued = makeSession(
+            id: "thread_runtime_continued",
+            projectID: project.id,
+            title: "续页会话",
+            status: "history",
+            source: "codex",
+            runtimeProvider: "codex"
+        )
+        let retainedClaude = makeSession(
+            id: "thread_runtime_retained_claude",
+            projectID: project.id,
+            title: "已缓存 Claude 会话",
+            status: "history",
+            source: "claude",
+            runtimeProvider: "claude"
+        )
+        let retainedOlderCodex = makeSession(
+            id: "thread_runtime_retained_older_codex",
+            projectID: project.id,
+            title: "已加载旧分页",
+            status: "history",
+            source: "codex",
+            runtimeProvider: "codex"
+        )
+        let client = WorkspaceRuntimeContinuationClient(
+            projects: [project],
+            page: SessionsPage(sessions: [continued])
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        store.recentWorkspaces = [AgentWorkspace(project: project)]
+        store.sessions = [seed, retainedClaude, retainedOlderCodex]
+        let workspace = try XCTUnwrap(store.workspacesByID[project.id])
+        let completionKey = store.workspaceSessionFirstPageKey(for: workspace)
+        store.workspaceSessionFirstPageCompletionByKey[completionKey] = WorkspaceSessionFirstPageCompletion(
+            consistency: .authoritative,
+            isPresentationWindowComplete: false,
+            continuationCursor: "runtime-continuation",
+            scannedSessionIDs: [seed.id],
+            completedAt: Date(timeIntervalSince1970: 10)
+        )
+
+        let page = try await store.workspaceRuntimeSessionsPage(
+            projectID: project.id,
+            runtimeProvider: "codex",
+            cursor: nil,
+            limit: SessionStore.initialSessionPageLimit
+        )
+
+        let requestedCursors = await client.requestedCursors()
+        XCTAssertEqual(requestedCursors, ["runtime-continuation"])
+        XCTAssertEqual(Set(page.sessions.map(\.id)), Set([seed.id, continued.id]))
+        XCTAssertEqual(
+            Set(store.sessions.map(\.id)),
+            Set([seed.id, continued.id, retainedClaude.id, retainedOlderCodex.id]),
+            "Runtime 首屏提交 cursor 时不能删除其他 Runtime 或旧分页的 canonical sessions"
+        )
+        let completion = try XCTUnwrap(store.workspaceSessionFirstPageCompletionByKey[completionKey])
+        XCTAssertEqual(completion.consistency, .authoritative)
+        XCTAssertTrue(completion.isPresentationWindowComplete)
+        XCTAssertNil(completion.continuationCursor)
+        XCTAssertEqual(Set(completion.scannedSessionIDs), Set([seed.id, continued.id]))
+    }
+}
+
+private struct WorkspaceRuntimeClientSnapshot: Sendable {
+    let callCount: Int
+    let consistencies: [SessionListConsistency]
+    let maximumConcurrentRequestCount: Int
+}
+
+private actor WorkspaceRuntimeFastThenAuthoritativeState {
+    let projects: [AgentProject]
+    let fastPage: SessionsPage
+    let authoritativePage: SessionsPage
+    var callCount = 0
+    var consistencies: [SessionListConsistency] = []
+    var concurrentRequestCount = 0
+    var maximumConcurrentRequestCount = 0
+    var fastContinuation: CheckedContinuation<SessionsPage, Never>?
+    var fastWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(projects: [AgentProject], fastPage: SessionsPage, authoritativePage: SessionsPage) {
+        self.projects = projects
+        self.fastPage = fastPage
+        self.authoritativePage = authoritativePage
+    }
+
+    func availableProjects() -> [AgentProject] { projects }
+    func authoritativeSessions() -> [AgentSession] { authoritativePage.sessions }
+
+    func sessionsPage(consistency: SessionListConsistency) async -> SessionsPage {
+        callCount += 1
+        consistencies.append(consistency)
+        concurrentRequestCount += 1
+        maximumConcurrentRequestCount = max(maximumConcurrentRequestCount, concurrentRequestCount)
+        defer { concurrentRequestCount -= 1 }
+        guard consistency == .fastIndexed else {
+            return authoritativePage
+        }
+        return await withCheckedContinuation { continuation in
+            fastContinuation = continuation
+            let waiters = fastWaiters
+            fastWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    func waitForBlockedFastRequest() async {
+        guard fastContinuation == nil else { return }
+        await withCheckedContinuation { continuation in
+            guard fastContinuation == nil else {
+                continuation.resume()
+                return
+            }
+            fastWaiters.append(continuation)
+        }
+    }
+
+    func releaseFastRequest() {
+        fastContinuation?.resume(returning: fastPage)
+        fastContinuation = nil
+    }
+
+    func snapshot() -> WorkspaceRuntimeClientSnapshot {
+        WorkspaceRuntimeClientSnapshot(
+            callCount: callCount,
+            consistencies: consistencies,
+            maximumConcurrentRequestCount: maximumConcurrentRequestCount
+        )
+    }
+}
+
+private final class WorkspaceRuntimeFastThenAuthoritativeClient: SessionStoreAPIClient {
+    private let state: WorkspaceRuntimeFastThenAuthoritativeState
+
+    init(projects: [AgentProject], fastPage: SessionsPage, authoritativePage: SessionsPage) {
+        state = WorkspaceRuntimeFastThenAuthoritativeState(
+            projects: projects,
+            fastPage: fastPage,
+            authoritativePage: authoritativePage
+        )
+    }
+
+    func projects() async throws -> [AgentProject] { await state.availableProjects() }
+
+    func sessions(projectID: String?, cursor: String?, limit: Int?) async throws -> [AgentSession] {
+        await state.authoritativeSessions()
+    }
+
+    func sessionsPage(
+        workspace: AgentWorkspace,
+        cursor: String?,
+        limit: Int?,
+        consistency: SessionListConsistency
+    ) async throws -> SessionsPage {
+        await state.sessionsPage(consistency: consistency)
+    }
+
+    func waitForBlockedFastRequest() async { await state.waitForBlockedFastRequest() }
+    func releaseFastRequest() async { await state.releaseFastRequest() }
+    func snapshot() async -> WorkspaceRuntimeClientSnapshot { await state.snapshot() }
+
+    func session(id: String, afterSeq: EventSequence?) async throws -> SessionResponse {
+        throw MockError.unimplemented
+    }
+
+    func createSession(_ payload: CreateSessionRequest) async throws -> CreateSessionResponse {
+        throw MockError.unimplemented
+    }
+
+    func stopSession(id: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func messages(sessionID: String, before: String?, limit: Int?) async throws -> [CodexHistoryMessage] {
+        []
+    }
+}
+
+private actor WorkspaceRuntimeContinuationState {
+    let projects: [AgentProject]
+    let page: SessionsPage
+    var cursors: [String?] = []
+
+    init(projects: [AgentProject], page: SessionsPage) {
+        self.projects = projects
+        self.page = page
+    }
+
+    func availableProjects() -> [AgentProject] { projects }
+    func availableSessions() -> [AgentSession] { page.sessions }
+
+    func sessionsPage(cursor: String?) -> SessionsPage {
+        cursors.append(cursor)
+        return page
+    }
+}
+
+private final class WorkspaceRuntimeContinuationClient: SessionStoreAPIClient {
+    private let state: WorkspaceRuntimeContinuationState
+
+    init(projects: [AgentProject], page: SessionsPage) {
+        state = WorkspaceRuntimeContinuationState(projects: projects, page: page)
+    }
+
+    func projects() async throws -> [AgentProject] { await state.availableProjects() }
+
+    func sessions(projectID: String?, cursor: String?, limit: Int?) async throws -> [AgentSession] {
+        await state.availableSessions()
+    }
+
+    func sessionsPage(
+        workspace: AgentWorkspace,
+        cursor: String?,
+        limit: Int?,
+        consistency: SessionListConsistency
+    ) async throws -> SessionsPage {
+        await state.sessionsPage(cursor: cursor)
+    }
+
+    func requestedCursors() async -> [String?] { await state.cursors }
+
+    func session(id: String, afterSeq: EventSequence?) async throws -> SessionResponse {
+        throw MockError.unimplemented
+    }
+
+    func createSession(_ payload: CreateSessionRequest) async throws -> CreateSessionResponse {
+        throw MockError.unimplemented
+    }
+
+    func stopSession(id: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func messages(sessionID: String, before: String?, limit: Int?) async throws -> [CodexHistoryMessage] {
+        []
+    }
+}


### PR DESCRIPTION
## 目标

修复 iOS 切换 Host 后首次打开工作区时，`refreshAll(autoAttach: true)` 与 WorkspaceRoot 同时发起 `thread/list`，导致 app-server 返回 `-32080` 的问题。

## 方案

- Codex 工作区首屏进入 Store 现有 canonical single-flight，fastIndexed 与 authoritative 请求串行执行。
- authoritative continuation 由同一 requestedCursor 门禁提交，并保留已缓存的 Claude 会话和旧 Codex 分页。
- Claude、load-more cursor 和带 exclusion 的分页继续走各自 Runtime 请求，不扩大本次修复范围。

## 验证

- 生产顺序回归：`refreshAll(autoAttach:true)` fastIndexed → Workspace foreground authoritative，最大并发数为 1。
- continuation 回归：游标单调完成，Claude 与旧 Codex canonical sessions 不丢失。
- 相关并发/取消回归：7 tests，0 failures。
- 排除当前 iOS 27 Beta 下失配的 `ConversationSnapshotTests`、`SkillModelPickerSnapshotTests` 后：1271 tests，3 skipped，0 failures。
- `bash ./scripts/verify-change.sh`：7/7 通过。
- `git diff --check`、PBX plist、源码体积门禁通过。

## 本地环境说明

完整测试曾运行 1321 项；19 个失败均来自上述两个未改动的视觉快照类，在 Xcode 27 Beta 5 / iOS 27 Simulator 下发生基线像素失配，功能测试无失败。