### PR TITLE
MIM-157 由稳定 LaunchAgent 托管共享 Codex daemon

### DIFF
--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -999,35 +999,22 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 	switch strings.ToLower(strings.TrimSpace(cfg.AppServer.Transport)) {
 	case "unix":
 		if cfg.AppServer.Managed {
-			// 官方 daemon 冷启动自身最多等待约 10 秒；外层留出进程创建与握手余量。
-			ensureCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-			status, ensureErr := appserver.EnsureLocalDaemon(ensureCtx, appserver.LocalDaemonOptions{
-				CodexBin: cfg.Codex.Bin,
-				Env:      cfg.Codex.Env,
-			})
+			// launchd 启动和官方 daemon 初始化都是异步的；外层覆盖最慢的冷启动。
+			ensureCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			mimiOwned := cfg.AppServer.SharedFallback != nil
+			options := appserver.LocalDaemonOptions{
+				CodexBin: cfg.Codex.Bin, Env: cfg.Codex.Env, StableOwner: mimiOwned, AttachOnly: !mimiOwned,
+			}
+			status, ensureErr := appserver.EnsureLocalDaemon(ensureCtx, options)
 			cancel()
 			if ensureErr != nil {
 				return fmt.Errorf("准备共享 Codex local daemon 失败：%w", ensureErr)
 			}
-			// live socket 可连接不代表重启后还能恢复。共享模式只接受官方 daemon
-			// 管理且 standalone 完整的生命周期，避免下次登录后 LaunchAgent 持续失败。
-			lifecycleCtx, cancelLifecycle := context.WithTimeout(context.Background(), 5*time.Second)
-			lifecycle, lifecycleErr := appserver.InspectLocalDaemonLifecycle(lifecycleCtx, appserver.LocalDaemonOptions{
-				CodexBin: cfg.Codex.Bin,
-				Env:      cfg.Codex.Env,
-			})
-			cancelLifecycle()
-			if lifecycleErr != nil {
-				return fmt.Errorf("确认共享 Codex local daemon 生命周期失败：%w", lifecycleErr)
-			}
-			if lifecycleErr := appserver.ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); lifecycleErr != nil {
-				return fmt.Errorf("共享 Codex local daemon 无法冷启动恢复：%w", lifecycleErr)
-			}
-			if identityErr := appserver.ValidateLocalDaemonProbeVersion(lifecycle, status.Version); identityErr != nil {
-				return fmt.Errorf("共享 Codex local daemon 身份校验失败：%w", identityErr)
+			if mimiOwned && !status.LifecycleValidated {
+				return fmt.Errorf("共享 Codex local daemon 未完成稳定 owner 生命周期校验")
 			}
 			sharedDaemonStatus = status
-			log.Printf("agentd shared Codex local daemon ready started=%t", status.Started)
+			log.Printf("agentd Codex local daemon ready started=%t mimi_owned=%t", status.Started, mimiOwned)
 		} else {
 			log.Printf("agentd external Codex local daemon upstream configured")
 		}

--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -740,6 +741,8 @@ func runNetwork(args []string) error {
 }
 
 func runDoctor(args []string) error {
+	doctorCtx, cancelDoctor := context.WithTimeout(context.Background(), 75*time.Second)
+	defer cancelDoctor()
 	checkPort := false
 	asJSON := false
 	fix := false
@@ -760,12 +763,17 @@ func runDoctor(args []string) error {
 		if !fix {
 			return err
 		}
-		fixes, repairedChecker, repairedResults, repairErr := rebuildDoctorConfig(context.Background(), configPath, checkPort)
+		fixes, repairedChecker, repairedResults, repairErr := rebuildDoctorConfig(doctorCtx, configPath, checkPort)
 		if repairErr != nil {
 			return fmt.Errorf("%v；自动修复也失败：%w", err, repairErr)
 		}
+		restartRequired := len(fixes) > 0
 		if asJSON {
-			return printJSON(map[string]any{"fixes": fixes, "results": repairedResults})
+			return printJSON(map[string]any{
+				"fixes":            fixes,
+				"results":          repairedResults,
+				"restart_required": restartRequired,
+			})
 		}
 		fmt.Fprintf(os.Stdout, "配置加载失败，已尝试自动修复：%v\n\n", err)
 		if len(fixes) > 0 {
@@ -776,16 +784,20 @@ func runDoctor(args []string) error {
 			fmt.Fprintln(os.Stdout)
 		}
 		doctor.Print(os.Stdout, repairedResults)
+		if restartRequired {
+			fmt.Fprintln(os.Stdout, "\n配置已更新，需要重启 agentd 后生效。")
+		}
 		_ = repairedChecker
 		if !repairedResults.OK {
 			return fmt.Errorf("doctor 检查未通过")
 		}
 		return nil
 	}
-	results := checker.Run(context.Background(), checkPort)
+	results := checker.Run(doctorCtx, checkPort)
 	fixes := []string{}
+	restartRequired := false
 	if fix {
-		fixes, checker, results, err = runDoctorFix(context.Background(), configPath, checkPort, results)
+		fixes, restartRequired, checker, results, err = runDoctorFix(doctorCtx, configPath, checkPort, results)
 		if err != nil {
 			return err
 		}
@@ -793,7 +805,11 @@ func runDoctor(args []string) error {
 	if asJSON {
 		payload := any(results)
 		if fix {
-			payload = map[string]any{"fixes": fixes, "results": results}
+			payload = map[string]any{
+				"fixes":            fixes,
+				"results":          results,
+				"restart_required": restartRequired,
+			}
 		}
 		if err := printJSON(payload); err != nil {
 			return err
@@ -807,6 +823,9 @@ func runDoctor(args []string) error {
 			fmt.Fprintln(os.Stdout)
 		}
 		doctor.Print(os.Stdout, results)
+		if fix && restartRequired {
+			fmt.Fprintln(os.Stdout, "\n配置已更新，需要重启 agentd 后生效。")
+		}
 		_ = checker
 	}
 	if !results.OK {
@@ -877,15 +896,21 @@ func loadRuntimeConfigFromPath(configPath string, forDoctor bool) (config.Config
 	return cfg, registry, checker, nil
 }
 
-func runDoctorFix(ctx context.Context, configPath string, checkPort bool, current doctor.Results) ([]string, *doctor.Checker, doctor.Results, error) {
+func runDoctorFix(
+	ctx context.Context,
+	configPath string,
+	checkPort bool,
+	current doctor.Results,
+) ([]string, bool, *doctor.Checker, doctor.Results, error) {
 	configPath = expandUserPath(configPath)
 	fixes := []string{}
+	restartRequired := false
 	needsSetup := false
 	if _, err := os.Stat(configPath); err != nil {
 		if os.IsNotExist(err) {
 			needsSetup = true
 		} else {
-			return nil, nil, current, fmt.Errorf("读取配置状态失败：%w", err)
+			return nil, false, nil, current, fmt.Errorf("读取配置状态失败：%w", err)
 		}
 	}
 	if hasFailedCheck(current, "token") || hasFailedCheck(current, "projects") {
@@ -894,7 +919,7 @@ func runDoctorFix(ctx context.Context, configPath string, checkPort bool, curren
 	if hasFailedCheck(current, "config-file") {
 		fixed, err := tightenSensitiveFilePermissions(configPath)
 		if err != nil {
-			return nil, nil, current, fmt.Errorf("修复配置文件权限失败：%w", err)
+			return nil, false, nil, current, fmt.Errorf("修复配置文件权限失败：%w", err)
 		}
 		if fixed {
 			fixes = append(fixes, "已将配置文件权限收紧为 0600")
@@ -904,14 +929,15 @@ func runDoctorFix(ctx context.Context, configPath string, checkPort bool, curren
 		// legacy 配置没有独立 upstream token，或原文件已丢失时，只补 token 路径，不重建整份用户配置。
 		tokenPath, repaired, repairErr := agentsetup.RepairManagedWSTokenFile(configPath)
 		if repairErr != nil {
-			return nil, nil, current, fmt.Errorf("修复 app-server token file 失败：%w", repairErr)
+			return nil, false, nil, current, fmt.Errorf("修复 app-server token file 失败：%w", repairErr)
 		}
 		if repaired {
 			fixes = append(fixes, "已生成独立 app-server token file 并原子更新配置")
+			restartRequired = true
 		} else if strings.TrimSpace(tokenPath) != "" {
 			fixed, fixErr := tightenSensitiveFilePermissions(tokenPath)
 			if fixErr != nil {
-				return nil, nil, current, fmt.Errorf("修复 app-server token file 权限失败：%w", fixErr)
+				return nil, false, nil, current, fmt.Errorf("修复 app-server token file 权限失败：%w", fixErr)
 			}
 			if fixed {
 				fixes = append(fixes, "已将 app-server token file 权限收紧为 0600")
@@ -923,21 +949,23 @@ func runDoctorFix(ctx context.Context, configPath string, checkPort bool, curren
 		codexPath, repaired, repairErr := agentsetup.RepairCodexBin(configPath)
 		if repairErr == nil && repaired {
 			fixes = append(fixes, "已恢复 Codex CLI 路径："+codexPath)
+			restartRequired = true
 		}
 	}
 	if needsSetup {
 		setupFixes, err := forceSetupWithBackup(ctx, configPath)
 		if err != nil {
-			return nil, nil, current, err
+			return nil, false, nil, current, err
 		}
 		fixes = append(fixes, setupFixes...)
+		restartRequired = restartRequired || len(setupFixes) > 0
 	}
 	_, registry, checker, err := loadRuntimeConfigFromPath(configPath, true)
 	if err != nil {
-		return nil, nil, current, err
+		return nil, false, nil, current, err
 	}
 	_ = registry
-	return fixes, checker, checker.Run(ctx, checkPort), nil
+	return fixes, restartRequired, checker, checker.Run(ctx, checkPort), nil
 }
 
 func tightenSensitiveFilePermissions(path string) (bool, error) {
@@ -996,7 +1024,44 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 	checker.StartFileAccessPreflight()
 	var appServerWSProcess *appserver.ManagedWebSocketProcess
 	var sharedDaemonStatus appserver.LocalDaemonStatus
-	switch strings.ToLower(strings.TrimSpace(cfg.AppServer.Transport)) {
+	appServerTransport := strings.ToLower(strings.TrimSpace(cfg.AppServer.Transport))
+	mimiOwnedSharedDaemon := appServerTransport == "unix" &&
+		cfg.AppServer.Managed && cfg.AppServer.SharedFallback != nil
+	configPath := strings.TrimSpace(checker.ConfigPath())
+	if mimiOwnedSharedDaemon {
+		if !appserver.SupportsStableSharedDaemonOwner() {
+			return fmt.Errorf("Codex 完整共享 daemon owner 当前仅支持 macOS")
+		}
+		if !config.IsPlatformDefaultPath(configPath) {
+			return fmt.Errorf("Mimi 管理的共享 Codex daemon 只能由平台默认配置启动：%s", config.PlatformDefaultPath())
+		}
+	}
+	if !mimiOwnedSharedDaemon {
+		// 用户全局 LaunchAgent 只归平台默认配置所有。前台运行自定义 profile
+		// 时不得清理默认服务的 owner。
+		if config.IsPlatformDefaultPath(configPath) {
+			artifactsPresent, artifactsErr := appserver.SharedDaemonOwnerArtifactsPresent()
+			if artifactsErr != nil {
+				return fmt.Errorf("检查残留共享 daemon owner 失败：%w", artifactsErr)
+			}
+			if artifactsPresent {
+				if configPath == "" {
+					return fmt.Errorf("清理残留共享 daemon owner 缺少可复核的配置路径")
+				}
+				expectedBin := cfg.Codex.Bin
+				expectedEnv := maps.Clone(cfg.Codex.Env)
+				cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), 15*time.Second)
+				cleanupErr := appserver.ReconcileDisabledSharedDaemonOwner(cleanupCtx, func() error {
+					return config.ValidateSharedDaemonDisabledOwnership(configPath, expectedBin, expectedEnv)
+				})
+				cancelCleanup()
+				if cleanupErr != nil {
+					return fmt.Errorf("清理残留共享 daemon owner 失败：%w", cleanupErr)
+				}
+			}
+		}
+	}
+	switch appServerTransport {
 	case "unix":
 		if cfg.AppServer.Managed {
 			// launchd 启动和官方 daemon 初始化都是异步的；外层覆盖最慢的冷启动。
@@ -1004,6 +1069,17 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 			mimiOwned := cfg.AppServer.SharedFallback != nil
 			options := appserver.LocalDaemonOptions{
 				CodexBin: cfg.Codex.Bin, Env: cfg.Codex.Env, StableOwner: mimiOwned, AttachOnly: !mimiOwned,
+			}
+			if mimiOwned {
+				if configPath == "" {
+					cancel()
+					return fmt.Errorf("共享 Codex daemon 缺少可复核的配置路径")
+				}
+				expectedBin := cfg.Codex.Bin
+				expectedEnv := maps.Clone(cfg.Codex.Env)
+				options.ValidateStableOwner = func() error {
+					return config.ValidateSharedDaemonRecoveryOwnership(configPath, expectedBin, expectedEnv)
+				}
 			}
 			status, ensureErr := appserver.EnsureLocalDaemon(ensureCtx, options)
 			cancel()
@@ -1063,6 +1139,7 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 		installationID,
 		nil,
 		httpapi.RouterOptions{
+			ConfigPath:                     checker.ConfigPath(),
 			GatewayTurnClaimStorePath:      gatewayTurnClaimStorePath,
 			ThreadHandoffRecoveryStorePath: threadHandoffRecoveryStorePath,
 		},

--- a/cmd/agentd/main_test.go
+++ b/cmd/agentd/main_test.go
@@ -1489,12 +1489,15 @@ func TestRunDoctorFixOnlyTightensSensitiveFilePermissions(t *testing.T) {
 		{Name: "config-file", OK: false},
 		{Name: "app-server-token-file", OK: false},
 	}}
-	fixes, _, _, err := runDoctorFix(context.Background(), configPath, false, current)
+	fixes, restartRequired, _, _, err := runDoctorFix(context.Background(), configPath, false, current)
 	if err != nil {
 		t.Fatalf("doctor --fix 收紧权限失败：%v", err)
 	}
 	if runtime.GOOS != "windows" && len(fixes) != 2 {
 		t.Fatalf("应分别修复配置与 token file 权限：%v", fixes)
+	}
+	if restartRequired {
+		t.Fatal("只收紧文件权限不应要求重启 agentd")
 	}
 	for _, path := range []string{configPath, tokenPath} {
 		info, err := os.Lstat(path)
@@ -1639,12 +1642,15 @@ func TestRunDoctorFixMissingConfigStillUsesFullSetup(t *testing.T) {
 		{Name: "app-server-token-file", OK: false},
 	}}
 
-	fixes, _, _, err := runDoctorFix(context.Background(), configPath, false, current)
+	fixes, restartRequired, _, _, err := runDoctorFix(context.Background(), configPath, false, current)
 	if err != nil {
 		t.Fatalf("配置完全缺失时仍应走完整 setup，而不是尝试局部迁移：%v", err)
 	}
 	if len(fixes) == 0 {
 		t.Fatal("完整 setup 应返回修复记录")
+	}
+	if !restartRequired {
+		t.Fatal("完整 setup 重建配置后必须要求重启 agentd")
 	}
 	cfg, err := config.Load(configPath)
 	if err != nil {

--- a/cmd/agentd/runtime.go
+++ b/cmd/agentd/runtime.go
@@ -22,11 +22,11 @@ func runRuntimeWithWriters(args []string, stdout, stderr io.Writer) error {
 	configPath := fs.String("config", config.DefaultPath(), "配置文件路径")
 	claudePreference := fs.String("claude", "", "Claude 启用策略：auto、enabled 或 disabled")
 	codexSharing := fs.String("codex-sharing", "", "Codex Desktop 共享 app-server：enabled 或 disabled")
-	codexSharingRestart := fs.Bool("codex-sharing-restart", false, "Mac App 内部：应用待处理的共享 Codex daemon 迁移")
+	codexSharingRestart := fs.Bool("codex-sharing-restart", false, "防误触 interlock：应用待处理的共享 Codex daemon 迁移")
 	codexSharingRestartConfirmed := fs.Bool(
 		"codex-sharing-restart-confirmed",
 		false,
-		"Mac App 内部：确认设置页已授权且 Desktop 已正常退出或本来未运行",
+		"防误触 interlock：调用方确认 Desktop 已正常退出或本来未运行（不是身份鉴权）",
 	)
 	restoreEnabled := fs.Bool("restore-enabled", false, "服务重载失败时恢复先前 enabled 状态")
 	asJSON := fs.Bool("json", false, "输出 JSON")
@@ -49,7 +49,7 @@ func runRuntimeWithWriters(args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("--codex-sharing-restart-confirmed 只能与内部迁移入口一起使用")
 	}
 	if hasCodexSharingRestart && !*codexSharingRestartConfirmed {
-		return fmt.Errorf("共享 daemon 迁移仅供 Mac App 在确认并正常退出 Codex Desktop 后调用")
+		return fmt.Errorf("共享 daemon 迁移必须同时传入确认防误触开关；该开关不构成调用方鉴权")
 	}
 	if err := prepareDefaultConfigMigration(fs, *configPath, stderr); err != nil {
 		return err

--- a/cmd/agentd/runtime.go
+++ b/cmd/agentd/runtime.go
@@ -22,6 +22,12 @@ func runRuntimeWithWriters(args []string, stdout, stderr io.Writer) error {
 	configPath := fs.String("config", config.DefaultPath(), "配置文件路径")
 	claudePreference := fs.String("claude", "", "Claude 启用策略：auto、enabled 或 disabled")
 	codexSharing := fs.String("codex-sharing", "", "Codex Desktop 共享 app-server：enabled 或 disabled")
+	codexSharingRestart := fs.Bool("codex-sharing-restart", false, "Mac App 内部：应用待处理的共享 Codex daemon 迁移")
+	codexSharingRestartConfirmed := fs.Bool(
+		"codex-sharing-restart-confirmed",
+		false,
+		"Mac App 内部：确认设置页已授权且 Desktop 已正常退出或本来未运行",
+	)
 	restoreEnabled := fs.Bool("restore-enabled", false, "服务重载失败时恢复先前 enabled 状态")
 	asJSON := fs.Bool("json", false, "输出 JSON")
 	if err := fs.Parse(args[1:]); err != nil {
@@ -29,8 +35,21 @@ func runRuntimeWithWriters(args []string, stdout, stderr io.Writer) error {
 	}
 	hasClaude := strings.TrimSpace(*claudePreference) != ""
 	hasCodexSharing := strings.TrimSpace(*codexSharing) != ""
-	if hasClaude == hasCodexSharing {
-		return fmt.Errorf("必须且只能传入 --claude 或 --codex-sharing 其中一项")
+	hasCodexSharingRestart := *codexSharingRestart
+	operationCount := 0
+	for _, selected := range []bool{hasClaude, hasCodexSharing, hasCodexSharingRestart} {
+		if selected {
+			operationCount++
+		}
+	}
+	if operationCount != 1 {
+		return fmt.Errorf("必须且只能传入 --claude、--codex-sharing 或 --codex-sharing-restart 其中一项")
+	}
+	if *codexSharingRestartConfirmed && !hasCodexSharingRestart {
+		return fmt.Errorf("--codex-sharing-restart-confirmed 只能与内部迁移入口一起使用")
+	}
+	if hasCodexSharingRestart && !*codexSharingRestartConfirmed {
+		return fmt.Errorf("共享 daemon 迁移仅供 Mac App 在确认并正常退出 Codex Desktop 后调用")
 	}
 	if err := prepareDefaultConfigMigration(fs, *configPath, stderr); err != nil {
 		return err
@@ -40,8 +59,21 @@ func runRuntimeWithWriters(args []string, stdout, stderr io.Writer) error {
 		if err != nil {
 			return err
 		}
-		configureCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+		configureCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 		result, err := agentsetup.ConfigureCodexSharing(configureCtx, *configPath, enabled)
+		cancel()
+		if err != nil {
+			return err
+		}
+		if *asJSON {
+			return printJSONTo(stdout, result)
+		}
+		fmt.Fprintln(stdout, result.Message)
+		return nil
+	}
+	if hasCodexSharingRestart {
+		restartCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		result, err := agentsetup.RestartCodexSharingDaemon(restartCtx, *configPath)
 		cancel()
 		if err != nil {
 			return err

--- a/cmd/agentd/runtime_test.go
+++ b/cmd/agentd/runtime_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeRejectsUnconfirmedSharedDaemonRestart(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := runRuntimeWithWriters(
+		[]string{"runtime", "--codex-sharing-restart"},
+		&stdout,
+		&stderr,
+	)
+	if err == nil || !strings.Contains(err.Error(), "仅供 Mac App") {
+		t.Fatalf("普通 CLI 不能绕过 Desktop 正常退出与设置页确认：%v", err)
+	}
+}

--- a/cmd/agentd/runtime_test.go
+++ b/cmd/agentd/runtime_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestRuntimeRejectsUnconfirmedSharedDaemonRestart(t *testing.T) {
+func TestRuntimeRestartInterlockRejectsMissingConfirmationFlag(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	err := runRuntimeWithWriters(
@@ -14,7 +14,7 @@ func TestRuntimeRejectsUnconfirmedSharedDaemonRestart(t *testing.T) {
 		&stdout,
 		&stderr,
 	)
-	if err == nil || !strings.Contains(err.Error(), "仅供 Mac App") {
-		t.Fatalf("普通 CLI 不能绕过 Desktop 正常退出与设置页确认：%v", err)
+	if err == nil || !strings.Contains(err.Error(), "防误触") {
+		t.Fatalf("缺少双 flag 时必须阻止误触破坏性迁移：%v", err)
 	}
 }

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -36,16 +36,16 @@ Desktop 使用官方 `CODEX_APP_SERVER_USE_LOCAL_DAEMON=1` 开关连接 Unix Soc
 
 Mac App 的“Codex Desktop → 共享本地 app-server 会话”会按以下顺序执行：
 
-1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket，并完成 `initialize` / `initialized` 握手；stale socket 文件不算就绪；
-2. 幂等安装 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；agentd 不再直接 spawn Codex daemon；
-3. 同时验证官方 standalone 可执行文件与 daemon lifecycle，确保注销或重启 Mac 后仍能冷启动；任一前置条件不完整都直接失败，配置与 Desktop 环境均不修改；
-4. 原子保存当前 `app_server` transport 作为 `shared_fallback`，再切换到 `unix://`；
+1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket；已有 listener 必须完成 `initialize` / `initialized` 握手，stale socket 文件不算就绪；
+2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；此时绝不启动新 Unix daemon；
+3. 验证官方 standalone 可执行文件与 daemon lifecycle 冷启动能力。全新启用还会写入私有 durable intent；任一提交前条件不完整都直接失败并清理本次 owner，配置与 Desktop 环境均不修改；
+4. 在 shared-daemon 操作锁内再次复核同一份原始配置，并用所有 Mimi 配置写入者共用的跨进程 CAS 锁，原子保存当前 `app_server` transport 为 `shared_fallback`、再切换到 `unix://`。只有配置 rename 已成功且启用前没有旧 listener，manual job 才会显式 `kickstart` 并校验完整协议、官方 pid backend、`CODEX_HOME`、standalone 路径和版本；即使冷启动全部通过，也继续保留 marker 与 `RunAtLoad=false`，因为 kickstart 与 socket 建立之间不能原子证明是谁赢得 listener。durable intent 只用于恢复“rename 已完成但首次冷启动尚未完成”的崩溃窗口，第一次完整 managed 校验通过后立即消费，不能被后续普通 recovery 重用。首次启用和接管既有 listener 都必须经过第 7 步的用户确认，才清 marker 并提升为 `RunAtLoad=true`。配置提交后的启动失败会作为“已提交、待恢复”结果返回，Mac App 会重新加载状态；若进程在 rename 与 kickstart 之间退出，下一次 shared agentd 会在锁内复核配置身份后继续该 durable intent，但仍不会自动完成 owner 迁移；
 5. 重启并确认 agentd 的 runtime 状态为 `transport=unix`、`shared=true`、daemon 可连接；
 6. 经 ownership 检查后，为 GUI 用户会话写入官方 daemon 开关、相同的 canonical `CODEX_HOME` 和 Mimi 私有的随机会话 marker，确保从 Dock / Finder 启动也生效；三键按事务写入，任一失败都会按相反顺序恢复，外部已有值不会被覆盖；
-7. 如果启用前已有 daemon，owner 变更会持久标记为“待迁移”，不会静默中断它。稳定 owner 已安装后，如果未来又由 Codex 原生 SSH bootstrap 先抢到 socket，agentd 仍会在完成协议、版本、`CODEX_HOME` 和 standalone 路径验证后保持 attach，并重建该标记，不会在日常启动中停止它。该标记独立于五分钟 runtime 缓存，每次状态请求都实时读取，因此用户取消确认或先退出 Desktop 后入口仍保留。用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 pid backend 管理时执行官方 `daemon stop`；旧 server 是 Codex 原生 SSH bootstrap 直启链时，只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` 命令行、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 PID 发送一次 `SIGTERM`。不使用进程组信号、`SIGKILL`、模糊进程名或自动重试。等待最长 15 秒，且旧 socket 持续拒绝连接 500 ms 后，才由 LaunchAgent 拉起一次并完成协议/生命周期/版本验证，成功后才重新打开 App；Desktop 已退出时只迁移 daemon，不擅自打开 App。任意检查或启动失败均保留待迁移标记并停止，不自动打开 Desktop；若旧进程在等待超时后才完成退出，用户稍后重试不会再发送第二次信号。两种情况都会短暂中断连接该 daemon 的手机、SSH 或 CLI；
-8. 如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与独立 CLI 迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
+7. 首次启用或启用前已有 daemon 时，owner 都会持久标记为“待迁移”，并把磁盘 plist 固定为 `RunAtLoad=false`，不会静默中断既有进程，也不会在注销、登录或 Mac 重启后自动完成迁移。稳定 owner 已安装后，如果未来又由 Codex 原生 SSH bootstrap 先抢到 socket，agentd 仍会在完成协议、版本、`CODEX_HOME` 和 standalone 路径验证后保持 attach，并把 owner 收敛回同一 pending 状态；socket 仍可连接时普通启动只 attach；仅 durable fresh-enable intent 且 socket 尚未创建时允许 manual job 恢复一次冷启动，恢复后仍保持 pending。其他 socket 不可连接场景下普通启动和 gateway recovery 直接返回 pending，既不 `kickstart` 也不清 marker。该标记独立于五分钟 runtime 缓存，每次状态请求都实时读取，因此用户取消确认或先退出 Desktop 后入口仍保留。用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 pid backend 管理时执行官方 `daemon stop`；旧 server 是 Codex 原生 SSH bootstrap 直启链时，只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` 命令行、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 PID 发送一次 `SIGTERM`。官方 stop 与新 daemon kickstart 各自在副作用前按固定 bundle ID 最终复核 Desktop，App 已重开或 LaunchServices 查询失败都立即停止迁移。不使用进程组信号、`SIGKILL`、模糊进程名或自动重试。等待最长 15 秒，且旧 socket 持续拒绝连接 500 ms 后，才由 LaunchAgent 拉起一次并完成协议/生命周期/版本验证；全部通过后才清 intent/marker、把 plist 恢复为 `RunAtLoad=true`，并按实际执行时的 Desktop 状态决定是否重新打开 App。任意检查或启动失败均保留 manual plist 与待迁移标记，不自动打开 Desktop；若旧进程在等待超时后才完成退出，用户稍后重试不会再发送第二次信号。两种情况都会短暂中断连接该 daemon 的手机、SSH 或 CLI；
+8. 在没有待迁移 marker 的正常已提交状态下，如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与显式迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
 
-移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读或观测器缺失时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
+移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；对 app-server 发给客户端的审批、补充输入和 MCP elicitation，移动端返回的反向 JSON-RPC response 也执行相同 guard，拒绝时保留 pending request 并恢复移动端卡片。`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读、观测器缺失或反向 request 缺少 thread scope 时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
 
 命令行等价操作：
 
@@ -56,13 +56,15 @@ agentd status --json --runtime
 agentd doctor
 ```
 
-破坏性 daemon 迁移不是命令行等价操作。它由 Mac App 在用户确认后、并在
-Codex Desktop 已正常退出的受控流程中调用内部 runtime 入口，避免脚本绕过原生
-Desktop 的退出顺序。
+破坏性 daemon 迁移的两个 CLI flag 是防误触 interlock，不是可信调用方鉴权。正式
+产品只由 Mac App 在用户确认后、并在 Codex Desktop 已正常退出的受控流程中调用；
+Go 端仍会实时复核 marker、owner 和 Desktop 状态。同一用户下的其他进程也能自行传入
+这两个公开 flag，因此不能把它们表述成“只有设置页才能授权”的安全边界；若未来需要
+可信来源认证，应改用带 audit token / code-sign requirement 的 XPC 或等价可信 IPC。
 
 ### 关闭与回滚
 
-关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file，并卸载 Mimi 的 LaunchAgent 与待迁移标记；不会停止当前 daemon，因为 Desktop 可能仍在使用它。配置恢复与 owner 卸载是一个可回滚事务：owner 卸载失败时恢复原 shared 配置；既有 owner 内容更新后若 bootout、bootstrap、marker 或最终检查失败，也会恢复原 plist、加载状态和 marker。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，启用时只 attach 已经可握手的 socket，缺失时明确失败且绝不启动；禁用时只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
+关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file，并卸载 Mimi 的 LaunchAgent 与待迁移标记；不会停止当前 daemon，因为 Desktop 可能仍在使用它。事务顺序固定为：先把 owner 降为 manual 并移除未来启动入口，再 CAS 提交非共享配置。这样进程在任意一步退出，最多留下 `shared + 无 owner/manual owner`，不会形成 `WS + RunAtLoad=true`。owner 卸载失败时配置不提交并保留 fail-closed 的 manual 状态；配置已被其他 writer 改动或提交失败时也不恢复可能已经失权的 auto owner，下一次明确操作再幂等收敛。`setup --force`、sharing、Claude、network 与 repair 写入共用配置提交锁；只有平台默认配置可以拥有或清理当前用户全局 LaunchAgent，自定义 `--config` profile 不会触碰默认服务的 owner。完整 stable-owner 共享目前只在 macOS 开放；非 macOS 升级后仍允许执行 disable 回退旧配置。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，启用时只 attach 已经可握手的 socket，缺失时明确失败且绝不启动；禁用时只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
 
 ```bash
 agentd runtime --codex-sharing=disabled --json
@@ -81,6 +83,7 @@ agentd restart --no-pair
 - 为了让 Dock / Finder 启动同样生效，Mac App 使用当前 GUI 用户的 `launchctl` 环境。它只管理自己写入的两个官方键，并用第三个随机 marker 区分当前登录会话的 ownership；禁用时仅在三者仍匹配时恢复原值。agentd 启动 Codex 子进程时会过滤 Desktop 专属 transport 开关与 marker，`CODEX_HOME` 则刻意保持一致。该设置不会默认开启。
 - `launchctl` 环境会在注销后消失；Mac App 只会为已经显式启用、backend 再次确认共享且三键均为空的用户生成新 marker 并恢复环境，不会借登录启动替新用户自动开启功能。新会话里其他程序即使写入相同的官方值，没有匹配 marker 也不会被 Mimi 认领。若 Desktop 比 Mimi 更早启动，设置页会保持“需要重启”，由用户确认后正常退出并重开。
 - Unix Socket 的安全边界是当前用户私有目录与 `0600` socket；它不会暴露到 TCP，也不复用 iPad 的 Bearer Token 或旧 app-server capability token。
+- Mimi 自己的配置写入通过用户私有的跨进程文件锁与同源 raw snapshot CAS 串行；不遵守该协议的外部编辑器无法被强制加锁，因此最终 rename 前仍会复核 bytes 并在可检测冲突时 fail closed，但不会宣称能对任意第三方写入提供数据库级事务。
 - LaunchAgent plist 可能包含为 Codex/MCP 配置的运行环境，因此固定为 `0600`，日志目录/文件也按当前用户私有权限创建；Desktop 专属 transport/ownership 环境变量由 job 的空值覆盖，避免继承 GUI 用户域值，同时保持 `launchd -> codex` 的直接进程链。
 - LaunchAgent 已安装、socket 可握手和版本一致只能证明结构与协议闭环；macOS TCC 的最终文件权限归因必须用正式签名 App 做一次受保护目录读写验收，Doctor 会明确保留这项运行态要求，不把单元测试冒充为 TCC 证明。
 - `thread/unsubscribe` 只取消当前连接订阅，不释放 writer；没有公开的单 thread takeover/unload RPC，因此不要重新叠加客户端 idle 猜测或自动抢占逻辑。
@@ -91,5 +94,5 @@ agentd restart --no-pair
 2. Desktop 正在运行 turn；手机应显示只读，不能并发发送。
 3. Desktop turn 完成并保持 thread 页面打开；手机再次发送，应成功。
 4. 禁用共享并重启两端；agentd 应恢复原 WS 配置，已有配对与 thread ID 不变。
-5. 杀掉共享 daemon 后从手机新建一次 gateway 连接，应由 LaunchAgent 自动恢复并只重试一次；已有 Desktop 空闲会话随后仍可读取。
+5. 在没有待迁移 marker 的正常已提交状态下杀掉共享 daemon，再从手机新建一次 gateway 连接，应由 LaunchAgent 自动恢复并只重试一次；pending 状态下同样操作必须保持 manual owner，等待用户再次确认。
 6. 用签名的 Mimi Remote Mac 与 Codex Desktop 分别访问一个受保护目录，确认系统权限提示/授权不再归因到 Mimi 的旧 App 路径；该项不能由无签名单测替代。

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -10,15 +10,18 @@ Codex App Server 新版对 thread writer 增加了跨进程互斥。同一个 th
 - Desktop 正在运行 turn、等待审批或等待补充输入时，移动端仍保持只读；
 - 不创建 fork，不复制会话，也不通过 archive/unarchive 改变用户数据；
 - 共享功能失败时不覆盖原有 WebSocket 配置，并可显式回滚。
+- 日常启动、连接恢复和 agentd 重启都不退出、重开或强制终止 Codex Desktop；唯一例外是用户在 Mac App 设置页显式确认的一次性 owner 迁移。
 
 ## 方案
 
 macOS 上显式启用 Codex 官方 local daemon：
 
 ```text
-Codex Desktop ─┐
-               ├─ $CODEX_HOME/app-server-control/app-server-control.sock
-Mimi agentd ───┘
+launchd LaunchAgent ──> 官方 codex daemon start ──> local daemon
+                                                    │
+Codex Desktop ──────────────────────────────────────┤
+Mimi agentd ────────────────────────────────────────┘
+                    $CODEX_HOME/app-server-control/app-server-control.sock
        ↑
 iPhone / iPad 通过 /api/app-server/ws 继续经过鉴权、cwd 和方法策略
 ```
@@ -33,15 +36,16 @@ Desktop 使用官方 `CODEX_APP_SERVER_USE_LOCAL_DAEMON=1` 开关连接 Unix Soc
 
 Mac App 的“Codex Desktop → 共享本地 app-server 会话”会按以下顺序执行：
 
-1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket，并完成 `initialize` / `initialized` 握手；
-2. socket 不存在时，只调用官方 `codex app-server daemon start`，不创建自定义常驻进程；
+1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket，并完成 `initialize` / `initialized` 握手；stale socket 文件不算就绪；
+2. 幂等安装 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；agentd 不再直接 spawn Codex daemon；
 3. 同时验证官方 standalone 可执行文件与 daemon lifecycle，确保注销或重启 Mac 后仍能冷启动；任一前置条件不完整都直接失败，配置与 Desktop 环境均不修改；
 4. 原子保存当前 `app_server` transport 作为 `shared_fallback`，再切换到 `unix://`；
 5. 重启并确认 agentd 的 runtime 状态为 `transport=unix`、`shared=true`、daemon 可连接；
 6. 经 ownership 检查后，为 GUI 用户会话写入官方 daemon 开关、相同的 canonical `CODEX_HOME` 和 Mimi 私有的随机会话 marker，确保从 Dock / Finder 启动也生效；三键按事务写入，任一失败都会按相反顺序恢复，外部已有值不会被覆盖；
-7. 已运行的 Desktop 不会被静默杀死。用户确认“重启并应用”后，只请求正常退出，等待完全结束，再通过 LaunchServices 启动同一个 App；不会 `forceTerminate`，也不会并存第二实例。
+7. 如果启用前已有 daemon，owner 变更会持久标记为“待迁移”，不会静默中断它。稳定 owner 已安装后，如果未来又由 Codex 原生 SSH bootstrap 先抢到 socket，agentd 仍会在完成协议、版本、`CODEX_HOME` 和 standalone 路径验证后保持 attach，并重建该标记，不会在日常启动中停止它。该标记独立于五分钟 runtime 缓存，每次状态请求都实时读取，因此用户取消确认或先退出 Desktop 后入口仍保留。用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 pid backend 管理时执行官方 `daemon stop`；旧 server 是 Codex 原生 SSH bootstrap 直启链时，只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` 命令行、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 PID 发送一次 `SIGTERM`。不使用进程组信号、`SIGKILL`、模糊进程名或自动重试。等待最长 15 秒，且旧 socket 持续拒绝连接 500 ms 后，才由 LaunchAgent 拉起一次并完成协议/生命周期/版本验证，成功后才重新打开 App；Desktop 已退出时只迁移 daemon，不擅自打开 App。任意检查或启动失败均保留待迁移标记并停止，不自动打开 Desktop；若旧进程在等待超时后才完成退出，用户稍后重试不会再发送第二次信号。两种情况都会短暂中断连接该 daemon 的手机、SSH 或 CLI；
+8. 如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与独立 CLI 迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
 
-移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；`thread/resume` 与读取接口仍可用于只读观察。只有“正在运行”的明确证据才会触发该保护，Desktop 仅打开空闲 thread 不会被当成占用；状态库短暂不可读时也不会猜测为 active。
+移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读或观测器缺失时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
 
 命令行等价操作：
 
@@ -52,9 +56,13 @@ agentd status --json --runtime
 agentd doctor
 ```
 
+破坏性 daemon 迁移不是命令行等价操作。它由 Mac App 在用户确认后、并在
+Codex Desktop 已正常退出的受控流程中调用内部 runtime 入口，避免脚本绕过原生
+Desktop 的退出顺序。
+
 ### 关闭与回滚
 
-关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file；不会停止官方 daemon，因为 Desktop 可能仍在使用它。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，则只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
+关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file，并卸载 Mimi 的 LaunchAgent 与待迁移标记；不会停止当前 daemon，因为 Desktop 可能仍在使用它。配置恢复与 owner 卸载是一个可回滚事务：owner 卸载失败时恢复原 shared 配置；既有 owner 内容更新后若 bootout、bootstrap、marker 或最终检查失败，也会恢复原 plist、加载状态和 marker。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，启用时只 attach 已经可握手的 socket，缺失时明确失败且绝不启动；禁用时只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
 
 ```bash
 agentd runtime --codex-sharing=disabled --json
@@ -66,11 +74,15 @@ agentd restart --no-pair
 ## 风险与优化
 
 - 官方 daemon 冷启动需要 `$CODEX_HOME/packages/standalone/current/codex`。已有健康 socket 但 standalone 缺失时，启用操作也会阻断，避免本次看似成功、Mac 重启后 agentd 持续拉起失败；Mimi Remote 不会静默执行 `curl | sh`，只给出官方安装指引。
+- 共享架构把两端的会话一致性放在同一个官方 app-server 上，因此该 server 自身崩溃时 Codex Desktop 与 Mimi 会同时短暂失去后端。稳定 owner 只在 server 已不可连时尝试恢复它，不会为了恢复而退出或重开 Codex Desktop。
 - Desktop 必须支持 local daemon，当前最低兼容 app-server 版本为 `0.141.0`。版本、socket 类型、目录权限、socket 权限和返回的 `codexHome` 都会在启用前校验。
 - Desktop 的自定义 CLI、强制 CLI 或资源覆盖可能让它回退到独立 stdio。Mac App 会确认 agentd 已连接共享 daemon，并明确要求完全重启 Desktop；Desktop 是否采用 daemon 仍要通过下面的跨端验收验证，不能只根据环境变量推断成功。
+- 稳定 LaunchAgent 的 `PATH` 会固定 Apple Silicon / Intel Homebrew 与系统工具目录，并在首次安装时追加调用进程可见的绝对用户工具目录；相对路径会被拒绝。之后 resident agentd 会复用已安装值，避免 MCP/plugin 路径随启动入口反复变化；需要完全自定义时可显式配置 `codex.env.PATH`。
 - 为了让 Dock / Finder 启动同样生效，Mac App 使用当前 GUI 用户的 `launchctl` 环境。它只管理自己写入的两个官方键，并用第三个随机 marker 区分当前登录会话的 ownership；禁用时仅在三者仍匹配时恢复原值。agentd 启动 Codex 子进程时会过滤 Desktop 专属 transport 开关与 marker，`CODEX_HOME` 则刻意保持一致。该设置不会默认开启。
 - `launchctl` 环境会在注销后消失；Mac App 只会为已经显式启用、backend 再次确认共享且三键均为空的用户生成新 marker 并恢复环境，不会借登录启动替新用户自动开启功能。新会话里其他程序即使写入相同的官方值，没有匹配 marker 也不会被 Mimi 认领。若 Desktop 比 Mimi 更早启动，设置页会保持“需要重启”，由用户确认后正常退出并重开。
 - Unix Socket 的安全边界是当前用户私有目录与 `0600` socket；它不会暴露到 TCP，也不复用 iPad 的 Bearer Token 或旧 app-server capability token。
+- LaunchAgent plist 可能包含为 Codex/MCP 配置的运行环境，因此固定为 `0600`，日志目录/文件也按当前用户私有权限创建；Desktop 专属 transport/ownership 环境变量由 job 的空值覆盖，避免继承 GUI 用户域值，同时保持 `launchd -> codex` 的直接进程链。
+- LaunchAgent 已安装、socket 可握手和版本一致只能证明结构与协议闭环；macOS TCC 的最终文件权限归因必须用正式签名 App 做一次受保护目录读写验收，Doctor 会明确保留这项运行态要求，不把单元测试冒充为 TCC 证明。
 - `thread/unsubscribe` 只取消当前连接订阅，不释放 writer；没有公开的单 thread takeover/unload RPC，因此不要重新叠加客户端 idle 猜测或自动抢占逻辑。
 
 验收场景：
@@ -79,3 +91,5 @@ agentd restart --no-pair
 2. Desktop 正在运行 turn；手机应显示只读，不能并发发送。
 3. Desktop turn 完成并保持 thread 页面打开；手机再次发送，应成功。
 4. 禁用共享并重启两端；agentd 应恢复原 WS 配置，已有配对与 thread ID 不变。
+5. 杀掉共享 daemon 后从手机新建一次 gateway 连接，应由 LaunchAgent 自动恢复并只重试一次；已有 Desktop 空闲会话随后仍可读取。
+6. 用签名的 Mimi Remote Mac 与 Codex Desktop 分别访问一个受保护目录，确认系统权限提示/授权不再归因到 Mimi 的旧 App 路径；该项不能由无签名单测替代。

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,6 +1,6 @@
 # Mimi Remote 项目现状与关键决策
 
-更新日期：2026-08-11
+更新日期：2026-08-12
 
 ## 目标
 
@@ -28,8 +28,8 @@ iPhone / iPad SwiftUI App
 ### 已确定的边界
 
 - `agentd` 是薄网关，不复制一套 Codex 业务协议。
-- macOS 可显式启用官方 local daemon，让 Desktop 与移动端共用同一个 thread writer；Desktop 只有打开但没有运行 turn 时，移动端可以在原 thread 继续，不创建 fork。启用失败时不改配置，关闭时恢复原 WS 配置。
-- 共享 daemon 不等于并发写：Desktop 正在运行的 turn 仍按 external activity 只读；客户端也不能靠 `thread/unsubscribe`、archive/unarchive 或猜测 idle 状态抢占另一个进程。
+- macOS 可显式启用官方 local daemon，让 Desktop 与移动端共用同一个 thread writer；daemon 由 Mimi 安装的用户 LaunchAgent 直接调用官方 CLI 创建，agentd 不再成为它的直接启动者。既有 daemon 只记录待迁移状态，必须由用户确认才会中断并切换 owner；外部 Unix backend 永远只 attach、不接管。Desktop 只有打开但没有运行 turn 时，移动端可以在原 thread 继续，不创建 fork。启用失败时不改配置，关闭时恢复原 WS 配置并卸载 Mimi 的 owner job。
+- 共享 daemon 不等于并发写：Desktop 正在运行的 turn 仍按 external activity 只读；共享模式观测失败时也会 fail-closed 拒绝写入。客户端不能靠 `thread/unsubscribe`、archive/unarchive 或猜测 idle 状态抢占另一个进程。
 - 生产主链路使用 `/api/app-server/ws`；旧 `/api/sessions*`、Web/PWA 和 PTY 文本解析链路不再恢复。
 - 未显式选择模型时不发送 `model`，交给本机 app-server rollout 决定；不要在客户端写死某个模型版本。
 - Codex 默认保持 `approvalPolicy=on-request`、`danger-full-access`、网络关闭；禁止 `approvalPolicy=never` 和默认开网。

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	golang.org/x/image v0.41.0
+	golang.org/x/sys v0.46.0
 	modernc.org/sqlite v1.55.0
 )
 
@@ -19,7 +20,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/appserver/local_daemon.go
+++ b/internal/appserver/local_daemon.go
@@ -36,21 +36,52 @@ const (
 // app-server 版本。
 var localDaemonVersionPattern = regexp.MustCompile(`^[^/\r\n]+/([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)(?:[[:space:](]|$)`)
 
-var ErrLocalDaemonStandaloneMissing = errors.New("Codex standalone 安装缺失")
+var (
+	ErrLocalDaemonStandaloneMissing = errors.New("Codex standalone 安装缺失")
+	// ErrSharedDaemonMigrationPending 表示稳定 owner 已进入人工迁移状态。
+	// 日常启动、gateway recovery 和登录恢复都必须保留该状态，不能把一次
+	// 显式迁移失败悄悄变成后台重试。
+	ErrSharedDaemonMigrationPending = errors.New("Codex 共享 daemon 正在等待用户再次确认迁移")
+)
 
 type LocalDaemonOptions struct {
 	CodexBin    string
 	Env         map[string]string
 	StableOwner bool
+	// ValidateStableOwner 在 shared-daemon 跨进程锁内复核调用方仍拥有恢复权。
+	// 旧 agentd Router 会在这里重新读取磁盘配置，避免禁用完成后用启动时的
+	// 旧配置重新安装 plist。nil 表示调用方不是长期缓存配置的恢复任务。
+	ValidateStableOwner func() error
+	// RollbackOwnerOnFailure 只供“尚未提交配置”的同步设置事务使用。
+	// agentd 启动、gateway recovery 等日常路径必须保持 false：一旦 owner
+	// 已进入 pending/manual 状态，瞬时 socket 或 lifecycle 错误也不能把它
+	// 回滚成 RunAtLoad=true，绕过下一次用户确认。
+	RollbackOwnerOnFailure bool
+	// PrepareOwnerForConfigCommit 只供“从非共享配置切换到 shared unix”的
+	// 两阶段事务使用。准备阶段始终把 owner 落成 RunAtLoad=false，并只允许
+	// 在确认没有旧 daemon 时显式启动一次；配置提交后仍等待用户确认，绝不
+	// 通过冷启动结果自动提升为登录自启。
+	PrepareOwnerForConfigCommit bool
 	// AttachOnly 用于用户或其他工具管理的 Unix backend。Mimi 只验证现有
 	// socket，不启动、不安装 owner，也不改变它的生命周期。
 	AttachOnly bool
 }
 
 type LocalDaemonStatus struct {
-	SocketPath             string
-	StartedAt              time.Time
-	Started                bool
+	SocketPath string
+	StartedAt  time.Time
+	Started    bool
+	// StartedByStableOwner 只有本次确实由 stable owner 执行 kickstart 时为 true。
+	// 通用 Started 也会在 start hook 期间外部 listener 抢先出现时为 true，不能
+	// 用它作为清除 migration marker 或提升 RunAtLoad 的归因证据。
+	StartedByStableOwner bool
+	// DaemonPreexisting 记录两阶段启用准备前已有 listener；此状态必须保持
+	// manual marker 等用户确认，不能在配置提交后自动 kickstart/提升。
+	DaemonPreexisting bool
+	// ConfigCommitted 表示两阶段 enable 的配置 rename 已完成。提交后的启动/
+	// 握手失败不能再作为普通 error 丢给上层，否则 Mac App 不会 reload，也看不到
+	// durable manual marker；setup 需要把它转换成可恢复的 pending 成功结果。
+	ConfigCommitted        bool
 	Version                string
 	OwnerInstalled         bool
 	OwnerCreated           bool
@@ -180,6 +211,9 @@ func ensureLocalDaemonWithStableOwner(
 	ctx context.Context,
 	options LocalDaemonOptions,
 ) (LocalDaemonStatus, error) {
+	if err := validateStableOwnerLease(options); err != nil {
+		return LocalDaemonStatus{}, err
+	}
 	// 先判断 socket 是否已经由旧链路拉起。只有“owner 本次发生变化，且 daemon
 	// 早已存在”时才需要一次显式迁移；全新冷启动由 launchd 直接创建，不应误报。
 	socketPath, pathErr := LocalDaemonSocketPath(options.Env)
@@ -196,26 +230,53 @@ func ensureLocalDaemonWithStableOwner(
 		preexistingErr,
 		sharedDaemonSocketAcceptsConnectionMust(options),
 	)
+	prepared, preparedErr := sharedDaemonEnablePrepared()
+	if preparedErr != nil {
+		return LocalDaemonStatus{}, preparedErr
+	}
 
-	owner, err := EnsureSharedDaemonOwner(ctx, options, daemonPreexisting)
+	owner, err := ensureSharedDaemonOwner(
+		ctx,
+		options,
+		daemonPreexisting,
+		options.PrepareOwnerForConfigCommit || prepared,
+	)
 	if err != nil {
 		return LocalDaemonStatus{}, err
+	}
+	if owner.MigrationRequired && !sharedDaemonSocketAcceptsConnectionMust(options) {
+		if prepared && options.ValidateStableOwner != nil && !options.PrepareOwnerForConfigCommit {
+			// 上一次 fresh enable 可能在“shared 配置已 rename、manual owner 已
+			// 落盘”后掉电。锁内恢复权复核已经证明磁盘仍是同一 shared 身份，
+			// 因此可继续提交后启动；WS 配置或旧快照不会进入这里。
+			return startPreparedSharedDaemonAfterConfigCommit(ctx, options)
+		}
+		if options.PrepareOwnerForConfigCommit && !daemonPreexisting {
+			// 两阶段启用的 owner 此时故意是 manual。没有旧 listener 时允许
+			// 由这个已加载 job 启动一次做冷启动验证；它仍不会在登录时自启。
+		} else {
+			// pending 时磁盘 plist 为 RunAtLoad=false。socket 已不可连只能等待用户
+			// 再次显式确认，不能让普通 ensure 走到 kickstart，也不能把刚落盘的
+			// manual owner/marker 回滚成可自动启动状态。
+			return LocalDaemonStatus{}, stableOwnerEnsureFailure(options, owner, ErrSharedDaemonMigrationPending)
+		}
 	}
 	startedByStableOwner := false
 	status, err := ensureLocalDaemon(ctx, options, localDaemonHooks{
 		probe: ProbeLocalDaemonInfo,
 		start: func(startCtx context.Context, startOptions LocalDaemonOptions) error {
 			var startErr error
-			startedByStableOwner, startErr = startLocalDaemonWithStableOwnerTracked(startCtx, startOptions)
+			if startOptions.PrepareOwnerForConfigCommit {
+				startedByStableOwner, startErr = startPreparedSharedDaemonWithStableOwnerTracked(startCtx, startOptions)
+			} else {
+				startedByStableOwner, startErr = startLocalDaemonWithStableOwnerTracked(startCtx, startOptions)
+			}
 			return startErr
 		},
 		stat: os.Stat,
 	})
 	if err != nil {
-		if rollbackErr := rollbackSharedDaemonOwnerChangeUnlocked(context.Background(), owner.Rollback); rollbackErr != nil {
-			return LocalDaemonStatus{}, fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", err, rollbackErr)
-		}
-		return LocalDaemonStatus{}, err
+		return LocalDaemonStatus{}, stableOwnerEnsureFailure(options, owner, err)
 	}
 	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
 	if err == nil {
@@ -224,28 +285,47 @@ func ensureLocalDaemonWithStableOwner(
 			status,
 			&owner,
 			startedByStableOwner,
-			markSharedDaemonMigrationRequired,
+			func() error {
+				// 现有 SSH bootstrap 重新抢到 socket 时，不只写 marker；还要把
+				// 登录启动持久化为 manual，保证下次登录不会绕过用户确认。
+				updated, ensureErr := ensureSharedDaemonOwner(ctx, options, true, true)
+				if ensureErr == nil {
+					owner = updated
+				}
+				return ensureErr
+			},
 		)
 	}
 	if err != nil {
-		if rollbackErr := rollbackSharedDaemonOwnerChangeUnlocked(context.Background(), owner.Rollback); rollbackErr != nil {
-			return LocalDaemonStatus{}, fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", err, rollbackErr)
-		}
-		return LocalDaemonStatus{}, err
-	}
-	// owner 已经稳定安装、旧 marker 仍存在且本次确实由稳定启动链创建了
-	// daemon 时，完整握手/生命周期/版本校验就是可清理 marker 的充分证据。
-	// owner 本次也发生变化时仍保留 marker，避免破坏配置事务的回滚令牌。
-	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, startedByStableOwner); err != nil {
-		return LocalDaemonStatus{}, err
+		return LocalDaemonStatus{}, stableOwnerEnsureFailure(options, owner, err)
 	}
 	status.OwnerInstalled = owner.Installed
 	status.OwnerCreated = owner.Created
 	status.OwnerChanged = owner.Changed
 	status.OwnerMigrationRequired = owner.MigrationRequired
 	status.OwnerRollback = owner.Rollback
+	status.StartedByStableOwner = startedByStableOwner
 	status.LifecycleValidated = true
+	if prepared && lifecycle.Backend != nil {
+		// 上次进程可能在 manual kickstart 已成功、但 post-commit helper 尚未
+		// 消费 intent 时崩溃。本次普通 Ensure 已在同一 operation lock 内完成
+		// managed lifecycle + probe 校验，必须在返回前消费这份“一次性恢复权”；
+		// marker/manual 继续保留，daemon 再掉线只能等用户重新确认。
+		if clearErr := clearSharedDaemonEnablePrepared(); clearErr != nil {
+			return LocalDaemonStatus{}, clearErr
+		}
+	}
 	return status, nil
+}
+
+func validateStableOwnerLease(options LocalDaemonOptions) error {
+	if options.ValidateStableOwner == nil {
+		return nil
+	}
+	if err := options.ValidateStableOwner(); err != nil {
+		return fmt.Errorf("共享 daemon 恢复权已失效：%w", err)
+	}
+	return nil
 }
 
 // reconcileStableOwnerLifecycle 区分“当前可连接”与“已由稳定 owner
@@ -266,7 +346,6 @@ func reconcileStableOwnerLifecycle(
 	if err := ValidateLocalDaemonProbeVersion(lifecycle, status.Version); err != nil {
 		return err
 	}
-
 	// 任何已声明的 backend 都必须是官方 pid。未知的未来 backend
 	// 不能借旧 marker 绕过校验。
 	if lifecycle.Backend != nil {
@@ -297,20 +376,18 @@ func localDaemonWasPreexisting(probeErr error, socketAcceptsConnection bool) boo
 	return probeErr == nil || socketAcceptsConnection
 }
 
-func finalizeRecoveredSharedDaemonMigration(
-	status *LocalDaemonStatus,
-	owner *SharedDaemonOwnerStatus,
-	startedByStableOwner bool,
+func stableOwnerEnsureFailure(
+	options LocalDaemonOptions,
+	owner SharedDaemonOwnerStatus,
+	cause error,
 ) error {
-	if status == nil || owner == nil || !status.Started || !startedByStableOwner ||
-		!owner.MigrationRequired || owner.Changed {
-		return nil
+	if !options.RollbackOwnerOnFailure {
+		return cause
 	}
-	if err := clearSharedDaemonMigrationFlag(); err != nil {
-		return fmt.Errorf("共享 daemon 已恢复，但清除旧迁移状态失败：%w", err)
+	if rollbackErr := rollbackSharedDaemonOwnerChangeUnlocked(context.Background(), owner.Rollback); rollbackErr != nil {
+		return fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", cause, rollbackErr)
 	}
-	owner.MigrationRequired = false
-	return nil
+	return cause
 }
 
 func rollbackSharedDaemonOwnerChangeUnlocked(
@@ -321,6 +398,253 @@ func rollbackSharedDaemonOwnerChangeUnlocked(
 		return nil
 	}
 	return rollback.rollbackUnlocked(ctx)
+}
+
+// CommitSharedDaemonEnable 把 manual owner 准备、daemon 冷启动验证和配置提交
+// 放进同一把跨进程锁。配置提交前后磁盘 owner 都保持
+// RunAtLoad=false；进程在任意准备步骤退出都不会让非共享配置留下自动启动入口。
+func CommitSharedDaemonEnable(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	validate func() error,
+	commit func() error,
+) (LocalDaemonStatus, error) {
+	options.StableOwner = true
+	options.PrepareOwnerForConfigCommit = true
+	options.RollbackOwnerOnFailure = false
+	return withSharedDaemonOperationLock(ctx, func() (LocalDaemonStatus, error) {
+		if validate == nil {
+			return LocalDaemonStatus{}, fmt.Errorf("提交共享配置前的复核回调不能为空")
+		}
+		if err := validate(); err != nil {
+			return LocalDaemonStatus{}, fmt.Errorf("共享配置快照已变化：%w", err)
+		}
+		if commit == nil {
+			return LocalDaemonStatus{}, fmt.Errorf("提交共享配置的回调不能为空")
+		}
+
+		status, err := prepareSharedDaemonOwnerForConfigCommit(ctx, options)
+		if err != nil {
+			// 此时磁盘配置仍是非共享；失败清理必须收敛到“无 Mimi owner”，
+			// 不能恢复一个历史 RunAtLoad=true 残留。
+			if cleanupErr := removeSharedDaemonOwnerUnlocked(context.Background()); cleanupErr != nil {
+				return LocalDaemonStatus{}, fmt.Errorf("%w；清理未提交的共享 daemon owner 也失败：%v", err, cleanupErr)
+			}
+			return LocalDaemonStatus{}, err
+		}
+		if !status.DaemonPreexisting {
+			if err := markSharedDaemonEnablePrepared(); err != nil {
+				if cleanupErr := removeSharedDaemonOwnerUnlocked(context.Background()); cleanupErr != nil {
+					return LocalDaemonStatus{}, fmt.Errorf("%w；清理未提交的共享 daemon owner 也失败：%v", err, cleanupErr)
+				}
+				return LocalDaemonStatus{}, err
+			}
+		}
+		if err := commit(); err != nil {
+			if cleanupErr := removeSharedDaemonOwnerUnlocked(context.Background()); cleanupErr != nil {
+				return LocalDaemonStatus{}, fmt.Errorf("%w；清理未提交的共享 daemon owner 也失败：%v", err, cleanupErr)
+			}
+			return LocalDaemonStatus{}, err
+		}
+		status.ConfigCommitted = true
+
+		// 此刻配置已经是 shared，硬崩溃只会留下 shared+manual owner；日常
+		// Ensure 会保持 pending，不会回退到独立 WS。没有旧 listener 时才由
+		// prepared owner 显式启动并完整握手，但仍保持 manual+marker；已有
+		// listener 同样等待用户确认。只有 Desktop 正常退出后的显式迁移入口
+		// 才能提升 auto，避免把启动窗口内抢占 socket 的进程误归因给 owner。
+		if !status.DaemonPreexisting {
+			started, startErr := startPreparedSharedDaemonAfterConfigCommit(ctx, options)
+			if startErr != nil {
+				status.OwnerMigrationRequired = true
+				return status, fmt.Errorf("共享配置已提交，但 Codex daemon 启动失败：%w", startErr)
+			}
+			status = started
+			status.ConfigCommitted = true
+		}
+		status.OwnerRollback = nil
+		return status, nil
+	})
+}
+
+func prepareSharedDaemonOwnerForConfigCommit(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (LocalDaemonStatus, error) {
+	if err := validateStableOwnerLease(options); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	probe, probeErr := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancel()
+	preexisting := localDaemonWasPreexisting(
+		probeErr,
+		sharedDaemonSocketAcceptsConnectionMust(options),
+	)
+	if preexisting && probeErr != nil {
+		// 仅能建立 Unix 连接不等于可共享。旧 daemon 忙死、协议不兼容或伪造
+		// listener 都必须在配置提交前失败；否则会把 WS 配置切到一个 reload
+		// 后无法 initialize 的 backend。
+		return LocalDaemonStatus{}, fmt.Errorf("Codex daemon socket 已存在但完整握手失败：%w", probeErr)
+	}
+	owner, err := ensureSharedDaemonOwner(ctx, options, preexisting, true)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
+	if err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("确认 Codex daemon 冷启动能力失败：%w", err)
+	}
+	if err := ValidateLocalDaemonStandaloneCapability(lifecycle, socketPath); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	status := LocalDaemonStatus{
+		SocketPath:             socketPath,
+		OwnerInstalled:         owner.Installed,
+		OwnerCreated:           owner.Created,
+		OwnerChanged:           owner.Changed,
+		OwnerMigrationRequired: owner.MigrationRequired,
+		OwnerRollback:          owner.Rollback,
+		DaemonPreexisting:      preexisting,
+	}
+	if probeErr == nil {
+		status.Version = probe.Version
+		if err := ValidateLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
+			return LocalDaemonStatus{}, err
+		}
+		if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
+			return LocalDaemonStatus{}, err
+		}
+		status.LifecycleValidated = true
+	}
+	return status, nil
+}
+
+func commitConfigWithSharedDaemonLock(
+	ctx context.Context,
+	removeOwner func(context.Context) error,
+	validate func() error,
+	commit func() error,
+) error {
+	_, err := withSharedDaemonOperationLock(ctx, func() (LocalDaemonStatus, error) {
+		if validate == nil {
+			return LocalDaemonStatus{}, fmt.Errorf("提交配置前的复核回调不能为空")
+		}
+		if err := validate(); err != nil {
+			return LocalDaemonStatus{}, fmt.Errorf("配置快照已变化：%w", err)
+		}
+		if commit == nil {
+			return LocalDaemonStatus{}, fmt.Errorf("配置提交回调不能为空")
+		}
+		if removeOwner != nil {
+			if err := removeOwner(ctx); err != nil {
+				return LocalDaemonStatus{}, err
+			}
+		}
+		if err := commit(); err != nil {
+			// commit 里的最后一次 CAS 可能因为不遵守 Mimi 锁的外部编辑器
+			// 已经写成 WS 而失败。此时恢复旧 auto owner 会制造“WS + 登录自启
+			// Unix daemon”的危险组合；shared+无 owner 与 WS+无 owner 都是可恢复
+			// 的 fail-closed 状态，因此提交失败后统一保持 owner 已移除。
+			return LocalDaemonStatus{}, err
+		}
+		return LocalDaemonStatus{}, nil
+	})
+	return err
+}
+
+// CommitConfigWithSharedDaemonLock 供 setup --force 这类通用配置写入者使用。
+// 它不假定当前配置拥有 Mimi 的 stable owner，只负责与 enable/disable/recovery
+// 共用同一把锁，避免在 shared 配置已经提交、owner 尚未提升的窗口插入写入。
+func CommitConfigWithSharedDaemonLock(
+	ctx context.Context,
+	validate func() error,
+	commit func() error,
+) error {
+	return commitConfigWithSharedDaemonLock(ctx, nil, validate, commit)
+}
+
+// CommitConfigReplacingSharedDaemon 供 setup --force 使用。setup 的结果不带
+// Mimi shared_fallback，因此只要磁盘仍有 Mimi plist/marker/enable intent，就必须
+// 在同一 operation lock 内先移除未来启动入口；没有任何 artifact 时不查询
+// launchctl，避免把测试 Home 或从未启用共享的机器误判成残缺 job。
+func CommitConfigReplacingSharedDaemon(
+	ctx context.Context,
+	validate func() error,
+	commit func() error,
+) error {
+	removeIfPresent := func(removeCtx context.Context) error {
+		present, err := SharedDaemonOwnerArtifactsPresent()
+		if err != nil {
+			return err
+		}
+		if !present {
+			return nil
+		}
+		_, err = removeSharedDaemonOwnerForTransactionUnlocked(removeCtx)
+		return err
+	}
+	return commitConfigWithSharedDaemonLock(ctx, removeIfPresent, validate, commit)
+}
+
+// CommitConfigRepairingSharedDaemonIdentity 供 Doctor 更新 codex.bin 使用。
+// auto owner 可以移除后由新 agentd 按新身份重建；manual/marker/enable intent
+// 则代表用户尚未确认迁移，必须原样保留。这样 Repair 不会把 pending 擦掉，
+// 也不会让下一次普通 Ensure 把 owner 误升为 RunAtLoad=true。
+func CommitConfigRepairingSharedDaemonIdentity(
+	ctx context.Context,
+	validate func() error,
+	commit func() error,
+) error {
+	removeUnlessPending := func(removeCtx context.Context) error {
+		owner, err := InspectSharedDaemonOwner(removeCtx)
+		if err != nil {
+			return err
+		}
+		prepared, err := sharedDaemonEnablePrepared()
+		if err != nil {
+			return err
+		}
+		if owner.MigrationRequired || (owner.Installed && !owner.RunAtLoad) || prepared {
+			return nil
+		}
+		present, err := SharedDaemonOwnerArtifactsPresent()
+		if err != nil {
+			return err
+		}
+		if !present {
+			return nil
+		}
+		_, err = removeSharedDaemonOwnerForTransactionUnlocked(removeCtx)
+		return err
+	}
+	return commitConfigWithSharedDaemonLock(ctx, removeUnlessPending, validate, commit)
+}
+
+// CommitSharedDaemonDisable 先移除 owner，再提交非共享配置。崩溃在
+// 两步之间只会留下“shared 配置 + 无 owner”，下次正常 shared 启动可自动修复；
+// 绝不会出现“WS 配置 + RunAtLoad=true owner”的危险方向。
+func CommitSharedDaemonDisable(
+	ctx context.Context,
+	validate func() error,
+	commit func() error,
+) error {
+	removeOwner := func(removeCtx context.Context) error {
+		_, err := removeSharedDaemonOwnerForTransactionUnlocked(removeCtx)
+		return err
+	}
+	return commitConfigWithSharedDaemonLock(ctx, removeOwner, validate, commit)
+}
+
+// ReconcileDisabledSharedDaemonOwner 供非 shared 的 agentd 启动路径清理上次
+// 两阶段启用在进程退出后留下的 manual owner。复核与清理同锁执行，不能误删
+// 已由另一个进程成功提交的新 shared owner。
+func ReconcileDisabledSharedDaemonOwner(ctx context.Context, validate func() error) error {
+	return CommitSharedDaemonDisable(ctx, validate, func() error { return nil })
 }
 
 func attachLocalDaemon(ctx context.Context, options LocalDaemonOptions) (LocalDaemonStatus, error) {
@@ -479,6 +803,13 @@ func ValidateLocalDaemonLifecycle(status LocalDaemonLifecycleStatus, expectedSoc
 	if !strings.EqualFold(strings.TrimSpace(status.Status), "running") {
 		return fmt.Errorf("Codex local daemon 未处于 running 状态")
 	}
+	return ValidateLocalDaemonStandaloneCapability(status, expectedSocket)
+}
+
+// ValidateLocalDaemonStandaloneCapability 只验证官方 daemon 的冷启动材料，
+// 不要求 socket 当前已经 running。fresh enable 在配置仍是 WS 时必须先做这个
+// 只读检查，再提交 shared 配置；绝不能为了验证而提前 kickstart 第二个 backend。
+func ValidateLocalDaemonStandaloneCapability(status LocalDaemonLifecycleStatus, expectedSocket string) error {
 	if strings.TrimSpace(status.SocketPath) == "" ||
 		!sameCanonicalPath(status.SocketPath, expectedSocket) {
 		return fmt.Errorf("Codex local daemon 使用了不同的 CODEX_HOME")

--- a/internal/appserver/local_daemon.go
+++ b/internal/appserver/local_daemon.go
@@ -39,15 +39,31 @@ var localDaemonVersionPattern = regexp.MustCompile(`^[^/\r\n]+/([0-9]+\.[0-9]+\.
 var ErrLocalDaemonStandaloneMissing = errors.New("Codex standalone 安装缺失")
 
 type LocalDaemonOptions struct {
-	CodexBin string
-	Env      map[string]string
+	CodexBin    string
+	Env         map[string]string
+	StableOwner bool
+	// AttachOnly 用于用户或其他工具管理的 Unix backend。Mimi 只验证现有
+	// socket，不启动、不安装 owner，也不改变它的生命周期。
+	AttachOnly bool
 }
 
 type LocalDaemonStatus struct {
-	SocketPath string
-	StartedAt  time.Time
-	Started    bool
-	Version    string
+	SocketPath             string
+	StartedAt              time.Time
+	Started                bool
+	Version                string
+	OwnerInstalled         bool
+	OwnerCreated           bool
+	OwnerChanged           bool
+	OwnerMigrationRequired bool
+	OwnerRollback          *SharedDaemonOwnerRollback
+	LifecycleValidated     bool
+}
+
+// SharedDaemonOwnerRollback 是配置提交前可使用的一次性回滚能力。令牌只驻留
+// 当前进程内存，不序列化 plist 内容或其中可能存在的 MCP 环境变量。
+type SharedDaemonOwnerRollback struct {
+	rollbackUnlocked func(context.Context) error
 }
 
 type localDaemonHooks struct {
@@ -64,7 +80,11 @@ type LocalDaemonProbe struct {
 // LocalDaemonLifecycleStatus 来自官方 `daemon version`，用于区分“当前 socket
 // 可连接”和“冷启动也有 standalone 安装可恢复”两个不同健康层级。
 type LocalDaemonLifecycleStatus struct {
-	Status              string  `json:"status"`
+	Status string `json:"status"`
+	// Backend/PID 由新版官方 daemon version 在自身持有 pid backend 时返回。
+	// 旧的 SSH 直启 socket 没有这两个字段，必须走显式、严格校验的接管流程。
+	Backend             *string `json:"backend,omitempty"`
+	PID                 *uint32 `json:"pid,omitempty"`
 	ManagedCodexPath    string  `json:"managedCodexPath"`
 	ManagedCodexVersion *string `json:"managedCodexVersion"`
 	SocketPath          string  `json:"socketPath"`
@@ -141,11 +161,183 @@ func LocalDaemonHandshakeURL() string {
 // 已运行并连接，不在退出时停止它；否则重启 Mimi 会把正在使用共享 daemon 的
 // Codex Desktop 一并打断，违背共享服务的生命周期边界。
 func EnsureLocalDaemon(ctx context.Context, options LocalDaemonOptions) (LocalDaemonStatus, error) {
-	return ensureLocalDaemon(ctx, options, localDaemonHooks{
-		probe: ProbeLocalDaemonInfo,
-		start: startLocalDaemon,
-		stat:  os.Stat,
+	if options.AttachOnly {
+		return attachLocalDaemon(ctx, options)
+	}
+	if !options.StableOwner {
+		return ensureLocalDaemon(ctx, options, localDaemonHooks{
+			probe: ProbeLocalDaemonInfo,
+			start: startLocalDaemon,
+			stat:  os.Stat,
+		})
+	}
+	return withSharedDaemonOperationLock(ctx, func() (LocalDaemonStatus, error) {
+		return ensureLocalDaemonWithStableOwner(ctx, options)
 	})
+}
+
+func ensureLocalDaemonWithStableOwner(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (LocalDaemonStatus, error) {
+	// 先判断 socket 是否已经由旧链路拉起。只有“owner 本次发生变化，且 daemon
+	// 早已存在”时才需要一次显式迁移；全新冷启动由 launchd 直接创建，不应误报。
+	socketPath, pathErr := LocalDaemonSocketPath(options.Env)
+	if pathErr != nil {
+		return LocalDaemonStatus{}, pathErr
+	}
+	probeCtx, cancelProbe := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	_, preexistingErr := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancelProbe()
+	// 完整协议探测可能因为旧 daemon 正忙而超时；只要 Unix socket 仍真实监听，
+	// 就必须按“已有 daemon”保守处理并留下显式迁移标记。否则一次瞬时超时会把
+	// 旧责任链误判成全新冷启动，静默跳过用户确认。
+	daemonPreexisting := localDaemonWasPreexisting(
+		preexistingErr,
+		sharedDaemonSocketAcceptsConnectionMust(options),
+	)
+
+	owner, err := EnsureSharedDaemonOwner(ctx, options, daemonPreexisting)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	startedByStableOwner := false
+	status, err := ensureLocalDaemon(ctx, options, localDaemonHooks{
+		probe: ProbeLocalDaemonInfo,
+		start: func(startCtx context.Context, startOptions LocalDaemonOptions) error {
+			var startErr error
+			startedByStableOwner, startErr = startLocalDaemonWithStableOwnerTracked(startCtx, startOptions)
+			return startErr
+		},
+		stat: os.Stat,
+	})
+	if err != nil {
+		if rollbackErr := rollbackSharedDaemonOwnerChangeUnlocked(context.Background(), owner.Rollback); rollbackErr != nil {
+			return LocalDaemonStatus{}, fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", err, rollbackErr)
+		}
+		return LocalDaemonStatus{}, err
+	}
+	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
+	if err == nil {
+		err = reconcileStableOwnerLifecycle(
+			lifecycle,
+			status,
+			&owner,
+			startedByStableOwner,
+			markSharedDaemonMigrationRequired,
+		)
+	}
+	if err != nil {
+		if rollbackErr := rollbackSharedDaemonOwnerChangeUnlocked(context.Background(), owner.Rollback); rollbackErr != nil {
+			return LocalDaemonStatus{}, fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", err, rollbackErr)
+		}
+		return LocalDaemonStatus{}, err
+	}
+	// owner 已经稳定安装、旧 marker 仍存在且本次确实由稳定启动链创建了
+	// daemon 时，完整握手/生命周期/版本校验就是可清理 marker 的充分证据。
+	// owner 本次也发生变化时仍保留 marker，避免破坏配置事务的回滚令牌。
+	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, startedByStableOwner); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	status.OwnerInstalled = owner.Installed
+	status.OwnerCreated = owner.Created
+	status.OwnerChanged = owner.Changed
+	status.OwnerMigrationRequired = owner.MigrationRequired
+	status.OwnerRollback = owner.Rollback
+	status.LifecycleValidated = true
+	return status, nil
+}
+
+// reconcileStableOwnerLifecycle 区分“当前可连接”与“已由稳定 owner
+// 管理”。已安装的 LaunchAgent 不代表它一定赢得了本次 socket
+// 竞争：Codex 原生 SSH bootstrap 仍可能先启动直接 listener。这时
+// agentd 应保持 attach 与移动端可用，同时重建待迁移标记；绝不在
+// 日常启动路径终止该进程。
+func reconcileStableOwnerLifecycle(
+	lifecycle LocalDaemonLifecycleStatus,
+	status LocalDaemonStatus,
+	owner *SharedDaemonOwnerStatus,
+	startedByStableOwner bool,
+	markMigrationRequired func() error,
+) error {
+	if err := ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); err != nil {
+		return err
+	}
+	if err := ValidateLocalDaemonProbeVersion(lifecycle, status.Version); err != nil {
+		return err
+	}
+
+	// 任何已声明的 backend 都必须是官方 pid。未知的未来 backend
+	// 不能借旧 marker 绕过校验。
+	if lifecycle.Backend != nil {
+		return ValidateManagedLocalDaemonLifecycle(lifecycle, status.SocketPath)
+	}
+	// 本次明确执行了稳定 owner kickstart，却仍看不到 backend，说明
+	// 启动结果不能归因给该 owner，必须 fail closed。
+	if startedByStableOwner {
+		return ValidateManagedLocalDaemonLifecycle(lifecycle, status.SocketPath)
+	}
+	if owner == nil || !owner.Installed || !owner.Loaded || !owner.Secure {
+		return fmt.Errorf("非 daemon 管理的 Codex app-server 缺少安全稳定 owner")
+	}
+	if owner.MigrationRequired {
+		return nil
+	}
+	if markMigrationRequired == nil {
+		return fmt.Errorf("检测到非 daemon 管理的 Codex app-server，但无法记录待迁移状态")
+	}
+	if err := markMigrationRequired(); err != nil {
+		return fmt.Errorf("检测到非 daemon 管理的 Codex app-server，但记录待迁移状态失败：%w", err)
+	}
+	owner.MigrationRequired = true
+	return nil
+}
+
+func localDaemonWasPreexisting(probeErr error, socketAcceptsConnection bool) bool {
+	return probeErr == nil || socketAcceptsConnection
+}
+
+func finalizeRecoveredSharedDaemonMigration(
+	status *LocalDaemonStatus,
+	owner *SharedDaemonOwnerStatus,
+	startedByStableOwner bool,
+) error {
+	if status == nil || owner == nil || !status.Started || !startedByStableOwner ||
+		!owner.MigrationRequired || owner.Changed {
+		return nil
+	}
+	if err := clearSharedDaemonMigrationFlag(); err != nil {
+		return fmt.Errorf("共享 daemon 已恢复，但清除旧迁移状态失败：%w", err)
+	}
+	owner.MigrationRequired = false
+	return nil
+}
+
+func rollbackSharedDaemonOwnerChangeUnlocked(
+	ctx context.Context,
+	rollback *SharedDaemonOwnerRollback,
+) error {
+	if rollback == nil || rollback.rollbackUnlocked == nil {
+		return nil
+	}
+	return rollback.rollbackUnlocked(ctx)
+}
+
+func attachLocalDaemon(ctx context.Context, options LocalDaemonOptions) (LocalDaemonStatus, error) {
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	probe, err := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancel()
+	if err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf(
+			"外部管理的 Codex Unix backend 未就绪；Mimi 不会启动或接管它：%w",
+			err,
+		)
+	}
+	return localDaemonStatus(socketPath, false, probe.Version, os.Stat), nil
 }
 
 func ensureLocalDaemon(
@@ -167,7 +359,11 @@ func ensureLocalDaemon(
 		return LocalDaemonStatus{}, err
 	}
 
-	startCtx, cancelStart := context.WithTimeout(ctx, localDaemonStartTimeout)
+	startTimeout := localDaemonStartTimeout
+	if options.StableOwner && sharedDaemonStartTimeoutForLocalEnsure > startTimeout {
+		startTimeout = sharedDaemonStartTimeoutForLocalEnsure
+	}
+	startCtx, cancelStart := context.WithTimeout(ctx, startTimeout)
 	err = hooks.start(startCtx, options)
 	cancelStart()
 	if err != nil {
@@ -207,7 +403,19 @@ func localDaemonStatus(
 	return status
 }
 
+// startLocalDaemon 不再由 agentd 直接创建 daemon 进程。macOS 的 TCC responsible
+// process 在进程创建时从父进程继承：agentd 一旦成为共享 daemon 的父进程，Desktop
+// 后续经由该 daemon 发起的文件访问就会被归因到 Mimi，且 Mimi 升级或移动后还会留下
+// 指向旧 App 路径的 stale responsibility（MIM-157）。因此启动动作交给平台上稳定的
+// 服务管理器；非 macOS 平台没有 TCC，继续沿用直接 exec。
 func startLocalDaemon(ctx context.Context, options LocalDaemonOptions) error {
+	if options.StableOwner {
+		return startLocalDaemonWithStableOwner(ctx, options)
+	}
+	return startLocalDaemonDirect(ctx, options)
+}
+
+func startLocalDaemonDirect(ctx context.Context, options LocalDaemonOptions) error {
 	bin := strings.TrimSpace(options.CodexBin)
 	if bin == "" {
 		bin = "codex"
@@ -296,6 +504,22 @@ func ValidateLocalDaemonLifecycle(status LocalDaemonLifecycleStatus, expectedSoc
 	}
 	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
 		return fmt.Errorf("%w；managed Codex 不是可执行的普通文件", ErrLocalDaemonStandaloneMissing)
+	}
+	return nil
+}
+
+// ValidateManagedLocalDaemonLifecycle 在通用冷启动校验上进一步证明当前 socket
+// 已由官方 pid backend 管理。旧 SSH 直启进程的 version 输出没有 backend；它只
+// 能在 migration marker 存在时短暂 attach，不能被当成稳定迁移已经完成。
+func ValidateManagedLocalDaemonLifecycle(
+	status LocalDaemonLifecycleStatus,
+	expectedSocket string,
+) error {
+	if err := ValidateLocalDaemonLifecycle(status, expectedSocket); err != nil {
+		return err
+	}
+	if status.Backend == nil || !strings.EqualFold(strings.TrimSpace(*status.Backend), "pid") {
+		return fmt.Errorf("Codex app-server 尚未由官方 pid daemon 管理")
 	}
 	return nil
 }

--- a/internal/appserver/local_daemon_test.go
+++ b/internal/appserver/local_daemon_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+func TestLocalDaemonPreexistingFallsBackToLiveSocket(t *testing.T) {
+	probeTimeout := errors.New("initialize timeout")
+	if !localDaemonWasPreexisting(probeTimeout, true) {
+		t.Fatal("协议探测超时时，仍在监听的 socket 必须按旧 daemon 处理")
+	}
+	if localDaemonWasPreexisting(probeTimeout, false) {
+		t.Fatal("协议和轻量连接都失败时才允许按全新冷启动处理")
+	}
+	if !localDaemonWasPreexisting(nil, false) {
+		t.Fatal("完整协议探测成功必须视为已有 daemon")
+	}
+}
+
 func TestLocalDaemonSocketPathUsesCanonicalCodexHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows 不支持 Codex Unix daemon")
@@ -126,6 +139,22 @@ func TestEnsureLocalDaemonAttachesBeforeStarting(t *testing.T) {
 	}
 }
 
+func TestAttachOnlyLocalDaemonNeverStartsBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows 不支持 Codex Unix daemon")
+	}
+	codexHome := shortCodexHome(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := EnsureLocalDaemon(ctx, LocalDaemonOptions{
+		Env:        map[string]string{"CODEX_HOME": codexHome},
+		AttachOnly: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "不会启动或接管") {
+		t.Fatalf("外部 Unix backend 缺失时必须 attach-only 失败：%v", err)
+	}
+}
+
 func TestEnsureLocalDaemonStartsOnceThenProbes(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows 不支持 Codex Unix daemon")
@@ -225,7 +254,7 @@ func TestInspectLocalDaemonLifecycleParsesOfficialJSON(t *testing.T) {
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "codex")
 	script := `#!/bin/sh
-printf '%s\n' '{"status":"running","managedCodexPath":"/tmp/codex","managedCodexVersion":"0.147.0","socketPath":"/tmp/app-server-control.sock","cliVersion":"0.147.0","appServerVersion":"0.147.0"}'
+printf '%s\n' '{"status":"running","backend":"pid","managedCodexPath":"/tmp/codex","managedCodexVersion":"0.147.0","socketPath":"/tmp/app-server-control.sock","cliVersion":"0.147.0","appServerVersion":"0.147.0"}'
 `
 	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
@@ -235,6 +264,7 @@ printf '%s\n' '{"status":"running","managedCodexPath":"/tmp/codex","managedCodex
 		t.Fatal(err)
 	}
 	if status.Status != "running" || status.AppServerVersion != "0.147.0" ||
+		status.Backend == nil || *status.Backend != "pid" ||
 		status.ManagedCodexVersion == nil || *status.ManagedCodexVersion != "0.147.0" {
 		t.Fatalf("daemon version JSON 解析错误：%+v", status)
 	}
@@ -273,6 +303,180 @@ func TestValidateLocalDaemonLifecycleRequiresOfficialManagedPath(t *testing.T) {
 	status.ManagedCodexPath = official
 	if err := ValidateLocalDaemonLifecycle(status, socketPath); err != nil {
 		t.Fatalf("同一 CODEX_HOME 的官方 standalone 应通过：%v", err)
+	}
+	if err := ValidateManagedLocalDaemonLifecycle(status, socketPath); err == nil {
+		t.Fatal("缺少 backend 的旧 SSH 直启 socket 不能冒充 managed daemon")
+	}
+	backend := "pid"
+	status.Backend = &backend
+	if err := ValidateManagedLocalDaemonLifecycle(status, socketPath); err != nil {
+		t.Fatalf("官方 pid backend 应通过 managed 校验：%v", err)
+	}
+}
+
+func TestReconcileStableOwnerLifecycleMarksDetectedUnmanagedBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows 不支持 Codex Unix daemon")
+	}
+	codexHome := shortCodexHome(t)
+	socketPath := filepath.Join(codexHome, localDaemonSocketDir, localDaemonSocketName)
+	official := filepath.Join(codexHome, "packages", "standalone", "current", "codex")
+	if err := os.MkdirAll(filepath.Dir(official), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(official, []byte("test"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	version := "0.147.0"
+	lifecycle := LocalDaemonLifecycleStatus{
+		Status:              "running",
+		ManagedCodexPath:    official,
+		ManagedCodexVersion: &version,
+		SocketPath:          socketPath,
+		CLIVersion:          version,
+		AppServerVersion:    version,
+	}
+	status := LocalDaemonStatus{SocketPath: socketPath, Version: version}
+	owner := SharedDaemonOwnerStatus{Installed: true, Loaded: true, Secure: true}
+	markCalls := 0
+	if err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, false, func() error {
+		markCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("稳定 owner 下检测到 SSH unmanaged backend 应保持 attach：%v", err)
+	}
+	if !owner.MigrationRequired || markCalls != 1 {
+		t.Fatalf("必须重建待迁移标记：owner=%+v markCalls=%d", owner, markCalls)
+	}
+	if err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, false, func() error {
+		markCalls++
+		return nil
+	}); err != nil || markCalls != 1 {
+		t.Fatalf("已有 marker 时必须幂等：err=%v markCalls=%d", err, markCalls)
+	}
+}
+
+func TestReconcileStableOwnerLifecycleRejectsUnmanagedAfterStableKickstart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows 不支持 Codex Unix daemon")
+	}
+	codexHome := shortCodexHome(t)
+	socketPath := filepath.Join(codexHome, localDaemonSocketDir, localDaemonSocketName)
+	official := filepath.Join(codexHome, "packages", "standalone", "current", "codex")
+	if err := os.MkdirAll(filepath.Dir(official), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(official, []byte("test"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	version := "0.147.0"
+	lifecycle := LocalDaemonLifecycleStatus{
+		Status:              "running",
+		ManagedCodexPath:    official,
+		ManagedCodexVersion: &version,
+		SocketPath:          socketPath,
+		CLIVersion:          version,
+		AppServerVersion:    version,
+	}
+	status := LocalDaemonStatus{SocketPath: socketPath, Version: version}
+	owner := SharedDaemonOwnerStatus{Installed: true, Loaded: true, Secure: true, MigrationRequired: true}
+	markCalls := 0
+	err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, true, func() error {
+		markCalls++
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "pid daemon") || markCalls != 0 {
+		t.Fatalf("稳定 owner kickstart 后仍无 backend 必须 fail closed：err=%v mark=%d", err, markCalls)
+	}
+}
+
+func TestReconcileStableOwnerLifecycleRejectsUnknownBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows 不支持 Codex Unix daemon")
+	}
+	codexHome := shortCodexHome(t)
+	socketPath := filepath.Join(codexHome, localDaemonSocketDir, localDaemonSocketName)
+	official := filepath.Join(codexHome, "packages", "standalone", "current", "codex")
+	if err := os.MkdirAll(filepath.Dir(official), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(official, []byte("test"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	version := "0.147.0"
+	backend := "future"
+	lifecycle := LocalDaemonLifecycleStatus{
+		Status:              "running",
+		Backend:             &backend,
+		ManagedCodexPath:    official,
+		ManagedCodexVersion: &version,
+		SocketPath:          socketPath,
+		CLIVersion:          version,
+		AppServerVersion:    version,
+	}
+	owner := SharedDaemonOwnerStatus{Installed: true, Loaded: true, Secure: true, MigrationRequired: true}
+	markCalls := 0
+	err := reconcileStableOwnerLifecycle(
+		lifecycle,
+		LocalDaemonStatus{SocketPath: socketPath, Version: version},
+		&owner,
+		false,
+		func() error { markCalls++; return nil },
+	)
+	if err == nil || markCalls != 0 {
+		t.Fatalf("未知 backend 不能借 marker 绕过 managed 校验：err=%v mark=%d", err, markCalls)
+	}
+}
+
+func TestReconcileStableOwnerLifecycleRequiresSecureOwnerAndWritableMarker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows 不支持 Codex Unix daemon")
+	}
+	codexHome := shortCodexHome(t)
+	socketPath := filepath.Join(codexHome, localDaemonSocketDir, localDaemonSocketName)
+	official := filepath.Join(codexHome, "packages", "standalone", "current", "codex")
+	if err := os.MkdirAll(filepath.Dir(official), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(official, []byte("test"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	version := "0.147.0"
+	lifecycle := LocalDaemonLifecycleStatus{
+		Status:              "running",
+		ManagedCodexPath:    official,
+		ManagedCodexVersion: &version,
+		SocketPath:          socketPath,
+		CLIVersion:          version,
+		AppServerVersion:    version,
+	}
+	status := LocalDaemonStatus{SocketPath: socketPath, Version: version}
+
+	unsafeOwners := map[string]SharedDaemonOwnerStatus{
+		"not installed": {Loaded: true, Secure: true},
+		"not loaded":    {Installed: true, Secure: true},
+		"not secure":    {Installed: true, Loaded: true},
+	}
+	for name, owner := range unsafeOwners {
+		t.Run(name, func(t *testing.T) {
+			markCalls := 0
+			err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, false, func() error {
+				markCalls++
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "缺少安全稳定 owner") || markCalls != 0 {
+				t.Fatalf("不安全 owner 必须在写 marker 前拒绝：err=%v mark=%d", err, markCalls)
+			}
+		})
+	}
+
+	markerErr := errors.New("磁盘只读")
+	owner := SharedDaemonOwnerStatus{Installed: true, Loaded: true, Secure: true}
+	err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, false, func() error {
+		return markerErr
+	})
+	if err == nil || !errors.Is(err, markerErr) || owner.MigrationRequired {
+		t.Fatalf("marker 写入失败必须 fail closed 且不得伪报待迁移：err=%v owner=%+v", err, owner)
 	}
 }
 

--- a/internal/appserver/local_daemon_test.go
+++ b/internal/appserver/local_daemon_test.go
@@ -29,6 +29,44 @@ func TestLocalDaemonPreexistingFallsBackToLiveSocket(t *testing.T) {
 	}
 }
 
+func TestStableOwnerEnsureFailureOnlyRollsBackConfigurationTransaction(t *testing.T) {
+	cause := errors.New("lifecycle unavailable")
+	tests := []struct {
+		name          string
+		options       LocalDaemonOptions
+		wantRollbacks int
+	}{
+		{
+			name:          "ordinary runtime preserves pending owner",
+			options:       LocalDaemonOptions{StableOwner: true},
+			wantRollbacks: 0,
+		},
+		{
+			name: "uncommitted configuration may restore previous owner",
+			options: LocalDaemonOptions{
+				StableOwner:            true,
+				RollbackOwnerOnFailure: true,
+			},
+			wantRollbacks: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rollbacks := 0
+			owner := SharedDaemonOwnerStatus{Rollback: &SharedDaemonOwnerRollback{
+				rollbackUnlocked: func(context.Context) error {
+					rollbacks++
+					return nil
+				},
+			}}
+			err := stableOwnerEnsureFailure(test.options, owner, cause)
+			if !errors.Is(err, cause) || rollbacks != test.wantRollbacks {
+				t.Fatalf("owner rollback 边界错误：err=%v rollbacks=%d", err, rollbacks)
+			}
+		})
+	}
+}
+
 func TestLocalDaemonSocketPathUsesCanonicalCodexHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows 不支持 Codex Unix daemon")
@@ -79,7 +117,7 @@ func TestProbeLocalDaemonPerformsInitializeHandshake(t *testing.T) {
 		t.Skip("Windows 不支持 Unix socket")
 	}
 	codexHome := shortCodexHome(t)
-	socketPath, initialized := startLocalDaemonTestServer(t, codexHome, "mimi_remote_daemon_probe/0.147.0-alpha.6.5 (Mac OS; arm64)")
+	socketPath, initialized, _ := startLocalDaemonTestServer(t, codexHome, "mimi_remote_daemon_probe/0.147.0-alpha.6.5 (Mac OS; arm64)")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -102,7 +140,7 @@ func TestProbeLocalDaemonRejectsUnsupportedVersion(t *testing.T) {
 		t.Skip("Windows 不支持 Unix socket")
 	}
 	codexHome := shortCodexHome(t)
-	socketPath, _ := startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.140.9 (Mac OS; arm64)")
+	socketPath, _, _ := startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.140.9 (Mac OS; arm64)")
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if _, err := ProbeLocalDaemonInfo(ctx, socketPath); err == nil {
@@ -494,7 +532,7 @@ func startLocalDaemonTestServer(
 	t *testing.T,
 	codexHome string,
 	userAgent string,
-) (string, <-chan struct{}) {
+) (string, <-chan struct{}, func()) {
 	t.Helper()
 	socketDir := filepath.Join(codexHome, localDaemonSocketDir)
 	if err := os.MkdirAll(socketDir, 0o700); err != nil {
@@ -537,11 +575,12 @@ func startLocalDaemonTestServer(
 		}
 	})}
 	go func() { _ = server.Serve(listener) }()
-	t.Cleanup(func() {
+	stop := func() {
 		_ = server.Close()
 		_ = listener.Close()
-	})
-	return socketPath, initialized
+	}
+	t.Cleanup(stop)
+	return socketPath, initialized, stop
 }
 
 func shortCodexHome(t *testing.T) string {

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -29,6 +29,7 @@ const (
 
 	sharedDaemonLaunchAgentLogName         = "codex-shared-daemon.log"
 	sharedDaemonMigrationFlagName          = "codex-shared-daemon-migration-required"
+	sharedDaemonEnablePreparedFlagName     = "codex-shared-daemon-enable-prepared"
 	sharedDaemonOperationLockName          = "codex-shared-daemon-operation.lock"
 	sharedDaemonStartTimeout               = 20 * time.Second
 	sharedDaemonStartTimeoutForLocalEnsure = sharedDaemonStartTimeout
@@ -41,6 +42,10 @@ const (
 	unmanagedSharedDaemonMessage           = "not managed by codex app-server daemon"
 	codexDesktopBundleID                   = "com.openai.codex"
 )
+
+// SupportsStableSharedDaemonOwner 明确标识“完整共享架构”的平台边界。该
+// 架构依赖 launchd LaunchAgent 与 macOS responsible-process/TCC 语义。
+func SupportsStableSharedDaemonOwner() bool { return true }
 
 type sharedDaemonListenerProcess struct {
 	PID        int
@@ -66,6 +71,7 @@ type SharedDaemonOwnerStatus struct {
 	Loaded            bool
 	Running           bool
 	Secure            bool
+	RunAtLoad         bool
 	Changed           bool
 	Created           bool
 	MigrationRequired bool
@@ -97,6 +103,17 @@ var sharedDaemonRequiredToolPaths = []string{
 // 测试只替换这一层，避免单元测试注册或卸载用户真实的 launchd job。
 var sharedDaemonLaunchctl = runLaunchctl
 
+// Desktop 存活检查使用固定 bundle id。显式迁移的 stop 与 kickstart 都在各自
+// 最后副作用前重新读取；查询失败和 App 已重开一律 fail closed。
+var sharedDaemonDesktopRunning = codexDesktopProcessRunning
+
+// 删除路径单独留出测试 seam，验证 bootout 后删除/marker 失败会恢复完整 owner；
+// 正式运行始终指向 os.Remove 与真实 marker 清理。
+var (
+	sharedDaemonRemoveLaunchAgentFile    = os.Remove
+	sharedDaemonClearMigrationForRemoval = clearSharedDaemonMigrationFlag
+)
+
 // SharedDaemonLaunchAgentPath 返回 plist 的安装路径。
 func SharedDaemonLaunchAgentPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -120,6 +137,14 @@ func sharedDaemonMigrationFlagPath() (string, error) {
 		return "", fmt.Errorf("解析用户 Home 失败：%w", err)
 	}
 	return filepath.Join(home, "Library", "Application Support", "mimi-remote", sharedDaemonMigrationFlagName), nil
+}
+
+func sharedDaemonEnablePreparedFlagPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("解析用户 Home 失败：%w", err)
+	}
+	return filepath.Join(home, "Library", "Application Support", "mimi-remote", sharedDaemonEnablePreparedFlagName), nil
 }
 
 func sharedDaemonOperationLockPath() (string, error) {
@@ -207,7 +232,12 @@ func resolveSharedDaemonCodexBin(configured string) (string, error) {
 // renderSharedDaemonLaunchAgent 生成 plist。ProgramArguments 直接执行官方 codex，
 // 不引入 shell 责任主体；Desktop 专属变量由 job 环境中的空值覆盖。TCC 最终归因
 // 仍必须由签名 App 做运行态验收，不能由 plist 结构或单元测试代替。
-func renderSharedDaemonLaunchAgent(codexBin string, env map[string]string, logPath string) ([]byte, error) {
+func renderSharedDaemonLaunchAgent(
+	codexBin string,
+	env map[string]string,
+	logPath string,
+	runAtLoadOption ...bool,
+) ([]byte, error) {
 	if strings.TrimSpace(codexBin) == "" {
 		return nil, fmt.Errorf("codex 路径不能为空")
 	}
@@ -216,6 +246,10 @@ func renderSharedDaemonLaunchAgent(codexBin string, env map[string]string, logPa
 		"app-server",
 		"daemon",
 		"start",
+	}
+	runAtLoad := true
+	if len(runAtLoadOption) > 0 {
+		runAtLoad = runAtLoadOption[0]
 	}
 
 	var buf bytes.Buffer
@@ -248,9 +282,14 @@ func renderSharedDaemonLaunchAgent(codexBin string, env map[string]string, logPa
 		buf.WriteString("\t</dict>\n")
 	}
 
-	// RunAtLoad 覆盖“Mac 登录后冷启动”场景：没有它，只有 agentd 主动 kickstart
-	// 才会有 daemon，而 Desktop 可能先于 agentd 启动。
-	buf.WriteString("\t<key>RunAtLoad</key>\n\t<true/>\n")
+	// 正常 owner 在登录时冷启动；进入 pending 后持久化为 false，保证注销、登录
+	// 或 Mac 重启都不能绕过用户再次确认。显式迁移成功后才提升回 true。
+	buf.WriteString("\t<key>RunAtLoad</key>\n")
+	if runAtLoad {
+		buf.WriteString("\t<true/>\n")
+	} else {
+		buf.WriteString("\t<false/>\n")
+	}
 	// job 是一次性控制命令，退出属于正常结束，不能让 launchd 反复重启。
 	buf.WriteString("\t<key>KeepAlive</key>\n\t<false/>\n")
 	buf.WriteString("\t<key>ThrottleInterval</key>\n\t<integer>1</integer>\n")
@@ -347,6 +386,36 @@ func sharedDaemonPlistStringValue(content []byte, targetKey string) string {
 	}
 }
 
+func sharedDaemonPlistBoolValue(content []byte, targetKey string) (bool, bool) {
+	decoder := xml.NewDecoder(bytes.NewReader(content))
+	lastKey := ""
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return false, false
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		switch start.Name.Local {
+		case "key":
+			var key string
+			if err := decoder.DecodeElement(&key, &start); err != nil {
+				return false, false
+			}
+			lastKey = key
+		case "true", "false":
+			if lastKey == targetKey {
+				return start.Name.Local == "true", true
+			}
+			lastKey = ""
+		case "array", "dict", "string", "integer":
+			lastKey = ""
+		}
+	}
+}
+
 func isSharedDaemonStrippedEnvKey(key string) bool {
 	for _, stripped := range sharedDaemonStrippedEnvKeys {
 		if key == stripped {
@@ -368,44 +437,53 @@ func escapePlistText(buf *bytes.Buffer, value string) {
 	_ = xml.EscapeText(buf, []byte(value))
 }
 
-// EnsureSharedDaemonLaunchAgent 幂等写入 plist，返回内容是否发生变化。
-func EnsureSharedDaemonLaunchAgent(options LocalDaemonOptions) (bool, error) {
+type sharedDaemonLaunchAgentPlan struct {
+	path            string
+	existing        []byte
+	existingPresent bool
+	desired         []byte
+}
+
+func planSharedDaemonLaunchAgent(
+	options LocalDaemonOptions,
+	runAtLoad bool,
+) (sharedDaemonLaunchAgentPlan, error) {
 	path, err := SharedDaemonLaunchAgentPath()
 	if err != nil {
-		return false, err
+		return sharedDaemonLaunchAgentPlan{}, err
 	}
 	codexBin, err := resolveSharedDaemonCodexBin(options.CodexBin)
 	if err != nil {
-		return false, err
+		return sharedDaemonLaunchAgentPlan{}, err
 	}
 	logPath, err := sharedDaemonLaunchAgentLogPath()
 	if err != nil {
-		return false, err
+		return sharedDaemonLaunchAgentPlan{}, err
 	}
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
-		return false, fmt.Errorf("创建 Mimi 日志目录失败：%w", err)
+		return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("创建 Mimi 日志目录失败：%w", err)
 	}
 	if info, statErr := os.Lstat(logPath); statErr == nil {
 		if !info.Mode().IsRegular() {
-			return false, fmt.Errorf("共享 daemon 日志必须是普通文件")
+			return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("共享 daemon 日志必须是普通文件")
 		}
 		if err := os.Chmod(logPath, 0o600); err != nil {
-			return false, fmt.Errorf("收紧共享 daemon 日志权限失败：%w", err)
+			return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("收紧共享 daemon 日志权限失败：%w", err)
 		}
 		if info.Size() > sharedDaemonMaxLogBytes {
 			if err := os.Truncate(logPath, 0); err != nil {
-				return false, fmt.Errorf("收缩共享 daemon 日志失败：%w", err)
+				return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("收缩共享 daemon 日志失败：%w", err)
 			}
 		}
 	} else if !os.IsNotExist(statErr) {
-		return false, fmt.Errorf("检查共享 daemon 日志失败：%w", statErr)
+		return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("检查共享 daemon 日志失败：%w", statErr)
 	}
 	// 不依赖 launchctl 用户域里可能残留的 CODEX_HOME。这里固定与 agentd 本次
 	// 解析出的 socket 完全一致的有效目录，避免 daemon 在 B 目录启动、agentd
 	// 却在 A 目录等待。LocalDaemonSocketPath 同时完成绝对路径和符号链接规范化。
 	socketPath, err := LocalDaemonSocketPath(options.Env)
 	if err != nil {
-		return false, err
+		return sharedDaemonLaunchAgentPlan{}, err
 	}
 	effectiveEnv := make(map[string]string, len(options.Env)+1)
 	for key, value := range options.Env {
@@ -413,13 +491,15 @@ func EnsureSharedDaemonLaunchAgent(options LocalDaemonOptions) (bool, error) {
 	}
 	effectiveEnv["CODEX_HOME"] = filepath.Dir(filepath.Dir(socketPath))
 	var existing []byte
+	existingPresent := false
 	if info, statErr := os.Lstat(path); statErr == nil {
 		if !info.Mode().IsRegular() {
-			return false, fmt.Errorf("共享 daemon LaunchAgent 必须是普通文件")
+			return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("共享 daemon LaunchAgent 必须是普通文件")
 		}
+		existingPresent = true
 		existing, err = os.ReadFile(path)
 		if err != nil {
-			return false, fmt.Errorf("读取共享 daemon LaunchAgent 失败：%w", err)
+			return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("读取共享 daemon LaunchAgent 失败：%w", err)
 		}
 		// 配置未显式指定 PATH 时，保留首次由 Mac App 捕获并规范化的用户工具
 		// 路径。否则 resident agentd 的较窄 PATH 会在每次启动时反复改写 owner。
@@ -427,33 +507,42 @@ func EnsureSharedDaemonLaunchAgent(options LocalDaemonOptions) (bool, error) {
 			effectiveEnv["PATH"] = sharedDaemonPlistStringValue(existing, "PATH")
 		}
 	} else if !os.IsNotExist(statErr) {
-		return false, fmt.Errorf("检查共享 daemon LaunchAgent 失败：%w", statErr)
+		return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("检查共享 daemon LaunchAgent 失败：%w", statErr)
 	}
-	desired, err := renderSharedDaemonLaunchAgent(codexBin, effectiveEnv, logPath)
+	desired, err := renderSharedDaemonLaunchAgent(codexBin, effectiveEnv, logPath, runAtLoad)
 	if err != nil {
-		return false, err
+		return sharedDaemonLaunchAgentPlan{}, err
 	}
-	if existing != nil && bytes.Equal(existing, desired) {
+	return sharedDaemonLaunchAgentPlan{
+		path:            path,
+		existing:        existing,
+		existingPresent: existingPresent,
+		desired:         desired,
+	}, nil
+}
+
+func applySharedDaemonLaunchAgentPlan(plan sharedDaemonLaunchAgentPlan) (bool, error) {
+	if plan.existingPresent && bytes.Equal(plan.existing, plan.desired) {
 		// 兼容早期 Beta 写出的 0644 plist：内容无需 reload，但权限必须原地
 		// 收紧，避免为了 chmod 打断已经加载的 job。
-		if info, statErr := os.Lstat(path); statErr == nil && info.Mode().IsRegular() && info.Mode().Perm() != 0o600 {
-			if err := os.Chmod(path, 0o600); err != nil {
+		if info, statErr := os.Lstat(plan.path); statErr == nil && info.Mode().IsRegular() && info.Mode().Perm() != 0o600 {
+			if err := os.Chmod(plan.path, 0o600); err != nil {
 				return false, fmt.Errorf("收紧 LaunchAgent 权限失败：%w", err)
 			}
 		}
 		return false, nil
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(plan.path), 0o755); err != nil {
 		return false, fmt.Errorf("创建 LaunchAgents 目录失败：%w", err)
 	}
 	// 先写临时文件再 rename，避免 launchd 在登录时读到半截 plist。
-	temp, err := os.CreateTemp(filepath.Dir(path), ".codex-shared-daemon-*.plist")
+	temp, err := os.CreateTemp(filepath.Dir(plan.path), ".codex-shared-daemon-*.plist")
 	if err != nil {
 		return false, fmt.Errorf("写入 LaunchAgent 失败：%w", err)
 	}
 	tempPath := temp.Name()
 	defer os.Remove(tempPath)
-	if _, err := temp.Write(desired); err != nil {
+	if _, err := temp.Write(plan.desired); err != nil {
 		temp.Close()
 		return false, fmt.Errorf("写入 LaunchAgent 失败：%w", err)
 	}
@@ -463,13 +552,34 @@ func EnsureSharedDaemonLaunchAgent(options LocalDaemonOptions) (bool, error) {
 		temp.Close()
 		return false, fmt.Errorf("设置 LaunchAgent 权限失败：%w", err)
 	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return false, fmt.Errorf("同步 LaunchAgent 失败：%w", err)
+	}
 	if err := temp.Close(); err != nil {
 		return false, fmt.Errorf("写入 LaunchAgent 失败：%w", err)
 	}
-	if err := os.Rename(tempPath, path); err != nil {
+	if err := os.Rename(tempPath, plan.path); err != nil {
 		return false, fmt.Errorf("安装 LaunchAgent 失败：%w", err)
 	}
+	if err := syncSharedDaemonDirectory(filepath.Dir(plan.path)); err != nil {
+		return false, fmt.Errorf("同步 LaunchAgent 目录失败：%w", err)
+	}
 	return true, nil
+}
+
+func ensureSharedDaemonLaunchAgent(options LocalDaemonOptions, runAtLoad bool) (bool, error) {
+	plan, err := planSharedDaemonLaunchAgent(options, runAtLoad)
+	if err != nil {
+		return false, err
+	}
+	return applySharedDaemonLaunchAgentPlan(plan)
+}
+
+// EnsureSharedDaemonLaunchAgent 安装正常冷启动 owner。进入人工迁移状态时必须
+// 通过 ensureSharedDaemonOwner 写入 RunAtLoad=false，不能直接调用这个入口。
+func EnsureSharedDaemonLaunchAgent(options LocalDaemonOptions) (bool, error) {
+	return ensureSharedDaemonLaunchAgent(options, true)
 }
 
 func writeSharedDaemonPrivateFileAtomically(path string, content []byte) error {
@@ -490,10 +600,34 @@ func writeSharedDaemonPrivateFileAtomically(path string, content []byte) error {
 		temp.Close()
 		return err
 	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return err
+	}
 	if err := temp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tempPath, path)
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	return syncSharedDaemonDirectory(filepath.Dir(path))
+}
+
+func syncSharedDaemonDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}
+
+func syncSharedDaemonDirectoryIfPresent(path string) error {
+	err := syncSharedDaemonDirectory(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 // SharedDaemonMigrationRequired 是提供给运行态状态接口的轻量读取；它不探测
@@ -514,6 +648,27 @@ func SharedDaemonMigrationRequired() (bool, error) {
 		return false, fmt.Errorf("共享 daemon 迁移标记必须是当前用户私有的普通文件")
 	}
 	return true, nil
+}
+
+// SharedDaemonOwnerArtifactsPresent 是非 shared 启动路径的只读快路径；只有
+// 真有 Mimi plist 或 marker 残留时才进入 launchctl 清理事务。
+func SharedDaemonOwnerArtifactsPresent() (bool, error) {
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		return false, err
+	}
+	if info, statErr := os.Lstat(path); statErr == nil {
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("共享 daemon LaunchAgent 必须是普通文件")
+		}
+		return true, nil
+	} else if !os.IsNotExist(statErr) {
+		return false, statErr
+	}
+	if required, err := SharedDaemonMigrationRequired(); err != nil || required {
+		return required, err
+	}
+	return sharedDaemonEnablePrepared()
 }
 
 func repairSharedDaemonMigrationFlagPermissions() error {
@@ -561,6 +716,13 @@ func InspectSharedDaemonOwner(ctx context.Context) (SharedDaemonOwnerStatus, err
 		}
 		status.Installed = true
 		status.Secure = info.Mode().Perm()&0o077 == 0
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return status, fmt.Errorf("读取共享 daemon LaunchAgent 失败：%w", readErr)
+		}
+		// 缺少 RunAtLoad 或 plist 无法解析时按 manual 处理；这是崩溃恢复的
+		// fail-closed 方向，后续 ensure 会补回 marker，绝不猜成可自动启动。
+		status.RunAtLoad, _ = sharedDaemonPlistBoolValue(content, "RunAtLoad")
 	}
 	status.Loaded, status.Running, err = inspectLaunchAgentState(ctx)
 	if err != nil {
@@ -581,6 +743,15 @@ func EnsureSharedDaemonOwner(
 	options LocalDaemonOptions,
 	daemonPreexisting bool,
 ) (SharedDaemonOwnerStatus, error) {
+	return ensureSharedDaemonOwner(ctx, options, daemonPreexisting, false)
+}
+
+func ensureSharedDaemonOwner(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	daemonPreexisting bool,
+	forcePending bool,
+) (SharedDaemonOwnerStatus, error) {
 	if err := repairSharedDaemonMigrationFlagPermissions(); err != nil {
 		return SharedDaemonOwnerStatus{}, err
 	}
@@ -595,7 +766,33 @@ func EnsureSharedDaemonOwner(
 			return SharedDaemonOwnerStatus{}, fmt.Errorf("读取原共享 daemon LaunchAgent 失败：%w", err)
 		}
 	}
-	fileChanged, err := EnsureSharedDaemonLaunchAgent(options)
+	// manual plist 本身就是持久 pending 证据。若进程在“写 manual plist → 写
+	// marker”之间崩溃，下一次 ensure 必须先补回 marker，再做任何 launchctl 操作。
+	pendingStateBefore := before.MigrationRequired || (before.Installed && !before.RunAtLoad)
+	markerRepaired := false
+	if before.Installed && !before.RunAtLoad && !before.MigrationRequired {
+		if err := writeSharedDaemonMigrationFlag(); err != nil {
+			return SharedDaemonOwnerStatus{}, fmt.Errorf("恢复待迁移标记失败：%w", err)
+		}
+		before.MigrationRequired = true
+		markerRepaired = true
+	}
+
+	autoPlan, err := planSharedDaemonLaunchAgent(options, true)
+	if err != nil {
+		return SharedDaemonOwnerStatus{}, err
+	}
+	autoChanged := !autoPlan.existingPresent || !bytes.Equal(autoPlan.existing, autoPlan.desired)
+	pending := before.MigrationRequired || forcePending ||
+		(daemonPreexisting && (autoChanged || !before.Loaded))
+	plan := autoPlan
+	if pending {
+		plan, err = planSharedDaemonLaunchAgent(options, false)
+		if err != nil {
+			return SharedDaemonOwnerStatus{}, err
+		}
+	}
+	fileChanged, err := applySharedDaemonLaunchAgentPlan(plan)
 	if err != nil {
 		return SharedDaemonOwnerStatus{}, err
 	}
@@ -607,6 +804,11 @@ func EnsureSharedDaemonOwner(
 			return SharedDaemonOwnerStatus{}, fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", cause, rollbackErr)
 		}
 		return SharedDaemonOwnerStatus{}, fmt.Errorf("%w；已恢复原 daemon owner", cause)
+	}
+	if pending && !before.MigrationRequired {
+		if err := writeSharedDaemonMigrationFlag(); err != nil {
+			return rollback(err)
+		}
 	}
 	loaded := before.Loaded
 	if fileChanged && loaded {
@@ -621,18 +823,13 @@ func EnsureSharedDaemonOwner(
 		if pathErr != nil {
 			return rollback(pathErr)
 		}
-		// RunAtLoad 会执行一次幂等的官方 `daemon start`。已有 daemon 不会被重启，
-		// 没有 daemon 时则从一开始就在 launchd 责任链下创建。
+		// 正常 owner 的 RunAtLoad 会在 bootstrap 时执行一次幂等 start；pending
+		// owner 为 false，只注册显式迁移稍后可 kickstart 的入口，不会启动 daemon。
 		if _, bootstrapErr := sharedDaemonLaunchctl(ctx, "bootstrap", launchAgentDomainTarget(), path); bootstrapErr != nil {
 			return rollback(bootstrapErr)
 		}
 	}
-	changed := fileChanged || !before.Loaded
-	if daemonPreexisting && changed {
-		if err := writeSharedDaemonMigrationFlag(); err != nil {
-			return rollback(err)
-		}
-	}
+	changed := fileChanged || !before.Loaded || markerRepaired
 	status, err := InspectSharedDaemonOwner(ctx)
 	if err != nil {
 		return rollback(err)
@@ -640,9 +837,14 @@ func EnsureSharedDaemonOwner(
 	if !status.Installed || !status.Loaded || !status.Secure {
 		return rollback(fmt.Errorf("共享 daemon LaunchAgent 安装后状态不完整"))
 	}
+	if status.RunAtLoad == pending {
+		return rollback(fmt.Errorf("共享 daemon LaunchAgent 自动启动状态与迁移状态不一致"))
+	}
 	status.Changed = changed
 	status.Created = created
-	if changed {
+	// 已经处于 pending 的 owner 修复属于安全状态收敛，不提供把它回滚回
+	// RunAtLoad=true 的令牌。只有本次配置动作新引入的 owner 变更才可回滚。
+	if changed && !pendingStateBefore {
 		appliedPlist, readErr := os.ReadFile(status.Path)
 		if readErr != nil {
 			return rollback(fmt.Errorf("读取已应用 LaunchAgent 失败：%w", readErr))
@@ -660,6 +862,7 @@ func EnsureSharedDaemonOwner(
 					return fmt.Errorf("确认共享 daemon owner 回滚边界失败：%w", inspectErr)
 				}
 				if currentStatus.Loaded != appliedLoaded ||
+					currentStatus.RunAtLoad != status.RunAtLoad ||
 					currentStatus.MigrationRequired != appliedMigrationRequired {
 					return fmt.Errorf("共享 daemon owner 状态已被其他进程修改，拒绝覆盖")
 				}
@@ -743,11 +946,88 @@ func writeSharedDaemonMigrationFlag() error {
 		temp.Close()
 		return fmt.Errorf("设置共享 daemon 迁移状态权限失败：%w", err)
 	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return fmt.Errorf("同步共享 daemon 迁移状态失败：%w", err)
+	}
 	if err := temp.Close(); err != nil {
 		return fmt.Errorf("记录共享 daemon 迁移状态失败：%w", err)
 	}
 	if err := os.Rename(tempPath, path); err != nil {
 		return fmt.Errorf("记录共享 daemon 迁移状态失败：%w", err)
+	}
+	if err := syncSharedDaemonDirectory(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("同步共享 daemon 状态目录失败：%w", err)
+	}
+	return nil
+}
+
+func markSharedDaemonEnablePrepared() error {
+	path, err := sharedDaemonEnablePreparedFlagPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("创建共享 daemon 状态目录失败：%w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".codex-daemon-enable-prepared-*")
+	if err != nil {
+		return fmt.Errorf("记录共享 daemon 启用事务失败：%w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if _, err := temp.Write([]byte("enable-prepared\n")); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("记录共享 daemon 启用事务失败：%w", err)
+	}
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("设置共享 daemon 启用事务权限失败：%w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("同步共享 daemon 启用事务失败：%w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("记录共享 daemon 启用事务失败：%w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("记录共享 daemon 启用事务失败：%w", err)
+	}
+	if err := syncSharedDaemonDirectory(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("同步共享 daemon 状态目录失败：%w", err)
+	}
+	return nil
+}
+
+func sharedDaemonEnablePrepared() (bool, error) {
+	path, err := sharedDaemonEnablePreparedFlagPath()
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("检查共享 daemon 启用事务失败：%w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return false, fmt.Errorf("共享 daemon 启用事务必须是当前用户私有的普通文件")
+	}
+	return true, nil
+}
+
+func clearSharedDaemonEnablePrepared() error {
+	path, err := sharedDaemonEnablePreparedFlagPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("清除共享 daemon 启用事务失败：%w", err)
+	}
+	if err := syncSharedDaemonDirectoryIfPresent(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("同步共享 daemon 启用事务删除失败：%w", err)
 	}
 	return nil
 }
@@ -763,6 +1043,9 @@ func clearSharedDaemonMigrationFlag() error {
 	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("清除共享 daemon 迁移状态失败：%w", err)
+	}
+	if err := syncSharedDaemonDirectoryIfPresent(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("同步共享 daemon 迁移状态删除失败：%w", err)
 	}
 	return nil
 }
@@ -784,8 +1067,11 @@ func RemoveSharedDaemonLaunchAgent(ctx context.Context) error {
 			return bootoutErr
 		}
 	}
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+	if err := sharedDaemonRemoveLaunchAgentFile(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("删除 LaunchAgent 失败：%w", err)
+	}
+	if err := syncSharedDaemonDirectoryIfPresent(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("同步 LaunchAgent 删除失败：%w", err)
 	}
 	return nil
 }
@@ -800,10 +1086,72 @@ func RemoveSharedDaemonOwner(ctx context.Context) error {
 }
 
 func removeSharedDaemonOwnerUnlocked(ctx context.Context) error {
-	if err := RemoveSharedDaemonLaunchAgent(ctx); err != nil {
-		return err
+	_, err := removeSharedDaemonOwnerForTransactionUnlocked(ctx)
+	return err
+}
+
+// removeSharedDaemonOwnerForTransactionUnlocked 在调用方持有 operation lock 时
+// 移除 owner。先把磁盘 plist 降为 manual，再 bootout/delete；因此删除任一步
+// 失败也不会留下可在下次登录自动启动的 owner。返回值保留兼容签名，但禁用
+// 事务不再恢复 auto owner：配置可能已被锁外编辑器改成 WS，恢复会越权。
+func removeSharedDaemonOwnerForTransactionUnlocked(
+	ctx context.Context,
+) (func(context.Context) error, error) {
+	before, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return clearSharedDaemonMigrationFlag()
+	if before.Loaded && !before.Installed {
+		// 没有磁盘 plist 就无法在失败时重新 bootstrap 同一个 job。先于 bootout
+		// 拒绝这种外部/残缺状态，保证后面的删除事务始终可完整回滚。
+		return nil, fmt.Errorf("共享 daemon LaunchAgent 已加载但磁盘 plist 缺失，拒绝卸载")
+	}
+	var previousPlist []byte
+	if before.Installed {
+		previousPlist, err = os.ReadFile(before.Path)
+		if err != nil {
+			return nil, fmt.Errorf("读取待移除的共享 daemon LaunchAgent 失败：%w", err)
+		}
+	}
+	if before.Installed && before.RunAtLoad {
+		manual, manualErr := sharedDaemonManualPlist(previousPlist)
+		if manualErr != nil {
+			return nil, manualErr
+		}
+		if writeErr := writeSharedDaemonPrivateFileAtomically(before.Path, manual); writeErr != nil {
+			return nil, fmt.Errorf("把共享 daemon owner 降为 manual 失败：%w", writeErr)
+		}
+	}
+	if before.Installed && !before.MigrationRequired {
+		// manual plist 本身已经 fail closed；marker 若写失败，下一次 ensure
+		// 会从 RunAtLoad=false 自动修复，不能因此把 auto plist 恢复回来。
+		if markerErr := writeSharedDaemonMigrationFlag(); markerErr != nil {
+			return nil, fmt.Errorf("记录共享 daemon manual 状态失败：%w", markerErr)
+		}
+	}
+	if err := RemoveSharedDaemonLaunchAgent(ctx); err != nil {
+		return nil, fmt.Errorf("移除共享 daemon owner 失败；已保留 manual 安全状态：%w", err)
+	}
+	if err := clearSharedDaemonEnablePrepared(); err != nil {
+		return nil, fmt.Errorf("清理共享 daemon 启用事务失败；自动启动入口已移除：%w", err)
+	}
+	if err := sharedDaemonClearMigrationForRemoval(); err != nil {
+		return nil, fmt.Errorf("清理共享 daemon marker 失败；自动启动入口已移除：%w", err)
+	}
+	return func(context.Context) error { return nil }, nil
+}
+
+func sharedDaemonManualPlist(content []byte) ([]byte, error) {
+	if runAtLoad, ok := sharedDaemonPlistBoolValue(content, "RunAtLoad"); !ok {
+		return nil, fmt.Errorf("共享 daemon LaunchAgent 缺少 RunAtLoad，拒绝修改")
+	} else if !runAtLoad {
+		return append([]byte(nil), content...), nil
+	}
+	needle := []byte("<key>RunAtLoad</key>\n\t<true/>")
+	if bytes.Count(content, needle) != 1 {
+		return nil, fmt.Errorf("共享 daemon LaunchAgent 的 RunAtLoad 格式未知，拒绝修改")
+	}
+	return bytes.Replace(content, needle, []byte("<key>RunAtLoad</key>\n\t<false/>"), 1), nil
 }
 
 // startLocalDaemonWithStableOwner 请 launchd 创建 daemon：spawn 发生在 launchd
@@ -829,6 +1177,9 @@ func startLocalDaemonWithStableOwnerTracked(
 	if sharedDaemonSocketAcceptsConnectionMust(options) {
 		return false, nil
 	}
+	if owner.MigrationRequired {
+		return false, ErrSharedDaemonMigrationPending
+	}
 	if owner.Running {
 		// 登录或 bootstrap 的 RunAtLoad 可能仍在执行官方 start；不能在同一个
 		// job 尚未退出时再 kickstart，直接等待本次启动完成。
@@ -839,6 +1190,86 @@ func startLocalDaemonWithStableOwnerTracked(
 		return false, kickErr
 	}
 	return true, waitForSharedDaemonSocket(ctx, options, logOffset)
+}
+
+// startPreparedSharedDaemonWithStableOwnerTracked 只用于配置提交前的 manual
+// owner。调用方已经确认准备前没有 listener，因此这里允许显式 kickstart 一次
+// 做冷启动校验；plist 仍是 RunAtLoad=false，进程崩溃也不会变成登录自启。
+func startPreparedSharedDaemonWithStableOwnerTracked(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (bool, error) {
+	owner, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !owner.Installed || !owner.Loaded || owner.RunAtLoad || !owner.MigrationRequired {
+		return false, fmt.Errorf("共享 daemon 两阶段准备缺少 manual owner")
+	}
+	if sharedDaemonSocketAcceptsConnectionMust(options) {
+		return false, nil
+	}
+	logOffset := sharedDaemonLaunchAgentLogSize()
+	if owner.Running {
+		return false, waitForSharedDaemonSocket(ctx, options, logOffset)
+	}
+	if _, err := sharedDaemonLaunchctl(ctx, "kickstart", launchAgentServiceTarget()); err != nil {
+		return false, err
+	}
+	return true, waitForSharedDaemonSocket(ctx, options, logOffset)
+}
+
+// startPreparedSharedDaemonAfterConfigCommit 只在配置已经提交为 shared 后启动
+// manual owner。这样进程若在启动/握手中退出，磁盘也是 shared+manual，而不会
+// 在 WS 配置下遗留一个无人管理的 Unix daemon。
+func startPreparedSharedDaemonAfterConfigCommit(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (LocalDaemonStatus, error) {
+	// 配置提交后仍只允许 manual job 显式 kickstart。即使完整握手成功也不在
+	// 这里提升 auto：kickstart 与 socket 建立之间无法原子证明是谁赢得 listener，
+	// 因而必须保留 marker，由用户在 Desktop 已退出后走唯一迁移入口提交。
+	startedByOwner := false
+	var err error
+	if !sharedDaemonSocketAcceptsConnectionMust(options) {
+		startedByOwner, err = startPreparedSharedDaemonWithStableOwnerTracked(ctx, options)
+		if err != nil {
+			return LocalDaemonStatus{}, err
+		}
+	}
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	probe, err := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancel()
+	if err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 启动后协议握手失败：%w", err)
+	}
+	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
+	if err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 启动后生命周期检查失败：%w", err)
+	}
+	if err := ValidateManagedLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	status := localDaemonStatus(socketPath, startedByOwner, probe.Version, os.Stat)
+	status.StartedByStableOwner = startedByOwner
+	status.OwnerInstalled = true
+	status.OwnerMigrationRequired = true
+	status.LifecycleValidated = true
+	// durable intent 只授权“配置已提交但首次 manual 冷启动尚未完成”的恢复。
+	// 一旦完整 managed 校验通过就立即消费；marker/manual 继续要求用户确认。
+	// 否则显式迁移在 stop 后失败时，普通 gateway recovery 会误用旧 intent
+	// 静默再次 kickstart。
+	if err := clearSharedDaemonEnablePrepared(); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	return status, nil
 }
 
 func sharedDaemonSocketAcceptsConnectionMust(options LocalDaemonOptions) bool {
@@ -862,6 +1293,9 @@ func restartSharedDaemonWithStableOwner(
 	ctx context.Context,
 	options LocalDaemonOptions,
 ) (LocalDaemonStatus, error) {
+	if err := validateStableOwnerLease(options); err != nil {
+		return LocalDaemonStatus{}, err
+	}
 	socketPath, err := LocalDaemonSocketPath(options.Env)
 	if err != nil {
 		return LocalDaemonStatus{}, err
@@ -879,6 +1313,11 @@ func restartSharedDaemonWithStableOwner(
 	}
 	if !owner.Installed || !owner.Loaded {
 		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon LaunchAgent 未正确加载")
+	}
+	// 显式入口一旦开始就消费 fresh-enable 恢复权。之后任一 stop/start/校验
+	// 失败都只能保留 manual marker 等用户再次确认，普通 Ensure 不能重试。
+	if err := clearSharedDaemonEnablePrepared(); err != nil {
+		return LocalDaemonStatus{}, err
 	}
 	if !owner.MigrationRequired {
 		probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
@@ -907,7 +1346,7 @@ func restartSharedDaemonWithStableOwner(
 		return LocalDaemonStatus{}, err
 	}
 	logOffset := sharedDaemonLaunchAgentLogSize()
-	if _, err := sharedDaemonLaunchctl(ctx, "kickstart", launchAgentServiceTarget()); err != nil {
+	if err := kickstartSharedDaemon(ctx); err != nil {
 		return LocalDaemonStatus{}, err
 	}
 	if err := waitForSharedDaemonSocket(ctx, options, logOffset); err != nil {
@@ -929,12 +1368,41 @@ func restartSharedDaemonWithStableOwner(
 	if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
 		return LocalDaemonStatus{}, err
 	}
-	if err := clearSharedDaemonMigrationFlag(); err != nil {
+	if err := commitSharedDaemonMigration(options); err != nil {
 		return LocalDaemonStatus{}, err
 	}
 	status := localDaemonStatus(socketPath, true, probe.Version, os.Stat)
 	status.OwnerInstalled = true
 	return status, nil
+}
+
+func kickstartSharedDaemon(ctx context.Context) error {
+	if err := requireCodexDesktopStopped(ctx, "启动新 Codex daemon 前"); err != nil {
+		return err
+	}
+	_, err := sharedDaemonLaunchctl(ctx, "kickstart", launchAgentServiceTarget())
+	return err
+}
+
+func commitSharedDaemonMigration(options LocalDaemonOptions) error {
+	// intent 只说明 fresh enable 尚未由用户确认。完整验证已在调用方完成；先
+	// 清 intent 再提交 auto，崩溃在两者之间仍是 manual+marker，可安全重试。
+	if err := clearSharedDaemonEnablePrepared(); err != nil {
+		return err
+	}
+	if err := clearSharedDaemonMigrationFlag(); err != nil {
+		return err
+	}
+	// marker 是禁止自动启动的提交门。先清 marker，再把磁盘 plist 提升回
+	// RunAtLoad=true；若提升失败立刻补回 marker。若进程恰在两步间崩溃，
+	// 下一次 ensure 会从 manual plist 识别并恢复 pending，仍然 fail closed。
+	if _, err := ensureSharedDaemonLaunchAgent(options, true); err != nil {
+		if markerErr := writeSharedDaemonMigrationFlag(); markerErr != nil {
+			return fmt.Errorf("共享 daemon 已验证，但恢复自动启动失败：%w；重新记录待迁移状态也失败：%v", err, markerErr)
+		}
+		return fmt.Errorf("共享 daemon 已验证，但恢复自动启动失败：%w", err)
+	}
+	return nil
 }
 
 func waitForSharedDaemonStopped(ctx context.Context, socketPath string) error {
@@ -992,6 +1460,9 @@ func stopSharedDaemon(
 	if backend != "pid" {
 		return fmt.Errorf("Codex app-server 使用未知 lifecycle backend %q，拒绝迁移", *lifecycle.Backend)
 	}
+	if err := requireCodexDesktopStopped(ctx, "停止官方 Codex daemon 前"); err != nil {
+		return err
+	}
 
 	bin := strings.TrimSpace(options.CodexBin)
 	if bin == "" {
@@ -1016,6 +1487,17 @@ func stopSharedDaemon(
 		return fmt.Errorf("停止旧 Codex local daemon 失败：%w", err)
 	}
 	return fmt.Errorf("停止旧 Codex local daemon 失败：%s", message)
+}
+
+func requireCodexDesktopStopped(ctx context.Context, stage string) error {
+	running, err := sharedDaemonDesktopRunning(ctx)
+	if err != nil {
+		return fmt.Errorf("%s确认 Codex Desktop 已退出失败：%w", stage, err)
+	}
+	if running {
+		return fmt.Errorf("%s Codex Desktop 已重新打开，已停止迁移", stage)
+	}
+	return nil
 }
 
 func stopUnmanagedSharedDaemon(
@@ -1048,7 +1530,7 @@ func stopUnmanagedSharedDaemon(
 		socketPath,
 		lifecycle.ManagedCodexPath,
 		unmanagedSharedDaemonHooks{
-			desktopRunning: codexDesktopProcessRunning,
+			desktopRunning: sharedDaemonDesktopRunning,
 			inspect:        inspectSharedDaemonListenerProcess,
 			signalTERM:     signalSharedDaemonProcessTERM,
 			currentUID:     os.Getuid,

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -1,0 +1,1492 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// SharedDaemonLaunchAgentLabel 是 Mimi 安装的 LaunchAgent 标签。它只负责“请
+	// launchd 以官方 codex 身份创建共享 daemon”，不代表 Mimi 拥有该 daemon 的
+	// 生命周期：job 本身执行完 `daemon start` 就退出，daemon 继续独立运行。
+	SharedDaemonLaunchAgentLabel = "com.gaixianggeng.mimi.codex-shared-daemon"
+
+	sharedDaemonLaunchAgentLogName         = "codex-shared-daemon.log"
+	sharedDaemonMigrationFlagName          = "codex-shared-daemon-migration-required"
+	sharedDaemonOperationLockName          = "codex-shared-daemon-operation.lock"
+	sharedDaemonStartTimeout               = 20 * time.Second
+	sharedDaemonStartTimeoutForLocalEnsure = sharedDaemonStartTimeout
+	sharedDaemonStopTimeout                = 15 * time.Second
+	sharedDaemonStoppedConfirmationWindow  = 500 * time.Millisecond
+	sharedDaemonSocketPollInterval         = 100 * time.Millisecond
+	launchctlTimeout                       = 10 * time.Second
+	sharedDaemonMaxLogBytes                = 1 << 20
+	sharedDaemonLogDiagnosticBytes         = 64 << 10
+	unmanagedSharedDaemonMessage           = "not managed by codex app-server daemon"
+	codexDesktopBundleID                   = "com.openai.codex"
+)
+
+type sharedDaemonListenerProcess struct {
+	PID        int
+	UID        int
+	StartSec   int64
+	StartUsec  int32
+	Command    string
+	Executable string
+}
+
+type unmanagedSharedDaemonHooks struct {
+	desktopRunning func(context.Context) (bool, error)
+	inspect        func(context.Context, string) (sharedDaemonListenerProcess, error)
+	signalTERM     func(int) error
+	currentUID     func() int
+}
+
+// SharedDaemonOwnerStatus 描述 Mimi 为官方 daemon 安装的稳定启动入口。它只证明
+// launchd job 的安装状态；TCC 的最终责任主体仍需在真实签名 App 上做运行态验收。
+type SharedDaemonOwnerStatus struct {
+	Supported         bool
+	Installed         bool
+	Loaded            bool
+	Running           bool
+	Secure            bool
+	Changed           bool
+	Created           bool
+	MigrationRequired bool
+	Path              string
+	Label             string
+	Rollback          *SharedDaemonOwnerRollback
+}
+
+// sharedDaemonStrippedEnvKeys 与 buildManagedEnv 的过滤集合保持一致：这些键只属于
+// Codex Desktop 的 Electron 进程。LaunchAgent 会继承 launchd 用户域环境，而 Mac App
+// 正是用 `launchctl setenv` 为 Desktop 写入它们，因此 job 必须显式以空值覆盖，
+// 避免把 Desktop 的传输配置扩散给 daemon。
+var sharedDaemonStrippedEnvKeys = []string{
+	LocalDaemonEnvironmentKey,
+	"CODEX_APP_SERVER_WS_URL",
+	"MIMI_REMOTE_CODEX_DESKTOP_OWNERSHIP_EPOCH",
+}
+
+var sharedDaemonRequiredToolPaths = []string{
+	"/opt/homebrew/bin",
+	"/opt/homebrew/sbin",
+	"/usr/local/bin",
+	"/usr/bin",
+	"/bin",
+	"/usr/sbin",
+	"/sbin",
+}
+
+// 测试只替换这一层，避免单元测试注册或卸载用户真实的 launchd job。
+var sharedDaemonLaunchctl = runLaunchctl
+
+// SharedDaemonLaunchAgentPath 返回 plist 的安装路径。
+func SharedDaemonLaunchAgentPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("解析用户 Home 失败：%w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", SharedDaemonLaunchAgentLabel+".plist"), nil
+}
+
+func sharedDaemonLaunchAgentLogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("解析用户 Home 失败：%w", err)
+	}
+	return filepath.Join(home, "Library", "Logs", "mimi-remote", sharedDaemonLaunchAgentLogName), nil
+}
+
+func sharedDaemonMigrationFlagPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("解析用户 Home 失败：%w", err)
+	}
+	return filepath.Join(home, "Library", "Application Support", "mimi-remote", sharedDaemonMigrationFlagName), nil
+}
+
+func sharedDaemonOperationLockPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("解析用户 Home 失败：%w", err)
+	}
+	return filepath.Join(home, "Library", "Application Support", "mimi-remote", sharedDaemonOperationLockName), nil
+}
+
+// withSharedDaemonOperationLock 跨进程序列化启动、gateway 恢复与显式迁移。
+// 仅靠 Router mutex 无法阻止独立 runtime CLI 在 stop/start 中间被另一进程插入。
+func withSharedDaemonOperationLock(
+	ctx context.Context,
+	operation func() (LocalDaemonStatus, error),
+) (LocalDaemonStatus, error) {
+	path, err := sharedDaemonOperationLockPath()
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("创建共享 daemon 锁目录失败：%w", err)
+	}
+	if info, statErr := os.Lstat(path); statErr == nil {
+		if !info.Mode().IsRegular() {
+			return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 操作锁必须是普通文件")
+		}
+	} else if !os.IsNotExist(statErr) {
+		return LocalDaemonStatus{}, fmt.Errorf("检查共享 daemon 操作锁失败：%w", statErr)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("打开共享 daemon 操作锁失败：%w", err)
+	}
+	defer file.Close()
+	if err := file.Chmod(0o600); err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("收紧共享 daemon 操作锁权限失败：%w", err)
+	}
+	for {
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			return LocalDaemonStatus{}, fmt.Errorf("获取共享 daemon 操作锁失败：%w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return LocalDaemonStatus{}, ctx.Err()
+		case <-time.After(sharedDaemonSocketPollInterval):
+		}
+	}
+	defer syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	return operation()
+}
+
+// resolveSharedDaemonCodexBin 把配置里的 codex 路径解析成绝对路径。launchd 不做
+// PATH 查找，相对路径会让 job 在登录后静默失败。
+func resolveSharedDaemonCodexBin(configured string) (string, error) {
+	bin := strings.TrimSpace(configured)
+	if bin == "" {
+		bin = "codex"
+	}
+	if !filepath.IsAbs(bin) {
+		resolved, err := exec.LookPath(bin)
+		if err != nil {
+			return "", fmt.Errorf("未找到 codex 可执行文件：%w", err)
+		}
+		bin = resolved
+	}
+	absolute, err := filepath.Abs(bin)
+	if err != nil {
+		return "", fmt.Errorf("解析 codex 路径失败：%w", err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return "", fmt.Errorf("检查 codex 可执行文件失败：%w", err)
+	}
+	if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("codex 路径不是可执行文件：%s", absolute)
+	}
+	return absolute, nil
+}
+
+// renderSharedDaemonLaunchAgent 生成 plist。ProgramArguments 直接执行官方 codex，
+// 不引入 shell 责任主体；Desktop 专属变量由 job 环境中的空值覆盖。TCC 最终归因
+// 仍必须由签名 App 做运行态验收，不能由 plist 结构或单元测试代替。
+func renderSharedDaemonLaunchAgent(codexBin string, env map[string]string, logPath string) ([]byte, error) {
+	if strings.TrimSpace(codexBin) == "" {
+		return nil, fmt.Errorf("codex 路径不能为空")
+	}
+	arguments := []string{
+		codexBin,
+		"app-server",
+		"daemon",
+		"start",
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	buf.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	buf.WriteString(`<plist version="1.0">` + "\n<dict>\n")
+	writePlistString(&buf, "Label", SharedDaemonLaunchAgentLabel)
+	buf.WriteString("\t<key>ProgramArguments</key>\n\t<array>\n")
+	for _, argument := range arguments {
+		buf.WriteString("\t\t<string>")
+		escapePlistText(&buf, argument)
+		buf.WriteString("</string>\n")
+	}
+	buf.WriteString("\t</array>\n")
+
+	if values := sharedDaemonLaunchAgentEnv(env); len(values) > 0 {
+		buf.WriteString("\t<key>EnvironmentVariables</key>\n\t<dict>\n")
+		keys := make([]string, 0, len(values))
+		for key := range values {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			buf.WriteString("\t\t<key>")
+			escapePlistText(&buf, key)
+			buf.WriteString("</key>\n\t\t<string>")
+			escapePlistText(&buf, values[key])
+			buf.WriteString("</string>\n")
+		}
+		buf.WriteString("\t</dict>\n")
+	}
+
+	// RunAtLoad 覆盖“Mac 登录后冷启动”场景：没有它，只有 agentd 主动 kickstart
+	// 才会有 daemon，而 Desktop 可能先于 agentd 启动。
+	buf.WriteString("\t<key>RunAtLoad</key>\n\t<true/>\n")
+	// job 是一次性控制命令，退出属于正常结束，不能让 launchd 反复重启。
+	buf.WriteString("\t<key>KeepAlive</key>\n\t<false/>\n")
+	buf.WriteString("\t<key>ThrottleInterval</key>\n\t<integer>1</integer>\n")
+	// 077 的十进制是 63；确保 launchd 创建的 stdout/stderr 日志仅当前用户可读。
+	buf.WriteString("\t<key>Umask</key>\n\t<integer>63</integer>\n")
+	if strings.TrimSpace(logPath) != "" {
+		writePlistString(&buf, "StandardOutPath", logPath)
+		writePlistString(&buf, "StandardErrorPath", logPath)
+	}
+	buf.WriteString("</dict>\n</plist>\n")
+	return buf.Bytes(), nil
+}
+
+// sharedDaemonLaunchAgentEnv 只写入 daemon 真正需要的变量。CODEX_HOME 决定 socket
+// 位置，必须与 agentd 和 Desktop 解析结果完全一致，否则会再次分裂成两个进程。
+func sharedDaemonLaunchAgentEnv(env map[string]string) map[string]string {
+	values := map[string]string{}
+	for key, value := range env {
+		key = strings.TrimSpace(key)
+		if key == "" || isSharedDaemonStrippedEnvKey(key) {
+			continue
+		}
+		values[key] = value
+	}
+	values["PATH"] = normalizedSharedDaemonToolingPath(values["PATH"], os.Getenv("PATH"))
+	// EnvironmentVariables 会覆盖 launchctl setenv 的用户域值。直接 ProgramArguments
+	// 因此无需借 shell 执行 unset，进程树固定为 launchd -> codex。
+	for _, key := range sharedDaemonStrippedEnvKeys {
+		values[key] = ""
+	}
+	return values
+}
+
+// normalizedSharedDaemonToolingPath 与 Mac App 的 userTooling 规则保持一致：
+// 固定受信任的 Homebrew/系统目录，再追加调用进程能看到的绝对工具目录。相对
+// 路径（尤其是 .）会让 LaunchAgent 的工作目录影响可执行文件解析，必须丢弃。
+func normalizedSharedDaemonToolingPath(configured string, inherited string) string {
+	candidates := append([]string{}, sharedDaemonRequiredToolPaths...)
+	if strings.TrimSpace(configured) != "" {
+		candidates = append(candidates, strings.Split(configured, ":")...)
+	} else {
+		candidates = append(candidates, strings.Split(inherited, ":")...)
+	}
+	seen := map[string]struct{}{}
+	paths := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || !filepath.IsAbs(candidate) {
+			continue
+		}
+		candidate = filepath.Clean(candidate)
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		paths = append(paths, candidate)
+	}
+	return strings.Join(paths, ":")
+}
+
+func sharedDaemonPlistStringValue(content []byte, targetKey string) string {
+	decoder := xml.NewDecoder(bytes.NewReader(content))
+	lastKey := ""
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		switch start.Name.Local {
+		case "key":
+			var key string
+			if err := decoder.DecodeElement(&key, &start); err != nil {
+				return ""
+			}
+			lastKey = key
+		case "string":
+			var value string
+			if err := decoder.DecodeElement(&value, &start); err != nil {
+				return ""
+			}
+			if lastKey == targetKey {
+				return value
+			}
+			lastKey = ""
+		case "array", "dict":
+			// 该读取器只用于本文件生成的标量 EnvironmentVariables；遇到
+			// 容器就清除位置状态，不能把数组首项误认为某个 key 的值。
+			lastKey = ""
+		}
+	}
+}
+
+func isSharedDaemonStrippedEnvKey(key string) bool {
+	for _, stripped := range sharedDaemonStrippedEnvKeys {
+		if key == stripped {
+			return true
+		}
+	}
+	return false
+}
+
+func writePlistString(buf *bytes.Buffer, key string, value string) {
+	buf.WriteString("\t<key>")
+	escapePlistText(buf, key)
+	buf.WriteString("</key>\n\t<string>")
+	escapePlistText(buf, value)
+	buf.WriteString("</string>\n")
+}
+
+func escapePlistText(buf *bytes.Buffer, value string) {
+	_ = xml.EscapeText(buf, []byte(value))
+}
+
+// EnsureSharedDaemonLaunchAgent 幂等写入 plist，返回内容是否发生变化。
+func EnsureSharedDaemonLaunchAgent(options LocalDaemonOptions) (bool, error) {
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		return false, err
+	}
+	codexBin, err := resolveSharedDaemonCodexBin(options.CodexBin)
+	if err != nil {
+		return false, err
+	}
+	logPath, err := sharedDaemonLaunchAgentLogPath()
+	if err != nil {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		return false, fmt.Errorf("创建 Mimi 日志目录失败：%w", err)
+	}
+	if info, statErr := os.Lstat(logPath); statErr == nil {
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("共享 daemon 日志必须是普通文件")
+		}
+		if err := os.Chmod(logPath, 0o600); err != nil {
+			return false, fmt.Errorf("收紧共享 daemon 日志权限失败：%w", err)
+		}
+		if info.Size() > sharedDaemonMaxLogBytes {
+			if err := os.Truncate(logPath, 0); err != nil {
+				return false, fmt.Errorf("收缩共享 daemon 日志失败：%w", err)
+			}
+		}
+	} else if !os.IsNotExist(statErr) {
+		return false, fmt.Errorf("检查共享 daemon 日志失败：%w", statErr)
+	}
+	// 不依赖 launchctl 用户域里可能残留的 CODEX_HOME。这里固定与 agentd 本次
+	// 解析出的 socket 完全一致的有效目录，避免 daemon 在 B 目录启动、agentd
+	// 却在 A 目录等待。LocalDaemonSocketPath 同时完成绝对路径和符号链接规范化。
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return false, err
+	}
+	effectiveEnv := make(map[string]string, len(options.Env)+1)
+	for key, value := range options.Env {
+		effectiveEnv[key] = value
+	}
+	effectiveEnv["CODEX_HOME"] = filepath.Dir(filepath.Dir(socketPath))
+	var existing []byte
+	if info, statErr := os.Lstat(path); statErr == nil {
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("共享 daemon LaunchAgent 必须是普通文件")
+		}
+		existing, err = os.ReadFile(path)
+		if err != nil {
+			return false, fmt.Errorf("读取共享 daemon LaunchAgent 失败：%w", err)
+		}
+		// 配置未显式指定 PATH 时，保留首次由 Mac App 捕获并规范化的用户工具
+		// 路径。否则 resident agentd 的较窄 PATH 会在每次启动时反复改写 owner。
+		if strings.TrimSpace(effectiveEnv["PATH"]) == "" {
+			effectiveEnv["PATH"] = sharedDaemonPlistStringValue(existing, "PATH")
+		}
+	} else if !os.IsNotExist(statErr) {
+		return false, fmt.Errorf("检查共享 daemon LaunchAgent 失败：%w", statErr)
+	}
+	desired, err := renderSharedDaemonLaunchAgent(codexBin, effectiveEnv, logPath)
+	if err != nil {
+		return false, err
+	}
+	if existing != nil && bytes.Equal(existing, desired) {
+		// 兼容早期 Beta 写出的 0644 plist：内容无需 reload，但权限必须原地
+		// 收紧，避免为了 chmod 打断已经加载的 job。
+		if info, statErr := os.Lstat(path); statErr == nil && info.Mode().IsRegular() && info.Mode().Perm() != 0o600 {
+			if err := os.Chmod(path, 0o600); err != nil {
+				return false, fmt.Errorf("收紧 LaunchAgent 权限失败：%w", err)
+			}
+		}
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, fmt.Errorf("创建 LaunchAgents 目录失败：%w", err)
+	}
+	// 先写临时文件再 rename，避免 launchd 在登录时读到半截 plist。
+	temp, err := os.CreateTemp(filepath.Dir(path), ".codex-shared-daemon-*.plist")
+	if err != nil {
+		return false, fmt.Errorf("写入 LaunchAgent 失败：%w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if _, err := temp.Write(desired); err != nil {
+		temp.Close()
+		return false, fmt.Errorf("写入 LaunchAgent 失败：%w", err)
+	}
+	// 配置中的自定义 env 可能包含 MCP/API 凭据。LaunchAgent 只需当前用户和
+	// launchd 读取，必须与 agentd 配置一样保持 0600，不能泄露给其他本地用户。
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return false, fmt.Errorf("设置 LaunchAgent 权限失败：%w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return false, fmt.Errorf("写入 LaunchAgent 失败：%w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return false, fmt.Errorf("安装 LaunchAgent 失败：%w", err)
+	}
+	return true, nil
+}
+
+func writeSharedDaemonPrivateFileAtomically(path string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".mimi-shared-daemon-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if _, err := temp.Write(content); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}
+
+// SharedDaemonMigrationRequired 是提供给运行态状态接口的轻量读取；它不探测
+// launchctl，也不触碰 daemon。标记若被替换为链接或公开文件则 fail closed。
+func SharedDaemonMigrationRequired() (bool, error) {
+	path, err := sharedDaemonMigrationFlagPath()
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("检查共享 daemon 迁移标记失败：%w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return false, fmt.Errorf("共享 daemon 迁移标记必须是当前用户私有的普通文件")
+	}
+	return true, nil
+}
+
+func repairSharedDaemonMigrationFlagPermissions() error {
+	path, err := sharedDaemonMigrationFlagPath()
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("检查共享 daemon 迁移标记失败：%w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("共享 daemon 迁移标记必须是普通文件")
+	}
+	if info.Mode().Perm() != 0o600 {
+		if err := os.Chmod(path, 0o600); err != nil {
+			return fmt.Errorf("收紧共享 daemon 迁移标记权限失败：%w", err)
+		}
+	}
+	return nil
+}
+
+// InspectSharedDaemonOwner 只读取 job/marker 状态，不启动或停止任何进程。
+func InspectSharedDaemonOwner(ctx context.Context) (SharedDaemonOwnerStatus, error) {
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		return SharedDaemonOwnerStatus{}, err
+	}
+	status := SharedDaemonOwnerStatus{
+		Supported: true,
+		Path:      path,
+		Label:     SharedDaemonLaunchAgentLabel,
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil {
+		if !os.IsNotExist(statErr) {
+			return status, fmt.Errorf("检查共享 daemon LaunchAgent 失败：%w", statErr)
+		}
+	} else {
+		if !info.Mode().IsRegular() {
+			return status, fmt.Errorf("共享 daemon LaunchAgent 必须是普通文件")
+		}
+		status.Installed = true
+		status.Secure = info.Mode().Perm()&0o077 == 0
+	}
+	status.Loaded, status.Running, err = inspectLaunchAgentState(ctx)
+	if err != nil {
+		return status, err
+	}
+	status.MigrationRequired, err = SharedDaemonMigrationRequired()
+	if err != nil {
+		return status, err
+	}
+	return status, nil
+}
+
+// EnsureSharedDaemonOwner 幂等安装并加载稳定 job。daemonPreexisting 表示调用前已有
+// 可握手 socket；若本次同时改变了 owner，就写入持久迁移标记，等待用户明确点击
+// “应用待处理设置”并确认后再切换，绝不在设置过程中静默中断原生 Codex。
+func EnsureSharedDaemonOwner(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	daemonPreexisting bool,
+) (SharedDaemonOwnerStatus, error) {
+	if err := repairSharedDaemonMigrationFlagPermissions(); err != nil {
+		return SharedDaemonOwnerStatus{}, err
+	}
+	before, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return SharedDaemonOwnerStatus{}, err
+	}
+	var previousPlist []byte
+	if before.Installed {
+		previousPlist, err = os.ReadFile(before.Path)
+		if err != nil {
+			return SharedDaemonOwnerStatus{}, fmt.Errorf("读取原共享 daemon LaunchAgent 失败：%w", err)
+		}
+	}
+	fileChanged, err := EnsureSharedDaemonLaunchAgent(options)
+	if err != nil {
+		return SharedDaemonOwnerStatus{}, err
+	}
+	created := !before.Installed
+	rollback := func(cause error) (SharedDaemonOwnerStatus, error) {
+		rollbackCtx, cancel := context.WithTimeout(context.Background(), 2*launchctlTimeout)
+		defer cancel()
+		if rollbackErr := restoreSharedDaemonOwner(rollbackCtx, before, previousPlist); rollbackErr != nil {
+			return SharedDaemonOwnerStatus{}, fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", cause, rollbackErr)
+		}
+		return SharedDaemonOwnerStatus{}, fmt.Errorf("%w；已恢复原 daemon owner", cause)
+	}
+	loaded := before.Loaded
+	if fileChanged && loaded {
+		if _, bootoutErr := sharedDaemonLaunchctl(ctx, "bootout", launchAgentServiceTarget()); bootoutErr != nil &&
+			!isLaunchctlNotLoaded(bootoutErr) {
+			return rollback(bootoutErr)
+		}
+		loaded = false
+	}
+	if !loaded {
+		path, pathErr := SharedDaemonLaunchAgentPath()
+		if pathErr != nil {
+			return rollback(pathErr)
+		}
+		// RunAtLoad 会执行一次幂等的官方 `daemon start`。已有 daemon 不会被重启，
+		// 没有 daemon 时则从一开始就在 launchd 责任链下创建。
+		if _, bootstrapErr := sharedDaemonLaunchctl(ctx, "bootstrap", launchAgentDomainTarget(), path); bootstrapErr != nil {
+			return rollback(bootstrapErr)
+		}
+	}
+	changed := fileChanged || !before.Loaded
+	if daemonPreexisting && changed {
+		if err := writeSharedDaemonMigrationFlag(); err != nil {
+			return rollback(err)
+		}
+	}
+	status, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return rollback(err)
+	}
+	if !status.Installed || !status.Loaded || !status.Secure {
+		return rollback(fmt.Errorf("共享 daemon LaunchAgent 安装后状态不完整"))
+	}
+	status.Changed = changed
+	status.Created = created
+	if changed {
+		appliedPlist, readErr := os.ReadFile(status.Path)
+		if readErr != nil {
+			return rollback(fmt.Errorf("读取已应用 LaunchAgent 失败：%w", readErr))
+		}
+		appliedLoaded := status.Loaded
+		appliedMigrationRequired := status.MigrationRequired
+		status.Rollback = &SharedDaemonOwnerRollback{
+			rollbackUnlocked: func(rollbackCtx context.Context) error {
+				current, currentErr := os.ReadFile(status.Path)
+				if currentErr != nil || !bytes.Equal(current, appliedPlist) {
+					return fmt.Errorf("共享 daemon owner 已被其他进程修改，拒绝覆盖")
+				}
+				currentStatus, inspectErr := InspectSharedDaemonOwner(rollbackCtx)
+				if inspectErr != nil {
+					return fmt.Errorf("确认共享 daemon owner 回滚边界失败：%w", inspectErr)
+				}
+				if currentStatus.Loaded != appliedLoaded ||
+					currentStatus.MigrationRequired != appliedMigrationRequired {
+					return fmt.Errorf("共享 daemon owner 状态已被其他进程修改，拒绝覆盖")
+				}
+				return restoreSharedDaemonOwner(rollbackCtx, before, previousPlist)
+			},
+		}
+	}
+	return status, nil
+}
+
+// RollbackSharedDaemonOwnerChange 供配置事务在落盘前失败时恢复 owner。文件锁
+// 覆盖校验与恢复全程，且令牌会拒绝覆盖其他进程在此期间写入的新 owner。
+func RollbackSharedDaemonOwnerChange(ctx context.Context, rollback *SharedDaemonOwnerRollback) error {
+	if rollback == nil {
+		return nil
+	}
+	_, err := withSharedDaemonOperationLock(ctx, func() (LocalDaemonStatus, error) {
+		return LocalDaemonStatus{}, rollbackSharedDaemonOwnerChangeUnlocked(ctx, rollback)
+	})
+	return err
+}
+
+// restoreSharedDaemonOwner 把 plist、launchd 加载状态和迁移标记一起恢复到调用前。
+// job 是一次性官方控制命令，回滚不会 stop 已运行的 app-server daemon。
+func restoreSharedDaemonOwner(
+	ctx context.Context,
+	before SharedDaemonOwnerStatus,
+	previousPlist []byte,
+) error {
+	loaded, _, inspectErr := inspectLaunchAgentState(ctx)
+	if inspectErr != nil {
+		return inspectErr
+	}
+	if loaded {
+		if _, err := sharedDaemonLaunchctl(ctx, "bootout", launchAgentServiceTarget()); err != nil &&
+			!isLaunchctlNotLoaded(err) {
+			return err
+		}
+	}
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		return err
+	}
+	if before.Installed {
+		if err := writeSharedDaemonPrivateFileAtomically(path, previousPlist); err != nil {
+			return fmt.Errorf("恢复原 LaunchAgent 文件失败：%w", err)
+		}
+		if before.Loaded {
+			if _, err := sharedDaemonLaunchctl(ctx, "bootstrap", launchAgentDomainTarget(), path); err != nil {
+				return err
+			}
+		}
+	} else if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("删除本次新建 LaunchAgent 失败：%w", err)
+	}
+	if before.MigrationRequired {
+		return writeSharedDaemonMigrationFlag()
+	}
+	return clearSharedDaemonMigrationFlag()
+}
+
+func writeSharedDaemonMigrationFlag() error {
+	path, err := sharedDaemonMigrationFlagPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("创建共享 daemon 状态目录失败：%w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".codex-daemon-migration-*")
+	if err != nil {
+		return fmt.Errorf("记录共享 daemon 迁移状态失败：%w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if _, err := temp.Write([]byte("restart-required\n")); err != nil {
+		temp.Close()
+		return fmt.Errorf("记录共享 daemon 迁移状态失败：%w", err)
+	}
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("设置共享 daemon 迁移状态权限失败：%w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("记录共享 daemon 迁移状态失败：%w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("记录共享 daemon 迁移状态失败：%w", err)
+	}
+	return nil
+}
+
+func markSharedDaemonMigrationRequired() error {
+	return writeSharedDaemonMigrationFlag()
+}
+
+func clearSharedDaemonMigrationFlag() error {
+	path, err := sharedDaemonMigrationFlagPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("清除共享 daemon 迁移状态失败：%w", err)
+	}
+	return nil
+}
+
+// RemoveSharedDaemonLaunchAgent 关闭共享时卸载 job 并删除 plist。不停止已经在运行
+// 的 daemon：那会打断仍在使用它的 Desktop 或移动端任务。
+func RemoveSharedDaemonLaunchAgent(ctx context.Context) error {
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		return err
+	}
+	loaded, _, inspectErr := inspectLaunchAgentState(ctx)
+	if inspectErr != nil {
+		return inspectErr
+	}
+	if loaded {
+		if _, bootoutErr := sharedDaemonLaunchctl(ctx, "bootout", launchAgentServiceTarget()); bootoutErr != nil &&
+			!isLaunchctlNotLoaded(bootoutErr) {
+			return bootoutErr
+		}
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("删除 LaunchAgent 失败：%w", err)
+	}
+	return nil
+}
+
+// RemoveSharedDaemonOwner 只移除 Mimi 安装的未来启动入口和迁移标记，不停止当前
+// daemon；关闭共享时 Desktop 可能仍在完成退出，直接 stop 会破坏原生流程。
+func RemoveSharedDaemonOwner(ctx context.Context) error {
+	_, err := withSharedDaemonOperationLock(ctx, func() (LocalDaemonStatus, error) {
+		return LocalDaemonStatus{}, removeSharedDaemonOwnerUnlocked(ctx)
+	})
+	return err
+}
+
+func removeSharedDaemonOwnerUnlocked(ctx context.Context) error {
+	if err := RemoveSharedDaemonLaunchAgent(ctx); err != nil {
+		return err
+	}
+	return clearSharedDaemonMigrationFlag()
+}
+
+// startLocalDaemonWithStableOwner 请 launchd 创建 daemon：spawn 发生在 launchd
+// 上下文，agentd 完全不进入责任链。这里没有“launchctl 失败就自己 exec”的兜底，
+// 因为那正是 MIM-157 的错误归因来源。
+func startLocalDaemonWithStableOwner(ctx context.Context, options LocalDaemonOptions) error {
+	_, err := startLocalDaemonWithStableOwnerTracked(ctx, options)
+	return err
+}
+
+// startLocalDaemonWithStableOwnerTracked 只有本次实际执行了 launchd kickstart 才
+// 返回 true。轻量 socket 短路或等待既有 running job 都不能作为 TCC owner 已迁移
+// 的证据，避免错误清除 migration marker。
+func startLocalDaemonWithStableOwnerTracked(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (bool, error) {
+	logOffset := sharedDaemonLaunchAgentLogSize()
+	owner, err := EnsureSharedDaemonOwner(ctx, options, false)
+	if err != nil {
+		return false, err
+	}
+	if sharedDaemonSocketAcceptsConnectionMust(options) {
+		return false, nil
+	}
+	if owner.Running {
+		// 登录或 bootstrap 的 RunAtLoad 可能仍在执行官方 start；不能在同一个
+		// job 尚未退出时再 kickstart，直接等待本次启动完成。
+		return false, waitForSharedDaemonSocket(ctx, options, logOffset)
+	}
+	// job 已注册：显式 kickstart 一次，不依赖刚才 bootstrap 的异步 RunAtLoad。
+	if _, kickErr := sharedDaemonLaunchctl(ctx, "kickstart", launchAgentServiceTarget()); kickErr != nil {
+		return false, kickErr
+	}
+	return true, waitForSharedDaemonSocket(ctx, options, logOffset)
+}
+
+func sharedDaemonSocketAcceptsConnectionMust(options LocalDaemonOptions) bool {
+	path, err := LocalDaemonSocketPath(options.Env)
+	return err == nil && sharedDaemonSocketAcceptsConnection(path)
+}
+
+// RestartSharedDaemonWithStableOwner 是唯一允许迁移既有 daemon 的入口。调用方必须
+// 先取得用户明确确认；它先用官方 stop 正常退出，再由 launchd job 拉起，绝不回退
+// 到 agentd 直接 spawn。成功完成协议握手后才清除 migration marker。
+func RestartSharedDaemonWithStableOwner(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (LocalDaemonStatus, error) {
+	return withSharedDaemonOperationLock(ctx, func() (LocalDaemonStatus, error) {
+		return restartSharedDaemonWithStableOwner(ctx, options)
+	})
+}
+
+func restartSharedDaemonWithStableOwner(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (LocalDaemonStatus, error) {
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	probeCtx, cancelProbe := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	_, preexistingErr := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancelProbe()
+	owner, err := EnsureSharedDaemonOwner(
+		ctx,
+		options,
+		localDaemonWasPreexisting(preexistingErr, sharedDaemonSocketAcceptsConnectionMust(options)),
+	)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	if !owner.Installed || !owner.Loaded {
+		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon LaunchAgent 未正确加载")
+	}
+	if !owner.MigrationRequired {
+		probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
+		probe, probeErr := ProbeLocalDaemonInfo(probeCtx, socketPath)
+		cancel()
+		if probeErr == nil {
+			lifecycle, lifecycleErr := InspectLocalDaemonLifecycle(ctx, options)
+			if lifecycleErr != nil {
+				return LocalDaemonStatus{}, fmt.Errorf("确认现有共享 daemon 生命周期失败：%w", lifecycleErr)
+			}
+			if lifecycleErr := ValidateManagedLocalDaemonLifecycle(lifecycle, socketPath); lifecycleErr != nil {
+				return LocalDaemonStatus{}, lifecycleErr
+			}
+			if identityErr := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); identityErr != nil {
+				return LocalDaemonStatus{}, identityErr
+			}
+			status := localDaemonStatus(socketPath, false, probe.Version, os.Stat)
+			status.OwnerInstalled = true
+			return status, nil
+		}
+	}
+	if err := stopSharedDaemon(ctx, options, owner); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	if err := waitForSharedDaemonStopped(ctx, socketPath); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	logOffset := sharedDaemonLaunchAgentLogSize()
+	if _, err := sharedDaemonLaunchctl(ctx, "kickstart", launchAgentServiceTarget()); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	if err := waitForSharedDaemonSocket(ctx, options, logOffset); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	probe, err := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancel()
+	if err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 重启后协议握手失败：%w", err)
+	}
+	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
+	if err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 重启后生命周期检查失败：%w", err)
+	}
+	if err := ValidateManagedLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	if err := clearSharedDaemonMigrationFlag(); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	status := localDaemonStatus(socketPath, true, probe.Version, os.Stat)
+	status.OwnerInstalled = true
+	return status, nil
+}
+
+func waitForSharedDaemonStopped(ctx context.Context, socketPath string) error {
+	deadline := time.Now().Add(sharedDaemonStopTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	var disconnectedSince time.Time
+	for {
+		now := time.Now()
+		if sharedDaemonSocketAcceptsConnection(socketPath) {
+			disconnectedSince = time.Time{}
+		} else if disconnectedSince.IsZero() {
+			disconnectedSince = now
+		} else if now.Sub(disconnectedSince) >= sharedDaemonStoppedConfirmationWindow {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if now.After(deadline) {
+			return fmt.Errorf("旧 Codex local daemon 在 stop 后仍未退出")
+		}
+		time.Sleep(sharedDaemonSocketPollInterval)
+	}
+}
+
+func stopSharedDaemon(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	owner SharedDaemonOwnerStatus,
+) error {
+	socketPath, pathErr := LocalDaemonSocketPath(options.Env)
+	if pathErr != nil {
+		return pathErr
+	}
+	// 上一次显式迁移可能已发出唯一次 SIGTERM，但旧
+	// server 在等待超时后才完成优雅退出。用户稍后重试时，
+	// socket 已不可连就是“无需再 stop”；外层还会要求它持续
+	// 不可连一个确认窗口后才 kickstart，不会重复发信号。
+	if !sharedDaemonSocketAcceptsConnection(socketPath) {
+		return nil
+	}
+	lifecycle, lifecycleErr := InspectLocalDaemonLifecycle(ctx, options)
+	if lifecycleErr != nil {
+		return lifecycleErr
+	}
+	if lifecycle.Backend == nil {
+		if !owner.Installed || !owner.Loaded || !owner.Secure || !owner.MigrationRequired {
+			return fmt.Errorf("非 daemon 管理的 Codex app-server 缺少已确认的稳定 owner 迁移状态，拒绝接管")
+		}
+		return stopUnmanagedSharedDaemon(ctx, options, lifecycle)
+	}
+	backend := strings.ToLower(strings.TrimSpace(*lifecycle.Backend))
+	if backend != "pid" {
+		return fmt.Errorf("Codex app-server 使用未知 lifecycle backend %q，拒绝迁移", *lifecycle.Backend)
+	}
+
+	bin := strings.TrimSpace(options.CodexBin)
+	if bin == "" {
+		bin = "codex"
+	}
+	cmd := exec.CommandContext(ctx, bin, "app-server", "daemon", "stop")
+	configureManagedCommand(cmd)
+	cmd.Env = buildManagedEnv(options.Env)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	message := sanitizeDiagnostic(string(output))
+	lower := strings.ToLower(message)
+	if strings.Contains(lower, "not running") || strings.Contains(lower, "no running") {
+		return nil
+	}
+	if strings.Contains(lower, unmanagedSharedDaemonMessage) {
+		return fmt.Errorf("官方 lifecycle 报告 pid backend，但 stop 拒绝管理该进程，已停止迁移")
+	}
+	if message == "" {
+		return fmt.Errorf("停止旧 Codex local daemon 失败：%w", err)
+	}
+	return fmt.Errorf("停止旧 Codex local daemon 失败：%s", message)
+}
+
+func stopUnmanagedSharedDaemon(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	lifecycle LocalDaemonLifecycleStatus,
+) error {
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return err
+	}
+	probeCtx, cancelProbe := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	probe, err := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancelProbe()
+	if err != nil {
+		return fmt.Errorf("无法确认待接管的 Codex app-server：%w", err)
+	}
+	if err := ValidateLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
+		return err
+	}
+	if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
+		return err
+	}
+	if err := validatePrivateSharedDaemonSocket(socketPath, os.Getuid()); err != nil {
+		return err
+	}
+
+	return stopUnmanagedSharedDaemonWithHooks(
+		ctx,
+		socketPath,
+		lifecycle.ManagedCodexPath,
+		unmanagedSharedDaemonHooks{
+			desktopRunning: codexDesktopProcessRunning,
+			inspect:        inspectSharedDaemonListenerProcess,
+			signalTERM:     signalSharedDaemonProcessTERM,
+			currentUID:     os.Getuid,
+		},
+	)
+}
+
+func stopUnmanagedSharedDaemonWithHooks(
+	ctx context.Context,
+	socketPath string,
+	managedCodexPath string,
+	hooks unmanagedSharedDaemonHooks,
+) error {
+	running, err := hooks.desktopRunning(ctx)
+	if err != nil {
+		return fmt.Errorf("确认 Codex Desktop 已退出失败：%w", err)
+	}
+	if running {
+		return fmt.Errorf("Codex Desktop 仍在运行，拒绝接管非 daemon 管理的 app-server")
+	}
+
+	listener, err := hooks.inspect(ctx, socketPath)
+	if err != nil {
+		return fmt.Errorf("识别非 daemon 管理的 Codex app-server 失败：%w", err)
+	}
+	if err := validateSharedDaemonListenerProcess(listener, hooks.currentUID(), managedCodexPath); err != nil {
+		return err
+	}
+	// PID 可能在检查命令行期间退出并被复用。发送信号前再次从 socket
+	// 反查 owner；PID、UID、命令与可执行文件任一变化都停止迁移。
+	confirmed, err := hooks.inspect(ctx, socketPath)
+	if err != nil {
+		return fmt.Errorf("再次确认 Codex app-server owner 失败：%w", err)
+	}
+	if confirmed != listener {
+		return fmt.Errorf("Codex app-server owner 在接管前发生变化，已停止迁移")
+	}
+	// 用户可能在首次检查后从 Dock 重新打开 Desktop。信号前必须
+	// 再按 bundle id 查一次；读取失败也 fail closed，不能凭旧快照
+	// 终止已经被新 Desktop 重新使用的 backend。
+	running, err = hooks.desktopRunning(ctx)
+	if err != nil {
+		return fmt.Errorf("信号前再次确认 Codex Desktop 已退出失败：%w", err)
+	}
+	if running {
+		return fmt.Errorf("Codex Desktop 在迁移前被重新打开，已停止接管")
+	}
+	if err := hooks.signalTERM(listener.PID); err != nil {
+		return fmt.Errorf("正常终止旧 Codex app-server 失败：%w", err)
+	}
+	return nil
+}
+
+func validateSharedDaemonListenerProcess(
+	process sharedDaemonListenerProcess,
+	currentUID int,
+	managedCodexPath string,
+) error {
+	if process.PID <= 1 {
+		return fmt.Errorf("Codex app-server socket owner PID 无效")
+	}
+	if process.UID != currentUID {
+		return fmt.Errorf("Codex app-server socket owner 不属于当前用户，拒绝接管")
+	}
+	if strings.TrimSpace(process.Executable) == "" ||
+		!sameCanonicalPath(process.Executable, managedCodexPath) {
+		return fmt.Errorf("Codex app-server socket owner 不是官方 managed standalone，拒绝接管")
+	}
+	if !isDirectUnixAppServerCommand(process.Command) {
+		return fmt.Errorf("Codex app-server socket owner 命令行不符合原生 SSH 启动模式，拒绝接管")
+	}
+	return nil
+}
+
+func isDirectUnixAppServerCommand(command string) bool {
+	var fields []string
+	if strings.Contains(command, "\x00") {
+		for _, field := range strings.Split(command, "\x00") {
+			if field != "" {
+				fields = append(fields, field)
+			}
+		}
+	} else {
+		fields = strings.Fields(strings.TrimSpace(command))
+	}
+	if len(fields) < 3 {
+		return false
+	}
+	appServerIndex := -1
+	for index, field := range fields {
+		if field == "app-server" {
+			appServerIndex = index
+			break
+		}
+	}
+	if appServerIndex < 0 {
+		return false
+	}
+	// `app-server daemon ...` 与 `app-server proxy ...` 都是另一种官方
+	// 责任链，不能当成 SSH bootstrap 的直接 listener 接管。
+	for _, field := range fields[appServerIndex+1:] {
+		if field == "daemon" || field == "proxy" {
+			return false
+		}
+	}
+	for index := appServerIndex + 1; index < len(fields); index++ {
+		switch {
+		case fields[index] == "--listen" && index+1 < len(fields):
+			return fields[index+1] == "unix://"
+		case strings.HasPrefix(fields[index], "--listen="):
+			return strings.TrimPrefix(fields[index], "--listen=") == "unix://"
+		}
+	}
+	return false
+}
+
+func codexDesktopProcessRunning(ctx context.Context) (bool, error) {
+	// Desktop 的当前 App 名与可执行文件名是 ChatGPT，历史名称却是
+	// Codex。进程名不是稳定契约；LaunchServices bundle id 与 Swift 端
+	// NSWorkspace 的识别方式一致，也能覆盖同 bundle 的多个实例。
+	cmd := exec.CommandContext(ctx, "/usr/bin/lsappinfo", "find", "bundleid="+codexDesktopBundleID)
+	configureManagedCommand(cmd)
+	output, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
+func inspectSharedDaemonListenerProcess(
+	ctx context.Context,
+	socketPath string,
+) (sharedDaemonListenerProcess, error) {
+	pid, peerUID, err := sharedDaemonSocketPeer(ctx, socketPath)
+	if err != nil {
+		return sharedDaemonListenerProcess{}, err
+	}
+	kinfo, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || int(kinfo.Proc.P_pid) != pid {
+		return sharedDaemonListenerProcess{}, fmt.Errorf("读取 socket owner 进程身份失败")
+	}
+	if int(kinfo.Eproc.Ucred.Uid) != peerUID {
+		return sharedDaemonListenerProcess{}, fmt.Errorf("socket peer UID 与进程 UID 不一致")
+	}
+	executable, arguments, err := sharedDaemonProcessArguments(pid)
+	if err != nil {
+		return sharedDaemonListenerProcess{}, err
+	}
+	return sharedDaemonListenerProcess{
+		PID:        pid,
+		UID:        peerUID,
+		StartSec:   kinfo.Proc.P_starttime.Sec,
+		StartUsec:  kinfo.Proc.P_starttime.Usec,
+		Command:    strings.Join(arguments, "\x00"),
+		Executable: executable,
+	}, nil
+}
+
+func sharedDaemonSocketPeer(ctx context.Context, socketPath string) (int, int, error) {
+	dialer := net.Dialer{Timeout: localDaemonProbeTimeout}
+	conn, err := dialer.DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("连接 Codex app-server socket 失败：%w", err)
+	}
+	defer conn.Close()
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0, 0, fmt.Errorf("Codex app-server socket 不是 UnixConn")
+	}
+	raw, err := unixConn.SyscallConn()
+	if err != nil {
+		return 0, 0, fmt.Errorf("读取 Codex app-server socket fd 失败：%w", err)
+	}
+	var peerPID int
+	var peerUID int
+	var controlErr error
+	if err := raw.Control(func(fd uintptr) {
+		peerPID, controlErr = unix.GetsockoptInt(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERPID)
+		if controlErr != nil {
+			return
+		}
+		credentials, credentialsErr := unix.GetsockoptXucred(
+			int(fd),
+			unix.SOL_LOCAL,
+			unix.LOCAL_PEERCRED,
+		)
+		if credentialsErr != nil {
+			controlErr = credentialsErr
+			return
+		}
+		peerUID = int(credentials.Uid)
+	}); err != nil {
+		return 0, 0, fmt.Errorf("读取 Codex app-server socket peer 失败：%w", err)
+	}
+	if controlErr != nil {
+		return 0, 0, fmt.Errorf("读取 Codex app-server socket peer 身份失败：%w", controlErr)
+	}
+	if peerPID <= 1 || peerUID < 0 {
+		return 0, 0, fmt.Errorf("Codex app-server socket peer 身份无效")
+	}
+	return peerPID, peerUID, nil
+}
+
+func sharedDaemonProcessArguments(pid int) (string, []string, error) {
+	raw, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return "", nil, fmt.Errorf("读取 socket owner 进程参数失败：%w", err)
+	}
+	if len(raw) < 5 {
+		return "", nil, fmt.Errorf("socket owner 进程参数过短")
+	}
+	argc := int(binary.LittleEndian.Uint32(raw[:4]))
+	if argc <= 0 || argc > 4096 {
+		return "", nil, fmt.Errorf("socket owner argc 无效")
+	}
+	cursor := raw[4:]
+	executableEnd := bytes.IndexByte(cursor, 0)
+	if executableEnd <= 0 {
+		return "", nil, fmt.Errorf("socket owner 缺少 executable path")
+	}
+	executable := string(cursor[:executableEnd])
+	if !filepath.IsAbs(executable) {
+		return "", nil, fmt.Errorf("socket owner executable path 不是绝对路径")
+	}
+	cursor = cursor[executableEnd+1:]
+	for len(cursor) > 0 && cursor[0] == 0 {
+		cursor = cursor[1:]
+	}
+	arguments := make([]string, 0, argc)
+	for len(arguments) < argc {
+		argumentEnd := bytes.IndexByte(cursor, 0)
+		if argumentEnd < 0 {
+			return "", nil, fmt.Errorf("socket owner argv 未完整终止")
+		}
+		arguments = append(arguments, string(cursor[:argumentEnd]))
+		cursor = cursor[argumentEnd+1:]
+	}
+	return executable, arguments, nil
+}
+
+func validatePrivateSharedDaemonSocket(socketPath string, currentUID int) error {
+	info, err := os.Lstat(socketPath)
+	if err != nil {
+		return fmt.Errorf("检查 Codex app-server socket 失败：%w", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("Codex app-server 路径不是 Unix socket")
+	}
+	if info.Mode().Perm() != 0o600 {
+		return fmt.Errorf("Codex app-server socket 权限不是 0600，拒绝接管")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != currentUID {
+		return fmt.Errorf("Codex app-server socket 不属于当前用户，拒绝接管")
+	}
+	return nil
+}
+
+func signalSharedDaemonProcessTERM(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(syscall.SIGTERM)
+}
+
+// waitForSharedDaemonSocket 把 launchd 的异步启动重新变成同步语义：官方
+// `daemon start` 原本是阻塞的，调用方依赖“返回即已就绪”。
+func waitForSharedDaemonSocket(ctx context.Context, options LocalDaemonOptions, logOffset int64) error {
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(sharedDaemonStartTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	for {
+		// 只判断 socket 文件存在是不够的：官方 `daemon stop` 不会删除 socket 文件，
+		// 上一个 daemon 退出后它会一直留在磁盘上。必须真正 connect 一次，才能区分
+		// “新 daemon 已在监听”和“stale socket 仍在、启动其实失败了”。
+		if sharedDaemonSocketAcceptsConnection(socketPath) {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if time.Now().After(deadline) {
+			return sharedDaemonStartupError(logOffset)
+		}
+		time.Sleep(sharedDaemonSocketPollInterval)
+	}
+}
+
+// sharedDaemonSocketAcceptsConnection 只做一次连通性判断，完整的 initialize 握手
+// 和版本校验仍由调用方的 probe 负责，避免这里重复实现协议判断。
+func sharedDaemonSocketAcceptsConnection(socketPath string) bool {
+	info, err := os.Lstat(socketPath)
+	if err != nil || info.Mode()&os.ModeSocket == 0 {
+		return false
+	}
+	conn, err := net.DialTimeout("unix", socketPath, localDaemonProbeTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// sharedDaemonStartupError 从 job 日志还原失败原因。daemon 由 launchd 创建后，
+// 官方 CLI 的报错只会落在 StandardErrorPath，不再经过 agentd 的 stdout。
+func sharedDaemonStartupError(logOffset int64) error {
+	tail := sharedDaemonLaunchAgentLogTail(logOffset)
+	lower := strings.ToLower(tail)
+	if strings.Contains(lower, "managed standalone codex install not found") ||
+		strings.Contains(lower, "requires the standalone install") {
+		return fmt.Errorf("%w；请先使用 Codex 官方安装器安装命令行工具，再重启 Mimi Remote", ErrLocalDaemonStandaloneMissing)
+	}
+	if tail == "" {
+		return fmt.Errorf("Codex local daemon 未在预期时间内就绪；请检查 %s", SharedDaemonLaunchAgentLabel)
+	}
+	return fmt.Errorf("Codex local daemon 未在预期时间内就绪：%s", sanitizeDiagnostic(tail))
+}
+
+func sharedDaemonLaunchAgentLogSize() int64 {
+	path, err := sharedDaemonLaunchAgentLogPath()
+	if err != nil {
+		return 0
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return 0
+	}
+	return info.Size()
+}
+
+func sharedDaemonLaunchAgentLogTail(offset int64) string {
+	path, err := sharedDaemonLaunchAgentLogPath()
+	if err != nil {
+		return ""
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return ""
+	}
+	size := info.Size()
+	if offset < 0 || offset > size {
+		offset = 0
+	}
+	if size-offset > sharedDaemonLogDiagnosticBytes {
+		offset = size - sharedDaemonLogDiagnosticBytes
+	}
+	if _, err := file.Seek(offset, 0); err != nil {
+		return ""
+	}
+	content, err := io.ReadAll(io.LimitReader(file, sharedDaemonLogDiagnosticBytes))
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) > 5 {
+		lines = lines[len(lines)-5:]
+	}
+	return strings.TrimSpace(strings.Join(lines, "; "))
+}
+
+func launchAgentDomainTarget() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+func launchAgentServiceTarget() string {
+	return launchAgentDomainTarget() + "/" + SharedDaemonLaunchAgentLabel
+}
+
+func inspectLaunchAgentState(ctx context.Context) (bool, bool, error) {
+	output, err := sharedDaemonLaunchctl(ctx, "print", launchAgentServiceTarget())
+	if err != nil {
+		if isLaunchctlNotLoaded(err) {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("检查共享 daemon LaunchAgent 加载状态失败：%w", err)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.EqualFold(strings.TrimSpace(line), "state = running") {
+			return true, true, nil
+		}
+	}
+	return true, false, nil
+}
+
+type launchctlError struct {
+	subcommand string
+	output     string
+	err        error
+}
+
+func (e *launchctlError) Error() string {
+	if e.output != "" {
+		return fmt.Sprintf("launchctl %s 失败：%s", e.subcommand, sanitizeDiagnostic(e.output))
+	}
+	return fmt.Sprintf("launchctl %s 失败：%v", e.subcommand, e.err)
+}
+
+func (e *launchctlError) Unwrap() error { return e.err }
+
+func runLaunchctl(ctx context.Context, arguments ...string) (string, error) {
+	if len(arguments) == 0 {
+		return "", fmt.Errorf("launchctl 参数不能为空")
+	}
+	commandCtx := ctx
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		commandCtx, cancel = context.WithTimeout(ctx, launchctlTimeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(commandCtx, "/bin/launchctl", arguments...)
+	output, err := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(output))
+	if err != nil {
+		return text, &launchctlError{subcommand: arguments[0], output: text, err: err}
+	}
+	return text, nil
+}
+
+// isLaunchctlNotLoaded 区分“本来就没注册”和真正的 bootout 失败。
+func isLaunchctlNotLoaded(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "no such process") ||
+		strings.Contains(lower, "no such service") ||
+		strings.Contains(lower, "could not find specified service") ||
+		strings.Contains(lower, "not find") ||
+		strings.Contains(lower, "not loaded")
+}

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -1,0 +1,1196 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func writeFakeCodexBin(t *testing.T, dir string, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("写入假 codex 失败：%v", err)
+	}
+	return path
+}
+
+// Darwin 的 Unix socket 路径上限很短；owner 测试必须使用短 Home，且显式
+// CODEX_HOME 要满足生产代码的“目录已存在”约束。
+func sharedDaemonTestHome(t *testing.T) string {
+	t.Helper()
+	home, err := os.MkdirTemp("/tmp", "mimi-owner-")
+	if err != nil {
+		t.Fatalf("创建短测试 Home 失败：%v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(home) })
+	for _, name := range []string{".codex", "other-codex"} {
+		if err := os.MkdirAll(filepath.Join(home, name), 0o700); err != nil {
+			t.Fatalf("创建测试 CODEX_HOME 失败：%v", err)
+		}
+	}
+	return home
+}
+
+func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
+	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/codex bin/codex",
+		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
+		"/Users/tester/Library/Logs/mimi-remote/codex-shared-daemon.log",
+	)
+	if err != nil {
+		t.Fatalf("渲染 plist 失败：%v", err)
+	}
+	content := string(rendered)
+
+	if strings.Contains(content, "<string>/bin/sh</string>") || strings.Contains(content, "exec &#34;") {
+		t.Fatalf("plist 不能引入 shell 责任主体：\n%s", content)
+	}
+	if !strings.Contains(content, "<string>/opt/codex bin/codex</string>") {
+		t.Fatalf("plist 必须使用绝对 codex 路径：\n%s", content)
+	}
+	for _, argument := range []string{"app-server", "daemon", "start"} {
+		if !strings.Contains(content, "<string>"+argument+"</string>") {
+			t.Fatalf("plist 缺少官方 daemon 参数 %s：\n%s", argument, content)
+		}
+	}
+	if !strings.Contains(content, "<key>RunAtLoad</key>\n\t<true/>") {
+		t.Fatalf("plist 必须覆盖登录冷启动：\n%s", content)
+	}
+	if !strings.Contains(content, "<key>KeepAlive</key>\n\t<false/>") {
+		t.Fatalf("一次性控制命令不能被 launchd 反复重启：\n%s", content)
+	}
+	if !strings.Contains(content, "<key>Umask</key>\n\t<integer>63</integer>") {
+		t.Fatalf("LaunchAgent 日志必须只允许当前用户读取：\n%s", content)
+	}
+	if !strings.Contains(content, "<key>CODEX_HOME</key>\n\t\t<string>/Users/tester/.codex</string>") {
+		t.Fatalf("plist 必须固定 CODEX_HOME：\n%s", content)
+	}
+	for _, key := range sharedDaemonStrippedEnvKeys {
+		// 空值覆盖 launchd 用户域中 Desktop 写入的值，同时避免 shell wrapper。
+		emptyEntry := "<key>" + key + "</key>\n\t\t<string></string>"
+		if !strings.Contains(content, emptyEntry) {
+			t.Fatalf("plist 必须以空值覆盖 Desktop 专属变量 %s：\n%s", key, content)
+		}
+	}
+}
+
+func TestRenderSharedDaemonLaunchAgentEscapesXML(t *testing.T) {
+	rendered, err := renderSharedDaemonLaunchAgent(
+		"/tmp/a&b/codex",
+		map[string]string{"CODEX_HOME": "/tmp/<home>"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("渲染 plist 失败：%v", err)
+	}
+	content := string(rendered)
+	if strings.Contains(content, "/tmp/a&b/codex") || strings.Contains(content, "<home>") {
+		t.Fatalf("plist 未转义特殊字符：\n%s", content)
+	}
+	if !strings.Contains(content, "/tmp/a&amp;b/codex") {
+		t.Fatalf("plist 缺少转义后的 codex 路径：\n%s", content)
+	}
+}
+
+func TestRenderSharedDaemonLaunchAgentRejectsEmptyBin(t *testing.T) {
+	if _, err := renderSharedDaemonLaunchAgent("  ", nil, ""); err == nil {
+		t.Fatal("空 codex 路径必须报错")
+	}
+}
+
+func TestEnsureSharedDaemonLaunchAgentIsIdempotent(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	options := LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+
+	changed, err := EnsureSharedDaemonLaunchAgent(options)
+	if err != nil {
+		t.Fatalf("首次安装失败：%v", err)
+	}
+	if !changed {
+		t.Fatal("首次安装应报告已变更")
+	}
+
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		t.Fatalf("解析 plist 路径失败：%v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("plist 未落盘：%v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("plist 可能包含 MCP/API 环境变量，权限应为 0600，实际 %v", info.Mode().Perm())
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err = EnsureSharedDaemonLaunchAgent(options)
+	if err != nil {
+		t.Fatalf("重复安装失败：%v", err)
+	}
+	if changed {
+		t.Fatal("内容未变时不应报告变更，否则每次启动都会重装 job")
+	}
+	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("旧版 0644 plist 应原地收紧为 0600：info=%v err=%v", info, err)
+	}
+
+	options.Env["CODEX_HOME"] = filepath.Join(home, "other-codex")
+	changed, err = EnsureSharedDaemonLaunchAgent(options)
+	if err != nil {
+		t.Fatalf("更新安装失败：%v", err)
+	}
+	if !changed {
+		t.Fatal("CODEX_HOME 变化必须触发重装")
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("读取 plist 失败：%v", err)
+	}
+	if !strings.Contains(string(content), filepath.Join(home, "other-codex")) {
+		t.Fatalf("plist 未更新 CODEX_HOME：\n%s", content)
+	}
+
+	// 临时文件必须清理，否则 LaunchAgents 目录会堆积半成品 plist。
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("读取 LaunchAgents 目录失败：%v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".codex-shared-daemon-") {
+			t.Fatalf("残留临时文件：%s", entry.Name())
+		}
+	}
+}
+
+func TestEnsureSharedDaemonLaunchAgentPinsEffectiveCodexHome(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+
+	changed, err := EnsureSharedDaemonLaunchAgent(LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"TERM": "xterm-256color"},
+	})
+	if err != nil {
+		t.Fatalf("安装 owner 失败：%v", err)
+	}
+	if !changed {
+		t.Fatal("首次安装应报告已变更")
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	socketPath, err := LocalDaemonSocketPath(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effectiveHome := filepath.Dir(filepath.Dir(socketPath))
+	expected := "<key>CODEX_HOME</key>\n\t\t<string>" + effectiveHome + "</string>"
+	if !strings.Contains(string(content), expected) {
+		t.Fatalf("plist 必须固定实际 CODEX_HOME：\n%s", content)
+	}
+}
+
+func TestEnsureSharedDaemonLaunchAgentPreservesSanitizedUserToolingPath(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	firstUserBin := filepath.Join(home, "tools", "bin")
+	secondUserBin := filepath.Join(home, "other-tools", "bin")
+	t.Setenv("PATH", firstUserBin+":.:/usr/bin")
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	options := LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+
+	if changed, err := EnsureSharedDaemonLaunchAgent(options); err != nil || !changed {
+		t.Fatalf("首次安装失败：changed=%t err=%v", changed, err)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolingPath := sharedDaemonPlistStringValue(before, "PATH")
+	for _, required := range []string{"/opt/homebrew/bin", "/opt/homebrew/sbin", firstUserBin} {
+		if !strings.Contains(toolingPath, required) {
+			t.Fatalf("稳定 owner PATH 缺少 %s：%s", required, toolingPath)
+		}
+	}
+	if strings.Contains(toolingPath, ":.:") || strings.HasSuffix(toolingPath, ":.") {
+		t.Fatalf("稳定 owner PATH 不能保留相对目录：%s", toolingPath)
+	}
+
+	// resident agentd 后续看到较窄或不同的进程 PATH 时，不能反向覆盖首次由
+	// Mac App 捕获的用户工具目录，否则每次启动都会触发 owner 迁移。
+	t.Setenv("PATH", secondUserBin+":/usr/bin")
+	if changed, err := EnsureSharedDaemonLaunchAgent(options); err != nil || changed {
+		t.Fatalf("进程 PATH 变化不应改写既有 owner：changed=%t err=%v", changed, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("未显式配置 PATH 时必须保持已安装的稳定工具环境")
+	}
+}
+
+func TestEnsureSharedDaemonOwnerMarksPreexistingDaemonForExplicitMigration(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	loaded := false
+	commands := []string{}
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		commands = append(commands, strings.Join(arguments, " "))
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "loaded", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "bootout":
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	status, err := EnsureSharedDaemonOwner(context.Background(), LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}, true)
+	if err != nil {
+		t.Fatalf("安装 owner 失败：%v", err)
+	}
+	if !status.Installed || !status.Loaded || !status.Secure || !status.Created ||
+		!status.Changed || !status.MigrationRequired {
+		t.Fatalf("旧 daemon 必须等待显式迁移：%+v", status)
+	}
+	if len(commands) == 0 || !strings.HasPrefix(commands[len(commands)-2], "bootstrap ") {
+		t.Fatalf("首次安装必须 bootstrap job：%v", commands)
+	}
+	flagPath, err := sharedDaemonMigrationFlagPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(flagPath); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("迁移标记缺失或权限错误：info=%v err=%v", info, err)
+	}
+
+	if err := RemoveSharedDaemonOwner(context.Background()); err != nil {
+		t.Fatalf("移除 owner 失败：%v", err)
+	}
+	plistPath, _ := SharedDaemonLaunchAgentPath()
+	if _, err := os.Stat(plistPath); !os.IsNotExist(err) {
+		t.Fatalf("plist 应被删除：%v", err)
+	}
+	if _, err := os.Stat(flagPath); !os.IsNotExist(err) {
+		t.Fatalf("迁移标记应被删除：%v", err)
+	}
+}
+
+func TestEnsureSharedDaemonOwnerFreshStartNeedsNoMigration(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	loaded := false
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "loaded", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	status, err := EnsureSharedDaemonOwner(context.Background(), LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}, false)
+	if err != nil {
+		t.Fatalf("安装 owner 失败：%v", err)
+	}
+	if status.MigrationRequired {
+		t.Fatalf("全新冷启动不应要求迁移：%+v", status)
+	}
+}
+
+func TestEnsureSharedDaemonOwnerRestoresPreviousJobWhenReloadFails(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	loaded := false
+	bootstrapCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = {\n\tstate = exited\n}", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			bootstrapCalls++
+			if bootstrapCalls == 2 {
+				return "", fmt.Errorf("new plist rejected")
+			}
+			loaded = true
+			return "", nil
+		case "bootout":
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	options := LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := EnsureSharedDaemonOwner(context.Background(), options, false); err != nil {
+		t.Fatalf("安装初始 owner 失败：%v", err)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options.Env = map[string]string{"CODEX_HOME": filepath.Join(home, "other-codex")}
+	if _, err := EnsureSharedDaemonOwner(context.Background(), options, false); err == nil ||
+		!strings.Contains(err.Error(), "已恢复原 daemon owner") {
+		t.Fatalf("新 job 加载失败时必须报告已回滚：%v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("回滚后 plist 必须逐字恢复：\nbefore=%s\nafter=%s", before, after)
+	}
+	if !loaded || bootstrapCalls != 3 {
+		t.Fatalf("回滚后原 job 必须重新加载：loaded=%t bootstrapCalls=%d", loaded, bootstrapCalls)
+	}
+}
+
+func TestRollbackSharedDaemonOwnerChangeRestoresPreviousOwnerAfterLaterFailure(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	loaded := false
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = {\n\tstate = exited\n}", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "bootout":
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	options := LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := EnsureSharedDaemonOwner(context.Background(), options, false); err != nil {
+		t.Fatalf("安装初始 owner 失败：%v", err)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options.Env = map[string]string{"CODEX_HOME": filepath.Join(home, "other-codex")}
+	status, err := EnsureSharedDaemonOwner(context.Background(), options, true)
+	if err != nil {
+		t.Fatalf("更新 owner 失败：%v", err)
+	}
+	if status.Rollback == nil || !status.MigrationRequired {
+		t.Fatalf("变更后的 owner 必须携带回滚令牌和迁移标记：%+v", status)
+	}
+	if err := RollbackSharedDaemonOwnerChange(context.Background(), status.Rollback); err != nil {
+		t.Fatalf("后续配置失败时回滚 owner 失败：%v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("回滚后 plist 必须恢复：\nbefore=%s\nafter=%s", before, after)
+	}
+	if !loaded {
+		t.Fatal("回滚后原 job 必须保持加载")
+	}
+	if required, err := SharedDaemonMigrationRequired(); err != nil || required {
+		t.Fatalf("回滚后必须恢复原迁移标记：required=%t err=%v", required, err)
+	}
+}
+
+func TestRollbackSharedDaemonOwnerChangeRefusesConcurrentModification(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	loaded := false
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = {\n\tstate = exited\n}", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	status, err := EnsureSharedDaemonOwner(context.Background(), LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}, false)
+	if err != nil {
+		t.Fatalf("安装 owner 失败：%v", err)
+	}
+	if status.Rollback == nil {
+		t.Fatal("首次创建 owner 必须提供回滚令牌")
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	concurrent := []byte("concurrent-owner\n")
+	if err := os.WriteFile(path, concurrent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RollbackSharedDaemonOwnerChange(context.Background(), status.Rollback); err == nil ||
+		!strings.Contains(err.Error(), "拒绝覆盖") {
+		t.Fatalf("并发修改后必须拒绝回滚：%v", err)
+	}
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(current) != string(concurrent) {
+		t.Fatalf("拒绝回滚时不能覆盖并发 owner：%q", current)
+	}
+}
+
+func TestEnsureSharedDaemonOwnerRepairsPrivateMigrationMarkerMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := sharedDaemonMigrationFlagPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("restart-required\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// 测试进程可能继承 LaunchAgent 的 0077 umask；显式放宽才能稳定复现
+	// 来自旧版本的公开 marker。
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if required, err := SharedDaemonMigrationRequired(); err == nil || required {
+		t.Fatalf("公开 marker 必须 fail closed：required=%t err=%v", required, err)
+	}
+	if err := repairSharedDaemonMigrationFlagPermissions(); err != nil {
+		t.Fatalf("应能收紧旧 marker 权限：%v", err)
+	}
+	if required, err := SharedDaemonMigrationRequired(); err != nil || !required {
+		t.Fatalf("修复后 marker 应可安全读取：required=%t err=%v", required, err)
+	}
+	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("marker 权限必须为 0600：info=%v err=%v", info, err)
+	}
+}
+
+func TestFinalizedStableOwnerRecoveryClearsOldMigrationMarker(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	if err := writeSharedDaemonMigrationFlag(); err != nil {
+		t.Fatal(err)
+	}
+	status := LocalDaemonStatus{Started: true}
+	owner := SharedDaemonOwnerStatus{Installed: true, MigrationRequired: true}
+	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, true); err != nil {
+		t.Fatal(err)
+	}
+	if owner.MigrationRequired {
+		t.Fatal("稳定 owner 本次启动并验证 daemon 后应清除内存迁移状态")
+	}
+	if required, err := SharedDaemonMigrationRequired(); err != nil || required {
+		t.Fatalf("稳定 owner 恢复完成后应清除持久 marker：required=%t err=%v", required, err)
+	}
+}
+
+func TestOwnerChangeKeepsMigrationMarkerForExplicitApply(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	if err := writeSharedDaemonMigrationFlag(); err != nil {
+		t.Fatal(err)
+	}
+	status := LocalDaemonStatus{Started: true}
+	owner := SharedDaemonOwnerStatus{Installed: true, Changed: true, MigrationRequired: true}
+	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, true); err != nil {
+		t.Fatal(err)
+	}
+	if required, err := SharedDaemonMigrationRequired(); err != nil || !required {
+		t.Fatalf("owner 本次也变化时必须保留显式迁移与事务回滚边界：required=%t err=%v", required, err)
+	}
+}
+
+func TestSocketShortCircuitCannotClearMigrationMarker(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	if err := writeSharedDaemonMigrationFlag(); err != nil {
+		t.Fatal(err)
+	}
+	status := LocalDaemonStatus{Started: true}
+	owner := SharedDaemonOwnerStatus{Installed: true, MigrationRequired: true}
+	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, false); err != nil {
+		t.Fatal(err)
+	}
+	if required, err := SharedDaemonMigrationRequired(); err != nil || !required {
+		t.Fatalf("未实际 kickstart 时不能用 Started 误清 marker：required=%t err=%v", required, err)
+	}
+}
+
+func TestSharedDaemonOperationLockSerializesCallers(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := withSharedDaemonOperationLock(context.Background(), func() (LocalDaemonStatus, error) {
+			close(firstEntered)
+			<-releaseFirst
+			return LocalDaemonStatus{}, nil
+		})
+		firstDone <- err
+	}()
+	<-firstEntered
+
+	var secondEntered atomic.Bool
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := withSharedDaemonOperationLock(context.Background(), func() (LocalDaemonStatus, error) {
+			secondEntered.Store(true)
+			return LocalDaemonStatus{}, nil
+		})
+		secondDone <- err
+	}()
+	time.Sleep(150 * time.Millisecond)
+	if secondEntered.Load() {
+		t.Fatal("第二个恢复/迁移不能插入第一个操作")
+	}
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("第一个操作结束后第二个应取得文件锁")
+	}
+	if !secondEntered.Load() {
+		t.Fatal("第二个操作未执行")
+	}
+}
+
+func TestInspectLaunchAgentStateDistinguishesLoadedFromRunning(t *testing.T) {
+	originalLaunchctl := sharedDaemonLaunchctl
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+		return "service = {\n\tstate = exited\n}", nil
+	}
+	loaded, running, err := inspectLaunchAgentState(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded || running {
+		t.Fatalf("exited job 应为 loaded 但非 running：loaded=%t running=%t", loaded, running)
+	}
+
+	sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+		return "service = {\n\tstate = running\n}", nil
+	}
+	loaded, running, err = inspectLaunchAgentState(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded || !running {
+		t.Fatalf("running job 状态解析错误：loaded=%t running=%t", loaded, running)
+	}
+
+	sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+		return "", fmt.Errorf("not loaded")
+	}
+	loaded, running, err = inspectLaunchAgentState(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded || running {
+		t.Fatalf("launchctl print 失败时应为未加载：loaded=%t running=%t", loaded, running)
+	}
+
+	sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+		return "", fmt.Errorf("permission denied")
+	}
+	if _, _, err := inspectLaunchAgentState(context.Background()); err == nil ||
+		!strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("非 not-loaded 的 launchctl 错误必须上报：%v", err)
+	}
+}
+
+func TestRemoveSharedDaemonLaunchAgentBootsOutLoadedJobWithoutPlist(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	loaded := true
+	bootoutCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = {\n\tstate = exited\n}", nil
+			}
+			return "", fmt.Errorf("no such service")
+		case "bootout":
+			bootoutCalls++
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	if err := RemoveSharedDaemonLaunchAgent(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if loaded || bootoutCalls != 1 {
+		t.Fatalf("磁盘 plist 缺失也必须清理已加载 job：loaded=%t bootoutCalls=%d", loaded, bootoutCalls)
+	}
+}
+
+func TestResolveSharedDaemonCodexBinRequiresExecutable(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "codex")
+	if err := os.WriteFile(plain, []byte("not executable"), 0o644); err != nil {
+		t.Fatalf("写入文件失败：%v", err)
+	}
+	if _, err := resolveSharedDaemonCodexBin(plain); err == nil {
+		t.Fatal("不可执行的 codex 必须报错")
+	}
+	if _, err := resolveSharedDaemonCodexBin(dir); err == nil {
+		t.Fatal("目录不能被当成 codex")
+	}
+
+	executable := writeFakeCodexBin(t, dir, "codex-real")
+	resolved, err := resolveSharedDaemonCodexBin(executable)
+	if err != nil {
+		t.Fatalf("解析可执行 codex 失败：%v", err)
+	}
+	if resolved != executable {
+		t.Fatalf("解析结果不一致：%s", resolved)
+	}
+}
+
+func TestSharedDaemonLaunchAgentEnvDropsDesktopKeys(t *testing.T) {
+	values := sharedDaemonLaunchAgentEnv(map[string]string{
+		"CODEX_HOME":              "/tmp/.codex",
+		LocalDaemonEnvironmentKey: "1",
+		"CODEX_APP_SERVER_WS_URL": "ws://127.0.0.1:4222",
+		"  ":                      "ignored",
+	})
+	if values["CODEX_HOME"] != "/tmp/.codex" {
+		t.Fatalf("CODEX_HOME 丢失：%v", values)
+	}
+	if value, ok := values[LocalDaemonEnvironmentKey]; !ok || value != "" {
+		t.Fatalf("Desktop transport 开关必须被空值覆盖：%v", values)
+	}
+	if value, ok := values["CODEX_APP_SERVER_WS_URL"]; !ok || value != "" {
+		t.Fatalf("Desktop 外部 WS 地址必须被空值覆盖：%v", values)
+	}
+	if values["PATH"] == "" {
+		t.Fatalf("launchd 不做 PATH 查找，必须给出默认 PATH：%v", values)
+	}
+	if !strings.Contains(values["PATH"], "/opt/homebrew/bin") {
+		t.Fatalf("Apple Silicon Homebrew 工具目录必须进入默认 PATH：%v", values)
+	}
+}
+
+// 官方 `daemon stop` 不删除 socket 文件；stale socket 必须被判为未就绪，
+// 否则启动失败会被误报成成功。
+func TestSharedDaemonSocketAcceptsConnectionRejectsStaleSocket(t *testing.T) {
+	// sockaddr_un.sun_path 在 Darwin 只有 104 字节，t.TempDir() 的 /var/folders
+	// 路径会直接 bind 失败，这里显式用短路径。
+	dir, err := os.MkdirTemp("/tmp", "mimi-sock-")
+	if err != nil {
+		t.Fatalf("创建测试目录失败：%v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "app.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("创建测试 socket 失败：%v", err)
+	}
+	if !sharedDaemonSocketAcceptsConnection(socketPath) {
+		listener.Close()
+		t.Fatal("正在监听的 socket 应判为就绪")
+	}
+
+	// 保留 socket 文件再关闭监听，复现官方 daemon stop 之后的现场。
+	unixListener, ok := listener.(*net.UnixListener)
+	if !ok {
+		listener.Close()
+		t.Fatal("期望 UnixListener")
+	}
+	unixListener.SetUnlinkOnClose(false)
+	if err := listener.Close(); err != nil {
+		t.Fatalf("关闭监听失败：%v", err)
+	}
+	if info, statErr := os.Lstat(socketPath); statErr != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("stale socket 文件应保留：%v", statErr)
+	}
+	if sharedDaemonSocketAcceptsConnection(socketPath) {
+		t.Fatal("stale socket 必须判为未就绪")
+	}
+
+	if sharedDaemonSocketAcceptsConnection(filepath.Join(dir, "missing.sock")) {
+		t.Fatal("不存在的 socket 必须判为未就绪")
+	}
+}
+
+func TestStopSharedDaemonAlreadyDisconnectedCanResumeWithoutSecondSignal(t *testing.T) {
+	codexHome := sharedDaemonTestHome(t)
+	socketPath, err := LocalDaemonSocketPath(map[string]string{"CODEX_HOME": codexHome})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 故意传入不存在的 CLI；如果代码仍调用 lifecycle version，
+	// 本测试必然失败。无 listener 表示上一次的唯一 TERM 已经
+	// 完成，重试只应进入稳定断开确认，不再 stop/signal。
+	options := LocalDaemonOptions{
+		CodexBin: filepath.Join(t.TempDir(), "missing-codex"),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	owner := SharedDaemonOwnerStatus{
+		Installed:         true,
+		Loaded:            true,
+		Secure:            true,
+		MigrationRequired: true,
+	}
+	if err := stopSharedDaemon(context.Background(), options, owner); err != nil {
+		t.Fatalf("已断开时重试不应再要求 lifecycle：%v", err)
+	}
+	started := time.Now()
+	if err := waitForSharedDaemonStopped(context.Background(), socketPath); err != nil {
+		t.Fatalf("稳定断开确认失败：%v", err)
+	}
+	if time.Since(started) < sharedDaemonStoppedConfirmationWindow {
+		t.Fatal("不可连状态必须持续一个确认窗口后才允许 kickstart")
+	}
+}
+
+func TestWaitForSharedDaemonStoppedResetsConfirmationAfterReconnect(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "mimi-stop-flap-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "app.sock")
+	ready := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// 先给 wait loop 一个短暂不可连窗口，但尚未达到
+		// 500 ms 的稳定确认条件。
+		time.Sleep(200 * time.Millisecond)
+		listener, listenErr := net.Listen("unix", socketPath)
+		ready <- listenErr
+		if listenErr != nil {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+		_ = listener.Close()
+	}()
+
+	started := time.Now()
+	if err := waitForSharedDaemonStopped(context.Background(), socketPath); err != nil {
+		t.Fatalf("断开抖动确认失败：%v", err)
+	}
+	listenErr := <-ready
+	<-done
+	if listenErr != nil {
+		t.Fatalf("创建中途恢复 listener 失败：%v", listenErr)
+	}
+	// 200 ms 后重连、300 ms 后再断开，之后还必须重新
+	// 等满 500 ms。如果没有重置 disconnectedSince，会在约 500 ms 时错误返回。
+	if elapsed := time.Since(started); elapsed < 850*time.Millisecond {
+		t.Fatalf("中途重连后必须重新计算稳定断开窗口：elapsed=%s", elapsed)
+	}
+}
+
+func TestStopUnmanagedSharedDaemonRequiresDesktopStopped(t *testing.T) {
+	termCalls := 0
+	err := stopUnmanagedSharedDaemonWithHooks(
+		context.Background(),
+		"/tmp/app.sock",
+		"/tmp/codex",
+		unmanagedSharedDaemonHooks{
+			desktopRunning: func(context.Context) (bool, error) { return true, nil },
+			inspect: func(context.Context, string) (sharedDaemonListenerProcess, error) {
+				t.Fatal("Desktop 运行时不应读取或终止 socket owner")
+				return sharedDaemonListenerProcess{}, nil
+			},
+			signalTERM: func(int) error { termCalls++; return nil },
+			currentUID: func() int { return 501 },
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "仍在运行") || termCalls != 0 {
+		t.Fatalf("Desktop 未退出必须 fail closed：err=%v term=%d", err, termCalls)
+	}
+}
+
+func TestStopUnmanagedSharedDaemonSignalsOneStrictlyMatchedProcess(t *testing.T) {
+	process := sharedDaemonListenerProcess{
+		PID:        1234,
+		UID:        501,
+		StartSec:   1786522048,
+		StartUsec:  123,
+		Command:    "codex -c features.code_mode_host=true app-server --listen unix://",
+		Executable: "/tmp/codex-real",
+	}
+	inspectCalls := 0
+	desktopChecks := 0
+	var signaled []int
+	err := stopUnmanagedSharedDaemonWithHooks(
+		context.Background(),
+		"/tmp/app.sock",
+		"/tmp/codex-real",
+		unmanagedSharedDaemonHooks{
+			desktopRunning: func(context.Context) (bool, error) { desktopChecks++; return false, nil },
+			inspect: func(context.Context, string) (sharedDaemonListenerProcess, error) {
+				inspectCalls++
+				return process, nil
+			},
+			signalTERM: func(pid int) error { signaled = append(signaled, pid); return nil },
+			currentUID: func() int { return 501 },
+		},
+	)
+	if err != nil {
+		t.Fatalf("严格匹配的原生 SSH daemon 应允许一次 TERM：%v", err)
+	}
+	if desktopChecks != 2 || inspectCalls != 2 || len(signaled) != 1 || signaled[0] != process.PID {
+		t.Fatalf("接管必须两次确认 Desktop、双重确认 PID 且只 TERM 一次：desktop=%d inspect=%d signaled=%v", desktopChecks, inspectCalls, signaled)
+	}
+}
+
+func TestStopUnmanagedSharedDaemonRejectsDesktopReopenedBeforeSignal(t *testing.T) {
+	process := sharedDaemonListenerProcess{
+		PID:        1234,
+		UID:        501,
+		StartSec:   1786522048,
+		StartUsec:  123,
+		Command:    "codex app-server --listen unix://",
+		Executable: "/tmp/codex-real",
+	}
+	desktopChecks := 0
+	termCalls := 0
+	err := stopUnmanagedSharedDaemonWithHooks(
+		context.Background(),
+		"/tmp/app.sock",
+		"/tmp/codex-real",
+		unmanagedSharedDaemonHooks{
+			desktopRunning: func(context.Context) (bool, error) {
+				desktopChecks++
+				return desktopChecks == 2, nil
+			},
+			inspect:    func(context.Context, string) (sharedDaemonListenerProcess, error) { return process, nil },
+			signalTERM: func(int) error { termCalls++; return nil },
+			currentUID: func() int { return 501 },
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "重新打开") || desktopChecks != 2 || termCalls != 0 {
+		t.Fatalf("Desktop 在信号前重开时必须 fail closed：err=%v checks=%d term=%d", err, desktopChecks, termCalls)
+	}
+}
+
+func TestStopUnmanagedSharedDaemonRejectsFinalDesktopCheckFailure(t *testing.T) {
+	process := sharedDaemonListenerProcess{
+		PID:        1234,
+		UID:        501,
+		StartSec:   1786522048,
+		StartUsec:  123,
+		Command:    "codex app-server --listen unix://",
+		Executable: "/tmp/codex-real",
+	}
+	desktopChecks := 0
+	termCalls := 0
+	err := stopUnmanagedSharedDaemonWithHooks(
+		context.Background(),
+		"/tmp/app.sock",
+		"/tmp/codex-real",
+		unmanagedSharedDaemonHooks{
+			desktopRunning: func(context.Context) (bool, error) {
+				desktopChecks++
+				if desktopChecks == 2 {
+					return false, fmt.Errorf("查询失败")
+				}
+				return false, nil
+			},
+			inspect:    func(context.Context, string) (sharedDaemonListenerProcess, error) { return process, nil },
+			signalTERM: func(int) error { termCalls++; return nil },
+			currentUID: func() int { return 501 },
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "信号前再次确认") || termCalls != 0 {
+		t.Fatalf("Desktop 最终检查失败时必须 fail closed：err=%v term=%d", err, termCalls)
+	}
+}
+
+func TestStopUnmanagedSharedDaemonRejectsUnsafeListener(t *testing.T) {
+	base := sharedDaemonListenerProcess{
+		PID:        1234,
+		UID:        501,
+		StartSec:   1786522048,
+		StartUsec:  123,
+		Command:    "codex -c features.code_mode_host=true app-server --listen unix://",
+		Executable: "/tmp/codex-real",
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*sharedDaemonListenerProcess)
+		message string
+	}{
+		{name: "wrong uid", mutate: func(p *sharedDaemonListenerProcess) { p.UID = 502 }, message: "不属于当前用户"},
+		{name: "wrong executable", mutate: func(p *sharedDaemonListenerProcess) { p.Executable = "/tmp/foreign" }, message: "不是官方 managed standalone"},
+		{name: "wrong argv", mutate: func(p *sharedDaemonListenerProcess) { p.Command = "codex app-server --listen ws://127.0.0.1:4222" }, message: "命令行不符合"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			process := base
+			test.mutate(&process)
+			termCalls := 0
+			err := stopUnmanagedSharedDaemonWithHooks(
+				context.Background(),
+				"/tmp/app.sock",
+				"/tmp/codex-real",
+				unmanagedSharedDaemonHooks{
+					desktopRunning: func(context.Context) (bool, error) { return false, nil },
+					inspect:        func(context.Context, string) (sharedDaemonListenerProcess, error) { return process, nil },
+					signalTERM:     func(int) error { termCalls++; return nil },
+					currentUID:     func() int { return 501 },
+				},
+			)
+			if err == nil || !strings.Contains(err.Error(), test.message) || termCalls != 0 {
+				t.Fatalf("不安全 listener 必须拒绝：err=%v term=%d", err, termCalls)
+			}
+		})
+	}
+}
+
+func TestStopUnmanagedSharedDaemonRejectsPIDReuseBeforeSignal(t *testing.T) {
+	first := sharedDaemonListenerProcess{
+		PID:        1234,
+		UID:        501,
+		StartSec:   1786522048,
+		StartUsec:  123,
+		Command:    "codex app-server --listen unix://",
+		Executable: "/tmp/codex-real",
+	}
+	second := first
+	second.StartSec++
+	inspectCalls := 0
+	termCalls := 0
+	err := stopUnmanagedSharedDaemonWithHooks(
+		context.Background(),
+		"/tmp/app.sock",
+		"/tmp/codex-real",
+		unmanagedSharedDaemonHooks{
+			desktopRunning: func(context.Context) (bool, error) { return false, nil },
+			inspect: func(context.Context, string) (sharedDaemonListenerProcess, error) {
+				inspectCalls++
+				if inspectCalls == 1 {
+					return first, nil
+				}
+				return second, nil
+			},
+			signalTERM: func(int) error { termCalls++; return nil },
+			currentUID: func() int { return 501 },
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "发生变化") || termCalls != 0 {
+		t.Fatalf("PID/start-time 复用必须在 TERM 前停止：err=%v term=%d", err, termCalls)
+	}
+}
+
+func TestDirectUnixAppServerCommandAcceptsNativeNULSeparatedArgv(t *testing.T) {
+	command := strings.Join([]string{
+		"codex",
+		"-c",
+		"features.code_mode_host=true",
+		"app-server",
+		"--listen",
+		"unix://",
+	}, "\x00")
+	if !isDirectUnixAppServerCommand(command) {
+		t.Fatal("原生 procargs2 argv 应识别为直接 Unix app-server")
+	}
+	if isDirectUnixAppServerCommand(strings.Replace(command, "unix://", "ws://127.0.0.1:4222", 1)) {
+		t.Fatal("非 Unix transport 必须拒绝")
+	}
+	if isDirectUnixAppServerCommand("codex app-server daemon start --listen unix://") {
+		t.Fatal("官方 daemon 控制命令不能当成 SSH 直接 listener 接管")
+	}
+	if isDirectUnixAppServerCommand("codex app-server proxy --listen unix://") {
+		t.Fatal("官方 proxy 不能当成 SSH 直接 listener 接管")
+	}
+}
+
+func TestSharedDaemonSocketPeerAndProcIdentityUseNativeDarwinMetadata(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "mimi-peer-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "app.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	pid, uid, err := sharedDaemonSocketPeer(context.Background(), socketPath)
+	if err != nil {
+		t.Fatalf("读取本机 Unix peer 失败：%v", err)
+	}
+	select {
+	case conn := <-accepted:
+		conn.Close()
+	case err := <-acceptErr:
+		t.Fatalf("接受测试连接失败：%v", err)
+	case <-time.After(time.Second):
+		t.Fatal("测试 listener 未收到连接")
+	}
+	if pid != os.Getpid() || uid != os.Getuid() {
+		t.Fatalf("peer 身份不匹配：pid=%d/%d uid=%d/%d", pid, os.Getpid(), uid, os.Getuid())
+	}
+	executable, arguments, err := sharedDaemonProcessArguments(pid)
+	if err != nil {
+		t.Fatalf("读取原生 procargs2 失败：%v", err)
+	}
+	if !filepath.IsAbs(executable) || len(arguments) == 0 {
+		t.Fatalf("进程身份缺少绝对 executable 或 argv：exe=%q argv=%v", executable, arguments)
+	}
+}
+
+func TestValidatePrivateSharedDaemonSocketRequiresModeAndOwner(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "mimi-private-sock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "app.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePrivateSharedDaemonSocket(socketPath, os.Getuid()); err != nil {
+		t.Fatalf("当前用户私有 socket 应通过：%v", err)
+	}
+	if err := os.Chmod(socketPath, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePrivateSharedDaemonSocket(socketPath, os.Getuid()); err == nil {
+		t.Fatal("公开 socket 必须拒绝接管")
+	}
+}
+
+func TestLiveSharedDaemonListenerIdentity(t *testing.T) {
+	socketPath := strings.TrimSpace(os.Getenv("MIMI_LIVE_SHARED_DAEMON_SOCKET"))
+	if socketPath == "" {
+		t.Skip("仅在显式提供真实共享 socket 时运行")
+	}
+	process, err := inspectSharedDaemonListenerProcess(context.Background(), socketPath)
+	if err != nil {
+		t.Fatalf("读取真实共享 daemon 身份失败：%v", err)
+	}
+	if process.PID <= 1 || process.UID != os.Getuid() || process.StartSec <= 0 ||
+		!filepath.IsAbs(process.Executable) || !isDirectUnixAppServerCommand(process.Command) {
+		t.Fatalf("真实共享 daemon 身份不完整或不是直接 Unix app-server：%+v", process)
+	}
+}

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -5,6 +5,7 @@ package appserver
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -81,6 +82,23 @@ func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
 		if !strings.Contains(content, emptyEntry) {
 			t.Fatalf("plist 必须以空值覆盖 Desktop 专属变量 %s：\n%s", key, content)
 		}
+	}
+}
+
+func TestRenderSharedDaemonLaunchAgentPendingDisablesRunAtLoad(t *testing.T) {
+	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/codex/bin/codex",
+		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
+		"",
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(rendered)
+	if !strings.Contains(content, "<key>RunAtLoad</key>\n\t<false/>") ||
+		strings.Contains(content, "<key>RunAtLoad</key>\n\t<true/>") {
+		t.Fatalf("待迁移 owner 必须禁止登录自动启动：\n%s", content)
 	}
 }
 
@@ -291,7 +309,7 @@ func TestEnsureSharedDaemonOwnerMarksPreexistingDaemonForExplicitMigration(t *te
 		t.Fatalf("安装 owner 失败：%v", err)
 	}
 	if !status.Installed || !status.Loaded || !status.Secure || !status.Created ||
-		!status.Changed || !status.MigrationRequired {
+		!status.Changed || !status.MigrationRequired || status.RunAtLoad {
 		t.Fatalf("旧 daemon 必须等待显式迁移：%+v", status)
 	}
 	if len(commands) == 0 || !strings.HasPrefix(commands[len(commands)-2], "bootstrap ") {
@@ -348,6 +366,9 @@ func TestEnsureSharedDaemonOwnerFreshStartNeedsNoMigration(t *testing.T) {
 	}
 	if status.MigrationRequired {
 		t.Fatalf("全新冷启动不应要求迁移：%+v", status)
+	}
+	if !status.RunAtLoad {
+		t.Fatalf("全新冷启动必须保留登录恢复：%+v", status)
 	}
 }
 
@@ -557,54 +578,1200 @@ func TestEnsureSharedDaemonOwnerRepairsPrivateMigrationMarkerMode(t *testing.T) 
 	}
 }
 
-func TestFinalizedStableOwnerRecoveryClearsOldMigrationMarker(t *testing.T) {
+func TestEnsureSharedDaemonOwnerRecoversMarkerFromManualPlist(t *testing.T) {
 	home := sharedDaemonTestHome(t)
 	t.Setenv("HOME", home)
-	if err := writeSharedDaemonMigrationFlag(); err != nil {
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, false); err != nil {
 		t.Fatal(err)
 	}
-	status := LocalDaemonStatus{Started: true}
-	owner := SharedDaemonOwnerStatus{Installed: true, MigrationRequired: true}
-	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, true); err != nil {
+	loaded := true
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		if arguments[0] == "print" && loaded {
+			return "service = { state = exited }", nil
+		}
+		return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	status, err := EnsureSharedDaemonOwner(context.Background(), options, false)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if owner.MigrationRequired {
-		t.Fatal("稳定 owner 本次启动并验证 daemon 后应清除内存迁移状态")
+	if !status.MigrationRequired || status.RunAtLoad {
+		t.Fatalf("manual plist 必须补回 pending marker：%+v", status)
 	}
-	if required, err := SharedDaemonMigrationRequired(); err != nil || required {
-		t.Fatalf("稳定 owner 恢复完成后应清除持久 marker：required=%t err=%v", required, err)
+	if required, err := SharedDaemonMigrationRequired(); err != nil || !required {
+		t.Fatalf("崩溃窗口恢复后 marker 必须存在：required=%t err=%v", required, err)
 	}
 }
 
-func TestOwnerChangeKeepsMigrationMarkerForExplicitApply(t *testing.T) {
+func TestStableOwnerNormalEnsureDoesNotKickstartPendingMigration(t *testing.T) {
 	home := sharedDaemonTestHome(t)
 	t.Setenv("HOME", home)
-	if err := writeSharedDaemonMigrationFlag(); err != nil {
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	loaded := false
+	kickstartCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "kickstart":
+			kickstartCalls++
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+	if _, err := EnsureSharedDaemonOwner(context.Background(), options, true); err != nil {
 		t.Fatal(err)
 	}
-	status := LocalDaemonStatus{Started: true}
-	owner := SharedDaemonOwnerStatus{Installed: true, Changed: true, MigrationRequired: true}
-	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, true); err != nil {
-		t.Fatal(err)
+
+	_, err := ensureLocalDaemonWithStableOwner(context.Background(), options)
+	if !errors.Is(err, ErrSharedDaemonMigrationPending) || kickstartCalls != 0 {
+		t.Fatalf("pending + socket missing 必须等待用户确认：err=%v kickstart=%d", err, kickstartCalls)
 	}
-	if required, err := SharedDaemonMigrationRequired(); err != nil || !required {
-		t.Fatalf("owner 本次也变化时必须保留显式迁移与事务回滚边界：required=%t err=%v", required, err)
+	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || !required {
+		t.Fatalf("普通恢复失败后 marker 必须保留：required=%t err=%v", required, markerErr)
 	}
 }
 
-func TestSocketShortCircuitCannotClearMigrationMarker(t *testing.T) {
+func TestPreparedIntentCreatesManualOwnerBeforeFirstBootstrap(t *testing.T) {
 	home := sharedDaemonTestHome(t)
 	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin:            writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:                 map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+		ValidateStableOwner: func() error { return nil },
+	}
+	if err := markSharedDaemonEnablePrepared(); err != nil {
+		t.Fatal(err)
+	}
+	bootstrapCalls := 0
+	loaded := false
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			bootstrapCalls++
+			path, err := SharedDaemonLaunchAgentPath()
+			if err != nil {
+				t.Fatal(err)
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if runAtLoad, ok := sharedDaemonPlistBoolValue(content, "RunAtLoad"); !ok || runAtLoad {
+				t.Fatalf("prepared intent 首次 bootstrap 前必须已经是 manual：ok=%t runAtLoad=%t", ok, runAtLoad)
+			}
+			loaded = true
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	_, err := ensureLocalDaemonWithStableOwner(context.Background(), options)
+	if err == nil || bootstrapCalls != 1 {
+		t.Fatalf("无 socket 的 prepared 恢复会在 manual bootstrap 后尝试一次启动：err=%v bootstrap=%d", err, bootstrapCalls)
+	}
+	owner, inspectErr := InspectSharedDaemonOwner(context.Background())
+	if inspectErr != nil {
+		t.Fatal(inspectErr)
+	}
+	if owner.RunAtLoad || !owner.MigrationRequired {
+		t.Fatalf("prepared 恢复失败必须保持 manual：%+v", owner)
+	}
+}
+
+func TestFailedExplicitMigrationCannotReuseFreshEnableIntent(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	loaded := false
+	kickstartCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	originalDesktop := sharedDaemonDesktopRunning
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "kickstart":
+			kickstartCalls++
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	sharedDaemonDesktopRunning = func(context.Context) (bool, error) { return true, nil }
+	t.Cleanup(func() {
+		sharedDaemonLaunchctl = originalLaunchctl
+		sharedDaemonDesktopRunning = originalDesktop
+	})
+	if _, err := EnsureSharedDaemonOwner(context.Background(), options, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := markSharedDaemonEnablePrepared(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := RestartSharedDaemonWithStableOwner(context.Background(), options)
+	if err == nil || !strings.Contains(err.Error(), "重新打开") {
+		t.Fatalf("Desktop guard 应使显式迁移失败：%v", err)
+	}
+	if pending, pendingErr := sharedDaemonEnablePrepared(); pendingErr != nil || pending {
+		t.Fatalf("显式迁移开始后必须消费 fresh intent：pending=%t err=%v", pending, pendingErr)
+	}
+	beforeEnsure := kickstartCalls
+	sharedDaemonDesktopRunning = func(context.Context) (bool, error) { return false, nil }
+	_, ensureErr := ensureLocalDaemonWithStableOwner(context.Background(), options)
+	if !errors.Is(ensureErr, ErrSharedDaemonMigrationPending) {
+		t.Fatalf("显式迁移失败后普通 Ensure 必须继续等待确认：%v", ensureErr)
+	}
+	if kickstartCalls != beforeEnsure {
+		t.Fatalf("普通 Ensure 不能复用旧 intent 静默启动：before=%d after=%d", beforeEnsure, kickstartCalls)
+	}
+}
+
+func TestStableOwnerRecoveryGuardRunsBeforeAnyEnsureOrRestartMutation(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	guardErr := errors.New("shared config disabled")
+	launchctlCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+		launchctlCalls++
+		return "", nil
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	options := LocalDaemonOptions{
+		CodexBin:    writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:         map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+		StableOwner: true,
+		ValidateStableOwner: func() error {
+			return guardErr
+		},
+	}
+	_, err := EnsureLocalDaemon(context.Background(), options)
+	if !errors.Is(err, guardErr) || launchctlCalls != 0 {
+		t.Fatalf("Ensure 恢复权失效必须在任何 launchctl 动作前拒绝：err=%v calls=%d", err, launchctlCalls)
+	}
+	_, err = RestartSharedDaemonWithStableOwner(context.Background(), options)
+	if !errors.Is(err, guardErr) || launchctlCalls != 0 {
+		t.Fatalf("Restart 恢复权失效必须在任何 launchctl 动作前拒绝：err=%v calls=%d", err, launchctlCalls)
+	}
+	path, pathErr := SharedDaemonLaunchAgentPath()
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("恢复权失效不能创建 plist：%v", statErr)
+	}
+}
+
+func TestCommitSharedDaemonDisableSerializesStaleRecovery(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	var shared atomic.Bool
+	shared.Store(true)
+	commitEntered := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	transactionDone := make(chan error, 1)
+
+	originalLaunchctl := sharedDaemonLaunchctl
+	mutationCalls := 0
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		if arguments[0] == "print" {
+			return "", fmt.Errorf("not loaded")
+		}
+		mutationCalls++
+		return "", nil
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	go func() {
+		transactionDone <- CommitSharedDaemonDisable(
+			context.Background(),
+			func() error { return nil },
+			func() error {
+				shared.Store(false)
+				close(commitEntered)
+				<-releaseCommit
+				return nil
+			},
+		)
+	}()
+	<-commitEntered
+
+	guardErr := errors.New("shared config disabled")
+	ensureDone := make(chan error, 1)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	go func() {
+		_, err := EnsureLocalDaemon(context.Background(), LocalDaemonOptions{
+			CodexBin:    codexBin,
+			Env:         map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+			StableOwner: true,
+			ValidateStableOwner: func() error {
+				if !shared.Load() {
+					return guardErr
+				}
+				return nil
+			},
+		})
+		ensureDone <- err
+	}()
+	select {
+	case err := <-ensureDone:
+		t.Fatalf("disable 持锁期间 stale Ensure 不得穿插：%v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseCommit)
+	if err := <-transactionDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-ensureDone; !errors.Is(err, guardErr) {
+		t.Fatalf("disable 提交后 stale Ensure 必须读取新状态并拒绝：%v", err)
+	}
+	if mutationCalls != 0 {
+		t.Fatalf("stale Ensure 不能 bootstrap/kickstart：%d", mutationCalls)
+	}
+}
+
+func TestCommitConfigWithSharedDaemonLockSerializesStaleRecovery(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	var shared atomic.Bool
+	shared.Store(true)
+	commitEntered := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	transactionDone := make(chan error, 1)
+
+	originalLaunchctl := sharedDaemonLaunchctl
+	launchctlCalls := 0
+	sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+		launchctlCalls++
+		return "", nil
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	go func() {
+		transactionDone <- CommitConfigWithSharedDaemonLock(
+			context.Background(),
+			func() error { return nil },
+			func() error {
+				shared.Store(false)
+				close(commitEntered)
+				<-releaseCommit
+				return nil
+			},
+		)
+	}()
+	<-commitEntered
+
+	guardErr := errors.New("setup replaced shared config")
+	ensureDone := make(chan error, 1)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	go func() {
+		_, err := EnsureLocalDaemon(context.Background(), LocalDaemonOptions{
+			CodexBin:    codexBin,
+			Env:         map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+			StableOwner: true,
+			ValidateStableOwner: func() error {
+				if !shared.Load() {
+					return guardErr
+				}
+				return nil
+			},
+		})
+		ensureDone <- err
+	}()
+	select {
+	case err := <-ensureDone:
+		t.Fatalf("setup 持锁期间 stale Ensure 不得穿插：%v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseCommit)
+	if err := <-transactionDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-ensureDone; !errors.Is(err, guardErr) {
+		t.Fatalf("setup 提交后 stale Ensure 必须读取新状态并拒绝：%v", err)
+	}
+	if launchctlCalls != 0 {
+		t.Fatalf("stale Ensure 不能 bootstrap/kickstart：%d", launchctlCalls)
+	}
+}
+
+func TestCommitConfigReplacingSharedDaemonCleansStaleOwnerBeforeCommit(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, true); err != nil {
+		t.Fatal(err)
+	}
+
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		if arguments[0] == "print" {
+			return "", fmt.Errorf("not loaded")
+		}
+		return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	committed := false
+	if err := CommitConfigReplacingSharedDaemon(
+		context.Background(),
+		func() error { return nil },
+		func() error {
+			path, _ := SharedDaemonLaunchAgentPath()
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("非 shared 配置提交前必须先移除 stale owner：%v", err)
+			}
+			committed = true
+			return nil
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !committed {
+		t.Fatal("清理 stale owner 后应提交新配置")
+	}
+	if present, err := SharedDaemonOwnerArtifactsPresent(); err != nil || present {
+		t.Fatalf("配置替换成功后不能残留 plist/marker/intent：present=%t err=%v", present, err)
+	}
+}
+
+func TestConfigIdentityRepairPreservesPendingOwnerAndCannotKickstart(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	oldOptions := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, home, "old-codex"),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	newOptions := LocalDaemonOptions{
+		CodexBin: writeManagedLifecycleCodexBin(t, codexHome),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	loaded := false
+	kickstartCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "bootout":
+			loaded = false
+			return "", nil
+		case "kickstart":
+			kickstartCalls++
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	if _, err := ensureSharedDaemonLaunchAgent(oldOptions, false); err != nil {
+		t.Fatal(err)
+	}
 	if err := writeSharedDaemonMigrationFlag(); err != nil {
 		t.Fatal(err)
 	}
-	status := LocalDaemonStatus{Started: true}
-	owner := SharedDaemonOwnerStatus{Installed: true, MigrationRequired: true}
-	if err := finalizeRecoveredSharedDaemonMigration(&status, &owner, false); err != nil {
+	committed := false
+	if err := CommitConfigRepairingSharedDaemonIdentity(
+		context.Background(),
+		func() error { return nil },
+		func() error { committed = true; return nil },
+	); err != nil {
 		t.Fatal(err)
 	}
-	if required, err := SharedDaemonMigrationRequired(); err != nil || !required {
-		t.Fatalf("未实际 kickstart 时不能用 Started 误清 marker：required=%t err=%v", required, err)
+	if !committed {
+		t.Fatal("repair 配置提交回调未执行")
+	}
+	owner, err := InspectSharedDaemonOwner(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !owner.Installed || owner.RunAtLoad || !owner.MigrationRequired {
+		t.Fatalf("Repair 必须保留 manual pending：%+v", owner)
+	}
+
+	newOptions.StableOwner = true
+	_, err = EnsureLocalDaemon(context.Background(), newOptions)
+	if !errors.Is(err, ErrSharedDaemonMigrationPending) || kickstartCalls != 0 {
+		t.Fatalf("Repair 后普通 Ensure 仍必须等待用户确认：err=%v kickstart=%d", err, kickstartCalls)
+	}
+	owner, inspectErr := InspectSharedDaemonOwner(context.Background())
+	if inspectErr != nil {
+		t.Fatal(inspectErr)
+	}
+	if owner.RunAtLoad || !owner.MigrationRequired {
+		t.Fatalf("更新 owner 身份后仍必须保持 pending：%+v", owner)
+	}
+}
+
+func TestCommitSharedDaemonDisableLeavesOwnerManualWhenRemovalFails(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, false); err != nil {
+		t.Fatal(err)
+	}
+	originalLaunchctl := sharedDaemonLaunchctl
+	originalRemove := sharedDaemonRemoveLaunchAgentFile
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		if arguments[0] == "print" {
+			return "", fmt.Errorf("not loaded")
+		}
+		return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+	}
+	sharedDaemonRemoveLaunchAgentFile = func(string) error { return errors.New("disk read-only") }
+	t.Cleanup(func() {
+		sharedDaemonLaunchctl = originalLaunchctl
+		sharedDaemonRemoveLaunchAgentFile = originalRemove
+	})
+
+	configState := "shared"
+	err := CommitSharedDaemonDisable(
+		context.Background(),
+		func() error { return nil },
+		func() error { configState = "ws"; return nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "manual 安全状态") || configState != "shared" {
+		t.Fatalf("owner remove 失败必须发生在配置提交前并保留 manual：state=%s err=%v", configState, err)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	content, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if runAtLoad, ok := sharedDaemonPlistBoolValue(content, "RunAtLoad"); !ok || runAtLoad {
+		t.Fatalf("卸载失败后 owner 必须保持 manual：ok=%t runAtLoad=%t", ok, runAtLoad)
+	}
+	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || !required {
+		t.Fatalf("卸载失败后必须保留 marker：required=%t err=%v", required, markerErr)
+	}
+}
+
+func TestCommitSharedDaemonDisableDoesNotRestoreAutoOwnerAfterConfigConflict(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, true); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := true
+	bootstrapCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootout":
+			loaded = false
+			return "", nil
+		case "bootstrap":
+			bootstrapCalls++
+			loaded = true
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	wantErr := errors.New("configuration changed to websocket")
+	err := CommitSharedDaemonDisable(
+		context.Background(),
+		func() error { return nil },
+		func() error {
+			// 模拟不使用 Mimi operation lock 的外部编辑器已经提交 WS，导致
+			// 最后一跳 CAS 拒绝覆盖。旧 auto owner 此时已经失去恢复权。
+			return wantErr
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("应保留配置冲突错误：%v", err)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("配置失权后不能恢复旧 auto owner：%v", statErr)
+	}
+	if loaded || bootstrapCalls != 0 {
+		t.Fatalf("配置冲突后不能重新加载旧 job：loaded=%t bootstrap=%d", loaded, bootstrapCalls)
+	}
+}
+
+func TestCommitSharedDaemonEnableKeepsOwnerManualUntilConfigCommit(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	options := LocalDaemonOptions{
+		CodexBin: writeManagedLifecycleCodexBin(t, codexHome),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	loaded := false
+	serverStarted := false
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "kickstart":
+			if !serverStarted {
+				startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.147.0 (Mac OS; arm64)")
+				serverStarted = true
+			}
+			return "", nil
+		case "bootout":
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	commitObserved := false
+	wantErr := errors.New("simulate crash before config rename")
+	_, err := CommitSharedDaemonEnable(
+		context.Background(),
+		options,
+		func() error { return nil },
+		func() error {
+			commitObserved = true
+			if serverStarted {
+				t.Fatal("配置仍为 WS 时绝不能提前 kickstart Unix daemon")
+			}
+			path, pathErr := SharedDaemonLaunchAgentPath()
+			if pathErr != nil {
+				t.Fatal(pathErr)
+			}
+			content, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if strings.Contains(string(content), "<key>RunAtLoad</key>\n\t<true/>") {
+				t.Fatal("配置 rename 前 owner 绝不能已经允许登录自启")
+			}
+			if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || !required {
+				t.Fatalf("配置 rename 前必须有 durable manual marker：required=%t err=%v", required, markerErr)
+			}
+			return wantErr
+		},
+	)
+	if !errors.Is(err, wantErr) || !commitObserved {
+		t.Fatalf("提交前失败应保留原错误并经过 manual 边界：observed=%t err=%v", commitObserved, err)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("非共享配置提交失败后应清理 Mimi owner：%v", statErr)
+	}
+}
+
+func TestCommittedFreshEnableRecoversAfterCrashBeforeKickstart(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	options := LocalDaemonOptions{
+		CodexBin:                    writeManagedLifecycleCodexBin(t, codexHome),
+		Env:                         map[string]string{"CODEX_HOME": codexHome},
+		StableOwner:                 true,
+		PrepareOwnerForConfigCommit: true,
+	}
+	loaded := false
+	serverStarted := false
+	kickstartCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "kickstart":
+			kickstartCalls++
+			if !serverStarted {
+				startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.147.0 (Mac OS; arm64)")
+				serverStarted = true
+			}
+			return "", nil
+		case "bootout":
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	prepared, err := prepareSharedDaemonOwnerForConfigCommit(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.DaemonPreexisting || kickstartCalls != 0 {
+		t.Fatalf("准备阶段只能落 manual owner：status=%+v kickstart=%d", prepared, kickstartCalls)
+	}
+	if err := markSharedDaemonEnablePrepared(); err != nil {
+		t.Fatal(err)
+	}
+	// 此处等价于配置 rename 已成功后进程立即掉电：磁盘为 shared 配置，
+	// manual owner/marker/enable intent 均已持久化，但 socket 尚不存在。
+	recovery := options
+	recovery.PrepareOwnerForConfigCommit = false
+	recovery.ValidateStableOwner = func() error { return nil }
+	status, err := EnsureLocalDaemon(context.Background(), recovery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.StartedByStableOwner || kickstartCalls != 1 || !status.LifecycleValidated {
+		t.Fatalf("已提交 fresh enable 必须由稳定 owner 恢复：status=%+v kickstart=%d", status, kickstartCalls)
+	}
+	owner, err := InspectSharedDaemonOwner(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owner.RunAtLoad || !owner.MigrationRequired {
+		t.Fatalf("恢复成功后仍应保持 manual 并等待用户确认：%+v", owner)
+	}
+	if pending, err := sharedDaemonEnablePrepared(); err != nil || pending {
+		t.Fatalf("首次 manual 冷启动验证后必须消费 enable intent：pending=%t err=%v", pending, err)
+	}
+}
+
+func TestPrepareSharedDaemonOwnerRejectsConnectableListenerWithoutHandshake(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	socketPath, err := LocalDaemonSocketPath(map[string]string{"CODEX_HOME": codexHome})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	launchctlCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+		launchctlCalls++
+		return "", errors.New("unexpected launchctl call")
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	_, err = prepareSharedDaemonOwnerForConfigCommit(context.Background(), LocalDaemonOptions{
+		CodexBin:                    "/missing/codex",
+		Env:                         map[string]string{"CODEX_HOME": codexHome},
+		StableOwner:                 true,
+		PrepareOwnerForConfigCommit: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "完整握手失败") {
+		t.Fatalf("只 accept、不完成 initialize 的 listener 必须阻止配置提交：%v", err)
+	}
+	if launchctlCalls != 0 {
+		t.Fatalf("握手失败必须在 owner mutation 前终止：launchctl=%d", launchctlCalls)
+	}
+	ownerPath, pathErr := SharedDaemonLaunchAgentPath()
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Lstat(ownerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("握手失败不能创建 owner：%v", statErr)
+	}
+}
+
+func TestCommitSharedDaemonEnableKeepsManualUntilExplicitMigration(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	options := LocalDaemonOptions{
+		CodexBin: writeManagedLifecycleCodexBin(t, codexHome),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	loaded := false
+	serverStarted := false
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "kickstart":
+			if !serverStarted {
+				startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.147.0 (Mac OS; arm64)")
+				serverStarted = true
+			}
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	configCommitted := false
+	status, err := CommitSharedDaemonEnable(
+		context.Background(),
+		options,
+		func() error { return nil },
+		func() error {
+			path, _ := SharedDaemonLaunchAgentPath()
+			content, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			if strings.Contains(string(content), "<key>RunAtLoad</key>\n\t<true/>") {
+				return fmt.Errorf("owner 在配置提交前提前提升")
+			}
+			configCommitted = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !configCommitted || !status.Started || !status.OwnerMigrationRequired {
+		t.Fatalf("全新 managed daemon 应在配置提交后保持 pending：committed=%t status=%+v", configCommitted, status)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+	content, readErr := os.ReadFile(path)
+	if readErr != nil || !strings.Contains(string(content), "<key>RunAtLoad</key>\n\t<false/>") {
+		t.Fatalf("显式迁移前必须保持 manual：read=%v content=%s", readErr, content)
+	}
+	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || !required {
+		t.Fatalf("显式迁移前必须保留 marker：required=%t err=%v", required, markerErr)
+	}
+	if prepared, preparedErr := sharedDaemonEnablePrepared(); preparedErr != nil || prepared {
+		t.Fatalf("首次 manual 冷启动验证后必须消费 durable intent：prepared=%t err=%v", prepared, preparedErr)
+	}
+}
+
+func TestAttachedManagedRecoveryConsumesFreshEnableIntentOnce(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	_, _, stopServer := startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.147.0 (Mac OS; arm64)")
+	options := LocalDaemonOptions{
+		CodexBin: writeManagedLifecycleCodexBin(t, codexHome),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	loaded := false
+	kickstartCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		case "kickstart":
+			kickstartCalls++
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+	if _, err := EnsureSharedDaemonOwner(context.Background(), options, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := markSharedDaemonEnablePrepared(); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := ensureLocalDaemonWithStableOwner(context.Background(), options)
+	if err != nil || !status.LifecycleValidated || !status.OwnerMigrationRequired {
+		t.Fatalf("已运行的 managed listener 应只 attach 并保持 pending：status=%+v err=%v", status, err)
+	}
+	if prepared, preparedErr := sharedDaemonEnablePrepared(); preparedErr != nil || prepared {
+		t.Fatalf("generic managed 校验后必须消费 intent：prepared=%t err=%v", prepared, preparedErr)
+	}
+	stopServer()
+	_, err = ensureLocalDaemonWithStableOwner(context.Background(), options)
+	if !errors.Is(err, ErrSharedDaemonMigrationPending) || kickstartCalls != 0 {
+		t.Fatalf("daemon 再掉线不能复用 intent：err=%v kickstart=%d", err, kickstartCalls)
+	}
+}
+
+func writeManagedLifecycleCodexBin(t *testing.T, codexHome string) string {
+	t.Helper()
+	if canonical, err := filepath.EvalSymlinks(codexHome); err == nil {
+		codexHome = canonical
+	}
+	path := filepath.Join(codexHome, "packages", "standalone", "current", "codex")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	socketPath := filepath.Join(codexHome, localDaemonSocketDir, localDaemonSocketName)
+	payload := fmt.Sprintf(
+		`{"status":"running","backend":"pid","managedCodexPath":"%s","managedCodexVersion":"0.147.0","socketPath":"%s","appServerVersion":"0.147.0"}`,
+		path,
+		socketPath,
+	)
+	script := "#!/bin/sh\nprintf '%s\\n' '" + payload + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestStableOwnerNormalEnsurePreservesPendingOwnerOnLifecycleFailure(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	_, _, _ = startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.147.0 (Mac OS; arm64)")
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+
+	loaded := false
+	bootstrapCalls := 0
+	bootoutCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			bootstrapCalls++
+			loaded = true
+			return "", nil
+		case "bootout":
+			bootoutCalls++
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	_, err := ensureLocalDaemonWithStableOwner(context.Background(), options)
+	if err == nil || !strings.Contains(err.Error(), "解析 Codex local daemon 状态失败") {
+		t.Fatalf("无效 lifecycle 输出必须 fail closed：%v", err)
+	}
+	if bootstrapCalls != 1 || bootoutCalls != 0 || !loaded {
+		t.Fatalf("普通 lifecycle 故障不能回滚 pending owner：bootstrap=%d bootout=%d loaded=%t", bootstrapCalls, bootoutCalls, loaded)
+	}
+	path, pathErr := SharedDaemonLaunchAgentPath()
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	content, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	runAtLoad, ok := sharedDaemonPlistBoolValue(content, "RunAtLoad")
+	if !ok || runAtLoad {
+		t.Fatalf("普通 lifecycle 故障后必须保留 manual plist：ok=%t runAtLoad=%t", ok, runAtLoad)
+	}
+	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || !required {
+		t.Fatalf("普通 lifecycle 故障后必须保留 marker：required=%t err=%v", required, markerErr)
+	}
+}
+
+func TestStableOwnerConfigurationRestoresPreviousOwnerWhenSocketDropsAfterInstall(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	oldOptions := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex-old"),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	loaded := false
+	bootstrapCalls := 0
+	bootoutCalls := 0
+	var stopSocket func()
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			bootstrapCalls++
+			loaded = true
+			// 第二次 bootstrap 已经写入 manual owner；模拟旧 SSH socket
+			// 正好在此时退出，覆盖 owner 安装与二次检查之间的竞态。
+			if bootstrapCalls == 2 && stopSocket != nil {
+				stopSocket()
+			}
+			return "", nil
+		case "bootout":
+			bootoutCalls++
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	if _, err := EnsureSharedDaemonOwner(context.Background(), oldOptions, false); err != nil {
+		t.Fatal(err)
+	}
+	path, pathErr := SharedDaemonLaunchAgentPath()
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	before, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	_, _, stopSocket = startLocalDaemonTestServer(t, codexHome, "Codex Desktop/0.147.0 (Mac OS; arm64)")
+
+	newOptions := LocalDaemonOptions{
+		CodexBin:               writeFakeCodexBin(t, t.TempDir(), "codex-new"),
+		Env:                    map[string]string{"CODEX_HOME": codexHome},
+		StableOwner:            true,
+		RollbackOwnerOnFailure: true,
+	}
+	_, err := ensureLocalDaemonWithStableOwner(context.Background(), newOptions)
+	if !errors.Is(err, ErrSharedDaemonMigrationPending) {
+		t.Fatalf("设置事务应报告 socket 竞态并回滚：%v", err)
+	}
+	after, readErr := os.ReadFile(path)
+	if readErr != nil || !bytes.Equal(before, after) {
+		t.Fatalf("设置未提交时必须逐字恢复原 plist：read=%v", readErr)
+	}
+	if !loaded || bootstrapCalls != 3 || bootoutCalls != 2 {
+		t.Fatalf("设置未提交时必须恢复原 loaded owner：loaded=%t bootstrap=%d bootout=%d", loaded, bootstrapCalls, bootoutCalls)
+	}
+	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || required {
+		t.Fatalf("设置未提交时必须恢复原 marker：required=%t err=%v", required, markerErr)
+	}
+}
+
+func TestCommitSharedDaemonMigrationPromotesAutoStartOnlyAfterExplicitSuccess(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSharedDaemonMigrationFlag(); err != nil {
+		t.Fatal(err)
+	}
+	if err := markSharedDaemonEnablePrepared(); err != nil {
+		t.Fatal(err)
+	}
+	if err := commitSharedDaemonMigration(options); err != nil {
+		t.Fatal(err)
+	}
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runAtLoad, ok := sharedDaemonPlistBoolValue(content, "RunAtLoad")
+	required, markerErr := SharedDaemonMigrationRequired()
+	if !ok || !runAtLoad || markerErr != nil || required {
+		t.Fatalf("显式成功提交后才应恢复自动启动并清 marker：runAtLoad=%t ok=%t required=%t err=%v", runAtLoad, ok, required, markerErr)
+	}
+	if prepared, preparedErr := sharedDaemonEnablePrepared(); preparedErr != nil || prepared {
+		t.Fatalf("显式成功提交后必须清理 enable intent：prepared=%t err=%v", prepared, preparedErr)
+	}
+}
+
+func TestRemoveSharedDaemonOwnerKeepsManualStateWhenDeleteFails(t *testing.T) {
+	testRemoveSharedDaemonOwnerFailureIsManual(t, "delete", func() {
+		sharedDaemonRemoveLaunchAgentFile = func(string) error { return errors.New("disk read-only") }
+	})
+}
+
+func TestRemoveSharedDaemonOwnerKeepsAutoEntryRemovedWhenMarkerClearFails(t *testing.T) {
+	testRemoveSharedDaemonOwnerFailureIsManual(t, "marker", func() {
+		sharedDaemonClearMigrationForRemoval = func() error { return errors.New("marker busy") }
+	})
+}
+
+func testRemoveSharedDaemonOwnerFailureIsManual(t *testing.T, stage string, injectFailure func()) {
+	t.Helper()
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, true); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := SharedDaemonLaunchAgentPath()
+
+	loaded := true
+	originalLaunchctl := sharedDaemonLaunchctl
+	originalRemove := sharedDaemonRemoveLaunchAgentFile
+	originalClear := sharedDaemonClearMigrationForRemoval
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootout":
+			loaded = false
+			return "", nil
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	injectFailure()
+	t.Cleanup(func() {
+		sharedDaemonLaunchctl = originalLaunchctl
+		sharedDaemonRemoveLaunchAgentFile = originalRemove
+		sharedDaemonClearMigrationForRemoval = originalClear
+	})
+
+	err := removeSharedDaemonOwnerUnlocked(context.Background())
+	if err == nil {
+		t.Fatalf("%s 注入失败必须返回错误", stage)
+	}
+	after, readErr := os.ReadFile(path)
+	if stage == "delete" {
+		if readErr != nil {
+			t.Fatalf("delete 失败应留下 manual plist：%v", readErr)
+		}
+		if runAtLoad, ok := sharedDaemonPlistBoolValue(after, "RunAtLoad"); !ok || runAtLoad {
+			t.Fatalf("delete 失败不能恢复 auto：ok=%t runAtLoad=%t", ok, runAtLoad)
+		}
+	} else if !os.IsNotExist(readErr) {
+		t.Fatalf("marker clear 失败时 auto 入口必须已删除：%v", readErr)
+	}
+	if loaded {
+		t.Fatalf("%s 失败后 job 不能重新 bootstrap", stage)
+	}
+	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || !required {
+		t.Fatalf("%s 失败后 marker 必须保持 fail-closed：required=%t err=%v", stage, required, markerErr)
+	}
+}
+
+func TestRemoveSharedDaemonOwnerRejectsLoadedJobWithoutRecoverablePlist(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	loaded := true
+	bootoutCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootout":
+			bootoutCalls++
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	err := removeSharedDaemonOwnerUnlocked(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "plist 缺失") || bootoutCalls != 0 || !loaded {
+		t.Fatalf("无法回滚的孤立 loaded job 必须在 bootout 前拒绝：err=%v bootout=%d loaded=%t", err, bootoutCalls, loaded)
 	}
 }
 
@@ -848,6 +2015,126 @@ func TestStopSharedDaemonAlreadyDisconnectedCanResumeWithoutSecondSignal(t *test
 	}
 	if time.Since(started) < sharedDaemonStoppedConfirmationWindow {
 		t.Fatal("不可连状态必须持续一个确认窗口后才允许 kickstart")
+	}
+}
+
+func TestKickstartSharedDaemonFailsClosedWhenDesktopIsRunningOrUnknown(t *testing.T) {
+	tests := []struct {
+		name        string
+		desktop     func(context.Context) (bool, error)
+		wantMessage string
+	}{
+		{
+			name:        "running",
+			desktop:     func(context.Context) (bool, error) { return true, nil },
+			wantMessage: "重新打开",
+		},
+		{
+			name:        "query failure",
+			desktop:     func(context.Context) (bool, error) { return false, errors.New("LaunchServices unavailable") },
+			wantMessage: "确认 Codex Desktop 已退出失败",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalDesktop := sharedDaemonDesktopRunning
+			originalLaunchctl := sharedDaemonLaunchctl
+			launchctlCalls := 0
+			sharedDaemonDesktopRunning = test.desktop
+			sharedDaemonLaunchctl = func(context.Context, ...string) (string, error) {
+				launchctlCalls++
+				return "", nil
+			}
+			t.Cleanup(func() {
+				sharedDaemonDesktopRunning = originalDesktop
+				sharedDaemonLaunchctl = originalLaunchctl
+			})
+
+			err := kickstartSharedDaemon(context.Background())
+			if err == nil || !strings.Contains(err.Error(), test.wantMessage) || launchctlCalls != 0 {
+				t.Fatalf("最终 Desktop guard 必须阻止 kickstart：err=%v calls=%d", err, launchctlCalls)
+			}
+		})
+	}
+}
+
+func TestStopSharedDaemonManagedBackendChecksDesktopBeforeOfficialStop(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	codexHome := filepath.Join(home, ".codex")
+	socketPath, err := LocalDaemonSocketPath(map[string]string{"CODEX_HOME": codexHome})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	stopMarker := filepath.Join(t.TempDir(), "official-stop-called")
+	bin := filepath.Join(t.TempDir(), "codex")
+	lifecycleJSON := fmt.Sprintf(
+		`{"status":"running","backend":"pid","socketPath":%q,"appServerVersion":"0.147.0"}`,
+		socketPath,
+	)
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$3" = "version" ]; then
+  printf '%%s\n' '%s'
+  exit 0
+fi
+if [ "$3" = "stop" ]; then
+  touch '%s'
+  exit 0
+fi
+exit 2
+`, lifecycleJSON, stopMarker)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	options := LocalDaemonOptions{
+		CodexBin: bin,
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	owner := SharedDaemonOwnerStatus{
+		Installed: true,
+		Loaded:    true,
+		Secure:    true,
+	}
+
+	tests := []struct {
+		name        string
+		desktop     func(context.Context) (bool, error)
+		wantMessage string
+	}{
+		{
+			name:        "desktop reopened",
+			desktop:     func(context.Context) (bool, error) { return true, nil },
+			wantMessage: "重新打开",
+		},
+		{
+			name:        "desktop query failed",
+			desktop:     func(context.Context) (bool, error) { return false, errors.New("query failed") },
+			wantMessage: "确认 Codex Desktop 已退出失败",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_ = os.Remove(stopMarker)
+			originalDesktop := sharedDaemonDesktopRunning
+			sharedDaemonDesktopRunning = test.desktop
+			t.Cleanup(func() { sharedDaemonDesktopRunning = originalDesktop })
+
+			err := stopSharedDaemon(context.Background(), options, owner)
+			if err == nil || !strings.Contains(err.Error(), test.wantMessage) {
+				t.Fatalf("官方 stop 前必须 fail closed：%v", err)
+			}
+			if _, statErr := os.Stat(stopMarker); !os.IsNotExist(statErr) {
+				t.Fatalf("Desktop guard 失败时不能执行官方 stop：%v", statErr)
+			}
+		})
 	}
 }
 

--- a/internal/appserver/shared_daemon_owner_other.go
+++ b/internal/appserver/shared_daemon_owner_other.go
@@ -1,0 +1,77 @@
+//go:build !darwin
+
+package appserver
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const sharedDaemonStartTimeoutForLocalEnsure = 15 * time.Second
+
+type SharedDaemonOwnerStatus struct {
+	Supported         bool
+	Installed         bool
+	Loaded            bool
+	Running           bool
+	Secure            bool
+	Changed           bool
+	Created           bool
+	MigrationRequired bool
+	Path              string
+	Label             string
+	Rollback          *SharedDaemonOwnerRollback
+}
+
+func EnsureSharedDaemonOwner(
+	context.Context,
+	LocalDaemonOptions,
+	bool,
+) (SharedDaemonOwnerStatus, error) {
+	return SharedDaemonOwnerStatus{}, nil
+}
+
+func InspectSharedDaemonOwner(context.Context) (SharedDaemonOwnerStatus, error) {
+	return SharedDaemonOwnerStatus{}, nil
+}
+
+func SharedDaemonMigrationRequired() (bool, error) { return false, nil }
+
+func clearSharedDaemonMigrationFlag() error { return nil }
+
+func markSharedDaemonMigrationRequired() error {
+	return fmt.Errorf("稳定共享 daemon owner 仅支持 macOS")
+}
+
+func withSharedDaemonOperationLock(
+	_ context.Context,
+	operation func() (LocalDaemonStatus, error),
+) (LocalDaemonStatus, error) {
+	return operation()
+}
+
+func RemoveSharedDaemonOwner(context.Context) error { return nil }
+
+func removeSharedDaemonOwnerUnlocked(context.Context) error { return nil }
+
+func RollbackSharedDaemonOwnerChange(context.Context, *SharedDaemonOwnerRollback) error { return nil }
+
+func RestartSharedDaemonWithStableOwner(
+	context.Context,
+	LocalDaemonOptions,
+) (LocalDaemonStatus, error) {
+	return LocalDaemonStatus{}, fmt.Errorf("稳定共享 daemon owner 仅支持 macOS")
+}
+
+// 非 macOS 平台没有 TCC responsible process 这一层，共享 daemon 的权限主体不受
+// 启动者影响，继续沿用官方 CLI 的直接启动路径。
+func startLocalDaemonWithStableOwner(ctx context.Context, options LocalDaemonOptions) error {
+	return startLocalDaemonDirect(ctx, options)
+}
+
+func startLocalDaemonWithStableOwnerTracked(ctx context.Context, options LocalDaemonOptions) (bool, error) {
+	return false, startLocalDaemonDirect(ctx, options)
+}
+
+func sharedDaemonSocketAcceptsConnectionMust(LocalDaemonOptions) bool { return false }

--- a/internal/appserver/shared_daemon_owner_other.go
+++ b/internal/appserver/shared_daemon_owner_other.go
@@ -5,6 +5,7 @@ package appserver
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 )
 
@@ -16,6 +17,7 @@ type SharedDaemonOwnerStatus struct {
 	Loaded            bool
 	Running           bool
 	Secure            bool
+	RunAtLoad         bool
 	Changed           bool
 	Created           bool
 	MigrationRequired bool
@@ -23,6 +25,10 @@ type SharedDaemonOwnerStatus struct {
 	Label             string
 	Rollback          *SharedDaemonOwnerRollback
 }
+
+// 非 macOS 没有本实现所依赖的 launchd/TCC owner 语义。与其用进程内 no-op
+// lock 假装支持共享 owner，不如在生产入口明确拒绝，避免并发配置留下双 backend。
+func SupportsStableSharedDaemonOwner() bool { return false }
 
 func EnsureSharedDaemonOwner(
 	context.Context,
@@ -32,11 +38,30 @@ func EnsureSharedDaemonOwner(
 	return SharedDaemonOwnerStatus{}, nil
 }
 
+// 非 macOS 没有 launchd/TCC owner 迁移状态。保留与 Darwin 内部 helper 相同的
+// 签名，让跨平台 local daemon 逻辑可以统一调用；forcePending 在这里没有语义。
+func ensureSharedDaemonOwner(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	daemonPreexisting bool,
+	_ bool,
+) (SharedDaemonOwnerStatus, error) {
+	return EnsureSharedDaemonOwner(ctx, options, daemonPreexisting)
+}
+
 func InspectSharedDaemonOwner(context.Context) (SharedDaemonOwnerStatus, error) {
 	return SharedDaemonOwnerStatus{}, nil
 }
 
 func SharedDaemonMigrationRequired() (bool, error) { return false, nil }
+
+func SharedDaemonOwnerArtifactsPresent() (bool, error) { return false, nil }
+
+func markSharedDaemonEnablePrepared() error { return nil }
+
+func sharedDaemonEnablePrepared() (bool, error) { return false, nil }
+
+func clearSharedDaemonEnablePrepared() error { return nil }
 
 func clearSharedDaemonMigrationFlag() error { return nil }
 
@@ -55,6 +80,38 @@ func RemoveSharedDaemonOwner(context.Context) error { return nil }
 
 func removeSharedDaemonOwnerUnlocked(context.Context) error { return nil }
 
+func removeSharedDaemonOwnerForTransactionUnlocked(
+	context.Context,
+) (func(context.Context) error, error) {
+	return func(context.Context) error { return nil }, nil
+}
+
+func startPreparedSharedDaemonAfterConfigCommit(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (LocalDaemonStatus, error) {
+	if err := startLocalDaemonDirect(ctx, options); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	probe, err := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancel()
+	if err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	status := localDaemonStatus(socketPath, true, probe.Version, os.Stat)
+	status.StartedByStableOwner = true
+	status.LifecycleValidated = true
+	if err := clearSharedDaemonEnablePrepared(); err != nil {
+		return LocalDaemonStatus{}, err
+	}
+	return status, nil
+}
+
 func RollbackSharedDaemonOwnerChange(context.Context, *SharedDaemonOwnerRollback) error { return nil }
 
 func RestartSharedDaemonWithStableOwner(
@@ -71,6 +128,13 @@ func startLocalDaemonWithStableOwner(ctx context.Context, options LocalDaemonOpt
 }
 
 func startLocalDaemonWithStableOwnerTracked(ctx context.Context, options LocalDaemonOptions) (bool, error) {
+	return false, startLocalDaemonDirect(ctx, options)
+}
+
+func startPreparedSharedDaemonWithStableOwnerTracked(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (bool, error) {
 	return false, startLocalDaemonDirect(ctx, options)
 }
 

--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -306,6 +306,24 @@ func (t *ExternalActivityTracker) Snapshot() ([]ExternalActivity, error) {
 	return activities, nil
 }
 
+// GatewayOwnsTurn 在 server request 到达时捕获精确的 Thread+Turn 归属。
+// 先刷新 rollout/claim，再返回当前证据；调用方可以把这个结果保存在对应的
+// pending request 上，避免用户长时间停留在审批页时仅因 claim TTL 到期而死锁。
+func (t *ExternalActivityTracker) GatewayOwnsTurn(threadID string, turnID string) (bool, error) {
+	threadID = strings.TrimSpace(threadID)
+	turnID = strings.TrimSpace(turnID)
+	if !validGatewayClaimID(threadID) || !validGatewayClaimID(turnID) {
+		return false, nil
+	}
+	if _, err := t.Snapshot(); err != nil {
+		return false, err
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.hasGatewayOwnedTurnClaim(threadID, turnID), nil
+}
+
 func (t *ExternalActivityTracker) loadCandidates() ([]externalActivityCandidate, error) {
 	db := t.store.databasePath()
 	signature, err := t.readDBSignature(db)

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -717,6 +717,45 @@ func TestExternalActivityPersistentClaimClearsOnTerminalAndExpiresToExternal(t *
 	}
 }
 
+func TestExternalActivityGatewayOwnsTurnCapturesExactClaimBeforeTTL(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 8, 13, 8, 0, 0, 0, time.UTC)
+	fixture.replaceTrackerWithClaimStore(
+		filepath.Join(t.TempDir(), "state", "claims.json"),
+		func() time.Time { return now },
+	)
+	fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
+	path := fixture.writeRollout(
+		"thread-ipad",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(now.Add(100*time.Millisecond), "task_started", "turn-ipad"),
+		externalUserMessageLine(now.Add(500*time.Millisecond), "client-ipad"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-ipad", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	owned, err := fixture.tracker.GatewayOwnsTurn("thread-ipad", "turn-ipad")
+	if err != nil || !owned {
+		t.Fatalf("精确 Thread+Turn 应在 server request 到达时被捕获：owned=%t err=%v", owned, err)
+	}
+	owned, err = fixture.tracker.GatewayOwnsTurn("thread-ipad", "turn-other")
+	if err != nil || owned {
+		t.Fatalf("不同 TurnID 不得继承 gateway 归属：owned=%t err=%v", owned, err)
+	}
+
+	now = now.Add(gatewayOwnedTurnClaimTTL + time.Second)
+	owned, err = fixture.tracker.GatewayOwnsTurn("thread-ipad", "turn-ipad")
+	if err != nil || owned {
+		t.Fatalf("没有 pending 捕获时，过期 claim 仍须安全降级：owned=%t err=%v", owned, err)
+	}
+}
+
 func TestExternalActivityExpiredClaimWithFreshRolloutFailsClosedAsExternal(t *testing.T) {
 	fixture := newExternalActivityTrackerFixture(t)
 	now := time.Date(2026, 7, 31, 3, 0, 0, 0, time.UTC)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -298,6 +298,21 @@ func loadRawWithoutProjectDiscovery(raw []byte) (Config, error) {
 	return cfg, nil
 }
 
+// LoadSharedDaemonControlConfig 只加载 stable-owner 控制面所需配置，不访问
+// scan_roots。显式迁移发生在 Desktop 已退出之后，不能因为无关的网络盘、
+// 移动磁盘或项目目录临时不可读而阻止 daemon 生命周期操作。
+func LoadSharedDaemonControlConfig(path string) (Config, error) {
+	cfg, err := loadWithoutProjectDiscovery(path)
+	if err != nil {
+		return Config{}, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") ||
+		!cfg.AppServer.Managed || cfg.AppServer.SharedFallback == nil {
+		return Config{}, fmt.Errorf("当前配置不是 Mimi 管理的共享 daemon")
+	}
+	return cfg, nil
+}
+
 // ValidateSharedDaemonRecoveryOwnership 在长期存活的旧进程尝试恢复 owner 前，
 // 只复核磁盘上的共享模式与 Codex 启动身份。它故意跳过 project discovery 和
 // 全量 Validate；错误只会让恢复 fail closed，不影响用户修复其他配置项。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
 	"os"
@@ -145,6 +146,43 @@ func PlatformDefaultPath() string {
 	return filepath.Join(dir, "config.json")
 }
 
+// IsPlatformDefaultPath 判断目标是否就是后台服务唯一使用的平台默认配置。
+// Mimi 的 launchd owner 是当前用户全局资源，不能因为操作另一个 --config
+// profile 就把默认配置的 owner 删除或重建，因此所有 owner 写操作都必须先过
+// 这道路径边界。
+func IsPlatformDefaultPath(path string) bool {
+	return SameConfigPath(path, PlatformDefaultPath())
+}
+
+// ConfigPathIdentity 返回用于跨进程配置锁的稳定路径身份。它按所在卷的
+// 大小写语义规范化路径；同一默认文件的 `/Config.json` 与 `/config.json`
+// 在普通 APFS 上必须取得同一把锁，而 case-sensitive APFS 上仍保持独立。
+func ConfigPathIdentity(path string) (string, error) {
+	absolute, err := absoluteExpandedPath(path)
+	if err != nil {
+		return "", err
+	}
+	// 配置文件本身可能尚未创建；目录存在时仍解析目录 symlink，避免同一个
+	// 默认文件经不同路径写法绕过全局 owner 的归属检查。
+	if canonicalDir, evalErr := filepath.EvalSymlinks(filepath.Dir(absolute)); evalErr == nil {
+		absolute = filepath.Join(canonicalDir, filepath.Base(absolute))
+	}
+	caseSensitive, err := configPathCaseSensitive(filepath.Dir(absolute))
+	if err == nil && !caseSensitive {
+		absolute = strings.ToLower(absolute)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+// SameConfigPath 比较两个配置目标的目录项身份。不能直接用 os.SameFile：两个
+// 不同路径的 hard link 虽指向同一 inode，但原子 rename 只替换其中一个目录项；
+// 若把它们当成默认配置，会先误删全局 owner、再只改写另一个路径。
+func SameConfigPath(left, right string) bool {
+	leftIdentity, leftErr := ConfigPathIdentity(left)
+	rightIdentity, rightErr := ConfigPathIdentity(right)
+	return leftErr == nil && rightErr == nil && leftIdentity == rightIdentity
+}
+
 func UserConfigDir() (string, error) {
 	dir, err := os.UserConfigDir()
 	if err != nil {
@@ -164,33 +202,85 @@ func Load(path string) (Config, error) {
 	return cfg, nil
 }
 
+// LoadSnapshot 从调用方已经原子读取的一份配置快照解析完整 Config。共享
+// daemon 的配置事务必须让 typed cfg、未知 JSON 字段与 CAS baseline 全部来自
+// 同一组 bytes；不能先 Load(path) 后再 ReadFile(path)，否则并发写入会把两代
+// 配置拼成一个事务。它保留普通 Load 的默认值、环境覆盖、项目发现和校验语义。
+func LoadSnapshot(raw []byte) (Config, error) {
+	cfg, err := loadSnapshot(raw)
+	if err != nil {
+		return Config{}, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
 func LoadForDoctor(path string) (Config, error) {
 	return load(path)
 }
 
 func load(path string) (Config, error) {
-	cfg := defaults()
+	cfg, err := loadWithoutProjectDiscovery(path)
+	if err != nil {
+		return Config{}, err
+	}
+	scanned, err := discoverProjects(cfg.ScanRoots)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Projects = mergeProjects(cfg.Projects, scanned)
+	return cfg, nil
+}
+
+func loadSnapshot(raw []byte) (Config, error) {
+	cfg, err := loadRawWithoutProjectDiscovery(raw)
+	if err != nil {
+		return Config{}, err
+	}
+	scanned, err := discoverProjects(cfg.ScanRoots)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Projects = mergeProjects(cfg.Projects, scanned)
+	return cfg, nil
+}
+
+// loadWithoutProjectDiscovery 只解析配置文件、默认值与进程级覆盖，不访问
+// scan_roots。共享 daemon 的锁内所有权复核必须保持快速且只依赖相关配置，
+// 不能因为无关网络盘或受保护目录暂时不可读而长期占住生命周期锁。
+func loadWithoutProjectDiscovery(path string) (Config, error) {
 	path = expandPath(path)
+	var raw []byte
 	if path != "" {
 		if b, err := os.ReadFile(path); err == nil {
-			listenConfigured := false
-			var document map[string]json.RawMessage
-			if json.Unmarshal(b, &document) == nil {
-				var appServer map[string]json.RawMessage
-				if raw, ok := document["app_server"]; ok && json.Unmarshal(raw, &appServer) == nil {
-					_, listenConfigured = appServer["listen"]
-				}
-			}
-			if err := json.Unmarshal(b, &cfg); err != nil {
-				return Config{}, fmt.Errorf("解析配置文件失败：%w", err)
-			}
-			if normalizeTransport(cfg.AppServer.Transport) == "unix" && !listenConfigured {
-				// defaults() 必须自身可 Validate，因此带 WS 默认 listen；但 JSON
-				// 显式选 Unix 且省略 listen 时，不能把这个结构体默认误当成用户配置。
-				cfg.AppServer.Listen = ""
-			}
+			raw = b
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return Config{}, fmt.Errorf("读取配置文件失败：%w", err)
+		}
+	}
+	return loadRawWithoutProjectDiscovery(raw)
+}
+
+func loadRawWithoutProjectDiscovery(raw []byte) (Config, error) {
+	cfg := defaults()
+	if raw != nil {
+		listenConfigured := false
+		var document map[string]json.RawMessage
+		if json.Unmarshal(raw, &document) == nil {
+			var appServer map[string]json.RawMessage
+			if encoded, ok := document["app_server"]; ok && json.Unmarshal(encoded, &appServer) == nil {
+				_, listenConfigured = appServer["listen"]
+			}
+		}
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return Config{}, fmt.Errorf("解析配置文件失败：%w", err)
+		}
+		if normalizeTransport(cfg.AppServer.Transport) == "unix" && !listenConfigured {
+			// defaults() 必须自身可 Validate，因此带 WS 默认 listen；但 JSON
+			// 显式选 Unix 且省略 listen 时，不能把这个结构体默认误当成用户配置。
+			cfg.AppServer.Listen = ""
 		}
 	}
 
@@ -205,12 +295,53 @@ func load(path string) (Config, error) {
 	if strings.EqualFold(cfg.AppServer.Transport, "unix") && strings.TrimSpace(cfg.AppServer.Listen) == "" {
 		cfg.AppServer.Listen = defaultAppServerUnixListen
 	}
-	scanned, err := discoverProjects(cfg.ScanRoots)
-	if err != nil {
-		return Config{}, err
-	}
-	cfg.Projects = mergeProjects(cfg.Projects, scanned)
 	return cfg, nil
+}
+
+// ValidateSharedDaemonRecoveryOwnership 在长期存活的旧进程尝试恢复 owner 前，
+// 只复核磁盘上的共享模式与 Codex 启动身份。它故意跳过 project discovery 和
+// 全量 Validate；错误只会让恢复 fail closed，不影响用户修复其他配置项。
+func ValidateSharedDaemonRecoveryOwnership(
+	path string,
+	expectedBin string,
+	expectedEnv map[string]string,
+) error {
+	cfg, err := loadWithoutProjectDiscovery(path)
+	if err != nil {
+		return fmt.Errorf("重新读取 agentd 配置失败：%w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") ||
+		!cfg.AppServer.Managed || cfg.AppServer.SharedFallback == nil {
+		return fmt.Errorf("当前配置已取消 Mimi 共享 daemon")
+	}
+	if strings.TrimSpace(cfg.Codex.Bin) != strings.TrimSpace(expectedBin) ||
+		!maps.Equal(cfg.Codex.Env, expectedEnv) {
+		return fmt.Errorf("当前 Codex 配置已变化，旧进程不得恢复 shared daemon")
+	}
+	return nil
+}
+
+// ValidateSharedDaemonDisabledOwnership 是非 shared agentd 清理 Mimi 残留 owner
+// 前的锁内复核。它与 recovery validator 互为相反条件：一旦另一个进程已经
+// 提交新的 shared 配置，旧 WS 进程必须停止清理，不能删除刚创建的 owner。
+func ValidateSharedDaemonDisabledOwnership(
+	path string,
+	expectedBin string,
+	expectedEnv map[string]string,
+) error {
+	cfg, err := loadWithoutProjectDiscovery(path)
+	if err != nil {
+		return fmt.Errorf("重新读取 agentd 配置失败：%w", err)
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") &&
+		cfg.AppServer.Managed && cfg.AppServer.SharedFallback != nil {
+		return fmt.Errorf("当前配置已经启用 Mimi 共享 daemon")
+	}
+	if strings.TrimSpace(cfg.Codex.Bin) != strings.TrimSpace(expectedBin) ||
+		!maps.Equal(cfg.Codex.Env, expectedEnv) {
+		return fmt.Errorf("当前 Codex 配置已变化，旧进程不得清理 shared daemon owner")
+	}
+	return nil
 }
 
 func expandPath(path string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,3 +149,76 @@ func TestPlatformDefaultPathIgnoresAgentdConfig(t *testing.T) {
 		t.Fatalf("平台默认配置路径异常：got=%q want=%q", platformDefault, filepath.Join(wantDir, "config.json"))
 	}
 }
+
+func TestIsPlatformDefaultPathResolvesEquivalentDirectorySymlink(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	platformDefault := PlatformDefaultPath()
+	if err := os.MkdirAll(filepath.Dir(platformDefault), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := filepath.Join(t.TempDir(), "config-alias")
+	if err := os.Symlink(filepath.Dir(platformDefault), aliasRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsPlatformDefaultPath(filepath.Join(aliasRoot, filepath.Base(platformDefault))) {
+		t.Fatal("同一默认配置目录的 symlink 路径应视为平台默认配置")
+	}
+	if IsPlatformDefaultPath(filepath.Join(t.TempDir(), "custom.json")) {
+		t.Fatal("自定义配置不能取得用户全局 shared-daemon owner")
+	}
+}
+
+func TestConfigPathIdentityMatchesVolumeCaseSemantics(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	platformDefault := PlatformDefaultPath()
+	if err := os.MkdirAll(filepath.Dir(platformDefault), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(platformDefault, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	caseVariant := filepath.Join(filepath.Dir(platformDefault), "Config.json")
+	_, variantErr := os.Stat(caseVariant)
+	if variantErr == nil {
+		if !IsPlatformDefaultPath(caseVariant) {
+			t.Fatal("大小写不敏感卷上的同一默认文件必须取得全局 owner 权限")
+		}
+		left, err := ConfigPathIdentity(platformDefault)
+		if err != nil {
+			t.Fatal(err)
+		}
+		right, err := ConfigPathIdentity(caseVariant)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if left != right {
+			t.Fatalf("大小写别名必须取得同一配置锁：left=%q right=%q", left, right)
+		}
+		return
+	}
+	if !os.IsNotExist(variantErr) {
+		t.Fatal(variantErr)
+	}
+	if IsPlatformDefaultPath(caseVariant) {
+		t.Fatal("大小写敏感卷上的不同文件不能共享 owner")
+	}
+}
+
+func TestIsPlatformDefaultPathRejectsDifferentHardLinkEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	platformDefault := PlatformDefaultPath()
+	if err := os.MkdirAll(filepath.Dir(platformDefault), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(platformDefault, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hardLink := filepath.Join(t.TempDir(), "config-hardlink.json")
+	if err := os.Link(platformDefault, hardLink); err != nil {
+		t.Fatal(err)
+	}
+	if IsPlatformDefaultPath(hardLink) {
+		t.Fatal("不同 hard-link 目录项不能取得平台默认配置的全局 owner 权限")
+	}
+}

--- a/internal/config/path_case_darwin.go
+++ b/internal/config/path_case_darwin.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+package config
+
+import "golang.org/x/sys/unix"
+
+const darwinPathconfCaseSensitive = 11 // _PC_CASE_SENSITIVE from sys/unistd.h
+
+func configPathCaseSensitive(path string) (bool, error) {
+	value, err := unix.Pathconf(path, darwinPathconfCaseSensitive)
+	if err != nil {
+		return true, err
+	}
+	return value != 0, nil
+}

--- a/internal/config/path_case_unix.go
+++ b/internal/config/path_case_unix.go
@@ -1,0 +1,5 @@
+//go:build !darwin && !windows
+
+package config
+
+func configPathCaseSensitive(string) (bool, error) { return true, nil }

--- a/internal/config/path_case_windows.go
+++ b/internal/config/path_case_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package config
+
+func configPathCaseSensitive(string) (bool, error) { return false, nil }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -97,6 +97,9 @@ func (c *Checker) Run(ctx context.Context, checkPort bool) Results {
 	if check := c.localDaemonLifecycleCheck(ctx); check.Name != "" {
 		checks = append(checks, check)
 	}
+	if check := c.sharedDaemonOwnerCheck(ctx); check.Name != "" {
+		checks = append(checks, check)
+	}
 	checks = append(checks, c.claudeBridgeCheck(ctx))
 	if check := c.appServerGatewayCheck(ctx); check.Name != "" {
 		checks = append(checks, check)
@@ -414,6 +417,44 @@ func (c *Checker) localDaemonLifecycleCheck(ctx context.Context) Check {
 	}
 	check.OK = true
 	check.Message = "官方 Codex daemon 生命周期可恢复（" + status.AppServerVersion + "）"
+	return check
+}
+
+func (c *Checker) sharedDaemonOwnerCheck(ctx context.Context) Check {
+	if !strings.EqualFold(strings.TrimSpace(c.cfg.AppServer.Transport), "unix") ||
+		c.cfg.AppServer.SharedFallback == nil {
+		return Check{}
+	}
+	status, err := appserver.InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return Check{
+			Name:    "codex-daemon-owner",
+			OK:      false,
+			Message: "无法检查共享 Codex daemon 的 launchd owner",
+			Fix:     err.Error(),
+		}
+	}
+	if !status.Supported {
+		return Check{}
+	}
+	check := Check{
+		Name: "codex-daemon-owner",
+		Fix:  "在 Mimi Remote Mac 中关闭后重新开启共享；若提示需要迁移，请保存任务后点击“应用待处理设置”并确认",
+	}
+	switch {
+	case !status.Installed:
+		check.Message = "共享 Codex daemon 缺少稳定 LaunchAgent owner"
+	case !status.Secure:
+		check.Message = "共享 Codex daemon LaunchAgent 权限过宽，可能暴露运行环境"
+	case !status.Loaded:
+		check.Message = "共享 Codex daemon LaunchAgent 已安装但未加载"
+	case status.MigrationRequired:
+		check.Message = "共享 Codex daemon 的稳定 owner 迁移尚未完成，等待显式应用"
+	default:
+		check.OK = true
+		check.Message = "共享 Codex daemon 的稳定 LaunchAgent owner 已安装；TCC 归因仍需签名 App 运行态验收"
+		check.Fix = ""
+	}
 	return check
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -57,6 +57,15 @@ func NewChecker(version string, cfg config.Config, registry *projects.Registry, 
 	return checker
 }
 
+// ConfigPath 返回启动时已解析的真实配置路径，供同一进程中的长期恢复任务
+// 在执行持久化动作前重新验证配置所有权。空值表示调用方未注入路径。
+func (c *Checker) ConfigPath() string {
+	if c == nil {
+		return ""
+	}
+	return c.configPath
+}
+
 func (c *Checker) Run(ctx context.Context, checkPort bool) Results {
 	projectsCount := len(c.registry.List())
 	tokenOK := c.cfg.DevInsecure || c.cfg.Auth.Token != ""

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -605,6 +606,20 @@ func (r *Router) appServerCodexGatewayWS(w http.ResponseWriter, req *http.Reques
 	dialStart := time.Now()
 	upstream, _, err := dialer.DialContext(req.Context(), upstreamURL, upstreamHeaders)
 	dialDuration := time.Since(dialStart)
+	if err != nil && r.recoverSharedCodexDaemon != nil {
+		// 只在一次真实客户端连接失败后恢复，避免 readyz 轮询不停拉进程。恢复仍
+		// 走 appserver.EnsureLocalDaemon -> launchd owner，绝不由 HTTP handler spawn。
+		recoverCtx, cancel := context.WithTimeout(req.Context(), 35*time.Second)
+		recoverErr := r.recoverSharedCodexDaemon(recoverCtx)
+		cancel()
+		if recoverErr == nil {
+			dialStart = time.Now()
+			upstream, _, err = dialer.DialContext(req.Context(), upstreamURL, upstreamHeaders)
+			dialDuration = time.Since(dialStart)
+		} else {
+			log.Printf("shared Codex daemon recovery failed: %v", recoverErr)
+		}
+	}
 	if err != nil {
 		r.monitor.recordGatewayDialFailure(dialDuration, err)
 		writeCodexGatewayRuntimeError(client, "CODEX_UPSTREAM_UNAVAILABLE", "Codex app-server 暂时不可用，请稍后重试")

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -271,11 +271,12 @@ type appServerGatewayPendingClientRequest struct {
 }
 
 type appServerGatewayPendingServerRequest struct {
-	method    string
-	threadID  string
-	turnID    string
-	itemID    string
-	createdAt time.Time
+	method           string
+	threadID         string
+	turnID           string
+	itemID           string
+	gatewayOwnedTurn bool
+	createdAt        time.Time
 }
 
 type appServerGatewayPendingHistoryRequest struct {

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -46,7 +46,28 @@ func (p *appServerGatewayPolicy) validateClientFrameContext(ctx context.Context,
 		if frame.ID != nil && (len(frame.Result) > 0 || len(frame.Error) > 0) {
 			rewritten, err := p.validateClientResponse(payload, &frame)
 			if err != nil {
-				return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
+				policyErr := &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
+				if errors.Is(err, errAppServerExternalThreadActive) ||
+					errors.Is(err, errAppServerExternalActivityUnavailable) {
+					reason := "external_thread_active"
+					if errors.Is(err, errAppServerExternalActivityUnavailable) {
+						reason = "external_activity_unavailable"
+					}
+					policyErr.data = map[string]any{
+						"reason":         reason,
+						"accepted":       false,
+						"retryable":      true,
+						"retry_after_ms": int64(1000),
+						// 反向 response 不属于客户端 pending RPC。移动端据此把
+						// fire-and-forget 的审批/补充输入恢复成可重试卡片。
+						"response_to_server_request": true,
+					}
+					if pending, ok := p.pendingServerRequest(frame.ID); ok {
+						policyErr.data["server_request_method"] = pending.method
+						policyErr.data["thread_id"] = pending.threadID
+					}
+				}
+				return nil, policyErr
 			}
 			return rewritten, nil
 		}
@@ -180,8 +201,16 @@ func (p *appServerGatewayPolicy) guardExternalDesktopThread(method string, param
 		return nil
 	}
 	sharedBackend := strings.EqualFold(strings.TrimSpace(p.router.cfg.AppServer.Transport), "unix")
+	return p.guardExternalDesktopThreadID(method, threadID, sharedBackend)
+}
+
+func (p *appServerGatewayPolicy) guardExternalDesktopThreadID(
+	operation string,
+	threadID string,
+	sharedBackend bool,
+) error {
 	if sharedBackend && p.router.externalActivity == nil {
-		return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝写入：%w", method, errAppServerExternalActivityUnavailable)
+		return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝写入：%w", operation, errAppServerExternalActivityUnavailable)
 	}
 	active, err := p.router.codexDesktopThreadActive(threadID)
 	if err != nil {
@@ -189,13 +218,13 @@ func (p *appServerGatewayPolicy) guardExternalDesktopThread(method string, param
 		if sharedBackend {
 			// shared unix 下 Desktop 与手机写入同一个 runtime。观测失效时继续写
 			// 会重新制造双 writer；宁可短暂只读，也不能影响 Codex 原生任务。
-			return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝写入：%w", method, errAppServerExternalActivityUnavailable)
+			return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝写入：%w", operation, errAppServerExternalActivityUnavailable)
 		}
 		// 独立 WS 没有共同 writer，继续保留历史可用性策略。
 		return nil
 	}
 	if active {
-		return fmt.Errorf("%s.threadId 当前由 Codex Desktop 运行，请等待本轮结束后重试：%w", method, errAppServerExternalThreadActive)
+		return fmt.Errorf("%s.threadId 当前由 Codex Desktop 运行，请等待本轮结束后重试：%w", operation, errAppServerExternalThreadActive)
 	}
 	return nil
 }
@@ -464,20 +493,50 @@ func (p *appServerGatewayPolicy) validateClientResponse(payload []byte, frame *a
 	if frame.ID == nil {
 		return nil, fmt.Errorf("JSON-RPC response 缺少 id")
 	}
-	request, ok := p.consumePendingServerRequest(frame.ID)
+	request, ok := p.pendingServerRequest(frame.ID)
 	if !ok {
 		return nil, fmt.Errorf("JSON-RPC response id 未由 app-server 发起")
 	}
+	if err := p.guardExternalDesktopServerResponse(request); err != nil {
+		// 拒绝发生在写入 upstream 之前，pending 必须保留；Desktop turn 完成后
+		// 移动端可安全重试，断线重放也仍有真实 outstanding request。
+		return nil, err
+	}
+	var rewritten []byte
 	if len(frame.Error) > 0 {
-		return payload, nil
-	}
-	if len(frame.Result) == 0 {
+		rewritten = payload
+	} else if len(frame.Result) == 0 {
 		return nil, fmt.Errorf("JSON-RPC response 缺少 result")
+	} else if !isPermissionsApprovalMethod(request.method) {
+		rewritten = payload
+	} else {
+		var err error
+		rewritten, err = rewriteGatewayPermissionsApprovalResponse(payload)
+		if err != nil {
+			return nil, err
+		}
 	}
-	if !isPermissionsApprovalMethod(request.method) {
-		return payload, nil
+	// 只有 external guard、response 结构和必要改写全部成功后才消费 pending。
+	// 坏帧或策略拒绝仍可重试，且断线重放仍对应真实 outstanding request。
+	if _, ok := p.consumePendingServerRequest(frame.ID); !ok {
+		return nil, fmt.Errorf("JSON-RPC response id 已被处理")
 	}
-	return rewriteGatewayPermissionsApprovalResponse(payload)
+	return rewritten, nil
+}
+
+func (p *appServerGatewayPolicy) guardExternalDesktopServerResponse(
+	request appServerGatewayPendingServerRequest,
+) error {
+	if p == nil || p.router == nil || normalizeAppServerRuntimeID(p.runtimeID) != "codex" ||
+		!strings.EqualFold(strings.TrimSpace(p.router.cfg.AppServer.Transport), "unix") {
+		// 独立 WS backend 与 Claude bridge 不共享 Desktop writer，保留原行为。
+		return nil
+	}
+	threadID := strings.TrimSpace(request.threadID)
+	if threadID == "" {
+		return fmt.Errorf("%s.threadId 缺失，无法确认 Desktop 是否空闲，已拒绝响应：%w", request.method, errAppServerExternalActivityUnavailable)
+	}
+	return p.guardExternalDesktopThreadID(request.method, threadID, true)
 }
 
 func rewriteGatewayPermissionsApprovalResponse(payload []byte) ([]byte, error) {

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -536,6 +536,31 @@ func (p *appServerGatewayPolicy) guardExternalDesktopServerResponse(
 	if threadID == "" {
 		return fmt.Errorf("%s.threadId 缺失，无法确认 Desktop 是否空闲，已拒绝响应：%w", request.method, errAppServerExternalActivityUnavailable)
 	}
+	if request.gatewayOwnedTurn && strings.TrimSpace(request.turnID) != "" {
+		if p.router.externalActivity == nil {
+			return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝响应：%w", request.method, errAppServerExternalActivityUnavailable)
+		}
+		activities, err := p.router.externalActivity.Snapshot()
+		if err != nil {
+			log.Printf("external activity guard unavailable: %v", err)
+			return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝响应：%w", request.method, errAppServerExternalActivityUnavailable)
+		}
+		for _, activity := range activities {
+			if strings.TrimSpace(activity.ThreadID) != threadID ||
+				!strings.EqualFold(strings.TrimSpace(activity.Source), "codex_desktop") ||
+				!strings.EqualFold(strings.TrimSpace(activity.State), "running") {
+				continue
+			}
+			if strings.TrimSpace(activity.TurnID) == strings.TrimSpace(request.turnID) {
+				// claim TTL 到期只会让同一个长时间等待审批的 iPad turn 被
+				// tracker 保守重分类为 Desktop；pending 上捕获的原始归属仍然
+				// 允许完成这一个 response。不同或缺失 TurnID 继续 fail-closed。
+				continue
+			}
+			return fmt.Errorf("%s.threadId 当前由 Codex Desktop 运行，请等待本轮结束后重试：%w", request.method, errAppServerExternalThreadActive)
+		}
+		return nil
+	}
 	return p.guardExternalDesktopThreadID(request.method, threadID, true)
 }
 

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -21,7 +21,10 @@ You are now in Default mode. Any previous instructions for other modes (e.g. Pla
 
 Your active mode changes only when new developer instructions with a different <collaboration_mode> change it; user requests or tool descriptions do not change mode by themselves.`
 
-var errAppServerExternalThreadActive = errors.New("Codex Desktop 正在运行此会话")
+var (
+	errAppServerExternalThreadActive        = errors.New("Codex Desktop 正在运行此会话")
+	errAppServerExternalActivityUnavailable = errors.New("无法确认 Codex Desktop 会话是否空闲")
+)
 
 func (p *appServerGatewayPolicy) validateClientFrame(messageType int, payload []byte) ([]byte, *appServerGatewayPolicyError) {
 	return p.validateClientFrameContext(context.Background(), messageType, payload)
@@ -70,11 +73,15 @@ func (p *appServerGatewayPolicy) validateClientFrameContext(ctx context.Context,
 	if err := p.guardExternalDesktopThread(method, params); err != nil {
 		p.router.releaseManagedWorktreePendingUse(validated.pendingManagedWorktreePath)
 		p.forgetPending(frame.ID)
+		reason := "external_thread_active"
+		if errors.Is(err, errAppServerExternalActivityUnavailable) {
+			reason = "external_activity_unavailable"
+		}
 		return nil, &appServerGatewayPolicyError{
 			id:      frame.ID,
 			message: err.Error(),
 			data: map[string]any{
-				"reason":         "external_thread_active",
+				"reason":         reason,
 				"accepted":       false,
 				"retryable":      true,
 				"retry_after_ms": int64(1000),
@@ -172,11 +179,19 @@ func (p *appServerGatewayPolicy) guardExternalDesktopThread(method string, param
 	if !ok {
 		return nil
 	}
+	sharedBackend := strings.EqualFold(strings.TrimSpace(p.router.cfg.AppServer.Transport), "unix")
+	if sharedBackend && p.router.externalActivity == nil {
+		return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝写入：%w", method, errAppServerExternalActivityUnavailable)
+	}
 	active, err := p.router.codexDesktopThreadActive(threadID)
 	if err != nil {
-		// 外部活动是同机 rollout 的辅助证据，不是鉴权边界。读取失败时保留现有
-		// same-thread 发送能力，避免 SQLite 短暂锁定把空闲会话误判为只读。
 		log.Printf("external activity guard unavailable: %v", err)
+		if sharedBackend {
+			// shared unix 下 Desktop 与手机写入同一个 runtime。观测失效时继续写
+			// 会重新制造双 writer；宁可短暂只读，也不能影响 Codex 原生任务。
+			return fmt.Errorf("%s.threadId 暂时无法确认 Desktop 是否空闲，已拒绝写入：%w", method, errAppServerExternalActivityUnavailable)
+		}
+		// 独立 WS 没有共同 writer，继续保留历史可用性策略。
 		return nil
 	}
 	if active {

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -2165,6 +2165,79 @@ func TestAppServerGatewayRejectsReverseResponseWhileCodexDesktopTurnIsActive(t *
 	}
 }
 
+func TestAppServerGatewayAllowsOwnedReverseResponseAfterClaimTTLReclassification(t *testing.T) {
+	_, router, _ := buildAppServerGatewayFixture(t, "", nil)
+	router.cfg.AppServer.Transport = "unix"
+	activity := &gatewayOwnedExternalActivitySource{
+		threadID: "thread-ipad",
+		turnID:   "turn-ipad",
+	}
+	router.externalActivity = activity
+	policy := &appServerGatewayPolicy{
+		router:                router,
+		runtimeID:             "codex",
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	request := []byte(`{"id":"approval-long","method":"item/commandExecution/requestApproval","params":{"threadId":"thread-ipad","turnId":"turn-ipad","itemId":"item-1"}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request); policyErr != nil || !forward {
+		t.Fatalf("gateway-owned 反向审批 request 应正常登记：forward=%t err=%+v", forward, policyErr)
+	}
+	id := json.RawMessage(`"approval-long"`)
+	pending, ok := policy.pendingServerRequest(&id)
+	if !ok || !pending.gatewayOwnedTurn {
+		t.Fatalf("pending 必须捕获 request 创建时的精确 gateway turn 归属：pending=%+v ok=%t", pending, ok)
+	}
+
+	// 模拟 40 分钟 claim TTL 到期：tracker 会把仍在等待审批的同一 turn
+	// 保守重分类为 codex_desktop，但它不是一个新的 Mac writer。
+	activity.activities = []codexhistory.ExternalActivity{{
+		ThreadID: "thread-ipad",
+		TurnID:   "turn-ipad",
+		Source:   "codex_desktop",
+		State:    "running",
+	}}
+	response := []byte(`{"id":"approval-long","result":{"decision":"accept"}}`)
+	forwarded, policyErr := policy.validateClientFrame(websocket.TextMessage, response)
+	if policyErr != nil || !bytes.Equal(forwarded, response) {
+		t.Fatalf("原 gateway turn 的长时间 pending response 不应被 TTL 永久锁死：forwarded=%s err=%+v", forwarded, policyErr)
+	}
+}
+
+func TestAppServerGatewayOwnedReverseResponseStillRejectsDifferentDesktopTurn(t *testing.T) {
+	_, router, _ := buildAppServerGatewayFixture(t, "", nil)
+	router.cfg.AppServer.Transport = "unix"
+	activity := &gatewayOwnedExternalActivitySource{
+		threadID: "thread-ipad",
+		turnID:   "turn-ipad",
+	}
+	router.externalActivity = activity
+	policy := &appServerGatewayPolicy{
+		router:                router,
+		runtimeID:             "codex",
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	request := []byte(`{"id":"approval-stale","method":"item/fileChange/requestApproval","params":{"threadId":"thread-ipad","turnId":"turn-ipad","itemId":"item-1"}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request); policyErr != nil || !forward {
+		t.Fatalf("gateway-owned 反向审批 request 应正常登记：forward=%t err=%+v", forward, policyErr)
+	}
+
+	activity.activities = []codexhistory.ExternalActivity{{
+		ThreadID: "thread-ipad",
+		TurnID:   "turn-mac-new",
+		Source:   "codex_desktop",
+		State:    "running",
+	}}
+	response := []byte(`{"id":"approval-stale","result":{"decision":"accept"}}`)
+	forwarded, policyErr := policy.validateClientFrame(websocket.TextMessage, response)
+	if len(forwarded) != 0 || policyErr == nil || policyErr.data["reason"] != "external_thread_active" {
+		t.Fatalf("新的 Mac turn 必须继续阻止旧 gateway response：forwarded=%s err=%+v", forwarded, policyErr)
+	}
+	id := json.RawMessage(`"approval-stale"`)
+	if _, ok := policy.pendingServerRequest(&id); !ok {
+		t.Fatal("被新的 Mac turn 拒绝后必须保留 pending，不能丢失上游请求")
+	}
+}
+
 func TestAppServerGatewayLegacyApprovalUsesConversationIDForExternalWriterGuard(t *testing.T) {
 	_, router, _ := buildAppServerGatewayFixture(t, "", nil)
 	router.cfg.AppServer.Transport = "unix"

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -2121,6 +2121,183 @@ func TestAppServerGatewaySharedModeFailsClosedWhenDesktopActivityIsUnavailable(t
 	}
 }
 
+func TestAppServerGatewayRejectsReverseResponseWhileCodexDesktopTurnIsActive(t *testing.T) {
+	_, router, _ := buildAppServerGatewayFixture(t, "", nil)
+	router.cfg.AppServer.Transport = "unix"
+	router.externalActivity = stubExternalActivitySource{activities: []codexhistory.ExternalActivity{{
+		ThreadID: "thread-1",
+		Source:   "codex_desktop",
+		State:    "running",
+	}}}
+	policy := &appServerGatewayPolicy{
+		router:                router,
+		runtimeID:             "codex",
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	request := []byte(`{"id":"approval-active","method":"item/commandExecution/requestApproval","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1"}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request); policyErr != nil || !forward {
+		t.Fatalf("反向审批 request 应先以只读卡片转发：forward=%t err=%+v", forward, policyErr)
+	}
+
+	response := []byte(`{"id":"approval-active","result":{"decision":"accept"}}`)
+	forwarded, policyErr := policy.validateClientFrame(websocket.TextMessage, response)
+	if len(forwarded) != 0 || policyErr == nil {
+		t.Fatalf("Desktop active turn 的反向 response 必须拒绝：forwarded=%s err=%+v", forwarded, policyErr)
+	}
+	if policyErr.data["reason"] != "external_thread_active" ||
+		policyErr.data["response_to_server_request"] != true ||
+		policyErr.data["thread_id"] != "thread-1" {
+		t.Fatalf("反向拒绝必须携带移动端恢复卡片所需字段：%v", policyErr.data)
+	}
+	id := json.RawMessage(`"approval-active"`)
+	if _, ok := policy.pendingServerRequest(&id); !ok {
+		t.Fatal("策略拒绝后必须保留 pending，等待 Desktop 空闲后重试")
+	}
+
+	// 同一个 outstanding request 在 Desktop turn 完成后可以重试；成功后才消费。
+	router.externalActivity = stubExternalActivitySource{}
+	forwarded, policyErr = policy.validateClientFrame(websocket.TextMessage, response)
+	if policyErr != nil || !bytes.Equal(forwarded, response) {
+		t.Fatalf("Desktop 空闲后应允许原 response 重试：forwarded=%s err=%+v", forwarded, policyErr)
+	}
+	if _, ok := policy.pendingServerRequest(&id); ok {
+		t.Fatal("成功转发后必须消费 pending")
+	}
+}
+
+func TestAppServerGatewayLegacyApprovalUsesConversationIDForExternalWriterGuard(t *testing.T) {
+	_, router, _ := buildAppServerGatewayFixture(t, "", nil)
+	router.cfg.AppServer.Transport = "unix"
+	router.externalActivity = stubExternalActivitySource{activities: []codexhistory.ExternalActivity{{
+		ThreadID: "thread-legacy",
+		Source:   "codex_desktop",
+		State:    "running",
+	}}}
+	policy := &appServerGatewayPolicy{
+		router:                router,
+		runtimeID:             "codex",
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	request := []byte(`{"id":"legacy-approval","method":"execCommandApproval","params":{"conversationId":"thread-legacy","callId":"call-1","command":["rm","tmp"]}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request); policyErr != nil || !forward {
+		t.Fatalf("legacy 反向审批 request 应正常登记：forward=%t err=%+v", forward, policyErr)
+	}
+
+	response := []byte(`{"id":"legacy-approval","result":{"decision":"denied"}}`)
+	forwarded, policyErr := policy.validateClientFrame(websocket.TextMessage, response)
+	if len(forwarded) != 0 || policyErr == nil || policyErr.data["reason"] != "external_thread_active" ||
+		policyErr.data["thread_id"] != "thread-legacy" {
+		t.Fatalf("conversationId 必须映射到共享 writer guard：forwarded=%s err=%+v", forwarded, policyErr)
+	}
+	id := json.RawMessage(`"legacy-approval"`)
+	if _, ok := policy.pendingServerRequest(&id); !ok {
+		t.Fatal("legacy 审批被 guard 拒绝后必须保留 pending")
+	}
+
+	router.externalActivity = stubExternalActivitySource{}
+	forwarded, policyErr = policy.validateClientFrame(websocket.TextMessage, response)
+	if policyErr != nil || !bytes.Equal(forwarded, response) {
+		t.Fatalf("Desktop 空闲后 legacy 审批应可重试：forwarded=%s err=%+v", forwarded, policyErr)
+	}
+}
+
+func TestAppServerGatewaySharedReverseResponseFailsClosedWithoutReliableThreadActivity(t *testing.T) {
+	tests := []struct {
+		name          string
+		transport     string
+		threadParams  string
+		activity      externalActivitySource
+		response      string
+		wantReason    string
+		wantForwarded bool
+	}{
+		{
+			name:         "observer missing",
+			transport:    "unix",
+			threadParams: `"threadId":"thread-1",`,
+			response:     `{"id":"reverse-1","result":{"decision":"accept"}}`,
+			wantReason:   "external_activity_unavailable",
+		},
+		{
+			name:         "observer error",
+			transport:    "unix",
+			threadParams: `"threadId":"thread-1",`,
+			activity:     stubExternalActivitySource{err: errors.New("state database locked")},
+			response:     `{"id":"reverse-1","result":{"decision":"accept"}}`,
+			wantReason:   "external_activity_unavailable",
+		},
+		{
+			name:       "missing thread scope",
+			transport:  "unix",
+			activity:   stubExternalActivitySource{},
+			response:   `{"id":"reverse-1","result":{"decision":"accept"}}`,
+			wantReason: "external_activity_unavailable",
+		},
+		{
+			name:          "idle shared thread",
+			transport:     "unix",
+			threadParams:  `"threadId":"thread-1",`,
+			activity:      stubExternalActivitySource{},
+			response:      `{"id":"reverse-1","result":{"decision":"accept"}}`,
+			wantForwarded: true,
+		},
+		{
+			name:          "independent websocket keeps old behavior",
+			transport:     "ws",
+			threadParams:  `"threadId":"thread-1",`,
+			response:      `{"id":"reverse-1","result":{"decision":"accept"}}`,
+			wantForwarded: true,
+		},
+		{
+			name:         "error response is also a write",
+			transport:    "unix",
+			threadParams: `"threadId":"thread-1",`,
+			activity: stubExternalActivitySource{activities: []codexhistory.ExternalActivity{{
+				ThreadID: "thread-1",
+				Source:   "codex_desktop",
+				State:    "running",
+			}}},
+			response:   `{"id":"reverse-1","error":{"code":-1,"message":"declined"}}`,
+			wantReason: "external_thread_active",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, router, _ := buildAppServerGatewayFixture(t, "", nil)
+			router.cfg.AppServer.Transport = test.transport
+			router.externalActivity = test.activity
+			policy := &appServerGatewayPolicy{
+				router:                router,
+				runtimeID:             "codex",
+				pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+			}
+			request := []byte(`{"id":"reverse-1","method":"item/fileChange/requestApproval","params":{` + test.threadParams + `"turnId":"turn-1","itemId":"item-1"}}`)
+			if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request); policyErr != nil || !forward {
+				t.Fatalf("登记反向 request 失败：forward=%t err=%+v", forward, policyErr)
+			}
+
+			forwarded, policyErr := policy.validateClientFrame(websocket.TextMessage, []byte(test.response))
+			id := json.RawMessage(`"reverse-1"`)
+			if test.wantForwarded {
+				if policyErr != nil || !bytes.Equal(forwarded, []byte(test.response)) {
+					t.Fatalf("response 应保持原行为：forwarded=%s err=%+v", forwarded, policyErr)
+				}
+				if _, ok := policy.pendingServerRequest(&id); ok {
+					t.Fatal("成功 response 应消费 pending")
+				}
+				return
+			}
+			if len(forwarded) != 0 || policyErr == nil || policyErr.data["reason"] != test.wantReason {
+				t.Fatalf("shared response 应 fail closed：forwarded=%s err=%+v", forwarded, policyErr)
+			}
+			if _, ok := policy.pendingServerRequest(&id); !ok {
+				t.Fatal("拒绝 response 不得消费 pending")
+			}
+		})
+	}
+}
+
 func TestAppServerHistoryImageRedactionRewritesImageGenerationResult(t *testing.T) {
 	router := &Router{historyMedia: newAppServerHistoryMediaStore()}
 	pngBytes := append([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}, bytes.Repeat([]byte{0xAB}, 20<<10)...)

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http/httptest"
@@ -2076,6 +2077,47 @@ func TestAppServerGatewayRejectsWritesWhileCodexDesktopTurnIsActive(t *testing.T
 	}
 	if !gatewayMethodRequiresExternalIdle("turn/start") || gatewayMethodRequiresExternalIdle("thread/resume") {
 		t.Fatal("active turn 只阻止写操作，thread/resume 仍须可用于只读观察")
+	}
+}
+
+func TestAppServerGatewaySharedModeFailsClosedWhenDesktopActivityIsUnavailable(t *testing.T) {
+	_, router, projectDir := buildAppServerGatewayFixture(t, "", nil)
+	router.cfg.AppServer.Transport = "unix"
+	router.externalActivity = stubExternalActivitySource{err: errors.New("state database locked")}
+	scope, ok := router.gatewayScopeForPath(projectDir)
+	if !ok {
+		t.Fatal("测试项目目录应命中 gateway scope")
+	}
+	policy := &appServerGatewayPolicy{
+		router:    router,
+		runtimeID: "codex",
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-1": {
+				id: "thread-1", runtimeID: "codex", cwd: projectDir, scopeID: scope.id,
+			},
+		},
+	}
+	payload := []byte(fmt.Sprintf(
+		`{"id":42,"method":"turn/start","params":{"threadId":"thread-1","cwd":%q,"input":[{"type":"text","text":"hi"}],"clientUserMessageId":"client-ipad","approvalPolicy":"on-request","approvalsReviewer":"user","sandboxPolicy":{"type":"workspaceWrite","writableRoots":[%q],"networkAccess":false}}}`,
+		projectDir,
+		projectDir,
+	))
+
+	forwarded, policyErr := policy.validateClientFrame(websocket.TextMessage, payload)
+	if len(forwarded) != 0 || policyErr == nil {
+		t.Fatalf("共享 runtime 无法判断 Desktop 活动时必须在转发前拒绝：forwarded=%s err=%+v", forwarded, policyErr)
+	}
+	if got := policyErr.data["reason"]; got != "external_activity_unavailable" {
+		t.Fatalf("应返回可区分的观测失败 reason：got=%v data=%v", got, policyErr.data)
+	}
+	if accepted, ok := policyErr.data["accepted"].(bool); !ok || accepted {
+		t.Fatalf("观测失败发生在转发前，必须声明 accepted=false：data=%v", policyErr.data)
+	}
+
+	// 独立 WS 后端不存在共享 writer，SQLite 观测失败不能阻断原有发送路径。
+	router.cfg.AppServer.Transport = "ws"
+	if err := policy.guardExternalDesktopThread("turn/start", map[string]any{"threadId": "thread-1"}); err != nil {
+		t.Fatalf("独立 WS 模式应继续 fail-open：%v", err)
 	}
 }
 

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -2,8 +2,10 @@ package httpapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1249,7 +1251,12 @@ func TestAppServerGatewayDialFailureDoesNotExposeUpstreamURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	upstreamURL := "ws://" + closedAddress + "/private-upstream-url?access_token=secret-query"
-	handler, _ := appServerGatewayRouterFixture(t, upstreamURL)
+	handler, router, _ := buildAppServerGatewayFixture(t, upstreamURL, nil)
+	var recoveryCalls atomic.Int64
+	router.recoverSharedCodexDaemon = func(context.Context) error {
+		recoveryCalls.Add(1)
+		return fmt.Errorf("recovery unavailable")
+	}
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -1274,6 +1281,138 @@ func TestAppServerGatewayDialFailureDoesNotExposeUpstreamURL(t *testing.T) {
 		if bytes.Contains(payload, []byte(secret)) {
 			t.Fatalf("移动端 WebSocket 错误不能泄漏 upstream URL，secret=%q payload=%s", secret, payload)
 		}
+	}
+	if recoveryCalls.Load() != 1 {
+		t.Fatalf("共享 daemon 首次拨号失败应只触发一次稳定 owner 恢复：%d", recoveryCalls.Load())
+	}
+}
+
+func TestSharedDaemonRecoverySerializesAndCachesRecentResult(t *testing.T) {
+	var calls atomic.Int32
+	var nowMu sync.Mutex
+	nowValue := time.Unix(1_700_000_000, 0)
+	now := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return nowValue
+	}
+	recovery := newSharedDaemonRecovery(now, 30*time.Second, func(context.Context) error {
+		calls.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		return fmt.Errorf("daemon unavailable")
+	})
+
+	var wg sync.WaitGroup
+	errorsSeen := make(chan error, 8)
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errorsSeen <- recovery(context.Background())
+		}()
+	}
+	wg.Wait()
+	close(errorsSeen)
+	for err := range errorsSeen {
+		if err == nil || !strings.Contains(err.Error(), "unavailable") {
+			t.Fatalf("并发调用必须复用同一次失败：%v", err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("冷却期内只能实际恢复一次：calls=%d", calls.Load())
+	}
+
+	nowMu.Lock()
+	nowValue = nowValue.Add(31 * time.Second)
+	nowMu.Unlock()
+	_ = recovery(context.Background())
+	if calls.Load() != 2 {
+		t.Fatalf("冷却期后应允许再次尝试：calls=%d", calls.Load())
+	}
+}
+
+func TestSharedDaemonRecoveryWaiterHonorsCancellation(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	recovery := newSharedDaemonRecovery(time.Now, time.Minute, func(context.Context) error {
+		close(entered)
+		<-release
+		return nil
+	})
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- recovery(context.Background()) }()
+	<-entered
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	startedAt := time.Now()
+	if err := recovery(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("等待中的 gateway 连接必须响应取消：%v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 100*time.Millisecond {
+		t.Fatalf("取消的 waiter 不应等待完整恢复：%s", elapsed)
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSharedDaemonRecoveryStarterCancellationDoesNotPoisonCooldown(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	recovery := newSharedDaemonRecovery(time.Now, time.Minute, func(ctx context.Context) error {
+		calls.Add(1)
+		close(entered)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-release:
+			return nil
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- recovery(ctx) }()
+	<-entered
+	cancel()
+	if err := <-firstDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("发起请求取消后应立即返回，但不能取消共享恢复：%v", err)
+	}
+	close(release)
+	if err := recovery(context.Background()); err != nil {
+		t.Fatalf("后续请求应复用后台恢复成功结果：%v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("首个请求取消不能触发第二次恢复或污染冷却：calls=%d", calls.Load())
+	}
+}
+
+func TestSharedDaemonRecoveryPanicStillReleasesWaiters(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	recovery := newSharedDaemonRecovery(time.Now, time.Minute, func(context.Context) error {
+		calls.Add(1)
+		close(entered)
+		<-release
+		panic("test recovery panic")
+	})
+
+	results := make(chan error, 2)
+	go func() { results <- recovery(context.Background()) }()
+	<-entered
+	go func() { results <- recovery(context.Background()) }()
+	close(release)
+	for range 2 {
+		if err := <-results; err == nil || !strings.Contains(err.Error(), "恢复异常") {
+			t.Fatalf("panic 必须转换成可缓存错误并唤醒等待者：%v", err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("panic 时并发 waiter 仍只能共享一次尝试：calls=%d", calls.Load())
 	}
 }
 

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -1331,6 +1331,70 @@ func TestSharedDaemonRecoverySerializesAndCachesRecentResult(t *testing.T) {
 	}
 }
 
+func TestSharedDaemonRecoveryRechecksDiskConfigAfterDisable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg, registry, manager, checker, _ := appServerGatewayBaseFixture(t)
+	cfg.Runtime.Type = "codex_app_server"
+	cfg.Codex.Env = map[string]string{"CODEX_HOME": codexHome, "TERM": "xterm-256color"}
+	cfg.ScanRoots = []string{filepath.Join(home, "missing-network-volume")}
+	fallback := &config.AppServerFallbackConfig{
+		Transport: "ws",
+		Managed:   true,
+		Listen:    "ws://127.0.0.1:4555",
+	}
+	cfg.AppServer = config.AppServerConfig{
+		Transport:      "unix",
+		Managed:        true,
+		Listen:         appserver.LocalDaemonListen,
+		SharedFallback: fallback,
+	}
+	configPath := filepath.Join(home, "config.json")
+	writeConfig := func(value config.Config) {
+		raw, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(configPath, append(raw, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeConfig(cfg)
+	if err := config.ValidateSharedDaemonRecoveryOwnership(configPath, cfg.Codex.Bin, cfg.Codex.Env); err != nil {
+		t.Fatalf("无关 scan_root 不可读不能阻断 shared owner 复核：%v", err)
+	}
+
+	_, router := NewRouterWithRuntimeInstallationIDAndOptions(
+		cfg,
+		registry,
+		manager,
+		checker,
+		"test",
+		"",
+		nil,
+		RouterOptions{ConfigPath: configPath},
+	)
+	t.Cleanup(router.claudeBridge.shutdown)
+	if router.recoverSharedCodexDaemon == nil {
+		t.Fatal("Mimi shared unix Router 必须安装恢复器")
+	}
+
+	cfg.AppServer = config.AppServerConfig{
+		Transport: "ws",
+		Managed:   fallback.Managed,
+		Listen:    fallback.Listen,
+	}
+	writeConfig(cfg)
+	err := router.recoverSharedCodexDaemon(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "当前配置已取消 Mimi 共享 daemon") {
+		t.Fatalf("旧 Router 在 disable 后必须被磁盘配置撤销恢复权：%v", err)
+	}
+}
+
 func TestSharedDaemonRecoveryWaiterHonorsCancellation(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -846,11 +846,16 @@ func appServerGatewayServerRequestScope(rawParams json.RawMessage) (string, stri
 	if err != nil {
 		return "", "", ""
 	}
-	threadID, _ := gatewayStringParam(params, "threadId")
-	if threadID == "" {
-		threadID, _ = gatewayStringParam(params, "sessionId")
+	threadID := ""
+	for _, key := range []string{"threadId", "thread_id", "sessionId", "session_id", "conversationId", "conversation_id"} {
+		if threadID, _ = gatewayStringParam(params, key); threadID != "" {
+			break
+		}
 	}
 	turnID, _ := gatewayStringParam(params, "turnId")
+	if turnID == "" {
+		turnID, _ = gatewayStringParam(params, "turn_id")
+	}
 	if turnID == "" {
 		if turn, ok := params["turn"].(map[string]any); ok {
 			turnID, _ = gatewayStringParam(turn, "id")
@@ -858,7 +863,10 @@ func appServerGatewayServerRequestScope(rawParams json.RawMessage) (string, stri
 	}
 	itemID, _ := gatewayStringParam(params, "itemId")
 	if itemID == "" {
-		for _, key := range []string{"requestId", "approvalId", "callId"} {
+		itemID, _ = gatewayStringParam(params, "item_id")
+	}
+	if itemID == "" {
+		for _, key := range []string{"requestId", "request_id", "approvalId", "approval_id", "callId", "call_id"} {
 			if itemID, _ = gatewayStringParam(params, key); itemID != "" {
 				break
 			}
@@ -942,6 +950,18 @@ func (p *appServerGatewayPolicy) consumePendingServerRequest(id *json.RawMessage
 	if ok {
 		delete(p.pendingServerRequests, key)
 	}
+	return request, ok
+}
+
+func (p *appServerGatewayPolicy) pendingServerRequest(id *json.RawMessage) (appServerGatewayPendingServerRequest, bool) {
+	key := gatewayRequestIDKey(id)
+	if key == "" {
+		return appServerGatewayPendingServerRequest{}, false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.prunePendingServerRequestsLocked(time.Now())
+	request, ok := p.pendingServerRequests[key]
 	return request, ok
 }
 

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -821,6 +821,20 @@ func (p *appServerGatewayPolicy) rememberPendingServerRequest(id *json.RawMessag
 		return fmt.Errorf("app-server request 缺少 id")
 	}
 	threadID, turnID, itemID := appServerGatewayServerRequestScope(rawParams)
+	gatewayOwnedTurn := false
+	if p != nil && p.router != nil && normalizeAppServerRuntimeID(p.runtimeID) == "codex" &&
+		strings.EqualFold(strings.TrimSpace(p.router.cfg.AppServer.Transport), "unix") &&
+		threadID != "" && turnID != "" {
+		owned, err := p.router.codexGatewayOwnsTurn(threadID, turnID)
+		if err != nil {
+			// request 本身是只读投影，可以继续展示；归属不可确认时不放宽后续
+			// response，仍由 external guard fail-closed。
+			log.Printf("gateway server request ownership unavailable method=%s err=%v",
+				sanitizeGatewayDiagnostic(method), err)
+		} else {
+			gatewayOwnedTurn = owned
+		}
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	now := time.Now()
@@ -832,11 +846,12 @@ func (p *appServerGatewayPolicy) rememberPendingServerRequest(id *json.RawMessag
 		return fmt.Errorf("gateway pending server request 过多")
 	}
 	p.pendingServerRequests[key] = appServerGatewayPendingServerRequest{
-		method:    method,
-		threadID:  threadID,
-		turnID:    turnID,
-		itemID:    itemID,
-		createdAt: now,
+		method:           method,
+		threadID:         threadID,
+		turnID:           turnID,
+		itemID:           itemID,
+		gatewayOwnedTurn: gatewayOwnedTurn,
+		createdAt:        now,
 	}
 	return nil
 }

--- a/internal/httpapi/external_activity.go
+++ b/internal/httpapi/external_activity.go
@@ -18,6 +18,10 @@ type gatewayTurnStartRegistrar interface {
 	RegisterGatewayTurnStart(threadID string, clientUserMessageID string)
 }
 
+type gatewayTurnOwnershipSource interface {
+	GatewayOwnsTurn(threadID string, turnID string) (bool, error)
+}
+
 type externalActivityResponse struct {
 	Activities []codexhistory.ExternalActivity `json:"activities"`
 	ScannedAt  time.Time                       `json:"scanned_at"`
@@ -75,6 +79,20 @@ func (r *Router) codexDesktopThreadActive(threadID string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// codexGatewayOwnsTurn 只接受 tracker 给出的精确 Thread+Turn 证据。
+// 其他 external activity 实现没有这项能力时按未归属处理，不能由“当前没有
+// Desktop activity”反推为 gateway 所有。
+func (r *Router) codexGatewayOwnsTurn(threadID string, turnID string) (bool, error) {
+	if r == nil || r.externalActivity == nil {
+		return false, nil
+	}
+	source, ok := r.externalActivity.(gatewayTurnOwnershipSource)
+	if !ok {
+		return false, nil
+	}
+	return source.GatewayOwnsTurn(threadID, turnID)
 }
 
 func (r *Router) externalActivityHandler(w http.ResponseWriter, req *http.Request) {

--- a/internal/httpapi/external_activity_test.go
+++ b/internal/httpapi/external_activity_test.go
@@ -85,6 +85,24 @@ type recordingExternalActivitySource struct {
 	registrations []gatewayTurnStartRegistration
 }
 
+type gatewayOwnedExternalActivitySource struct {
+	activities []codexhistory.ExternalActivity
+	err        error
+	threadID   string
+	turnID     string
+}
+
+func (s *gatewayOwnedExternalActivitySource) Snapshot() ([]codexhistory.ExternalActivity, error) {
+	return s.activities, s.err
+}
+
+func (s *gatewayOwnedExternalActivitySource) GatewayOwnsTurn(threadID string, turnID string) (bool, error) {
+	if s.err != nil {
+		return false, s.err
+	}
+	return threadID == s.threadID && turnID == s.turnID, nil
+}
+
 type gatewayTurnStartRegistration struct {
 	threadID            string
 	clientUserMessageID string

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -127,8 +128,9 @@ type Router struct {
 
 // RouterOptions 只承载必须在构造时固定的进程级资源路径。
 // 空持久化路径保持纯内存行为，供普通测试和嵌入式调用使用；agentd 生产入口
-// 必须同时注入两条绝对路径。
+// 必须注入真实配置与私有状态路径。
 type RouterOptions struct {
+	ConfigPath                     string
 	GatewayTurnClaimStorePath      string
 	ThreadHandoffRecoveryStorePath string
 }
@@ -223,16 +225,24 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 	}
 	if strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") &&
 		cfg.AppServer.SharedFallback != nil {
+		recoveryOptions := appserver.LocalDaemonOptions{
+			CodexBin:    cfg.Codex.Bin,
+			Env:         cfg.Codex.Env,
+			StableOwner: true,
+		}
+		if configPath := strings.TrimSpace(options.ConfigPath); configPath != "" {
+			expectedBin := strings.TrimSpace(cfg.Codex.Bin)
+			expectedEnv := maps.Clone(cfg.Codex.Env)
+			recoveryOptions.ValidateStableOwner = func() error {
+				return validateSharedDaemonRecoveryConfig(configPath, expectedBin, expectedEnv)
+			}
+		}
 		r.sharedDaemonMigrationRequired = appserver.SharedDaemonMigrationRequired
 		r.recoverSharedCodexDaemon = newSharedDaemonRecovery(
 			time.Now,
 			sharedDaemonRecoveryCooldown,
 			func(ctx context.Context) error {
-				_, err := appserver.EnsureLocalDaemon(ctx, appserver.LocalDaemonOptions{
-					CodexBin:    cfg.Codex.Bin,
-					Env:         cfg.Codex.Env,
-					StableOwner: true,
-				})
+				_, err := appserver.EnsureLocalDaemon(ctx, recoveryOptions)
 				return err
 			},
 		)
@@ -310,6 +320,14 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 	mux.Handle("/api/app-server/history-output/", authed(http.HandlerFunc(r.appServerHistoryOutputHandler)))
 	mux.Handle("/api/app-server/ws", authed(http.HandlerFunc(r.appServerGatewayWS)))
 	return logging(limitAPIRequestBodies(mux), r.monitor), r
+}
+
+func validateSharedDaemonRecoveryConfig(
+	configPath string,
+	expectedBin string,
+	expectedEnv map[string]string,
+) error {
+	return config.ValidateSharedDaemonRecoveryOwnership(configPath, expectedBin, expectedEnv)
 }
 
 // newSharedDaemonRecovery 把跨连接恢复做成串行且带冷却的 single-flight。永久故障时

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/auth"
 	"github.com/gaixianggeng/mimi-remote/internal/codexhistory"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
@@ -26,6 +27,11 @@ import (
 	"github.com/gaixianggeng/mimi-remote/internal/protocolcontract"
 	"github.com/gaixianggeng/mimi-remote/internal/session"
 	"github.com/gaixianggeng/mimi-remote/internal/tailscaleinfo"
+)
+
+const (
+	sharedDaemonRecoveryCooldown       = 30 * time.Second
+	sharedDaemonRecoveryAttemptTimeout = 35 * time.Second
 )
 
 type Router struct {
@@ -46,6 +52,13 @@ type Router struct {
 	// externalActivity 只读取同一 CODEX_HOME 内 Codex Desktop 的脱敏运行态。
 	// 它与本进程 app-server runtime 分离，不能被用于 resume、审批或中断外部 turn。
 	externalActivity externalActivitySource
+	// recoverSharedCodexDaemon 仅在 Mimi 管理的 shared unix 配置下启用。daemon
+	// 异常退出后，下一次真实 gateway 连接通过稳定 owner 恢复一次；独立 WS 和
+	// 外部 Unix backend 都不会被 Mimi 接管。
+	recoverSharedCodexDaemon func(context.Context) error
+	// sharedDaemonMigrationRequired 只读取 Mimi owner 的持久迁移标记。单独注入
+	// 让 runtime cache 保持昂贵账号探测缓存，同时每次请求仍返回实时迁移状态。
+	sharedDaemonMigrationRequired func() (bool, error)
 	// tailscalePathLookup 只在连接验证/测速时读取一次本机 Tailscale 状态。
 	// 使用可注入函数既避免常驻轮询，也让无 Tailscale 环境下的接口行为可测试。
 	tailscalePathLookup tailscaleNetworkPathLookup
@@ -208,6 +221,22 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 		accountTokenUsageCacheTTL:   defaultAccountTokenUsageCacheTTL,
 		claudeBridge:                newClaudeBridgeSupervisor(),
 	}
+	if strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") &&
+		cfg.AppServer.SharedFallback != nil {
+		r.sharedDaemonMigrationRequired = appserver.SharedDaemonMigrationRequired
+		r.recoverSharedCodexDaemon = newSharedDaemonRecovery(
+			time.Now,
+			sharedDaemonRecoveryCooldown,
+			func(ctx context.Context) error {
+				_, err := appserver.EnsureLocalDaemon(ctx, appserver.LocalDaemonOptions{
+					CodexBin:    cfg.Codex.Bin,
+					Env:         cfg.Codex.Env,
+					StableOwner: true,
+				})
+				return err
+			},
+		)
+	}
 	r.refreshClaudeBridgeProbe(false)
 	r.upstreamReadiness = newAppServerReadinessProbe(r.probeAppServerUpstream)
 	r.runtimeStatus = newRuntimeStatusSnapshotCache(r.refreshRuntimeStatus, r.runtimeStatusPlaceholder)
@@ -281,6 +310,74 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 	mux.Handle("/api/app-server/history-output/", authed(http.HandlerFunc(r.appServerHistoryOutputHandler)))
 	mux.Handle("/api/app-server/ws", authed(http.HandlerFunc(r.appServerGatewayWS)))
 	return logging(limitAPIRequestBodies(mux), r.monitor), r
+}
+
+// newSharedDaemonRecovery 把跨连接恢复做成串行且带冷却的 single-flight。永久故障时
+// 新连接会复用最近一次失败，不会排队形成 N × 启动超时；冷却后才允许再次尝试。
+func newSharedDaemonRecovery(
+	now func() time.Time,
+	cooldown time.Duration,
+	recoverDaemon func(context.Context) error,
+) func(context.Context) error {
+	var mu sync.Mutex
+	var hasResult bool
+	var completedAt time.Time
+	var lastErr error
+	var inFlight chan struct{}
+	return func(ctx context.Context) error {
+		for {
+			mu.Lock()
+			current := now()
+			if hasResult && current.Sub(completedAt) >= 0 && current.Sub(completedAt) < cooldown {
+				result := lastErr
+				mu.Unlock()
+				return result
+			}
+			wait := inFlight
+			if wait == nil {
+				wait = make(chan struct{})
+				inFlight = wait
+				// 恢复属于共享进程生命周期，不能继承首个手机请求的取消。所有
+				// 请求（包括发起者）只作为可取消 waiter；后台尝试有独立硬上限。
+				go func(attemptDone chan struct{}) {
+					result := func() (resultErr error) {
+						defer func() {
+							if recovered := recover(); recovered != nil {
+								resultErr = fmt.Errorf("共享 Codex daemon 恢复异常：%v", recovered)
+							}
+						}()
+						recoveryCtx, cancel := context.WithTimeout(
+							context.Background(),
+							sharedDaemonRecoveryAttemptTimeout,
+						)
+						defer cancel()
+						return recoverDaemon(recoveryCtx)
+					}()
+
+					mu.Lock()
+					lastErr = result
+					completedAt = now()
+					hasResult = true
+					if inFlight == attemptDone {
+						inFlight = nil
+					}
+					close(attemptDone)
+					mu.Unlock()
+				}(wait)
+			}
+			mu.Unlock()
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-wait:
+				mu.Lock()
+				result := lastErr
+				mu.Unlock()
+				return result
+			}
+		}
+	}
 }
 
 // EnableTailscaleHostMetadata 只由生产 serve 入口启用。测试构造器默认不启动外部 CLI，

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -210,19 +210,20 @@ func (r *Router) storeClaudeRuntimeQuota(limits *runtimeRateLimits) {
 // runtimeAccountStatus 只包含菜单栏需要的脱敏状态。账号邮箱、Token、Keychain
 // 内容和上游原始错误都不能进入这个结构，避免 status CLI 或日志扩大凭据暴露面。
 type runtimeAccountStatus struct {
-	ID         string                 `json:"id"`
-	Title      string                 `json:"title"`
-	Enabled    bool                   `json:"enabled"`
-	State      runtimeConnectionState `json:"state"`
-	Transport  string                 `json:"transport,omitempty"`
-	Shared     bool                   `json:"shared,omitempty"`
-	CodexHome  string                 `json:"codex_home,omitempty"`
-	Version    string                 `json:"version,omitempty"`
-	StartedAt  *time.Time             `json:"started_at,omitempty"`
-	AuthMode   string                 `json:"auth_mode,omitempty"`
-	PlanType   string                 `json:"plan_type,omitempty"`
-	Reason     string                 `json:"reason,omitempty"`
-	RateLimits *runtimeRateLimits     `json:"rate_limits,omitempty"`
+	ID                    string                 `json:"id"`
+	Title                 string                 `json:"title"`
+	Enabled               bool                   `json:"enabled"`
+	State                 runtimeConnectionState `json:"state"`
+	Transport             string                 `json:"transport,omitempty"`
+	Shared                bool                   `json:"shared,omitempty"`
+	DaemonRestartRequired *bool                  `json:"daemon_restart_required,omitempty"`
+	CodexHome             string                 `json:"codex_home,omitempty"`
+	Version               string                 `json:"version,omitempty"`
+	StartedAt             *time.Time             `json:"started_at,omitempty"`
+	AuthMode              string                 `json:"auth_mode,omitempty"`
+	PlanType              string                 `json:"plan_type,omitempty"`
+	Reason                string                 `json:"reason,omitempty"`
+	RateLimits            *runtimeRateLimits     `json:"rate_limits,omitempty"`
 }
 
 type runtimeRateLimits struct {
@@ -289,7 +290,27 @@ func (r *Router) runtimeStatusHandler(w http.ResponseWriter, req *http.Request) 
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
-	writeJSON(w, http.StatusOK, r.runtimeStatus.Snapshot())
+	writeJSON(w, http.StatusOK, r.withLiveSharedDaemonMigrationStatus(r.runtimeStatus.Snapshot()))
+}
+
+func (r *Router) withLiveSharedDaemonMigrationStatus(response runtimeStatusResponse) runtimeStatusResponse {
+	if r.sharedDaemonMigrationRequired == nil {
+		return response
+	}
+	required, err := r.sharedDaemonMigrationRequired()
+	if err != nil {
+		// 读取失败时保持 nil（未知），不能错误授权一次会中断客户端的迁移。
+		return response
+	}
+	response.Runtimes = append([]runtimeAccountStatus(nil), response.Runtimes...)
+	for index := range response.Runtimes {
+		if strings.EqualFold(response.Runtimes[index].ID, "codex") {
+			value := required
+			response.Runtimes[index].DaemonRestartRequired = &value
+			break
+		}
+	}
+	return response
 }
 
 // SetCodexRuntimeStartedAt 连接 serve 层托管的 resident Codex 进程与本机状态接口。

--- a/internal/httpapi/runtime_status_test.go
+++ b/internal/httpapi/runtime_status_test.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -61,6 +62,38 @@ func TestRuntimeStatusRequiresAuthAndReturnsSanitizedCodexSnapshot(t *testing.T)
 	claude := response.Runtimes[1]
 	if claude.ID != "claude" || claude.Enabled || claude.State != runtimeStateDisabled {
 		t.Fatalf("未启用 Claude 应保留灰态行：%+v", claude)
+	}
+}
+
+func TestRuntimeStatusOverlaysLiveSharedDaemonMigrationMarker(t *testing.T) {
+	required := true
+	router := &Router{
+		sharedDaemonMigrationRequired: func() (bool, error) { return required, nil },
+	}
+	cached := runtimeStatusResponse{Runtimes: []runtimeAccountStatus{
+		{ID: "codex", Title: "Codex"},
+		{ID: "claude", Title: "Claude"},
+	}}
+
+	first := router.withLiveSharedDaemonMigrationStatus(cached)
+	if first.Runtimes[0].DaemonRestartRequired == nil || !*first.Runtimes[0].DaemonRestartRequired {
+		t.Fatalf("必须覆盖实时待迁移状态：%+v", first.Runtimes[0])
+	}
+	if cached.Runtimes[0].DaemonRestartRequired != nil {
+		t.Fatal("实时覆盖不能污染五分钟缓存")
+	}
+	required = false
+	second := router.withLiveSharedDaemonMigrationStatus(cached)
+	if second.Runtimes[0].DaemonRestartRequired == nil || *second.Runtimes[0].DaemonRestartRequired {
+		t.Fatalf("清除标记后下一次请求必须立即变为 false：%+v", second.Runtimes[0])
+	}
+
+	router.sharedDaemonMigrationRequired = func() (bool, error) {
+		return false, fmt.Errorf("permission denied")
+	}
+	unknown := router.withLiveSharedDaemonMigrationStatus(cached)
+	if unknown.Runtimes[0].DaemonRestartRequired != nil {
+		t.Fatal("标记读取失败必须保持未知，不能授权迁移")
 	}
 }
 

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -182,7 +182,7 @@ func ConfigureClaude(
 	updated = append(updated, '\n')
 	changed := string(updated) != string(original)
 	if changed {
-		if err := writePrivateFileAtomically(cfgPath, updated); err != nil {
+		if err := writePrivateFileAtomicallyCAS(cfgPath, original, updated); err != nil {
 			return ClaudeConfigurationResult{}, fmt.Errorf("原子更新配置文件失败：%w", err)
 		}
 	}

--- a/internal/setup/codex.go
+++ b/internal/setup/codex.go
@@ -1,12 +1,15 @@
 package setup
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 type codexBinResolver func(configured string) (string, error)
@@ -81,7 +84,7 @@ func platformCodexCandidates() []string {
 // RepairCodexBin 只更新 codex.bin，并保留 auth、projects 及未来新增字段。
 // 写入复用私有文件的原子替换逻辑，避免修复中断后留下半份配置或放宽权限。
 func RepairCodexBin(configPath string) (string, bool, error) {
-	return repairCodexBin(configPath, ResolveCodexBin, writePrivateFileAtomically)
+	return repairCodexBin(configPath, ResolveCodexBin, nil)
 }
 
 func repairCodexBin(configPath string, resolve codexBinResolver, writeConfig configWriter) (string, bool, error) {
@@ -152,8 +155,37 @@ func repairCodexBin(configPath string, resolve codexBinResolver, writeConfig con
 		return "", false, fmt.Errorf("编码配置文件失败：%w", err)
 	}
 	updated = append(updated, '\n')
-	if err := writeConfig(cfgPath, updated); err != nil {
-		return "", false, fmt.Errorf("原子更新配置文件失败：%w", err)
+	var writeErr error
+	if writeConfig == nil {
+		validateOriginal := func() error {
+			current, readErr := os.ReadFile(cfgPath)
+			if readErr != nil {
+				return fmt.Errorf("重新读取配置失败：%w", readErr)
+			}
+			if !bytes.Equal(current, original) {
+				return fmt.Errorf("配置已被其他进程修改，请重新执行")
+			}
+			return nil
+		}
+		// codex.bin 是 stable-owner 身份的一部分。先取得 daemon operation
+		// lock，再以同一 raw snapshot CAS 提交。auto owner 可由新 agentd
+		// 按新路径重建；manual pending 必须保留，Doctor 不能替用户确认迁移。
+		// 当前 daemon 不会被停止，原生 Codex 流程不受影响。
+		commitCtx, cancelCommit := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancelCommit()
+		writeErr = commitConfigRepairingOwnedSharedDaemonIdentity(
+			commitCtx,
+			cfgPath,
+			validateOriginal,
+			func() error {
+				return writePrivateFileAtomicallyCAS(cfgPath, original, updated)
+			},
+		)
+	} else {
+		writeErr = writeConfig(cfgPath, updated)
+	}
+	if writeErr != nil {
+		return "", false, fmt.Errorf("原子更新配置文件失败：%w", writeErr)
 	}
 	return resolved, true, nil
 }

--- a/internal/setup/codex_darwin_test.go
+++ b/internal/setup/codex_darwin_test.go
@@ -1,0 +1,146 @@
+//go:build darwin
+
+package setup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+func TestRepairCodexBinWaitsForSharedDaemonOperation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	configPath := config.PlatformDefaultPath()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("{\n  \"codex\": {\"bin\": \"/stale/codex\"}\n}\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- appserver.CommitConfigWithSharedDaemonLock(
+			context.Background(),
+			func() error { return nil },
+			func() error {
+				close(entered)
+				<-release
+				return nil
+			},
+		)
+	}()
+	<-entered
+
+	repairDone := make(chan error, 1)
+	go func() {
+		_, _, err := repairCodexBin(
+			configPath,
+			func(string) (string, error) { return "/new/codex", nil },
+			nil,
+		)
+		repairDone <- err
+	}()
+	select {
+	case err := <-repairDone:
+		t.Fatalf("codex.bin 修复不得穿过 shared-daemon operation lock：%v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if err := <-lockDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-repairDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCustomConfigCommitDoesNotRemoveDefaultSharedDaemonOwner(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ownerPath, err := appserver.SharedDaemonLaunchAgentPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(ownerPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := []byte("default-owner-must-survive\n")
+	if err := os.WriteFile(ownerPath, sentinel, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	customPath := filepath.Join(t.TempDir(), "custom-profile.json")
+	committed := false
+	if err := commitConfigReplacingOwnedSharedDaemon(
+		context.Background(),
+		customPath,
+		func() error { return nil },
+		func() error {
+			committed = true
+			return nil
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !committed {
+		t.Fatal("自定义配置提交回调未执行")
+	}
+	got, err := os.ReadFile(ownerPath)
+	if err != nil {
+		t.Fatalf("自定义配置不能删除默认服务 owner：%v", err)
+	}
+	if string(got) != string(sentinel) {
+		t.Fatalf("自定义配置不能改写默认服务 owner：got=%q", got)
+	}
+}
+
+func TestLegacyCustomSharedDisablePreservesDefaultOwner(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	customPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	if _, err := configureCodexSharing(
+		context.Background(),
+		customPath,
+		true,
+		func(_ context.Context, options appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			return appserver.LocalDaemonStatus{
+				SocketPath: filepath.Join(options.Env["CODEX_HOME"], "app-server-control", "app-server-control.sock"),
+				Version:    "0.147.0",
+			}, nil
+		},
+		recoverableLifecycleInspector(t, codexHome),
+		noopRemoveSharedDaemonOwner,
+	); err != nil {
+		t.Fatalf("准备 legacy custom shared 配置失败：%v", err)
+	}
+	ownerPath, err := appserver.SharedDaemonLaunchAgentPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(ownerPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := []byte("default-owner-must-survive-custom-disable\n")
+	if err := os.WriteFile(ownerPath, sentinel, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ConfigureCodexSharing(context.Background(), customPath, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Enabled || result.Transport != "ws" || !result.Changed || result.Warning == "" {
+		t.Fatalf("legacy custom shared 应恢复 fallback：%+v", result)
+	}
+	got, err := os.ReadFile(ownerPath)
+	if err != nil || string(got) != string(sentinel) {
+		t.Fatalf("custom disable 不能触碰默认 owner：got=%q err=%v", got, err)
+	}
+}

--- a/internal/setup/codex_sharing.go
+++ b/internal/setup/codex_sharing.go
@@ -7,18 +7,29 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 )
 
+const codexSharingCleanupTimeout = 10 * time.Second
+
 type CodexSharingConfigurationResult struct {
-	Enabled         bool   `json:"enabled"`
-	Changed         bool   `json:"changed"`
-	RestartRequired bool   `json:"restart_required"`
-	Transport       string `json:"transport"`
-	CodexHome       string `json:"codex_home,omitempty"`
-	Message         string `json:"message"`
+	Enabled               bool   `json:"enabled"`
+	Changed               bool   `json:"changed"`
+	RestartRequired       bool   `json:"restart_required"`
+	DaemonRestartRequired bool   `json:"daemon_restart_required"`
+	Transport             string `json:"transport"`
+	CodexHome             string `json:"codex_home,omitempty"`
+	Message               string `json:"message"`
+}
+
+type CodexSharingDaemonRestartResult struct {
+	Restarted  bool   `json:"restarted"`
+	SocketPath string `json:"socket_path"`
+	Version    string `json:"version"`
+	Message    string `json:"message"`
 }
 
 type ensureLocalDaemonFunc func(
@@ -30,6 +41,13 @@ type inspectLocalDaemonLifecycleFunc func(
 	context.Context,
 	appserver.LocalDaemonOptions,
 ) (appserver.LocalDaemonLifecycleStatus, error)
+
+type removeSharedDaemonOwnerFunc func(context.Context) error
+
+type restartSharedDaemonFunc func(
+	context.Context,
+	appserver.LocalDaemonOptions,
+) (appserver.LocalDaemonStatus, error)
 
 // ConfigureCodexSharing 是从 legacy 独立 WS 进程切换到官方 local daemon 的
 // 唯一持久化入口。先确认 daemon 真正可握手，再原子提交配置，避免只设置 Desktop
@@ -45,6 +63,7 @@ func ConfigureCodexSharing(
 		enabled,
 		appserver.EnsureLocalDaemon,
 		appserver.InspectLocalDaemonLifecycle,
+		appserver.RemoveSharedDaemonOwner,
 	)
 }
 
@@ -54,6 +73,7 @@ func configureCodexSharing(
 	enabled bool,
 	ensureDaemon ensureLocalDaemonFunc,
 	inspectDaemon inspectLocalDaemonLifecycleFunc,
+	removeOwner removeSharedDaemonOwnerFunc,
 ) (CodexSharingConfigurationResult, error) {
 	resolvedPath, err := resolveConfigPath(configPath)
 	if err != nil {
@@ -72,34 +92,89 @@ func configureCodexSharing(
 	}
 
 	codexHome := ""
+	daemonRestartRequired := false
+	ownerCleanupRequired := false
+	var ownerRollback *appserver.SharedDaemonOwnerRollback
+	failBeforeCommit := func(cause error) (CodexSharingConfigurationResult, error) {
+		// 原请求可能已经超时，但回滚必须有独立且有上限的机会完成；Background
+		// 会在另一进程持锁时无限等待，最终被 Mac App 强杀并遗留半成品 owner。
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), codexSharingCleanupTimeout)
+		defer cancelCleanup()
+		if enabled && ownerRollback != nil {
+			if cleanupErr := appserver.RollbackSharedDaemonOwnerChange(cleanupCtx, ownerRollback); cleanupErr != nil {
+				return CodexSharingConfigurationResult{}, fmt.Errorf(
+					"准备共享 Codex 配置失败：%w；恢复原 daemon owner 也失败：%v",
+					cause,
+					cleanupErr,
+				)
+			}
+		} else if enabled && ownerCleanupRequired {
+			if cleanupErr := removeOwner(cleanupCtx); cleanupErr != nil {
+				return CodexSharingConfigurationResult{}, fmt.Errorf(
+					"准备共享 Codex 配置失败：%w；清理新建 daemon owner 也失败：%v",
+					cause,
+					cleanupErr,
+				)
+			}
+		}
+		return CodexSharingConfigurationResult{}, cause
+	}
 	if enabled {
-		status, err := ensureDaemon(ctx, appserver.LocalDaemonOptions{
-			CodexBin: cfg.Codex.Bin,
-			Env:      cfg.Codex.Env,
-		})
-		if err != nil {
-			return CodexSharingConfigurationResult{}, err
-		}
-		lifecycle, err := inspectDaemon(ctx, appserver.LocalDaemonOptions{
-			CodexBin: cfg.Codex.Bin,
-			Env:      cfg.Codex.Env,
-		})
-		if err != nil {
-			return CodexSharingConfigurationResult{}, fmt.Errorf("确认 Codex daemon 冷启动能力失败：%w", err)
-		}
-		if err := appserver.ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); err != nil {
-			return CodexSharingConfigurationResult{}, err
-		}
-		if err := appserver.ValidateLocalDaemonProbeVersion(lifecycle, status.Version); err != nil {
-			return CodexSharingConfigurationResult{}, err
-		}
-		codexHome = localDaemonCodexHome(status.SocketPath)
-		if strings.EqualFold(cfg.AppServer.Transport, "unix") {
+		transport := strings.ToLower(strings.TrimSpace(cfg.AppServer.Transport))
+		if transport == "unix" && cfg.AppServer.SharedFallback == nil {
+			// 这是用户或其他工具预先配置的 Unix backend。共享开关只允许
+			// Desktop attach；绝不能借“managed”字段替外部 owner 启动进程。
+			status, attachErr := ensureDaemon(ctx, appserver.LocalDaemonOptions{
+				CodexBin:   cfg.Codex.Bin,
+				Env:        cfg.Codex.Env,
+				AttachOnly: true,
+			})
+			if attachErr != nil {
+				return CodexSharingConfigurationResult{}, attachErr
+			}
 			return CodexSharingConfigurationResult{
 				Enabled:   true,
 				Transport: "unix",
-				CodexHome: codexHome,
-				Message:   codexSharingAlreadyEnabledMessage(cfg.AppServer.SharedFallback != nil),
+				CodexHome: localDaemonCodexHome(status.SocketPath),
+				Message:   codexSharingAlreadyEnabledMessage(false, false),
+			}, nil
+		}
+		status, err := ensureDaemon(ctx, appserver.LocalDaemonOptions{
+			CodexBin:    cfg.Codex.Bin,
+			Env:         cfg.Codex.Env,
+			StableOwner: true,
+		})
+		if err != nil {
+			return CodexSharingConfigurationResult{}, err
+		}
+		// 从非 Unix 配置启用失败时，本次新建或更新的 Mimi owner 都必须
+		// 清理，不能让默认 WS 用户下次登录被一个半成品 job 静默拉起。
+		ownerCleanupRequired = status.OwnerCreated || (transport != "unix" && status.OwnerChanged)
+		ownerRollback = status.OwnerRollback
+		daemonRestartRequired = status.OwnerMigrationRequired
+		if !status.LifecycleValidated {
+			lifecycle, err := inspectDaemon(ctx, appserver.LocalDaemonOptions{
+				CodexBin: cfg.Codex.Bin,
+				Env:      cfg.Codex.Env,
+			})
+			if err != nil {
+				return failBeforeCommit(fmt.Errorf("确认 Codex daemon 冷启动能力失败：%w", err))
+			}
+			if err := appserver.ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); err != nil {
+				return failBeforeCommit(err)
+			}
+			if err := appserver.ValidateLocalDaemonProbeVersion(lifecycle, status.Version); err != nil {
+				return failBeforeCommit(err)
+			}
+		}
+		codexHome = localDaemonCodexHome(status.SocketPath)
+		if transport == "unix" {
+			return CodexSharingConfigurationResult{
+				Enabled:               true,
+				Transport:             "unix",
+				CodexHome:             codexHome,
+				DaemonRestartRequired: daemonRestartRequired,
+				Message:               codexSharingAlreadyEnabledMessage(cfg.AppServer.SharedFallback != nil, daemonRestartRequired),
 			}, nil
 		}
 	} else {
@@ -121,9 +196,13 @@ func configureCodexSharing(
 		}
 	}
 
+	original, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return failBeforeCommit(fmt.Errorf("读取配置失败：%w", err))
+	}
 	document, appServerDocument, err := readCodexSharingConfigDocument(resolvedPath)
 	if err != nil {
-		return CodexSharingConfigurationResult{}, err
+		return failBeforeCommit(err)
 	}
 	next := cfg
 	if enabled {
@@ -154,34 +233,100 @@ func configureCodexSharing(
 		next.AppServer.SharedFallback = nil
 	}
 	if err := next.Validate(); err != nil {
-		return CodexSharingConfigurationResult{}, fmt.Errorf("共享 Codex 配置无效：%w", err)
+		return failBeforeCommit(fmt.Errorf("共享 Codex 配置无效：%w", err))
 	}
 	if err := encodeCodexSharingAppServer(appServerDocument, next.AppServer); err != nil {
-		return CodexSharingConfigurationResult{}, err
+		return failBeforeCommit(err)
 	}
 	encodedAppServer, err := json.Marshal(appServerDocument)
 	if err != nil {
-		return CodexSharingConfigurationResult{}, fmt.Errorf("编码 app_server 配置失败：%w", err)
+		return failBeforeCommit(fmt.Errorf("编码 app_server 配置失败：%w", err))
 	}
 	document["app_server"] = encodedAppServer
 	updated, err := json.MarshalIndent(document, "", "  ")
 	if err != nil {
-		return CodexSharingConfigurationResult{}, fmt.Errorf("编码配置失败：%w", err)
+		return failBeforeCommit(fmt.Errorf("编码配置失败：%w", err))
 	}
 	updated = append(updated, '\n')
 	if err := writePrivateFileAtomically(resolvedPath, updated); err != nil {
-		return CodexSharingConfigurationResult{}, fmt.Errorf("写入共享 Codex 配置失败：%w", err)
+		return failBeforeCommit(fmt.Errorf("写入共享 Codex 配置失败：%w", err))
+	}
+	if !enabled {
+		if err := removeOwner(ctx); err != nil {
+			if rollbackErr := writePrivateFileAtomically(resolvedPath, original); rollbackErr != nil {
+				return CodexSharingConfigurationResult{}, fmt.Errorf(
+					"卸载共享 daemon owner 失败：%v；恢复原配置也失败：%w",
+					err,
+					rollbackErr,
+				)
+			}
+			return CodexSharingConfigurationResult{}, fmt.Errorf("卸载共享 daemon owner 失败，已恢复原配置：%w", err)
+		}
 	}
 
 	transport := strings.ToLower(strings.TrimSpace(next.AppServer.Transport))
 	return CodexSharingConfigurationResult{
-		Enabled:         enabled,
-		Changed:         true,
-		RestartRequired: true,
-		Transport:       transport,
-		CodexHome:       codexHome,
-		Message:         codexSharingMessage(enabled),
+		Enabled:               enabled,
+		Changed:               true,
+		RestartRequired:       true,
+		DaemonRestartRequired: daemonRestartRequired,
+		Transport:             transport,
+		CodexHome:             codexHome,
+		Message:               codexSharingMessage(enabled, daemonRestartRequired),
 	}, nil
+}
+
+// RestartCodexSharingDaemon 只供 Mac App 在用户确认“应用待处理设置”后调用。配置未由
+// Mimi 切换到 shared unix 时拒绝执行，避免碰触外部部署方管理的 daemon。
+func RestartCodexSharingDaemon(
+	ctx context.Context,
+	configPath string,
+) (CodexSharingDaemonRestartResult, error) {
+	return restartCodexSharingDaemon(
+		ctx,
+		configPath,
+		appserver.RestartSharedDaemonWithStableOwner,
+	)
+}
+
+func restartCodexSharingDaemon(
+	ctx context.Context,
+	configPath string,
+	restartDaemon restartSharedDaemonFunc,
+) (CodexSharingDaemonRestartResult, error) {
+	resolvedPath, err := resolveConfigPath(configPath)
+	if err != nil {
+		return CodexSharingDaemonRestartResult{}, err
+	}
+	cfg, err := config.Load(resolvedPath)
+	if err != nil {
+		return CodexSharingDaemonRestartResult{}, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") ||
+		cfg.AppServer.SharedFallback == nil {
+		return CodexSharingDaemonRestartResult{}, fmt.Errorf("当前 Codex backend 不是 Mimi 管理的共享 daemon")
+	}
+	options := appserver.LocalDaemonOptions{CodexBin: cfg.Codex.Bin, Env: cfg.Codex.Env, StableOwner: true}
+	status, err := restartDaemon(ctx, options)
+	if err != nil {
+		return CodexSharingDaemonRestartResult{}, err
+	}
+	// appserver 在同一把跨进程锁内完成 stop、kickstart、协议/生命周期/
+	// 版本校验，最后才清除 migration marker。这里不能在提交点之后再做
+	// 一次可失败的重复校验，否则瞬时读失败会“报错但已丢失可重试标记”。
+	return CodexSharingDaemonRestartResult{
+		Restarted:  status.Started,
+		SocketPath: status.SocketPath,
+		Version:    status.Version,
+		Message:    codexSharingDaemonRestartMessage(status.Started),
+	}, nil
+}
+
+func codexSharingDaemonRestartMessage(restarted bool) string {
+	if restarted {
+		return "共享 Codex daemon 已由稳定 launchd owner 重新创建。"
+	}
+	return "共享 Codex daemon 已由稳定 launchd owner 管理，无需重复重启。"
 }
 
 func localDaemonCodexHome(socketPath string) string {
@@ -246,15 +391,21 @@ func encodeCodexSharingAppServer(
 	return nil
 }
 
-func codexSharingMessage(enabled bool) string {
+func codexSharingMessage(enabled bool, daemonRestartRequired bool) string {
 	if enabled {
+		if daemonRestartRequired {
+			return "共享 Codex app-server 已启用；请使用 Mac App 的“应用待处理设置”迁移旧 daemon；若 Codex Desktop 正在运行，成功后会重新打开。"
+		}
 		return "共享 Codex app-server 已启用；重启 agentd 和 Codex Desktop 后生效。"
 	}
 	return "共享 Codex app-server 已关闭；重启 agentd 和 Codex Desktop 后生效。"
 }
 
-func codexSharingAlreadyEnabledMessage(owned bool) string {
+func codexSharingAlreadyEnabledMessage(owned bool, daemonRestartRequired bool) string {
 	if owned {
+		if daemonRestartRequired {
+			return "Codex Desktop 与 Mimi 已配置为共用本地 app-server，但稳定 owner 迁移尚未完成；请在 Mac App 中选择“应用待处理设置”。"
+		}
 		return "Codex Desktop 与 Mimi 已配置为共用本地 app-server。"
 	}
 	return "已检测到外部管理的 Unix app-server；Mimi 只配置 Desktop 环境，不会在关闭时覆盖该 backend。"

--- a/internal/setup/codex_sharing.go
+++ b/internal/setup/codex_sharing.go
@@ -1,19 +1,17 @@
 package setup
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 )
-
-const codexSharingCleanupTimeout = 10 * time.Second
 
 type CodexSharingConfigurationResult struct {
 	Enabled               bool   `json:"enabled"`
@@ -22,6 +20,7 @@ type CodexSharingConfigurationResult struct {
 	DaemonRestartRequired bool   `json:"daemon_restart_required"`
 	Transport             string `json:"transport"`
 	CodexHome             string `json:"codex_home,omitempty"`
+	Warning               string `json:"warning,omitempty"`
 	Message               string `json:"message"`
 }
 
@@ -49,6 +48,23 @@ type restartSharedDaemonFunc func(
 	appserver.LocalDaemonOptions,
 ) (appserver.LocalDaemonStatus, error)
 
+type commitSharedDaemonDisableFunc func(
+	context.Context,
+	func() error,
+	func() error,
+) error
+
+type commitSharedDaemonEnableFunc func(
+	context.Context,
+	appserver.LocalDaemonOptions,
+	func() error,
+	func() error,
+) (appserver.LocalDaemonStatus, error)
+
+// 单独保留读取 seam，只用于验证 typed config、未知字段 document 与 CAS
+// baseline 确实来自同一份 bytes；生产始终调用 os.ReadFile。
+var readCodexSharingConfigFile = os.ReadFile
+
 // ConfigureCodexSharing 是从 legacy 独立 WS 进程切换到官方 local daemon 的
 // 唯一持久化入口。先确认 daemon 真正可握手，再原子提交配置，避免只设置 Desktop
 // 环境却让 agentd 继续使用另一进程，重新制造 writer lock 冲突。
@@ -57,14 +73,43 @@ func ConfigureCodexSharing(
 	configPath string,
 	enabled bool,
 ) (CodexSharingConfigurationResult, error) {
-	return configureCodexSharing(
+	// 空路径与其他 setup API 一样表示默认配置。必须在判断默认 owner 归属前
+	// 先解析，否则 disable 会把默认 shared 配置改回 WS，却误走 custom 分支
+	// 而留下用户全局的 RunAtLoad owner。
+	resolvedPath, platformDefault, err := resolveCodexSharingTarget(configPath, enabled)
+	if err != nil {
+		return CodexSharingConfigurationResult{}, err
+	}
+	commitDisable := commitSharedDaemonDisableFunc(appserver.CommitSharedDaemonDisable)
+	if !platformDefault {
+		// 旧版本曾允许 custom profile 开启 direct shared。升级后必须允许它
+		// 恢复自己的 fallback，但 custom profile 永远不能移除平台默认配置
+		// 所有的用户全局 LaunchAgent。
+		commitDisable = func(ctx context.Context, validate func() error, commit func() error) error {
+			return appserver.CommitConfigWithSharedDaemonLock(ctx, validate, commit)
+		}
+	}
+	return configureCodexSharingWithTransactions(
 		ctx,
-		configPath,
+		resolvedPath,
 		enabled,
 		appserver.EnsureLocalDaemon,
 		appserver.InspectLocalDaemonLifecycle,
 		appserver.RemoveSharedDaemonOwner,
+		appserver.CommitSharedDaemonEnable,
+		commitDisable,
 	)
+}
+
+func resolveCodexSharingTarget(configPath string, enabled bool) (string, bool, error) {
+	resolvedPath, err := resolveConfigPath(configPath)
+	if err != nil {
+		return "", false, err
+	}
+	if err := validateStableSharedDaemonTarget(resolvedPath, enabled); err != nil {
+		return "", false, err
+	}
+	return resolvedPath, config.IsPlatformDefaultPath(resolvedPath), nil
 }
 
 func configureCodexSharing(
@@ -74,6 +119,73 @@ func configureCodexSharing(
 	ensureDaemon ensureLocalDaemonFunc,
 	inspectDaemon inspectLocalDaemonLifecycleFunc,
 	removeOwner removeSharedDaemonOwnerFunc,
+) (CodexSharingConfigurationResult, error) {
+	return configureCodexSharingWithTransactions(
+		ctx,
+		configPath,
+		enabled,
+		ensureDaemon,
+		inspectDaemon,
+		removeOwner,
+		func(
+			ctx context.Context,
+			options appserver.LocalDaemonOptions,
+			validate func() error,
+			commit func() error,
+		) (appserver.LocalDaemonStatus, error) {
+			if err := validate(); err != nil {
+				return appserver.LocalDaemonStatus{}, err
+			}
+			status, err := ensureDaemon(ctx, options)
+			if err != nil {
+				return appserver.LocalDaemonStatus{}, err
+			}
+			cleanupPreparedOwner := func(cause error) (appserver.LocalDaemonStatus, error) {
+				if status.OwnerCreated || status.OwnerChanged {
+					if cleanupErr := removeOwner(context.Background()); cleanupErr != nil {
+						return appserver.LocalDaemonStatus{}, fmt.Errorf("%w；清理未提交的共享 daemon owner 也失败：%v", cause, cleanupErr)
+					}
+				}
+				return appserver.LocalDaemonStatus{}, cause
+			}
+			if !status.LifecycleValidated {
+				lifecycle, inspectErr := inspectDaemon(ctx, options)
+				if inspectErr != nil {
+					return cleanupPreparedOwner(inspectErr)
+				}
+				if validateErr := appserver.ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); validateErr != nil {
+					return cleanupPreparedOwner(validateErr)
+				}
+				if validateErr := appserver.ValidateLocalDaemonProbeVersion(lifecycle, status.Version); validateErr != nil {
+					return cleanupPreparedOwner(validateErr)
+				}
+			}
+			if err := commit(); err != nil {
+				return cleanupPreparedOwner(err)
+			}
+			return status, nil
+		},
+		func(ctx context.Context, validate func() error, commit func() error) error {
+			if err := validate(); err != nil {
+				return err
+			}
+			if err := removeOwner(ctx); err != nil {
+				return err
+			}
+			return commit()
+		},
+	)
+}
+
+func configureCodexSharingWithTransactions(
+	ctx context.Context,
+	configPath string,
+	enabled bool,
+	ensureDaemon ensureLocalDaemonFunc,
+	inspectDaemon inspectLocalDaemonLifecycleFunc,
+	removeOwner removeSharedDaemonOwnerFunc,
+	commitEnable commitSharedDaemonEnableFunc,
+	commitDisable commitSharedDaemonDisableFunc,
 ) (CodexSharingConfigurationResult, error) {
 	resolvedPath, err := resolveConfigPath(configPath)
 	if err != nil {
@@ -86,41 +198,32 @@ func configureCodexSharing(
 	if !existed {
 		return CodexSharingConfigurationResult{}, fmt.Errorf("配置文件不存在，请先完成 Mimi Remote 设置")
 	}
-	cfg, err := config.Load(resolvedPath)
+	original, err := readCodexSharingConfigFile(resolvedPath)
+	if err != nil {
+		return CodexSharingConfigurationResult{}, fmt.Errorf("读取配置失败：%w", err)
+	}
+	// typed cfg、保留未知字段的 JSON document 与后续 CAS 必须来自同一次
+	// ReadFile。分开 Load(path)/ReadFile(path) 会在并发写入时把两代配置拼接，
+	// 让旧操作错误取得新快照的提交权。
+	cfg, err := config.LoadSnapshot(original)
 	if err != nil {
 		return CodexSharingConfigurationResult{}, err
+	}
+	validateOriginal := func() error {
+		current, readErr := readCodexSharingConfigFile(resolvedPath)
+		if readErr != nil {
+			return fmt.Errorf("重新读取配置失败：%w", readErr)
+		}
+		if !bytes.Equal(current, original) {
+			return fmt.Errorf("配置已被其他进程修改，请重新执行")
+		}
+		return nil
 	}
 
 	codexHome := ""
 	daemonRestartRequired := false
-	ownerCleanupRequired := false
-	var ownerRollback *appserver.SharedDaemonOwnerRollback
-	failBeforeCommit := func(cause error) (CodexSharingConfigurationResult, error) {
-		// 原请求可能已经超时，但回滚必须有独立且有上限的机会完成；Background
-		// 会在另一进程持锁时无限等待，最终被 Mac App 强杀并遗留半成品 owner。
-		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), codexSharingCleanupTimeout)
-		defer cancelCleanup()
-		if enabled && ownerRollback != nil {
-			if cleanupErr := appserver.RollbackSharedDaemonOwnerChange(cleanupCtx, ownerRollback); cleanupErr != nil {
-				return CodexSharingConfigurationResult{}, fmt.Errorf(
-					"准备共享 Codex 配置失败：%w；恢复原 daemon owner 也失败：%v",
-					cause,
-					cleanupErr,
-				)
-			}
-		} else if enabled && ownerCleanupRequired {
-			if cleanupErr := removeOwner(cleanupCtx); cleanupErr != nil {
-				return CodexSharingConfigurationResult{}, fmt.Errorf(
-					"准备共享 Codex 配置失败：%w；清理新建 daemon owner 也失败：%v",
-					cause,
-					cleanupErr,
-				)
-			}
-		}
-		return CodexSharingConfigurationResult{}, cause
-	}
+	transport := strings.ToLower(strings.TrimSpace(cfg.AppServer.Transport))
 	if enabled {
-		transport := strings.ToLower(strings.TrimSpace(cfg.AppServer.Transport))
 		if transport == "unix" && cfg.AppServer.SharedFallback == nil {
 			// 这是用户或其他工具预先配置的 Unix backend。共享开关只允许
 			// Desktop attach；绝不能借“managed”字段替外部 owner 启动进程。
@@ -139,36 +242,37 @@ func configureCodexSharing(
 				Message:   codexSharingAlreadyEnabledMessage(false, false),
 			}, nil
 		}
-		status, err := ensureDaemon(ctx, appserver.LocalDaemonOptions{
-			CodexBin:    cfg.Codex.Bin,
-			Env:         cfg.Codex.Env,
-			StableOwner: true,
-		})
-		if err != nil {
-			return CodexSharingConfigurationResult{}, err
-		}
-		// 从非 Unix 配置启用失败时，本次新建或更新的 Mimi owner 都必须
-		// 清理，不能让默认 WS 用户下次登录被一个半成品 job 静默拉起。
-		ownerCleanupRequired = status.OwnerCreated || (transport != "unix" && status.OwnerChanged)
-		ownerRollback = status.OwnerRollback
-		daemonRestartRequired = status.OwnerMigrationRequired
-		if !status.LifecycleValidated {
-			lifecycle, err := inspectDaemon(ctx, appserver.LocalDaemonOptions{
-				CodexBin: cfg.Codex.Bin,
-				Env:      cfg.Codex.Env,
-			})
-			if err != nil {
-				return failBeforeCommit(fmt.Errorf("确认 Codex daemon 冷启动能力失败：%w", err))
-			}
-			if err := appserver.ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); err != nil {
-				return failBeforeCommit(err)
-			}
-			if err := appserver.ValidateLocalDaemonProbeVersion(lifecycle, status.Version); err != nil {
-				return failBeforeCommit(err)
-			}
-		}
-		codexHome = localDaemonCodexHome(status.SocketPath)
 		if transport == "unix" {
+			options := appserver.LocalDaemonOptions{
+				CodexBin:    cfg.Codex.Bin,
+				Env:         cfg.Codex.Env,
+				StableOwner: true,
+				ValidateStableOwner: func() error {
+					return config.ValidateSharedDaemonRecoveryOwnership(
+						resolvedPath,
+						cfg.Codex.Bin,
+						cfg.Codex.Env,
+					)
+				},
+			}
+			status, ensureErr := ensureDaemon(ctx, options)
+			if ensureErr != nil {
+				return CodexSharingConfigurationResult{}, ensureErr
+			}
+			if !status.LifecycleValidated {
+				lifecycle, inspectErr := inspectDaemon(ctx, options)
+				if inspectErr != nil {
+					return CodexSharingConfigurationResult{}, fmt.Errorf("确认 Codex daemon 冷启动能力失败：%w", inspectErr)
+				}
+				if validateErr := appserver.ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); validateErr != nil {
+					return CodexSharingConfigurationResult{}, validateErr
+				}
+				if validateErr := appserver.ValidateLocalDaemonProbeVersion(lifecycle, status.Version); validateErr != nil {
+					return CodexSharingConfigurationResult{}, validateErr
+				}
+			}
+			codexHome = localDaemonCodexHome(status.SocketPath)
+			daemonRestartRequired = status.OwnerMigrationRequired
 			return CodexSharingConfigurationResult{
 				Enabled:               true,
 				Transport:             "unix",
@@ -178,7 +282,16 @@ func configureCodexSharing(
 			}, nil
 		}
 	} else {
-		if !strings.EqualFold(cfg.AppServer.Transport, "unix") {
+		if transport != "unix" {
+			// 上一次关闭可能已提交 WS 配置，却在卸载 Mimi 专属 owner 前进程
+			// 退出。关闭操作必须可重入：即使配置已经是非 Unix，也再次收敛
+			// plist/loaded job/marker，避免残留 owner 在下次登录继续自启。
+			if commitDisable == nil {
+				return CodexSharingConfigurationResult{}, fmt.Errorf("禁用共享 daemon 缺少原子清理能力")
+			}
+			if err := commitDisable(ctx, validateOriginal, func() error { return nil }); err != nil {
+				return CodexSharingConfigurationResult{}, fmt.Errorf("清理残留共享 daemon owner 失败：%w", err)
+			}
 			return CodexSharingConfigurationResult{
 				Enabled:   false,
 				Transport: cfg.AppServer.Transport,
@@ -187,7 +300,14 @@ func configureCodexSharing(
 		}
 		if cfg.AppServer.SharedFallback == nil {
 			// 当前 Unix transport 不是 Mimi 从 WS 切换而来，因此没有可验证的
-			// 原配置可恢复。关闭 Desktop 环境即可；绝不能虚构默认 WS 覆盖外部配置。
+			// 原配置可恢复。只清理 Mimi 自己可能残留的 owner，绝不能虚构
+			// 默认 WS 覆盖外部配置，也不会停止当前外部 daemon。
+			if commitDisable == nil {
+				return CodexSharingConfigurationResult{}, fmt.Errorf("禁用共享 daemon 缺少原子清理能力")
+			}
+			if err := commitDisable(ctx, validateOriginal, func() error { return nil }); err != nil {
+				return CodexSharingConfigurationResult{}, fmt.Errorf("清理残留共享 daemon owner 失败：%w", err)
+			}
 			return CodexSharingConfigurationResult{
 				Enabled:   false,
 				Transport: "unix",
@@ -196,13 +316,9 @@ func configureCodexSharing(
 		}
 	}
 
-	original, err := os.ReadFile(resolvedPath)
+	document, appServerDocument, err := parseCodexSharingConfigDocument(original)
 	if err != nil {
-		return failBeforeCommit(fmt.Errorf("读取配置失败：%w", err))
-	}
-	document, appServerDocument, err := readCodexSharingConfigDocument(resolvedPath)
-	if err != nil {
-		return failBeforeCommit(err)
+		return CodexSharingConfigurationResult{}, err
 	}
 	next := cfg
 	if enabled {
@@ -233,38 +349,80 @@ func configureCodexSharing(
 		next.AppServer.SharedFallback = nil
 	}
 	if err := next.Validate(); err != nil {
-		return failBeforeCommit(fmt.Errorf("共享 Codex 配置无效：%w", err))
+		return CodexSharingConfigurationResult{}, fmt.Errorf("共享 Codex 配置无效：%w", err)
 	}
 	if err := encodeCodexSharingAppServer(appServerDocument, next.AppServer); err != nil {
-		return failBeforeCommit(err)
+		return CodexSharingConfigurationResult{}, err
 	}
 	encodedAppServer, err := json.Marshal(appServerDocument)
 	if err != nil {
-		return failBeforeCommit(fmt.Errorf("编码 app_server 配置失败：%w", err))
+		return CodexSharingConfigurationResult{}, fmt.Errorf("编码 app_server 配置失败：%w", err)
 	}
 	document["app_server"] = encodedAppServer
 	updated, err := json.MarshalIndent(document, "", "  ")
 	if err != nil {
-		return failBeforeCommit(fmt.Errorf("编码配置失败：%w", err))
+		return CodexSharingConfigurationResult{}, fmt.Errorf("编码配置失败：%w", err)
 	}
 	updated = append(updated, '\n')
-	if err := writePrivateFileAtomically(resolvedPath, updated); err != nil {
-		return failBeforeCommit(fmt.Errorf("写入共享 Codex 配置失败：%w", err))
+	commitConfig := func() error {
+		// daemon 准备可能持续数秒；最终 CAS 与 rename 共用 Mimi 配置提交锁，
+		// 避免 Claude/network/另一条 sharing 命令在两步间互相覆盖。
+		if err := writePrivateFileAtomicallyCAS(resolvedPath, original, updated); err != nil {
+			return fmt.Errorf("写入共享 Codex 配置失败：%w", err)
+		}
+		return nil
 	}
-	if !enabled {
-		if err := removeOwner(ctx); err != nil {
-			if rollbackErr := writePrivateFileAtomically(resolvedPath, original); rollbackErr != nil {
-				return CodexSharingConfigurationResult{}, fmt.Errorf(
-					"卸载共享 daemon owner 失败：%v；恢复原配置也失败：%w",
-					err,
-					rollbackErr,
-				)
+	if enabled {
+		if commitEnable == nil {
+			return CodexSharingConfigurationResult{}, fmt.Errorf("启用共享 daemon 缺少两阶段提交能力")
+		}
+		status, commitErr := commitEnable(
+			ctx,
+			appserver.LocalDaemonOptions{
+				CodexBin:                    cfg.Codex.Bin,
+				Env:                         cfg.Codex.Env,
+				StableOwner:                 true,
+				PrepareOwnerForConfigCommit: true,
+			},
+			validateOriginal,
+			commitConfig,
+		)
+		if commitErr != nil {
+			if !status.ConfigCommitted {
+				return CodexSharingConfigurationResult{}, commitErr
 			}
-			return CodexSharingConfigurationResult{}, fmt.Errorf("卸载共享 daemon owner 失败，已恢复原配置：%w", err)
+			// 配置 rename 是提交点。其后的 daemon start/握手失败必须仍以
+			// enabled+pending 的机器可读结果返回，让 Mac App 重载 shared 配置
+			// 并显示“应用待处理设置”，而不是留在旧 WS Router 且无恢复入口。
+			codexHome = localDaemonCodexHome(status.SocketPath)
+			daemonRestartRequired = true
+			return CodexSharingConfigurationResult{
+				Enabled:               true,
+				Changed:               true,
+				RestartRequired:       true,
+				DaemonRestartRequired: true,
+				Transport:             "unix",
+				CodexHome:             codexHome,
+				Warning:               commitErr.Error(),
+				Message:               "共享 Codex 配置已提交；daemon 启动未完成，请重载服务后使用“应用待处理设置”恢复。",
+			}, nil
+		}
+		codexHome = localDaemonCodexHome(status.SocketPath)
+		daemonRestartRequired = status.OwnerMigrationRequired
+	} else {
+		if commitDisable == nil {
+			return CodexSharingConfigurationResult{}, fmt.Errorf("禁用共享 daemon 缺少原子提交能力")
+		}
+		if err := commitDisable(ctx, validateOriginal, commitConfig); err != nil {
+			return CodexSharingConfigurationResult{}, err
 		}
 	}
 
-	transport := strings.ToLower(strings.TrimSpace(next.AppServer.Transport))
+	transport = strings.ToLower(strings.TrimSpace(next.AppServer.Transport))
+	warning := ""
+	if !enabled && !config.IsPlatformDefaultPath(resolvedPath) {
+		warning = "已恢复自定义配置的 fallback；未触碰平台默认配置所拥有的共享 daemon owner。"
+	}
 	return CodexSharingConfigurationResult{
 		Enabled:               enabled,
 		Changed:               true,
@@ -272,6 +430,7 @@ func configureCodexSharing(
 		DaemonRestartRequired: daemonRestartRequired,
 		Transport:             transport,
 		CodexHome:             codexHome,
+		Warning:               warning,
 		Message:               codexSharingMessage(enabled, daemonRestartRequired),
 	}, nil
 }
@@ -282,11 +441,30 @@ func RestartCodexSharingDaemon(
 	ctx context.Context,
 	configPath string,
 ) (CodexSharingDaemonRestartResult, error) {
+	if err := validateStableSharedDaemonTarget(configPath, true); err != nil {
+		return CodexSharingDaemonRestartResult{}, err
+	}
 	return restartCodexSharingDaemon(
 		ctx,
 		configPath,
 		appserver.RestartSharedDaemonWithStableOwner,
 	)
+}
+
+func validateStableSharedDaemonTarget(configPath string, enabling bool) error {
+	// 非 macOS 旧版本可能已经写入 Mimi shared 配置。升级后仍允许 disable
+	// 回退到保存的 fallback；只拒绝继续启用或执行 owner restart。
+	if enabling && !appserver.SupportsStableSharedDaemonOwner() {
+		return fmt.Errorf("Codex 完整共享 daemon owner 当前仅支持 macOS")
+	}
+	resolvedPath, err := resolveConfigPath(configPath)
+	if err != nil {
+		return err
+	}
+	if enabling && appserver.SupportsStableSharedDaemonOwner() && !config.IsPlatformDefaultPath(resolvedPath) {
+		return fmt.Errorf("Codex 完整共享 daemon 只能使用平台默认配置：%s", config.PlatformDefaultPath())
+	}
+	return nil
 }
 
 func restartCodexSharingDaemon(
@@ -306,7 +484,14 @@ func restartCodexSharingDaemon(
 		cfg.AppServer.SharedFallback == nil {
 		return CodexSharingDaemonRestartResult{}, fmt.Errorf("当前 Codex backend 不是 Mimi 管理的共享 daemon")
 	}
-	options := appserver.LocalDaemonOptions{CodexBin: cfg.Codex.Bin, Env: cfg.Codex.Env, StableOwner: true}
+	options := appserver.LocalDaemonOptions{
+		CodexBin:    cfg.Codex.Bin,
+		Env:         cfg.Codex.Env,
+		StableOwner: true,
+		ValidateStableOwner: func() error {
+			return config.ValidateSharedDaemonRecoveryOwnership(resolvedPath, cfg.Codex.Bin, cfg.Codex.Env)
+		},
+	}
 	status, err := restartDaemon(ctx, options)
 	if err != nil {
 		return CodexSharingDaemonRestartResult{}, err
@@ -336,15 +521,11 @@ func localDaemonCodexHome(socketPath string) string {
 	return filepath.Dir(filepath.Dir(filepath.Clean(socketPath)))
 }
 
-func readCodexSharingConfigDocument(path string) (
+func parseCodexSharingConfigDocument(raw []byte) (
 	map[string]json.RawMessage,
 	map[string]json.RawMessage,
 	error,
 ) {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("读取配置失败：%w", err)
-	}
 	document := map[string]json.RawMessage{}
 	if err := json.Unmarshal(raw, &document); err != nil {
 		return nil, nil, fmt.Errorf("解析配置文件失败：%w", err)

--- a/internal/setup/codex_sharing.go
+++ b/internal/setup/codex_sharing.go
@@ -476,12 +476,14 @@ func restartCodexSharingDaemon(
 	if err != nil {
 		return CodexSharingDaemonRestartResult{}, err
 	}
-	cfg, err := config.Load(resolvedPath)
+	// Desktop 此时可能已经按用户确认正常退出。控制面只读取 daemon 身份，
+	// 不能让无关的 scan_roots I/O 再把迁移挡在生命周期操作之前。
+	cfg, err := config.LoadSharedDaemonControlConfig(resolvedPath)
 	if err != nil {
 		return CodexSharingDaemonRestartResult{}, err
 	}
 	if !strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") ||
-		cfg.AppServer.SharedFallback == nil {
+		!cfg.AppServer.Managed || cfg.AppServer.SharedFallback == nil {
 		return CodexSharingDaemonRestartResult{}, fmt.Errorf("当前 Codex backend 不是 Mimi 管理的共享 daemon")
 	}
 	options := appserver.LocalDaemonOptions{

--- a/internal/setup/codex_sharing_test.go
+++ b/internal/setup/codex_sharing_test.go
@@ -7,13 +7,36 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gaixianggeng/mimi-remote/internal/appserver"
+	"github.com/gaixianggeng/mimi-remote/internal/config"
 )
+
+func TestResolveCodexSharingTargetTreatsEmptyPathAsPlatformDefault(t *testing.T) {
+	clearSetupEnv(t)
+	resolved, platformDefault, err := resolveCodexSharingTarget("", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !platformDefault || !config.SameConfigPath(resolved, config.PlatformDefaultPath()) {
+		t.Fatalf("空路径必须解析到平台默认配置并使用默认 owner 事务：path=%q default=%t", resolved, platformDefault)
+	}
+}
+
+func TestStableSharedDaemonTargetAllowsLegacyCustomDisable(t *testing.T) {
+	customPath := filepath.Join(t.TempDir(), "legacy-custom.json")
+	if err := validateStableSharedDaemonTarget(customPath, false); err != nil {
+		t.Fatalf("升级后必须允许 custom/非 macOS 旧 shared 配置回退：%v", err)
+	}
+	if err := validateStableSharedDaemonTarget(customPath, true); err == nil {
+		t.Fatal("完整 stable-owner 共享不能继续从 custom profile 启用")
+	}
+}
 
 func TestConfigureCodexSharingRoundTripsLegacyFallback(t *testing.T) {
 	clearSetupEnv(t)
@@ -24,8 +47,8 @@ func TestConfigureCodexSharingRoundTripsLegacyFallback(t *testing.T) {
 		if options.CodexBin != "/test/codex" || options.Env["CODEX_HOME"] != codexHome {
 			t.Fatalf("daemon options 未沿用 Codex 配置：%+v", options)
 		}
-		if !options.StableOwner || options.AttachOnly {
-			t.Fatalf("Mimi 从 WS 切换时必须使用稳定 owner：%+v", options)
+		if !options.StableOwner || !options.PrepareOwnerForConfigCommit || options.RollbackOwnerOnFailure || options.AttachOnly {
+			t.Fatalf("Mimi 从 WS 切换时必须使用 manual owner 两阶段事务：%+v", options)
 		}
 		return appserver.LocalDaemonStatus{
 			SocketPath:             filepath.Join(codexHome, "app-server-control", "app-server-control.sock"),
@@ -162,6 +185,32 @@ func TestConfigureCodexSharingOwnerRemovalFailureRestoresSharedConfig(t *testing
 	}
 }
 
+func TestConfigureCodexSharingDisabledRetryCleansResidualOwner(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, _, _ := writeCodexSharingTestConfig(t)
+	removeCalls := 0
+	result, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		false,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			t.Fatal("已是 WS 配置时不能启动或探测 daemon")
+			return appserver.LocalDaemonStatus{}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		func(context.Context) error {
+			removeCalls++
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Enabled || result.Changed || result.RestartRequired || result.Transport != "ws" || removeCalls != 1 {
+		t.Fatalf("禁用重试必须幂等清理残留 owner：calls=%d result=%+v", removeCalls, result)
+	}
+}
+
 func TestRestartCodexSharingDaemonRequiresMimiOwnedSharedConfig(t *testing.T) {
 	clearSetupEnv(t)
 	configPath, _, _ := writeCodexSharingTestConfig(t)
@@ -204,6 +253,9 @@ func TestRestartCodexSharingDaemonReturnsAtomicRestartResult(t *testing.T) {
 			if options.CodexBin != "/test/codex" || options.Env["CODEX_HOME"] != codexHome {
 				t.Fatalf("重启必须沿用现有 Codex 配置：%+v", options)
 			}
+			if options.ValidateStableOwner == nil {
+				t.Fatal("显式重启必须在 appserver 跨进程锁内重新验证磁盘配置")
+			}
 			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0", Started: true}, nil
 		},
 	)
@@ -245,6 +297,59 @@ func TestConfigureCodexSharingDaemonFailureDoesNotWriteConfig(t *testing.T) {
 	}
 }
 
+func TestConfigureCodexSharingReturnsCommittedPendingResultAfterPostCommitStartFailure(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	socketPath := filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+	wantErr := errors.New("launchctl kickstart failed")
+	result, err := configureCodexSharingWithTransactions(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			t.Fatal("production commit helper should own fresh enable")
+			return appserver.LocalDaemonStatus{}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		noopRemoveSharedDaemonOwner,
+		func(
+			_ context.Context,
+			_ appserver.LocalDaemonOptions,
+			validate func() error,
+			commit func() error,
+		) (appserver.LocalDaemonStatus, error) {
+			if err := validate(); err != nil {
+				return appserver.LocalDaemonStatus{}, err
+			}
+			if err := commit(); err != nil {
+				return appserver.LocalDaemonStatus{}, err
+			}
+			return appserver.LocalDaemonStatus{
+				SocketPath:             socketPath,
+				OwnerMigrationRequired: true,
+				ConfigCommitted:        true,
+			}, wantErr
+		},
+		func(context.Context, func() error, func() error) error {
+			t.Fatal("enable path must not call disable transaction")
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("提交后的启动失败不能丢失机器可读结果：%v", err)
+	}
+	if !result.Enabled || !result.Changed || !result.RestartRequired ||
+		!result.DaemonRestartRequired || result.Transport != "unix" ||
+		result.CodexHome != codexHome || !strings.Contains(result.Warning, wantErr.Error()) {
+		t.Fatalf("已提交失败必须返回 pending+warning：%+v", result)
+	}
+	document := readCodexSharingTestDocument(t, configPath)
+	appServer := document["app_server"].(map[string]any)
+	if appServer["transport"] != "unix" || appServer["shared_fallback"] == nil {
+		t.Fatalf("机器结果必须匹配已经提交的 shared 配置：%+v", appServer)
+	}
+}
+
 func TestConfigureCodexSharingAlreadyEnabledStillVerifiesDaemon(t *testing.T) {
 	clearSetupEnv(t)
 	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
@@ -278,6 +383,130 @@ func TestConfigureCodexSharingAlreadyEnabledStillVerifiesDaemon(t *testing.T) {
 	}
 	if !verified || result.Changed || result.RestartRequired || !result.Enabled || result.CodexHome != codexHome {
 		t.Fatalf("已启用时仍应验证 daemon，但无需重写配置：verified=%t result=%+v", verified, result)
+	}
+}
+
+func TestConcurrentStaleEnableCannotRecreateOwnerAfterDisable(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	socketPath := filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+	lifecycle := recoverableLifecycleInspector(t, codexHome)
+	if _, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0"}, nil
+		},
+		lifecycle,
+		noopRemoveSharedDaemonOwner,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	staleRead := make(chan struct{})
+	releaseEnsure := make(chan struct{})
+	enableDone := make(chan error, 1)
+	go func() {
+		_, err := configureCodexSharing(
+			context.Background(),
+			configPath,
+			true,
+			func(_ context.Context, options appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+				if options.ValidateStableOwner == nil {
+					return appserver.LocalDaemonStatus{}, fmt.Errorf("已 shared 的幂等 enable 缺少锁内配置复核")
+				}
+				close(staleRead)
+				<-releaseEnsure
+				if err := options.ValidateStableOwner(); err != nil {
+					return appserver.LocalDaemonStatus{}, err
+				}
+				return appserver.LocalDaemonStatus{}, fmt.Errorf("stale enable 不应通过复核")
+			},
+			unexpectedLifecycleInspector(t),
+			noopRemoveSharedDaemonOwner,
+		)
+		enableDone <- err
+	}()
+	<-staleRead
+
+	if _, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		false,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			t.Fatal("disable 不能 ensure daemon")
+			return appserver.LocalDaemonStatus{}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		noopRemoveSharedDaemonOwner,
+	); err != nil {
+		t.Fatal(err)
+	}
+	close(releaseEnsure)
+	if err := <-enableDone; err == nil || !strings.Contains(err.Error(), "已取消 Mimi 共享 daemon") {
+		t.Fatalf("旧 enable 必须看到 disable 后的新磁盘配置并拒绝：%v", err)
+	}
+}
+
+func TestConfigureCodexSharingUsesOneRawSnapshotForConfigDocumentAndCAS(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, _, documentA := writeCodexSharingTestConfig(t)
+	documentB := readCodexSharingTestDocument(t, configPath)
+	codexHomeB := t.TempDir()
+	documentB["codex"].(map[string]any)["bin"] = "/new/codex"
+	documentB["codex"].(map[string]any)["env"] = map[string]string{
+		"CODEX_HOME": codexHomeB,
+		"TERM":       "xterm-256color",
+	}
+	documentB["future_root"] = "new-generation"
+	rawA, err := json.MarshalIndent(documentA, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawB, err := json.MarshalIndent(documentB, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawA = append(rawA, '\n')
+	rawB = append(rawB, '\n')
+
+	originalRead := readCodexSharingConfigFile
+	reads := 0
+	readCodexSharingConfigFile = func(path string) ([]byte, error) {
+		reads++
+		if reads == 1 {
+			return append([]byte(nil), rawA...), nil
+		}
+		return os.ReadFile(path)
+	}
+	t.Cleanup(func() { readCodexSharingConfigFile = originalRead })
+	// 第一份快照读完后，模拟另一配置命令提交 B。旧请求的 validator 必须
+	// 在任何 owner/daemon 变更前看到 bytes 已变化并拒绝。
+	if err := os.WriteFile(configPath, rawB, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ensureCalls := 0
+	_, err = configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			ensureCalls++
+			return appserver.LocalDaemonStatus{}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		noopRemoveSharedDaemonOwner,
+	)
+	if err == nil || !strings.Contains(err.Error(), "配置已被其他进程修改") {
+		t.Fatalf("过期快照必须在 owner mutation 前失败：%v", err)
+	}
+	if ensureCalls != 0 {
+		t.Fatalf("过期快照不能进入 daemon/owner 路径：%d", ensureCalls)
+	}
+	after, readErr := os.ReadFile(configPath)
+	if readErr != nil || !bytes.Equal(after, rawB) {
+		t.Fatalf("过期操作不能覆盖新配置：read=%v got=%s", readErr, after)
 	}
 }
 
@@ -323,7 +552,7 @@ func TestConfigureCodexSharingAlreadyEnabledReportsPendingOwnerMigration(t *test
 	}
 }
 
-func TestConfigureCodexSharingDoesNotOverwriteExternalUnixBackendOnDisable(t *testing.T) {
+func TestConfigureCodexSharingKeepsExternalUnixBackendAndCleansOnlyMimiOwner(t *testing.T) {
 	clearSetupEnv(t)
 	configPath, _, _ := writeCodexSharingTestConfig(t)
 	document := readCodexSharingTestDocument(t, configPath)
@@ -343,6 +572,7 @@ func TestConfigureCodexSharingDoesNotOverwriteExternalUnixBackendOnDisable(t *te
 		t.Fatal(err)
 	}
 
+	removeCalls := 0
 	result, err := configureCodexSharing(
 		context.Background(),
 		configPath,
@@ -353,7 +583,7 @@ func TestConfigureCodexSharingDoesNotOverwriteExternalUnixBackendOnDisable(t *te
 		},
 		unexpectedLifecycleInspector(t),
 		func(context.Context) error {
-			t.Fatal("外部 Unix backend 不能卸载 Mimi owner")
+			removeCalls++
 			return nil
 		},
 	)
@@ -362,6 +592,9 @@ func TestConfigureCodexSharingDoesNotOverwriteExternalUnixBackendOnDisable(t *te
 	}
 	if result.Enabled || result.Changed || result.RestartRequired || result.Transport != "unix" {
 		t.Fatalf("外部 Unix backend 应保持原样：%+v", result)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("禁用外部 Unix 时只应幂等清理一次 Mimi 专属 owner：%d", removeCalls)
 	}
 	after, err := os.ReadFile(configPath)
 	if err != nil {

--- a/internal/setup/codex_sharing_test.go
+++ b/internal/setup/codex_sharing_test.go
@@ -267,6 +267,55 @@ func TestRestartCodexSharingDaemonReturnsAtomicRestartResult(t *testing.T) {
 	}
 }
 
+func TestRestartCodexSharingDaemonIgnoresUnavailableScanRoot(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	socketPath := filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+	if _, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0", Started: true}, nil
+		},
+		recoverableLifecycleInspector(t, codexHome),
+		noopRemoveSharedDaemonOwner,
+	); err != nil {
+		t.Fatal(err)
+	}
+	document := readCodexSharingTestDocument(t, configPath)
+	document["scan_roots"] = []string{filepath.Join(t.TempDir(), "offline-volume")}
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	restartCalls := 0
+	result, err := restartCodexSharingDaemon(
+		context.Background(),
+		configPath,
+		func(_ context.Context, options appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			restartCalls++
+			if options.ValidateStableOwner == nil {
+				t.Fatal("迁移仍必须在 daemon 锁内复核配置所有权")
+			}
+			if err := options.ValidateStableOwner(); err != nil {
+				t.Fatalf("离线 scan_root 不能阻断锁内 owner 复核：%v", err)
+			}
+			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0", Started: true}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restartCalls != 1 || !result.Restarted {
+		t.Fatalf("离线 scan_root 不应阻止显式迁移：calls=%d result=%+v", restartCalls, result)
+	}
+}
+
 func TestConfigureCodexSharingDaemonFailureDoesNotWriteConfig(t *testing.T) {
 	clearSetupEnv(t)
 	configPath, _, _ := writeCodexSharingTestConfig(t)

--- a/internal/setup/codex_sharing_test.go
+++ b/internal/setup/codex_sharing_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gaixianggeng/mimi-remote/internal/appserver"
@@ -23,18 +24,25 @@ func TestConfigureCodexSharingRoundTripsLegacyFallback(t *testing.T) {
 		if options.CodexBin != "/test/codex" || options.Env["CODEX_HOME"] != codexHome {
 			t.Fatalf("daemon options 未沿用 Codex 配置：%+v", options)
 		}
+		if !options.StableOwner || options.AttachOnly {
+			t.Fatalf("Mimi 从 WS 切换时必须使用稳定 owner：%+v", options)
+		}
 		return appserver.LocalDaemonStatus{
-			SocketPath: filepath.Join(codexHome, "app-server-control", "app-server-control.sock"),
-			Version:    "0.147.0",
+			SocketPath:             filepath.Join(codexHome, "app-server-control", "app-server-control.sock"),
+			Version:                "0.147.0",
+			OwnerInstalled:         true,
+			OwnerCreated:           true,
+			OwnerMigrationRequired: true,
 		}, nil
 	}
 
 	lifecycle := recoverableLifecycleInspector(t, codexHome)
-	enabled, err := configureCodexSharing(context.Background(), configPath, true, ensure, lifecycle)
+	enabled, err := configureCodexSharing(context.Background(), configPath, true, ensure, lifecycle, noopRemoveSharedDaemonOwner)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ensureCalls != 1 || !enabled.Enabled || !enabled.Changed || !enabled.RestartRequired || enabled.Transport != "unix" || enabled.CodexHome != codexHome {
+	if ensureCalls != 1 || !enabled.Enabled || !enabled.Changed || !enabled.RestartRequired ||
+		!enabled.DaemonRestartRequired || enabled.Transport != "unix" || enabled.CodexHome != codexHome {
 		t.Fatalf("启用结果错误：calls=%d result=%+v", ensureCalls, enabled)
 	}
 	document := readCodexSharingTestDocument(t, configPath)
@@ -47,6 +55,7 @@ func TestConfigureCodexSharingRoundTripsLegacyFallback(t *testing.T) {
 		t.Fatalf("legacy fallback 未完整保存：%+v", appServer["shared_fallback"])
 	}
 
+	removeCalls := 0
 	disabled, err := configureCodexSharing(
 		context.Background(),
 		configPath,
@@ -56,11 +65,15 @@ func TestConfigureCodexSharingRoundTripsLegacyFallback(t *testing.T) {
 			return appserver.LocalDaemonStatus{}, nil
 		},
 		unexpectedLifecycleInspector(t),
+		func(context.Context) error {
+			removeCalls++
+			return nil
+		},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if disabled.Enabled || !disabled.Changed || !disabled.RestartRequired || disabled.Transport != "ws" {
+	if disabled.Enabled || !disabled.Changed || !disabled.RestartRequired || disabled.Transport != "ws" || removeCalls != 1 {
 		t.Fatalf("关闭结果错误：%+v", disabled)
 	}
 	restored := readCodexSharingTestDocument(t, configPath)
@@ -73,6 +86,132 @@ func TestConfigureCodexSharingRoundTripsLegacyFallback(t *testing.T) {
 	}
 	if restored["future_root"] != original["future_root"] {
 		t.Fatalf("顶层未知字段被改写：want=%v got=%v", original["future_root"], restored["future_root"])
+	}
+}
+
+func TestConfigureCodexSharingUsesProductionValidatedLifecycleStatus(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	socketPath := filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+
+	result, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			return appserver.LocalDaemonStatus{
+				SocketPath:             socketPath,
+				Version:                "0.147.0",
+				OwnerInstalled:         true,
+				OwnerChanged:           true,
+				OwnerMigrationRequired: true,
+				LifecycleValidated:     true,
+			}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		noopRemoveSharedDaemonOwner,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Changed || !result.DaemonRestartRequired || result.CodexHome != codexHome {
+		t.Fatalf("生产校验状态必须跳过重复 CLI 检查并保留 owner 结果：%+v", result)
+	}
+}
+
+func TestConfigureCodexSharingOwnerRemovalFailureRestoresSharedConfig(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	ensure := func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+		return appserver.LocalDaemonStatus{
+			SocketPath: filepath.Join(codexHome, "app-server-control", "app-server-control.sock"),
+			Version:    "0.147.0",
+		}, nil
+	}
+	lifecycle := recoverableLifecycleInspector(t, codexHome)
+	if _, err := configureCodexSharing(
+		context.Background(), configPath, true, ensure, lifecycle, noopRemoveSharedDaemonOwner,
+	); err != nil {
+		t.Fatal(err)
+	}
+	beforeDisable, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("launchctl bootout denied")
+	_, err = configureCodexSharing(
+		context.Background(),
+		configPath,
+		false,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			t.Fatal("关闭共享不能重新确保 daemon")
+			return appserver.LocalDaemonStatus{}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		func(context.Context) error { return wantErr },
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("应返回 owner 卸载错误：%v", err)
+	}
+	afterFailure, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(beforeDisable, afterFailure) {
+		t.Fatal("owner 卸载失败时必须恢复原 shared 配置")
+	}
+}
+
+func TestRestartCodexSharingDaemonRequiresMimiOwnedSharedConfig(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, _, _ := writeCodexSharingTestConfig(t)
+	_, err := restartCodexSharingDaemon(
+		context.Background(),
+		configPath,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			t.Fatal("独立 WS 配置不能重启共享 daemon")
+			return appserver.LocalDaemonStatus{}, nil
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "不是 Mimi 管理") {
+		t.Fatalf("应拒绝非 Mimi owner：%v", err)
+	}
+}
+
+func TestRestartCodexSharingDaemonReturnsAtomicRestartResult(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	socketPath := filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+	lifecycle := recoverableLifecycleInspector(t, codexHome)
+	if _, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0", Started: true}, nil
+		},
+		lifecycle,
+		noopRemoveSharedDaemonOwner,
+	); err != nil {
+		t.Fatal(err)
+	}
+	restartCalls := 0
+	result, err := restartCodexSharingDaemon(
+		context.Background(),
+		configPath,
+		func(_ context.Context, options appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			restartCalls++
+			if options.CodexBin != "/test/codex" || options.Env["CODEX_HOME"] != codexHome {
+				t.Fatalf("重启必须沿用现有 Codex 配置：%+v", options)
+			}
+			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0", Started: true}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restartCalls != 1 || !result.Restarted || result.SocketPath != socketPath || result.Version != "0.147.0" {
+		t.Fatalf("重启结果错误：calls=%d result=%+v", restartCalls, result)
 	}
 }
 
@@ -92,6 +231,7 @@ func TestConfigureCodexSharingDaemonFailureDoesNotWriteConfig(t *testing.T) {
 			return appserver.LocalDaemonStatus{}, wantErr
 		},
 		unexpectedLifecycleInspector(t),
+		noopRemoveSharedDaemonOwner,
 	)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("应原样返回 daemon 错误：%v", err)
@@ -115,7 +255,7 @@ func TestConfigureCodexSharingAlreadyEnabledStillVerifiesDaemon(t *testing.T) {
 		}, nil
 	}
 	lifecycle := recoverableLifecycleInspector(t, codexHome)
-	if _, err := configureCodexSharing(context.Background(), configPath, true, firstEnsure, lifecycle); err != nil {
+	if _, err := configureCodexSharing(context.Background(), configPath, true, firstEnsure, lifecycle, noopRemoveSharedDaemonOwner); err != nil {
 		t.Fatal(err)
 	}
 	verified := false
@@ -131,12 +271,55 @@ func TestConfigureCodexSharingAlreadyEnabledStillVerifiesDaemon(t *testing.T) {
 			}, nil
 		},
 		lifecycle,
+		noopRemoveSharedDaemonOwner,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !verified || result.Changed || result.RestartRequired || !result.Enabled || result.CodexHome != codexHome {
 		t.Fatalf("已启用时仍应验证 daemon，但无需重写配置：verified=%t result=%+v", verified, result)
+	}
+}
+
+func TestConfigureCodexSharingAlreadyEnabledReportsPendingOwnerMigration(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	socketPath := filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+	lifecycle := recoverableLifecycleInspector(t, codexHome)
+	if _, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0"}, nil
+		},
+		lifecycle,
+		noopRemoveSharedDaemonOwner,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			return appserver.LocalDaemonStatus{
+				SocketPath:             socketPath,
+				Version:                "0.147.0",
+				OwnerInstalled:         true,
+				OwnerMigrationRequired: true,
+				LifecycleValidated:     true,
+			}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		noopRemoveSharedDaemonOwner,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.DaemonRestartRequired || !strings.Contains(result.Message, "迁移尚未完成") {
+		t.Fatalf("非 JSON CLI 也必须明确显示待迁移：%+v", result)
 	}
 }
 
@@ -169,6 +352,10 @@ func TestConfigureCodexSharingDoesNotOverwriteExternalUnixBackendOnDisable(t *te
 			return appserver.LocalDaemonStatus{}, nil
 		},
 		unexpectedLifecycleInspector(t),
+		func(context.Context) error {
+			t.Fatal("外部 Unix backend 不能卸载 Mimi owner")
+			return nil
+		},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -182,6 +369,61 @@ func TestConfigureCodexSharingDoesNotOverwriteExternalUnixBackendOnDisable(t *te
 	}
 	if !bytes.Equal(before, after) {
 		t.Fatal("Mimi 未拥有 fallback 时，禁用不能改写外部 Unix 配置")
+	}
+}
+
+func TestConfigureCodexSharingExternalUnixIsAttachOnly(t *testing.T) {
+	clearSetupEnv(t)
+	configPath, codexHome, _ := writeCodexSharingTestConfig(t)
+	document := readCodexSharingTestDocument(t, configPath)
+	appServer := document["app_server"].(map[string]any)
+	appServer["transport"] = " UnIx "
+	appServer["managed"] = true
+	appServer["listen"] = "unix://"
+	delete(appServer, "shared_fallback")
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(configPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ensureCalls := 0
+	result, err := configureCodexSharing(
+		context.Background(),
+		configPath,
+		true,
+		func(_ context.Context, options appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
+			ensureCalls++
+			if !options.AttachOnly || options.StableOwner {
+				t.Fatalf("外部 Unix backend 只能 attach，不能安装 owner：%+v", options)
+			}
+			return appserver.LocalDaemonStatus{
+				SocketPath: filepath.Join(codexHome, "app-server-control", "app-server-control.sock"),
+				Version:    "0.147.0",
+			}, nil
+		},
+		unexpectedLifecycleInspector(t),
+		func(context.Context) error {
+			t.Fatal("外部 Unix backend 不能安装或移除 Mimi owner")
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ensureCalls != 1 || !result.Enabled || result.Changed || result.RestartRequired ||
+		result.DaemonRestartRequired || result.Transport != "unix" || result.CodexHome != codexHome {
+		t.Fatalf("外部 Unix attach 结果错误：calls=%d result=%+v", ensureCalls, result)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, after) {
+		t.Fatal("启用外部 Unix 共享不能改写配置")
 	}
 }
 
@@ -215,6 +457,7 @@ func TestConfigureCodexSharingRejectsMalformedFallbackBeforeMutation(t *testing.
 			return appserver.LocalDaemonStatus{}, nil
 		},
 		unexpectedLifecycleInspector(t),
+		noopRemoveSharedDaemonOwner,
 	)
 	if err == nil {
 		t.Fatal("不可恢复的 shared_fallback 必须在修改前被拒绝")
@@ -236,12 +479,17 @@ func TestConfigureCodexSharingRejectsDaemonWithoutColdStartLifecycle(t *testing.
 		t.Fatal(err)
 	}
 	socketPath := filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+	removeCalls := 0
 	_, err = configureCodexSharing(
 		context.Background(),
 		configPath,
 		true,
 		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonStatus, error) {
-			return appserver.LocalDaemonStatus{SocketPath: socketPath, Version: "0.147.0"}, nil
+			return appserver.LocalDaemonStatus{
+				SocketPath:   socketPath,
+				Version:      "0.147.0",
+				OwnerChanged: true,
+			}, nil
 		},
 		func(context.Context, appserver.LocalDaemonOptions) (appserver.LocalDaemonLifecycleStatus, error) {
 			return appserver.LocalDaemonLifecycleStatus{
@@ -251,9 +499,16 @@ func TestConfigureCodexSharingRejectsDaemonWithoutColdStartLifecycle(t *testing.
 				ManagedCodexPath: filepath.Join(codexHome, "packages", "standalone", "current", "codex"),
 			}, nil
 		},
+		func(context.Context) error {
+			removeCalls++
+			return nil
+		},
 	)
 	if !errors.Is(err, appserver.ErrLocalDaemonStandaloneMissing) {
 		t.Fatalf("缺少 standalone 时必须阻止持久化共享配置：%v", err)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("前置校验失败时必须清理本次新建或更新的 owner：%d", removeCalls)
 	}
 	after, readErr := os.ReadFile(configPath)
 	if readErr != nil {
@@ -296,6 +551,8 @@ func unexpectedLifecycleInspector(t *testing.T) inspectLocalDaemonLifecycleFunc 
 		return appserver.LocalDaemonLifecycleStatus{}, nil
 	}
 }
+
+func noopRemoveSharedDaemonOwner(context.Context) error { return nil }
 
 func writeCodexSharingTestConfig(t *testing.T) (string, string, map[string]any) {
 	t.Helper()

--- a/internal/setup/config_commit_lock.go
+++ b/internal/setup/config_commit_lock.go
@@ -1,0 +1,81 @@
+package setup
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+// withConfigCommitLock 只覆盖“重新读取 expected bytes → rename”的最终提交段。
+// Mimi 的 sharing/Claude/network/repair 写入都使用同一把跨进程锁，因此不会在
+// 各自的 compare-and-swap 与 rename 之间互相插入。锁外编辑器无法被强制遵守
+// 本协议，调用方仍保留最后一跳 bytes 复核并在冲突时 fail closed。
+func withConfigCommitLock(
+	ctx context.Context,
+	configPath string,
+	commit func() error,
+) error {
+	if commit == nil {
+		return fmt.Errorf("配置提交回调不能为空")
+	}
+	lockPath, err := configCommitLockPath(configPath)
+	if err != nil {
+		return err
+	}
+	unlock, err := acquireConfigCommitLock(ctx, lockPath)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return commit()
+}
+
+func configCommitLockPath(configPath string) (string, error) {
+	absPath, err := config.ConfigPathIdentity(configPath)
+	if err != nil {
+		return "", fmt.Errorf("解析配置提交锁目标失败：%w", err)
+	}
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("解析配置提交锁目录失败：%w", err)
+	}
+	digest := sha256.Sum256([]byte(absPath))
+	name := hex.EncodeToString(digest[:16]) + ".lock"
+	return filepath.Join(cacheDir, "mimi-remote", "config-locks", name), nil
+}
+
+// commitConfigReplacingOwnedSharedDaemon 把“用户全局 owner”严格限定给平台
+// 默认配置。自定义 --config profile 仍与 daemon 事务串行提交，但绝不能因此
+// 删除默认后台服务正在使用的 LaunchAgent。
+func commitConfigReplacingOwnedSharedDaemon(
+	ctx context.Context,
+	configPath string,
+	validate func() error,
+	commit func() error,
+) error {
+	if config.IsPlatformDefaultPath(configPath) {
+		return appserver.CommitConfigReplacingSharedDaemon(ctx, validate, commit)
+	}
+	return appserver.CommitConfigWithSharedDaemonLock(ctx, validate, commit)
+}
+
+// commitConfigRepairingOwnedSharedDaemonIdentity 与普通 setup replacement
+// 分开：Doctor 只更新 codex.bin，配置仍是 shared。默认配置若正处于 manual
+// pending，必须保留 marker/owner；custom profile 仍不能触碰用户全局 owner。
+func commitConfigRepairingOwnedSharedDaemonIdentity(
+	ctx context.Context,
+	configPath string,
+	validate func() error,
+	commit func() error,
+) error {
+	if config.IsPlatformDefaultPath(configPath) {
+		return appserver.CommitConfigRepairingSharedDaemonIdentity(ctx, validate, commit)
+	}
+	return appserver.CommitConfigWithSharedDaemonLock(ctx, validate, commit)
+}

--- a/internal/setup/config_commit_lock_test.go
+++ b/internal/setup/config_commit_lock_test.go
@@ -1,0 +1,82 @@
+package setup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConfigCommitLockMakesCASAndRenameAtomicAcrossMimiWriters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	original := []byte("{\"generation\":1}\n")
+	newer := []byte("{\"generation\":2}\n")
+	stale := []byte("{\"generation\":3}\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		firstDone <- withConfigCommitLock(ctx, path, func() error {
+			close(entered)
+			<-release
+			return writePrivateFileAtomically(path, newer)
+		})
+	}()
+	<-entered
+
+	staleDone := make(chan error, 1)
+	go func() {
+		staleDone <- writePrivateFileAtomicallyCAS(path, original, stale)
+	}()
+	select {
+	case err := <-staleDone:
+		t.Fatalf("第二个 Mimi writer 不得穿过提交锁：%v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-staleDone; err == nil || !strings.Contains(err.Error(), "配置已被其他进程修改") {
+		t.Fatalf("锁释放后 stale CAS 必须拒绝覆盖：%v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(newer) {
+		t.Fatalf("最终配置必须保留先提交的新版本：%s", got)
+	}
+}
+
+func TestConfigCommitLockPathMatchesFilesystemCaseSemantics(t *testing.T) {
+	dir := t.TempDir()
+	lower := filepath.Join(dir, "config.json")
+	upper := filepath.Join(dir, "Config.json")
+	if err := os.WriteFile(lower, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lowerLock, err := configCommitLockPath(lower)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upperLock, err := configCommitLockPath(upper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, upperStatErr := os.Stat(upper)
+	if upperStatErr == nil && lowerLock != upperLock {
+		t.Fatalf("大小写不敏感卷的别名必须共用锁：lower=%q upper=%q", lowerLock, upperLock)
+	}
+	if os.IsNotExist(upperStatErr) && lowerLock == upperLock {
+		t.Fatalf("大小写敏感卷的不同文件不能误用同一把锁：%q", lowerLock)
+	}
+}

--- a/internal/setup/config_commit_lock_unix.go
+++ b/internal/setup/config_commit_lock_unix.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package setup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func acquireConfigCommitLock(ctx context.Context, path string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("创建配置提交锁目录失败：%w", err)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("配置提交锁必须是普通文件")
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("检查配置提交锁失败：%w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("打开配置提交锁失败：%w", err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("收紧配置提交锁权限失败：%w", err)
+	}
+	for {
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+			}, nil
+		}
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			_ = file.Close()
+			return nil, fmt.Errorf("获取配置提交锁失败：%w", err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			return nil, ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}

--- a/internal/setup/config_commit_lock_windows.go
+++ b/internal/setup/config_commit_lock_windows.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package setup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func acquireConfigCommitLock(ctx context.Context, path string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("创建配置提交锁目录失败：%w", err)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("配置提交锁必须是普通文件")
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("检查配置提交锁失败：%w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("打开配置提交锁失败：%w", err)
+	}
+	var overlapped windows.Overlapped
+	for {
+		err = windows.LockFileEx(
+			windows.Handle(file.Fd()),
+			windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			&overlapped,
+		)
+		if err == nil {
+			return func() {
+				_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+				_ = file.Close()
+			}, nil
+		}
+		if err != windows.ERROR_LOCK_VIOLATION {
+			_ = file.Close()
+			return nil, fmt.Errorf("获取配置提交锁失败：%w", err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			return nil, ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}

--- a/internal/setup/network.go
+++ b/internal/setup/network.go
@@ -379,7 +379,7 @@ func SetLANAccess(configPath string, enabled bool) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("编码配置文件失败：%w", err)
 	}
-	if err := writePrivateFileAtomically(cfgPath, append(updated, '\n')); err != nil {
+	if err := writePrivateFileAtomicallyCAS(cfgPath, original, append(updated, '\n')); err != nil {
 		return false, fmt.Errorf("原子更新配置文件失败：%w", err)
 	}
 	return true, nil

--- a/internal/setup/repair.go
+++ b/internal/setup/repair.go
@@ -1,12 +1,15 @@
 package setup
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type configWriter func(path string, raw []byte) error
@@ -21,7 +24,7 @@ type privateFileStageOps struct {
 // 调用方应先通过 Doctor 确认当前配置确实是 managed WS；这里保留原 JSON 中的
 // auth、projects、actions 及未来新增字段，只更新 app_server.ws_token_file。
 func RepairManagedWSTokenFile(configPath string) (string, bool, error) {
-	return repairManagedWSTokenFile(configPath, writePrivateFileAtomically)
+	return repairManagedWSTokenFile(configPath, nil)
 }
 
 func repairManagedWSTokenFile(configPath string, writeConfig configWriter) (string, bool, error) {
@@ -90,8 +93,14 @@ func repairManagedWSTokenFile(configPath string, writeConfig configWriter) (stri
 	updated = append(updated, '\n')
 
 	// token 先以 O_EXCL 安全落盘，配置再以 rename 作为唯一提交点；提交失败会删除新 token，旧配置保持原样。
-	if err := writeConfig(cfgPath, updated); err != nil {
-		return "", false, fmt.Errorf("原子更新配置文件失败：%w", err)
+	var writeErr error
+	if writeConfig == nil {
+		writeErr = writePrivateFileAtomicallyCAS(cfgPath, original, updated)
+	} else {
+		writeErr = writeConfig(cfgPath, updated)
+	}
+	if writeErr != nil {
+		return "", false, fmt.Errorf("原子更新配置文件失败：%w", writeErr)
 	}
 	committed = true
 	return tokenPath, true, nil
@@ -136,6 +145,21 @@ func createPrivateTokenFile(dir string, token string) (string, error) {
 
 func writePrivateFileAtomically(path string, raw []byte) error {
 	return writePrivateFileAtomicallyWithRename(path, raw, os.Rename)
+}
+
+func writePrivateFileAtomicallyCAS(path string, expected []byte, raw []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return withConfigCommitLock(ctx, path, func() error {
+		current, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("重新读取配置失败：%w", err)
+		}
+		if !bytes.Equal(current, expected) {
+			return fmt.Errorf("配置已被其他进程修改，请重新执行")
+		}
+		return writePrivateFileAtomically(path, raw)
+	})
 }
 
 func writePrivateFileAtomicallyWithRename(path string, raw []byte, rename renameFile) error {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -71,6 +72,13 @@ func runWithFileOps(ctx context.Context, options Options, fileOps setupFileTrans
 		}
 		result.Created = false
 		return result, nil
+	}
+	var originalConfig []byte
+	if configExisted {
+		originalConfig, err = os.ReadFile(cfgPath)
+		if err != nil {
+			return Result{}, fmt.Errorf("读取原配置快照失败：%w", err)
+		}
 	}
 
 	cfgDir := filepath.Dir(cfgPath)
@@ -169,13 +177,28 @@ func runWithFileOps(ctx context.Context, options Options, fileOps setupFileTrans
 	if err != nil {
 		return Result{}, fmt.Errorf("编码配置失败：%w", err)
 	}
-	if err := writeSetupFilesAtomically(
-		cfgPath,
-		tokenFile,
-		append(raw, '\n'),
-		[]byte(appServerToken+"\n"),
-		fileOps,
-	); err != nil {
+	validateOriginal := func() error {
+		return validateSetupConfigSnapshot(cfgPath, configExisted, originalConfig)
+	}
+	commitFiles := func() error {
+		// 两个文件的备份、rename 与目录同步都在配置提交锁内完成。sharing、
+		// Claude、network 和 setup --force 因而不会在各自 CAS 与 rename 之间互相覆盖。
+		return withConfigCommitLock(ctx, cfgPath, func() error {
+			if err := validateOriginal(); err != nil {
+				return err
+			}
+			return writeSetupFilesAtomically(
+				cfgPath,
+				tokenFile,
+				append(raw, '\n'),
+				[]byte(appServerToken+"\n"),
+				fileOps,
+			)
+		})
+	}
+	// setup 的新文档不包含 Mimi shared_fallback；即使原配置损坏或已经丢失，
+	// 只要还残留 Mimi owner/marker，也必须在同一 daemon lock 内先清理。
+	if err := commitConfigReplacingOwnedSharedDaemon(ctx, cfgPath, validateOriginal, commitFiles); err != nil {
 		return Result{}, fmt.Errorf("原子写入 setup 配置失败：%w", err)
 	}
 	filesCommitted = true
@@ -190,6 +213,27 @@ func runWithFileOps(ctx context.Context, options Options, fileOps setupFileTrans
 	result.AppServerListen = appServerListen
 	result.AppServerTokenFile = tokenFile
 	return result, nil
+}
+
+func validateSetupConfigSnapshot(path string, expectedExists bool, expected []byte) error {
+	exists, err := regularFileOrMissing(path, "配置文件")
+	if err != nil {
+		return err
+	}
+	if exists != expectedExists {
+		return fmt.Errorf("配置已被其他进程修改，请重新执行")
+	}
+	if !exists {
+		return nil
+	}
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("重新读取配置失败：%w", err)
+	}
+	if !bytes.Equal(current, expected) {
+		return fmt.Errorf("配置已被其他进程修改，请重新执行")
+	}
+	return nil
 }
 
 func Pair(ctx context.Context, configPath string) (Result, error) {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -491,6 +491,9 @@ func TestPairWarnsWhenEndpointIsLoopback(t *testing.T) {
 
 func clearSetupEnv(t *testing.T) {
 	t.Helper()
+	// setup 的并发提交现在会取得用户级 shared-daemon 锁。每个测试使用独立
+	// HOME，既避免碰到开发机真实 LaunchAgent，也防止并行用例互相串锁。
+	t.Setenv("HOME", t.TempDir())
 	for _, key := range []string{
 		"AGENTD_CONFIG",
 		"AGENTD_LISTEN",

--- a/internal/setup/setup_transaction_test.go
+++ b/internal/setup/setup_transaction_test.go
@@ -73,6 +73,23 @@ func TestSetupWriteFailuresLeaveNoFreshInstallArtifacts(t *testing.T) {
 	}
 }
 
+func TestSetupRejectsConfigAndTokenPathAliases(t *testing.T) {
+	dir := t.TempDir()
+	exact := filepath.Join(dir, "app-server-ws-token")
+	if err := writeSetupFilesAtomically(exact, exact, []byte("config"), []byte("token"), defaultSetupFileTransactionOps()); err == nil {
+		t.Fatal("配置与 token 的完全相同路径必须拒绝")
+	}
+
+	caseAlias := filepath.Join(dir, "App-Server-WS-Token")
+	if !config.SameConfigPath(caseAlias, exact) {
+		t.Skip("当前测试卷区分大小写，不存在大小写别名")
+	}
+	if err := writeSetupFilesAtomically(caseAlias, exact, []byte("config"), []byte("token"), defaultSetupFileTransactionOps()); err == nil {
+		t.Fatal("大小写不敏感卷上的同一目录项别名必须在写入前拒绝")
+	}
+	assertSetupDirectoryEntries(t, dir)
+}
+
 func TestFreshSetupFailureRemovesNewEmptyConfigDirectory(t *testing.T) {
 	clearSetupEnv(t)
 	parent := t.TempDir()

--- a/internal/setup/transaction.go
+++ b/internal/setup/transaction.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
 )
 
 type setupFileTransactionOps struct {
@@ -29,7 +31,7 @@ func defaultSetupFileTransactionOps() setupFileTransactionOps {
 func writeSetupFilesAtomically(configPath string, tokenPath string, configRaw []byte, tokenRaw []byte, ops setupFileTransactionOps) error {
 	configPath = filepath.Clean(configPath)
 	tokenPath = filepath.Clean(tokenPath)
-	if configPath == tokenPath {
+	if config.SameConfigPath(configPath, tokenPath) {
 		return fmt.Errorf("配置文件与 app-server token file 不能使用同一路径")
 	}
 	configExisted, err := regularFileOrMissing(configPath, "配置文件")

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -1762,10 +1762,7 @@ extension CodexAppServerSessionRuntime {
     }
 
     func approvalSessionID(from params: [String: CodexAppServerJSONValue]) -> SessionID? {
-        params["threadId"]?.stringValue
-            ?? params["conversationId"]?.stringValue
-            ?? params["sessionId"]?.stringValue
-            ?? params["session_id"]?.stringValue
+        CodexAppServerRequestScope.sessionID(in: params)
     }
 
     func uniqueStrings(_ values: [String]) -> [String] {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -3024,6 +3024,10 @@ actor CodexAppServerSessionRuntime {
     }
 
     func handle(_ notification: CodexAppServerNotification) {
+        if notification.method == "_mimi/serverRequestResponse/rejected" {
+            restoreRejectedServerRequestResponse(notification)
+            return
+        }
         if notification.method == "_mimi/claudeReplayCursor/reset",
            runtimeProvider == "claude",
            let rawSequence = notification.params?.objectValue?["sequence"]?.intValue,
@@ -3134,6 +3138,53 @@ actor CodexAppServerSessionRuntime {
         for sessionID in resolved.userInputSessionIDs where sessionID != emittedSessionID {
             emitUserInputResolved(sessionID: sessionID, skipped: false)
         }
+    }
+
+    func restoreRejectedServerRequestResponse(_ notification: CodexAppServerNotification) {
+        let params = notification.params?.objectValue ?? [:]
+        guard let requestID = replayedServerRequestID(params["requestId"]) else {
+            return
+        }
+        let message = params["message"]?.stringValue
+            ?? L10n.text("ui.this_session_is_running_on_another_client_please_aacfc6a6")
+        let reason = params["reason"]?.stringValue ?? "external_thread_active"
+        if let request = pendingApprovalRequestsByID.values.first(where: { $0.id == requestID }),
+           let sessionID = approvalSessionID(for: request) {
+            emitApprovalResolved(sessionID: sessionID)
+            if let event = projector.project(request) {
+                emit(event)
+            }
+            emitServerResponseRejectionWarning(message, code: reason, sessionID: sessionID)
+            return
+        }
+        if let request = pendingUserInputRequestsByID.values.first(where: { $0.id == requestID }),
+           let sessionID = approvalSessionID(for: request) {
+            emitUserInputResolved(sessionID: sessionID, skipped: false)
+            if let event = projector.project(request) {
+                emit(event)
+            }
+            emitServerResponseRejectionWarning(message, code: reason, sessionID: sessionID)
+        }
+    }
+
+    func emitServerResponseRejectionWarning(_ message: String, code: String, sessionID: SessionID) {
+        emit(.warning(
+            AgentErrorPayload(
+                message: message,
+                code: code,
+                retryable: true
+            ),
+            AgentEventMetadata(
+                seq: nil,
+                sessionID: sessionID,
+                turnID: nil,
+                itemID: nil,
+                messageID: nil,
+                clientMessageID: nil,
+                revision: nil,
+                createdAt: Date()
+            )
+        ))
     }
 
     /// 由 MainActor 在 Conversation/Session 投影全部落地后调用。单调提交避免并行订阅

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
@@ -496,6 +496,26 @@ actor CodexAppServerConnection {
     }
 
     private func resolve(_ response: CodexAppServerResponse) {
+        if let error = response.error,
+           error.data?.objectValue?["response_to_server_request"]?.boolValue == true {
+            // server request 的 response 是 fire-and-forget，不在 pendingResponses
+            // 中。gateway 拒绝它时转成私有通知，让 runtime 恢复审批/输入卡片，
+            // 避免界面显示“已发送”而实际 shared daemon 没有收到。
+            let requestID: CodexAppServerJSONValue
+            switch response.id {
+            case .int(let value): requestID = .int(value)
+            case .string(let value): requestID = .string(value)
+            case .null: requestID = .null
+            }
+            var params = error.data?.objectValue ?? [:]
+            params["requestId"] = requestID
+            params["message"] = .string(error.message)
+            notificationContinuation?.yield(CodexAppServerNotification(
+                method: "_mimi/serverRequestResponse/rejected",
+                params: .object(params)
+            ))
+            return
+        }
         guard let pending = pendingResponses.removeValue(forKey: response.id) else {
             return
         }

--- a/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentEvent.swift
@@ -33,6 +33,28 @@ enum CodexMCPToolApprovalProtocol {
     }
 }
 
+/// app-server 的新旧协议曾使用过多组会话字段名。事件投影和交互状态必须共享同一份
+/// alias 列表，否则请求虽然能通过 gateway，iPad 端却可能因为找不到会话而丢失审批卡片。
+enum CodexAppServerRequestScope {
+    static let sessionIDKeys = [
+        "threadId",
+        "thread_id",
+        "sessionId",
+        "session_id",
+        "conversationId",
+        "conversation_id"
+    ]
+
+    static func sessionID(in params: [String: CodexAppServerJSONValue]) -> SessionID? {
+        for key in sessionIDKeys {
+            if let sessionID = params[key]?.stringValue, !sessionID.isEmpty {
+                return sessionID
+            }
+        }
+        return nil
+    }
+}
+
 enum AgentEvent {
     case session(AgentSession)
     case sessionRow(DataFlowSessionRow, AgentEventMetadata)
@@ -874,7 +896,7 @@ struct CodexAppServerEventProjector {
     }
 
     private mutating func makeMetadata(from params: [String: CodexAppServerJSONValue]) -> AgentEventMetadata {
-        let sessionID = firstString(in: params, keys: ["threadId", "conversationId", "sessionId", "session_id"])
+        let sessionID = CodexAppServerRequestScope.sessionID(in: params)
             ?? nestedString(in: params, key: "thread", nestedKey: "id")
         let turnID = firstString(in: params, keys: ["turnId", "turn_id"]) ?? nestedString(in: params, key: "turn", nestedKey: "id")
         let item = params["item"]?.objectValue

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -1882,6 +1882,37 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertTrue(approval.body?.contains("验证改动") == true)
     }
 
+    func testProjectorMapsSnakeCaseApprovalSessionAliases() throws {
+        var projector = CodexAppServerEventProjector()
+        let legacyRequest = CodexAppServerServerRequest(
+            id: .string("legacy-approval"),
+            method: "execCommandApproval",
+            params: .object([
+                "conversation_id": .string("legacy-conversation"),
+                "itemId": .string("legacy-command"),
+                "command": .string("pwd")
+            ])
+        )
+        guard case .approvalRequest(_, let legacyMetadata) = projector.project(legacyRequest) else {
+            return XCTFail("expected legacy approval request")
+        }
+        XCTAssertEqual(legacyMetadata.sessionID, "legacy-conversation")
+
+        let modernRequest = CodexAppServerServerRequest(
+            id: .string("modern-approval"),
+            method: "item/commandExecution/requestApproval",
+            params: .object([
+                "thread_id": .string("modern-thread"),
+                "itemId": .string("modern-command"),
+                "command": .string("go test ./...")
+            ])
+        )
+        guard case .approvalRequest(_, let modernMetadata) = projector.project(modernRequest) else {
+            return XCTFail("expected modern approval request")
+        }
+        XCTAssertEqual(modernMetadata.sessionID, "modern-thread")
+    }
+
     func testProjectorMapsClaudeFileApprovalAndPersistentLocalRule() throws {
         let request = CodexAppServerServerRequest(
             id: .string("claude-approval-1"),

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
@@ -385,6 +385,81 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(request?.params?["command"]?.stringValue, "go test ./...")
     }
 
+    func testCodexAppServerConnectionRoutesRejectedReverseResponseAsPrivateNotification() async {
+        let connection = CodexAppServerConnection(
+            transport: FakeCodexAppServerTransport(),
+            requestTimeout: 2
+        )
+        let notificationStream = await connection.notifications()
+        var iterator = notificationStream.makeAsyncIterator()
+
+        await connection.ingestTextForTesting(
+            #"{"id":"approval-rpc","error":{"code":-32600,"message":"Desktop 正在运行此会话","data":{"reason":"external_thread_active","accepted":false,"retryable":true,"response_to_server_request":true,"thread_id":"thr_reverse"}}}"#
+        )
+
+        let notification = await iterator.next()
+        XCTAssertEqual(notification?.method, "_mimi/serverRequestResponse/rejected")
+        XCTAssertEqual(notification?.params?["requestId"]?.stringValue, "approval-rpc")
+        XCTAssertEqual(notification?.params?["reason"]?.stringValue, "external_thread_active")
+        XCTAssertEqual(notification?.params?["thread_id"]?.stringValue, "thr_reverse")
+    }
+
+    func testDirectRuntimeRestoresApprovalCardAfterGatewayRejectsReverseResponse() async {
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "reverse-response-rejection"
+        )
+        let request = CodexAppServerServerRequest(
+            id: .string("approval-rpc"),
+            method: "item/commandExecution/requestApproval",
+            params: .object([
+                "conversation_id": .string("thr_reverse"),
+                "turnId": .string("turn_reverse"),
+                "itemId": .string("cmd_reverse"),
+                "command": .string("go test ./...")
+            ])
+        )
+        await runtime.handle(request)
+        _ = await runtime.bufferedEvents(sessionID: "thr_reverse", replayPolicy: .all)
+
+        await runtime.handle(CodexAppServerNotification(
+            method: "_mimi/serverRequestResponse/rejected",
+            params: .object([
+                "requestId": .string("approval-rpc"),
+                "reason": .string("external_thread_active"),
+                "message": .string("Desktop 正在运行此会话")
+            ])
+        ))
+
+        let events = await runtime.bufferedEvents(sessionID: "thr_reverse", replayPolicy: .all)
+        XCTAssertTrue(events.contains {
+            if case .approvalResolved(let metadata) = $0 {
+                return metadata.sessionID == "thr_reverse"
+            }
+            return false
+        })
+        XCTAssertTrue(events.contains {
+            if case .approvalRequest(let approval, let metadata) = $0 {
+                return approval.id == "cmd_reverse" && metadata.sessionID == "thr_reverse"
+            }
+            return false
+        })
+        XCTAssertTrue(events.contains {
+            if case .warning(let warning, let metadata) = $0 {
+                return warning.code == "external_thread_active"
+                    && metadata.sessionID == "thr_reverse"
+            }
+            return false
+        })
+        let pending = await runtime.pendingInteractionEvents(sessionID: "thr_reverse")
+        XCTAssertTrue(pending.contains {
+            if case .approvalRequest(let approval, _) = $0 {
+                return approval.id == "cmd_reverse"
+            }
+            return false
+        })
+    }
+
     func testCodexAppServerConnectionBuffersInboundStreamsWithoutDroppingOldEvents() async throws {
         let connection = CodexAppServerConnection(transport: FakeCodexAppServerTransport(), requestTimeout: 2)
         let notificationStream = await connection.notifications()

--- a/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
+++ b/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
@@ -128,6 +128,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
     let daemonRestartRequired: Bool?
     let transport: String?
     let codexHome: String?
+    let warning: String?
     let message: String
 
     enum CodingKeys: String, CodingKey {
@@ -137,6 +138,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
         case daemonRestartRequired = "daemon_restart_required"
         case transport
         case codexHome = "codex_home"
+        case warning
         case message
     }
 
@@ -147,6 +149,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
         daemonRestartRequired: Bool? = nil,
         transport: String? = nil,
         codexHome: String? = nil,
+        warning: String? = nil,
         message: String = ""
     ) {
         self.enabled = enabled
@@ -155,6 +158,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
         self.daemonRestartRequired = daemonRestartRequired
         self.transport = transport
         self.codexHome = codexHome
+        self.warning = warning
         self.message = message
     }
 }
@@ -180,6 +184,23 @@ struct AgentDoctorResults: Codable, Equatable, Sendable {
 struct DoctorFixResults: Codable, Equatable, Sendable {
     let fixes: [String]
     let results: AgentDoctorResults
+    let restartRequired: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case fixes
+        case results
+        case restartRequired = "restart_required"
+    }
+
+    init(
+        fixes: [String],
+        results: AgentDoctorResults,
+        restartRequired: Bool? = nil
+    ) {
+        self.fixes = fixes
+        self.results = results
+        self.restartRequired = restartRequired
+    }
 }
 
 struct AgentRuntimeStatusSnapshot: Codable, Equatable, Sendable {

--- a/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
+++ b/macos/MimiRemoteMac/Sources/Domain/AgentModels.swift
@@ -125,6 +125,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
     let enabled: Bool
     let changed: Bool
     let restartRequired: Bool
+    let daemonRestartRequired: Bool?
     let transport: String?
     let codexHome: String?
     let message: String
@@ -133,6 +134,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
         case enabled
         case changed
         case restartRequired = "restart_required"
+        case daemonRestartRequired = "daemon_restart_required"
         case transport
         case codexHome = "codex_home"
         case message
@@ -142,6 +144,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
         enabled: Bool,
         changed: Bool = false,
         restartRequired: Bool = false,
+        daemonRestartRequired: Bool? = nil,
         transport: String? = nil,
         codexHome: String? = nil,
         message: String = ""
@@ -149,6 +152,7 @@ struct CodexSharingConfigurationResult: Codable, Equatable, Sendable {
         self.enabled = enabled
         self.changed = changed
         self.restartRequired = restartRequired
+        self.daemonRestartRequired = daemonRestartRequired
         self.transport = transport
         self.codexHome = codexHome
         self.message = message
@@ -265,6 +269,8 @@ struct AgentRuntimeStatus: Codable, Equatable, Identifiable, Sendable {
     /// 旧 agentd 不返回这些字段，因此必须保持可选并按未确认处理。
     let transport: String?
     let shared: Bool?
+    /// Mimi-owned launchd owner 已安装，但现有 daemon 尚未在用户确认后迁移。
+    let daemonRestartRequired: Bool?
     let codexHome: String?
 
     enum CodingKeys: String, CodingKey {
@@ -280,6 +286,7 @@ struct AgentRuntimeStatus: Codable, Equatable, Identifiable, Sendable {
         case rateLimits = "rate_limits"
         case transport
         case shared
+        case daemonRestartRequired = "daemon_restart_required"
         case codexHome = "codex_home"
     }
 
@@ -296,6 +303,7 @@ struct AgentRuntimeStatus: Codable, Equatable, Identifiable, Sendable {
         rateLimits: AgentRuntimeRateLimits?,
         transport: String? = nil,
         shared: Bool? = nil,
+        daemonRestartRequired: Bool? = nil,
         codexHome: String? = nil
     ) {
         self.id = id
@@ -310,6 +318,7 @@ struct AgentRuntimeStatus: Codable, Equatable, Identifiable, Sendable {
         self.rateLimits = rateLimits
         self.transport = transport
         self.shared = shared
+        self.daemonRestartRequired = daemonRestartRequired
         self.codexHome = codexHome
     }
 

--- a/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
@@ -84,7 +84,7 @@ struct MacSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                Button("重启并应用设置") {
+                Button("应用待处理设置") {
                     confirmsCodexRestart = true
                 }
                 .disabled(!store.canRestartCodexDesktop)
@@ -111,13 +111,13 @@ struct MacSettingsView: View {
         } message: {
             Text("切换期间移动设备会短暂断开；Homebrew 启动失败时会自动恢复 App 服务。")
         }
-        .alert("重启 Codex Desktop 并应用设置？", isPresented: $confirmsCodexRestart) {
+        .alert("应用 Codex 共享设置？", isPresented: $confirmsCodexRestart) {
             Button("取消", role: .cancel) {}
-            Button("重启并应用") {
+            Button("确认应用") {
                 Task { await store.restartCodexDesktop() }
             }
         } message: {
-            Text("Mimi Remote 会先请求 Codex Desktop 正常退出，等待进程完全结束后再启动同一个 App。请先保存进行中的工作；不会强制终止，也不会并存启动第二个实例。")
+            Text("如果 Codex Desktop 正在运行，会先请求它正常退出，迁移共享 daemon 并验证成功后再重新打开；如果 Desktop 已退出，只迁移 daemon，不会擅自打开 App。该操作会短暂中断当前连接到 daemon 的手机、SSH 或 CLI，请先保存进行中的工作。")
         }
     }
 

--- a/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
@@ -15,6 +15,7 @@ struct AgentCommandClient: Sendable {
     ) async throws -> CodexSharingConfigurationResult = { enabled in
         CodexSharingConfigurationResult(enabled: enabled)
     }
+    var restartCodexSharing: @Sendable () async throws -> Void = {}
     var setLANAccess: @Sendable (_ enabled: Bool) async throws -> NetworkConfigurationResult
     var pair: @Sendable (_ network: PairingNetwork) async throws -> PairingInfo
     var version: @Sendable () async throws -> String
@@ -130,8 +131,18 @@ extension AgentCommandClient {
                     from: try await execute(
                         binary: binary,
                         arguments: codexSharingConfigurationArguments(enabled: enabled),
-                        timeout: .seconds(25)
+                        // 后端为 owner 安装、daemon 就绪和失败回滚预留 45 秒；
+                        // 调用端必须更长，不能在事务清理完成前强杀子进程。
+                        timeout: .seconds(50)
                     )
+                )
+            },
+            restartCodexSharing: {
+                let binary = try requireEmbeddedBinary()
+                _ = try await execute(
+                    binary: binary,
+                    arguments: codexSharingRestartArguments(),
+                    timeout: .seconds(50)
                 )
             },
             setLANAccess: { enabled in
@@ -203,6 +214,16 @@ extension AgentCommandClient {
             "runtime",
             "--codex-sharing=\(enabled ? "enabled" : "disabled")",
             "--json",
+        ]
+    }
+
+    static func codexSharingRestartArguments() -> [String] {
+        [
+            "runtime",
+            "--codex-sharing-restart",
+            // 该 client 只会在设置页确认后的 HostStore 迁移闭包中调用；后端
+            // 拒绝缺少此显式确认的普通 CLI，避免脚本误绕过 Desktop 退出顺序。
+            "--codex-sharing-restart-confirmed",
         ]
     }
 }

--- a/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
@@ -105,7 +105,10 @@ extension AgentCommandClient {
                     binary: binary,
                     arguments: arguments,
                     allowFailure: true,
-                    timeout: .seconds(20)
+                    // Doctor --fix 可能等待 daemon/config 两把跨进程锁，并在提交后
+                    // 重新跑完整检查；给它覆盖事务上界的时间，避免配置已提交却因
+                    // 客户端过早终止而漏掉 restart_required。
+                    timeout: .seconds(90)
                 )
                 if fix {
                     return try decode(DoctorFixResults.self, from: result)

--- a/macos/MimiRemoteMac/Sources/Infrastructure/CodexDesktopIntegrationClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/CodexDesktopIntegrationClient.swift
@@ -387,8 +387,9 @@ private final class CodexDesktopIntegrationRuntime {
         guard let bundleURL = snapshot.bundleURL else {
             throw CodexDesktopIntegrationError.appNotInstalled
         }
+        let shouldReopen = snapshot.appRunning
 
-        if snapshot.appRunning {
+        if shouldReopen {
             // terminateAndWait 内部只调用普通 NSRunningApplication.terminate，并等待
             // terminated；没有 forceTerminate，也不会在旧进程存活时开第二个实例。
             try await application.terminateAndWait(bundleURL)
@@ -398,6 +399,17 @@ private final class CodexDesktopIntegrationRuntime {
         // 这样 Desktop 不会在 socket 短暂消失时自行重连或拉起另一条启动链；准备
         // 失败则保持关闭，不把 Desktop 打开到已知不可用的共享后端。
         try await preparation()
+
+        // 确认弹窗与真正执行之间，用户可能已经自行退出 Desktop。实际快照为
+        // stopped 时只提交 daemon 迁移，绝不把用户主动关闭的 App 擅自打开。
+        if !shouldReopen {
+            defaults.removeObject(forKey: Self.restartRequiredAtKey)
+            return try await makeSnapshot(
+                environmentValue: snapshot.environmentValue,
+                codexHome: snapshot.codexHome,
+                sessionEpoch: snapshot.sessionEpoch
+            )
+        }
 
         // launchd 环境是 Dock/Finder 的长期保险；OpenConfiguration.environment
         // 是本次新实例的短期保险。禁用时传空字典，绝不注入官方开关。

--- a/macos/MimiRemoteMac/Sources/Infrastructure/CodexDesktopIntegrationClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/CodexDesktopIntegrationClient.swift
@@ -195,18 +195,38 @@ struct CodexDesktopIntegrationClient {
     var inspect: @MainActor () async throws -> CodexDesktopEnvironmentSnapshot
     var bootstrap: @MainActor () async throws -> CodexDesktopEnvironmentSnapshot
     var setEnabled: @MainActor (_ enabled: Bool, _ codexHome: String?) async throws -> CodexDesktopEnvironmentSnapshot
-    var restartAndApply: @MainActor () async throws -> CodexDesktopEnvironmentSnapshot
+    private var restartAndApplyOperation: @MainActor () async throws -> CodexDesktopEnvironmentSnapshot
+    private var restartAndApplyWithPreparationOperation: (@MainActor (
+        _ preparation: @escaping @MainActor () async throws -> Void
+    ) async throws -> CodexDesktopEnvironmentSnapshot)?
 
     init(
         inspect: @escaping @MainActor () async throws -> CodexDesktopEnvironmentSnapshot,
         bootstrap: @escaping @MainActor () async throws -> CodexDesktopEnvironmentSnapshot,
         setEnabled: @escaping @MainActor (_ enabled: Bool, _ codexHome: String?) async throws -> CodexDesktopEnvironmentSnapshot,
-        restartAndApply: @escaping @MainActor () async throws -> CodexDesktopEnvironmentSnapshot
+        restartAndApply: @escaping @MainActor () async throws -> CodexDesktopEnvironmentSnapshot,
+        restartAndApplyWithPreparation: (@MainActor (
+            _ preparation: @escaping @MainActor () async throws -> Void
+        ) async throws -> CodexDesktopEnvironmentSnapshot)? = nil
     ) {
         self.inspect = inspect
         self.bootstrap = bootstrap
         self.setEnabled = setEnabled
-        self.restartAndApply = restartAndApply
+        self.restartAndApplyOperation = restartAndApply
+        self.restartAndApplyWithPreparationOperation = restartAndApplyWithPreparation
+    }
+
+    @MainActor
+    func restartAndApply(
+        afterTermination preparation: @escaping @MainActor () async throws -> Void = {}
+    ) async throws -> CodexDesktopEnvironmentSnapshot {
+        if let restartAndApplyWithPreparationOperation {
+            return try await restartAndApplyWithPreparationOperation(preparation)
+        }
+        // 测试/预览的轻量 client 没有真实进程拆分能力；仍保持“准备成功后才调用
+        // restart”语义。正式 live client 在下方精确插入 terminate 与 open 之间。
+        try await preparation()
+        return try await restartAndApplyOperation()
     }
 
     /// 预览和单元测试使用的无副作用实现。默认保持关闭，不会假装 backend
@@ -240,7 +260,10 @@ struct CodexDesktopIntegrationClient {
             setEnabled: { enabled, codexHome in
                 try await runtime.setEnabled(enabled, codexHome: codexHome)
             },
-            restartAndApply: { try await runtime.restartAndApply() }
+            restartAndApply: { try await runtime.restartAndApply() },
+            restartAndApplyWithPreparation: { preparation in
+                try await runtime.restartAndApply(afterTermination: preparation)
+            }
         )
     }
 }
@@ -354,7 +377,9 @@ private final class CodexDesktopIntegrationRuntime {
         )
     }
 
-    func restartAndApply() async throws -> CodexDesktopEnvironmentSnapshot {
+    func restartAndApply(
+        afterTermination preparation: @escaping @MainActor () async throws -> Void = {}
+    ) async throws -> CodexDesktopEnvironmentSnapshot {
         let snapshot = try await applyPreference(
             preferenceEnabled,
             codexHome: canonicalCodexHome
@@ -368,6 +393,11 @@ private final class CodexDesktopIntegrationRuntime {
             // terminated；没有 forceTerminate，也不会在旧进程存活时开第二个实例。
             try await application.terminateAndWait(bundleURL)
         }
+
+        // 后端 owner 的显式迁移必须发生在旧 Desktop 完全退出之后、重新打开之前。
+        // 这样 Desktop 不会在 socket 短暂消失时自行重连或拉起另一条启动链；准备
+        // 失败则保持关闭，不把 Desktop 打开到已知不可用的共享后端。
+        try await preparation()
 
         // launchd 环境是 Dock/Finder 的长期保险；OpenConfiguration.environment
         // 是本次新实例的短期保险。禁用时传空字典，绝不注入官方开关。

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -146,7 +146,7 @@ final class HostStore {
     }
 
     private var codexDaemonMigrationRequired: Bool {
-        codexRuntime?.daemonRestartRequired == true
+        codexRuntime?.daemonRestartRequired == true && !codexDaemonMigrationCommittedLocally
     }
 
     private let agent: AgentCommandClient
@@ -161,6 +161,12 @@ final class HostStore {
     private var runtimeStatusFollowUpTask: Task<Void, Never>?
     private var stopServiceAndQuitTask: Task<Void, Never>?
     private var lastStatusRefreshAt: Date?
+    // 每次开始 agent.status() 都先分配单调序号。只允许最新请求落地，避免
+    // 迁移前已发出的 marker=true 在提交后的 fresh false 之后迟到并覆盖 UI。
+    private var statusRequestSequence: UInt64 = 0
+    // Go runtime 命令成功返回就是迁移提交点。其后的 status/inspect 可能仍读到
+    // 瞬时旧值或失败，不能反向把已清 marker 的操作显示成失败或再次执行。
+    private var codexDaemonMigrationCommittedLocally = false
 
     init(
         agent: AgentCommandClient,
@@ -453,16 +459,23 @@ final class HostStore {
         guard !isBusy else { return }
         isBusy = true
         lastError = nil
-        defer { isBusy = false }
+        var restartMacAgent = false
+        var restartHomebrewAgent = false
         do {
             let result = try await agent.doctor(fix)
             doctor = result.results
             appliedFixes = result.fixes
+            restartMacAgent = fix && result.restartRequired == true && owner == .macApp
+            restartHomebrewAgent = fix && result.restartRequired == true && owner == .homebrew
             switch owner {
             case .macApp:
-                await refreshMacAgentStatus()
+                if !restartMacAgent {
+                    await refreshMacAgentStatus()
+                }
             case .homebrew:
-                await refreshHomebrewStatus()
+                if !restartHomebrewAgent {
+                    await refreshHomebrewStatus()
+                }
             case .none:
                 if !result.results.ok {
                     lifecycle = .degraded(firstBlockingIssue(in: result.results))
@@ -470,6 +483,38 @@ final class HostStore {
             }
         } catch {
             lastError = error.localizedDescription
+        }
+        isBusy = false
+        if restartMacAgent {
+            // Doctor 改写 codex.bin、token 路径或整份配置后，resident agentd
+            // 仍持有旧快照。正常注销/注册一次，让 shared owner 以新身份在锁内
+            // 重建；不会停止当前 Codex daemon，也不会退出 Desktop。
+            await restartService()
+        } else if restartHomebrewAgent {
+            await restartHomebrewAfterDoctorRepair()
+        }
+    }
+
+    private func restartHomebrewAfterDoctorRepair() async {
+        guard !isBusy, owner == .homebrew else { return }
+        guard let binary = homebrew.installedAgentBinary() else {
+            fail(HomebrewServiceError.commandFailed("Doctor 已提交配置，但找不到 Homebrew agentd，无法重载。"))
+            return
+        }
+        isBusy = true
+        lifecycle = .starting
+        lastError = nil
+        defer { isBusy = false }
+        do {
+            try await homebrew.stop()
+            homebrewLoaded = false
+            try await homebrew.start()
+            try await waitForHomebrewReady(binary: binary)
+            homebrewLoaded = true
+            owner = .homebrew
+            lifecycle = .migrationRequired
+        } catch {
+            fail(error)
         }
     }
 
@@ -595,18 +640,19 @@ final class HostStore {
             isUpdatingCodexDesktop = false
             isBusy = false
         }
+        var didCommitDaemonMigration = false
         do {
-            // 确认弹窗与真正执行之间，用户可能从 Dock 重新打开 Desktop。不能
-            // 使用设置页缓存决定是否可以直接 stop daemon；必须在破坏性迁移前
-            // 重新读取真实进程状态，运行中就回到正常 terminate 流程。
+            // 先读取一次真实状态，避免只凭设置页缓存决定是否需要 terminate。
+            // 即便这里看到 running，live runtime 仍会在实际执行时再取快照，
+            // 覆盖用户在两次读取之间自行退出 Desktop 的竞态。
             let currentDesktop = try await codexDesktop.inspect()
-            if !currentDesktop.appRunning {
-                // 用户已经在设置页确认。Desktop 已退出时只迁移 daemon，不擅自
-                // 重开 Desktop；其他 SSH/CLI/手机连接仍会短暂断开。
+            if !currentDesktop.appRunning, codexDaemonMigrationRequired {
+                // Desktop 本来已退出时只迁移 daemon，不擅自打开 App；命令成功
+                // 就已提交，后续状态刷新失败也不能把它重新解释为迁移失败。
                 try await agent.restartCodexSharing()
-                _ = try await waitForCodexRuntimeShared(true)
-                let inspected = try await codexDesktop.inspect()
-                applyCodexDesktopSnapshot(inspected)
+                didCommitDaemonMigration = true
+                recordCommittedCodexMigration()
+                await refreshAfterCommittedCodexMigration()
                 return
             }
             let snapshot = try await codexDesktop.restartAndApply(afterTermination: {
@@ -614,10 +660,14 @@ final class HostStore {
                 // 正常退出后才 stop 旧 daemon，再由 launchd 拉起；失败时不重新打开。
                 if self.codexDesktopEnabled, self.codexDaemonMigrationRequired {
                     try await self.agent.restartCodexSharing()
-                    _ = try await self.waitForCodexRuntimeShared(true)
+                    didCommitDaemonMigration = true
+                    self.recordCommittedCodexMigration()
                 }
             })
             applyCodexDesktopSnapshot(snapshot)
+            if didCommitDaemonMigration {
+                await refreshAfterCommittedCodexMigration()
+            }
         } catch {
             codexDesktopError = error.localizedDescription
             // 不强制终止也不再并发启动第二个实例；terminate/open 超时或拒绝
@@ -805,7 +855,8 @@ final class HostStore {
 
             let current: AgentStatus
             do {
-                current = try await agent.status()
+                guard let latest = try await fetchAndApplyLatestStatus() else { return }
+                current = latest
             } catch is CancellationError {
                 return
             } catch {
@@ -814,9 +865,6 @@ final class HostStore {
                 await repairEnabledMacAgent(after: error)
                 return
             }
-
-            status = current
-            doctor = current.doctor
             if !current.processOK {
                 // status 命令本身可以成功，但它可能明确报告 resident agentd 未运行。
                 // 首次打开必须把这种状态当作启动失败，自动做一次有界换代，而不是
@@ -834,7 +882,7 @@ final class HostStore {
                     fail(error)
                 }
             } else {
-                apply(current)
+                // fetchAndApplyLatestStatus 已经落地最新状态。
             }
         case .notRegistered:
             await registerAvailableMacAgent(recoveringMissingRecord: false)
@@ -1010,8 +1058,7 @@ final class HostStore {
         var lastRuntime: AgentRuntimeStatus?
         for attempt in 0..<12 {
             try Task.checkCancellation()
-            if let current = try? await agent.status() {
-                apply(current)
+            if let current = try? await fetchAndApplyLatestStatus() {
                 lastRuntime = current.runtimeStatus?.runtimes.first(where: {
                     $0.id.caseInsensitiveCompare("codex") == .orderedSame
                 })
@@ -1066,8 +1113,7 @@ final class HostStore {
     private func waitForClaudeRuntime(enabled: Bool) async throws {
         for attempt in 0..<12 {
             try Task.checkCancellation()
-            if let current = try? await agent.status() {
-                apply(current)
+            if let current = try? await fetchAndApplyLatestStatus() {
                 if let runtime = current.runtimeStatus?.runtimes.first(where: {
                     $0.id.caseInsensitiveCompare("claude") == .orderedSame
                 }) {
@@ -1116,9 +1162,8 @@ final class HostStore {
         var lastStatus: AgentStatus?
         for _ in 0..<15 {
             try Task.checkCancellation()
-            if let current = try? await agent.status() {
+            if let current = try? await fetchAndApplyLatestStatus() {
                 lastStatus = current
-                apply(current)
                 if current.serviceOK { return }
             }
             try await Task.sleep(for: .seconds(1))
@@ -1221,7 +1266,7 @@ final class HostStore {
         switch services.agentStatus() {
         case .enabled:
             do {
-                apply(try await agent.status())
+                _ = try await fetchAndApplyLatestStatus()
             } catch is CancellationError {
                 return
             } catch {
@@ -1293,6 +1338,16 @@ final class HostStore {
     }
 
     private func apply(_ current: AgentStatus) {
+        // 本地提交标记只遮蔽命令成功前留在内存里的旧 pending 快照。下一份
+        // 真正携带 daemonRestartRequired 的服务端状态无论 true/false 都是新事实：
+        // false 确认提交，true 则表示服务端又检测到新的 unmanaged owner。
+        if codexDaemonMigrationCommittedLocally,
+           let runtime = current.runtimeStatus?.runtimes.first(where: {
+               $0.id.caseInsensitiveCompare("codex") == .orderedSame
+           }),
+           runtime.daemonRestartRequired != nil {
+            codexDaemonMigrationCommittedLocally = false
+        }
         let resolved = preservingRuntimeSnapshotIfNeeded(in: current)
         status = resolved
         doctor = resolved.doctor
@@ -1306,6 +1361,48 @@ final class HostStore {
             )
         } else {
             lifecycle = .stopped
+        }
+    }
+
+    private func nextStatusRequestSequence() -> UInt64 {
+        statusRequestSequence &+= 1
+        return statusRequestSequence
+    }
+
+    private func invalidateInFlightStatusRequests() {
+        statusRequestSequence &+= 1
+    }
+
+    private func recordCommittedCodexMigration() {
+        codexDaemonMigrationCommittedLocally = true
+        // Go 命令返回就是提交点。必须在重新打开 Desktop 的 await 之前立刻
+        // 作废迁移前请求，不能等 application.open 完成后再处理迟到旧状态。
+        invalidateInFlightStatusRequests()
+    }
+
+    @discardableResult
+    private func applyStatusResponse(_ current: AgentStatus, sequence: UInt64) -> Bool {
+        guard sequence == statusRequestSequence else { return false }
+        apply(current)
+        return true
+    }
+
+    private func fetchAndApplyLatestStatus() async throws -> AgentStatus? {
+        let sequence = nextStatusRequestSequence()
+        let current = try await agent.status()
+        return applyStatusResponse(current, sequence: sequence) ? current : nil
+    }
+
+    private func refreshAfterCommittedCodexMigration() async {
+        // 这些读取只刷新展示，不是第二个提交门。任一瞬时失败都保留 Go 已提交
+        // 的成功事实，Desktop 重开顺序也不受 12 秒轮询影响。
+        // recordCommittedCodexMigration 已在 Go 成功的同一同步段作废旧请求；
+        // 这里再发出新的权威刷新，失败也不反向改变提交事实。
+        _ = try? await fetchAndApplyLatestStatus()
+        if let snapshot = try? await codexDesktop.inspect() {
+            applyCodexDesktopSnapshot(snapshot)
+        } else {
+            refreshCodexDesktopPresentation()
         }
     }
 

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -56,7 +56,7 @@ final class HostStore {
 
     var canRestartCodexDesktop: Bool {
         codexDesktopStatus.appInstalled
-            && codexDesktopStatus.appRunning
+            && (codexDesktopStatus.appRunning || codexDaemonMigrationRequired)
             && owner == .macApp
             && !isBusy
             && !isUpdatingCodexDesktop
@@ -87,7 +87,10 @@ final class HostStore {
         case .backendNotShared:
             return "agentd 尚未确认 Unix socket 共享；确认后才会显示已就绪，不会提前声称已共享。"
         case .pendingRestart:
-            return "Codex Desktop 当前正在运行，需完全重启后应用设置。仅 Desktop 没有进行中的任务时手机可继续；正在运行的任务仍只读。"
+            if codexDaemonMigrationRequired, !codexDesktopStatus.appRunning {
+                return "共享 daemon 等待你确认迁移。应用时不会打开 Codex Desktop，但会短暂中断当前连接到该 daemon 的手机、SSH 或 CLI。"
+            }
+            return "Codex Desktop 当前正在运行，需正常退出后应用设置。迁移会短暂中断当前连接到共享 daemon 的客户端。"
         case .ready:
             return "agentd 已连接共享会话服务，Codex Desktop 已按共享环境配置。请用同一空闲会话完成一次跨端续写验证；正在运行的任务仍只读。"
         case .failed:
@@ -140,6 +143,10 @@ final class HostStore {
 
     private var codexRuntime: AgentRuntimeStatus? {
         status?.runtimeStatus?.runtimes.first { $0.id.caseInsensitiveCompare("codex") == .orderedSame }
+    }
+
+    private var codexDaemonMigrationRequired: Bool {
+        codexRuntime?.daemonRestartRequired == true
     }
 
     private let agent: AgentCommandClient
@@ -572,8 +579,12 @@ final class HostStore {
             codexDesktopError = "请先等待 Mimi Remote Mac 服务操作完成，再重启 Codex Desktop。"
             return
         }
-        guard codexDesktopStatus.appInstalled, codexDesktopStatus.appRunning else {
-            codexDesktopError = "Codex Desktop 当前未运行，无需重启；下次从 Dock/Finder 启动会读取设置。"
+        guard codexDesktopStatus.appInstalled else {
+            codexDesktopError = "未检测到 Codex Desktop。"
+            return
+        }
+        guard codexDesktopStatus.appRunning || codexDaemonMigrationRequired else {
+            codexDesktopError = "Codex Desktop 当前未运行，也没有待迁移的共享 daemon。"
             return
         }
 
@@ -585,7 +596,27 @@ final class HostStore {
             isBusy = false
         }
         do {
-            let snapshot = try await codexDesktop.restartAndApply()
+            // 确认弹窗与真正执行之间，用户可能从 Dock 重新打开 Desktop。不能
+            // 使用设置页缓存决定是否可以直接 stop daemon；必须在破坏性迁移前
+            // 重新读取真实进程状态，运行中就回到正常 terminate 流程。
+            let currentDesktop = try await codexDesktop.inspect()
+            if !currentDesktop.appRunning {
+                // 用户已经在设置页确认。Desktop 已退出时只迁移 daemon，不擅自
+                // 重开 Desktop；其他 SSH/CLI/手机连接仍会短暂断开。
+                try await agent.restartCodexSharing()
+                _ = try await waitForCodexRuntimeShared(true)
+                let inspected = try await codexDesktop.inspect()
+                applyCodexDesktopSnapshot(inspected)
+                return
+            }
+            let snapshot = try await codexDesktop.restartAndApply(afterTermination: {
+                // 开启共享时，用户的确认同时授权迁移共享 daemon。Desktop 已经
+                // 正常退出后才 stop 旧 daemon，再由 launchd 拉起；失败时不重新打开。
+                if self.codexDesktopEnabled, self.codexDaemonMigrationRequired {
+                    try await self.agent.restartCodexSharing()
+                    _ = try await self.waitForCodexRuntimeShared(true)
+                }
+            })
             applyCodexDesktopSnapshot(snapshot)
         } catch {
             codexDesktopError = error.localizedDescription
@@ -1319,13 +1350,16 @@ final class HostStore {
             if codexDesktopError.contains("外部") || codexDesktopError.contains("已被其他程序") {
                 return .externalConflict
             }
-            if forcePending, snapshot.appRunning {
+            if forcePending, snapshot.appRunning || codexDaemonMigrationRequired {
                 return .pendingRestart
             }
             return .failed
         }
         if snapshot.appInstalled == false {
             return .notInstalled
+        }
+        if snapshot.enabled, codexDaemonMigrationRequired {
+            return .pendingRestart
         }
         if snapshot.restartRequired, snapshot.appRunning {
             return .pendingRestart
@@ -1380,7 +1414,7 @@ final class HostStore {
             applyCodexDesktopSnapshot(snapshot, forcePending: forcePending)
         } else {
             let current = codexDesktopStatus
-            let state: CodexDesktopStatusState = forcePending && current.appRunning
+            let state: CodexDesktopStatusState = forcePending && (current.appRunning || codexDaemonMigrationRequired)
                 ? .pendingRestart
                 : .failed
             codexDesktopStatus = CodexDesktopStatus(

--- a/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
@@ -49,6 +49,14 @@ final class AgentCommandClientTests: XCTestCase {
             AgentCommandClient.codexSharingConfigurationArguments(enabled: false),
             ["runtime", "--codex-sharing=disabled", "--json"]
         )
+        XCTAssertEqual(
+            AgentCommandClient.codexSharingRestartArguments(),
+            [
+                "runtime",
+                "--codex-sharing-restart",
+                "--codex-sharing-restart-confirmed",
+            ]
+        )
     }
 
     func testProcessCancellationIsReportedAsCancellation() async {

--- a/macos/MimiRemoteMac/Tests/AgentModelsTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentModelsTests.swift
@@ -152,6 +152,7 @@ final class AgentModelsTests: XCTestCase {
         let decodedLegacy = try JSONDecoder().decode(AgentRuntimeStatus.self, from: legacyData)
         XCTAssertNil(decodedLegacy.transport)
         XCTAssertNil(decodedLegacy.shared)
+        XCTAssertNil(decodedLegacy.daemonRestartRequired)
 
         let shared = AgentRuntimeStatus(
             id: "codex",
@@ -163,7 +164,8 @@ final class AgentModelsTests: XCTestCase {
             reason: nil,
             rateLimits: nil,
             transport: "unix",
-            shared: true
+            shared: true,
+            daemonRestartRequired: true
         )
         let decodedShared = try JSONDecoder().decode(
             AgentRuntimeStatus.self,
@@ -171,6 +173,7 @@ final class AgentModelsTests: XCTestCase {
         )
         XCTAssertEqual(decodedShared.transport, "unix")
         XCTAssertEqual(decodedShared.shared, true)
+        XCTAssertEqual(decodedShared.daemonRestartRequired, true)
 
         let sharing = try JSONDecoder().decode(
             CodexSharingConfigurationResult.self,

--- a/macos/MimiRemoteMac/Tests/CodexDesktopIntegrationClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/CodexDesktopIntegrationClientTests.swift
@@ -338,6 +338,32 @@ final class CodexDesktopIntegrationClientTests: XCTestCase {
         XCTAssertFalse(appRunning)
     }
 
+    func testLiveRestartDoesNotOpenDesktopThatWasAlreadyStoppedAtExecutionTime() async throws {
+        let defaults = makeDefaults()
+        let launchctl = FakeLaunchctlState()
+        var events: [String] = []
+        let bundleURL = URL(filePath: "/Applications/Codex.app")
+        let client = makeStateClient(
+            defaults: defaults,
+            state: launchctl,
+            application: CodexDesktopApplicationClient(
+                current: {
+                    CodexDesktopApplicationInfo(bundleURL: bundleURL, isRunning: false)
+                },
+                terminateAndWait: { _ in events.append("terminate") },
+                open: { _, _ in events.append("open") }
+            )
+        )
+
+        _ = try await client.setEnabled(true, "/tmp/codex")
+        let snapshot = try await client.restartAndApply(afterTermination: {
+            events.append("migrate")
+        })
+
+        XCTAssertEqual(events, ["migrate"])
+        XCTAssertFalse(snapshot.appRunning)
+    }
+
     func testExplicitEnableReacquiresOwnershipAfterLoginSessionReset() async throws {
         let defaults = makeDefaults()
         let launchctl = FakeLaunchctlState()

--- a/macos/MimiRemoteMac/Tests/CodexDesktopIntegrationClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/CodexDesktopIntegrationClientTests.swift
@@ -264,6 +264,80 @@ final class CodexDesktopIntegrationClientTests: XCTestCase {
         XCTAssertEqual(events, ["terminate", "open"])
     }
 
+    func testLiveRestartRunsMigrationStrictlyBetweenTerminateAndOpen() async throws {
+        let defaults = makeDefaults()
+        let launchctl = FakeLaunchctlState()
+        var appRunning = true
+        var events: [String] = []
+        let bundleURL = URL(filePath: "/Applications/Codex.app")
+        let client = makeStateClient(
+            defaults: defaults,
+            state: launchctl,
+            application: CodexDesktopApplicationClient(
+                current: {
+                    CodexDesktopApplicationInfo(bundleURL: bundleURL, isRunning: appRunning)
+                },
+                terminateAndWait: { _ in
+                    events.append("terminate")
+                    appRunning = false
+                },
+                open: { _, _ in
+                    XCTAssertFalse(appRunning, "旧 Desktop 未完全退出前不能打开新实例")
+                    events.append("open")
+                    appRunning = true
+                }
+            )
+        )
+
+        _ = try await client.setEnabled(true, "/tmp/codex")
+        _ = try await client.restartAndApply(afterTermination: {
+            XCTAssertFalse(appRunning)
+            events.append("migrate")
+        })
+
+        XCTAssertEqual(events, ["terminate", "migrate", "open"])
+        XCTAssertTrue(appRunning)
+    }
+
+    func testLiveRestartMigrationFailureKeepsDesktopClosedAndNeverOpens() async throws {
+        let defaults = makeDefaults()
+        let launchctl = FakeLaunchctlState()
+        var appRunning = true
+        var events: [String] = []
+        let bundleURL = URL(filePath: "/Applications/Codex.app")
+        let client = makeStateClient(
+            defaults: defaults,
+            state: launchctl,
+            application: CodexDesktopApplicationClient(
+                current: {
+                    CodexDesktopApplicationInfo(bundleURL: bundleURL, isRunning: appRunning)
+                },
+                terminateAndWait: { _ in
+                    events.append("terminate")
+                    appRunning = false
+                },
+                open: { _, _ in
+                    events.append("open")
+                    appRunning = true
+                }
+            )
+        )
+
+        _ = try await client.setEnabled(true, "/tmp/codex")
+        do {
+            _ = try await client.restartAndApply(afterTermination: {
+                events.append("migrate")
+                throw NSError(domain: "CodexDesktopTests", code: 157)
+            })
+            XCTFail("迁移失败必须向上抛出")
+        } catch {
+            XCTAssertEqual((error as NSError).code, 157)
+        }
+
+        XCTAssertEqual(events, ["terminate", "migrate"])
+        XCTAssertFalse(appRunning)
+    }
+
     func testExplicitEnableReacquiresOwnershipAfterLoginSessionReset() async throws {
         let defaults = makeDefaults()
         let launchctl = FakeLaunchctlState()

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -1269,6 +1269,169 @@ final class HostStoreTests: XCTestCase {
         XCTAssertFalse(store.canRestartCodexDesktop)
     }
 
+    func testConfirmedDesktopRestartMigratesSharedDaemonBeforeReopeningDesktop() async {
+        let events = EventRecorder()
+        let migrationRequired = SharingFlag()
+        migrationRequired.set(true)
+        let pending = CodexDesktopEnvironmentSnapshot(
+            hasLocalPreference: true,
+            enabled: true,
+            environmentValue: "1",
+            codexHome: "/tmp/codex",
+            appInstalled: true,
+            appRunning: true,
+            restartRequired: true
+        )
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: { pending },
+            bootstrap: { pending },
+            setEnabled: { _, _ in pending },
+            restartAndApply: {
+                events.append("desktop-restart")
+                return CodexDesktopEnvironmentSnapshot(
+                    hasLocalPreference: true,
+                    enabled: true,
+                    environmentValue: "1",
+                    codexHome: "/tmp/codex",
+                    appInstalled: true,
+                    appRunning: true
+                )
+            }
+        )
+        let store = makeStore(
+            configExists: true,
+            status: {
+                Self.statusWithCodex(
+                    shared: true,
+                    daemonRestartRequired: migrationRequired.value
+                )
+            },
+            restartCodexSharing: {
+                events.append("daemon-restart")
+                migrationRequired.set(false)
+            },
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        XCTAssertTrue(store.canRestartCodexDesktop)
+        await store.restartCodexDesktop()
+
+        XCTAssertEqual(events.values, ["daemon-restart", "desktop-restart"])
+        XCTAssertNil(store.codexDesktopError)
+    }
+
+    func testEnableWithDesktopStoppedKeepsDaemonMigrationPendingUntilUserConfirms() async {
+        let events = EventRecorder()
+        let sharing = SharingFlag()
+        let migrationRequired = SharingFlag()
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: {
+                Self.codexDesktopSnapshot(enabled: sharing.value, appInstalled: true, appRunning: false)
+            },
+            bootstrap: {
+                Self.codexDesktopSnapshot(enabled: false, appInstalled: true, appRunning: false)
+            },
+            setEnabled: { enabled, _ in
+                events.append("desktop-\(enabled)")
+                return Self.codexDesktopSnapshot(enabled: enabled, appInstalled: true, appRunning: false)
+            },
+            restartAndApply: {
+                events.append("desktop-restart")
+                return Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: true)
+            }
+        )
+        let store = makeStore(
+            configExists: true,
+            status: {
+                Self.statusWithCodex(
+                    shared: sharing.value,
+                    daemonRestartRequired: migrationRequired.value
+                )
+            },
+            configureCodexSharing: { enabled in
+                sharing.set(enabled)
+                migrationRequired.set(enabled)
+                return CodexSharingConfigurationResult(
+                    enabled: enabled,
+                    changed: true,
+                    daemonRestartRequired: enabled,
+                    transport: enabled ? "unix" : "ws",
+                    codexHome: enabled ? "/tmp/codex" : nil
+                )
+            },
+            restartCodexSharing: {
+                events.append("daemon-restart")
+                migrationRequired.set(false)
+            },
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        await store.setCodexDesktopEnabled(true)
+
+        XCTAssertEqual(events.values, ["desktop-true"])
+        XCTAssertEqual(store.codexDesktopStatusTitle, "需要重启")
+        XCTAssertTrue(store.canRestartCodexDesktop)
+
+        await store.restartCodexDesktop()
+
+        XCTAssertEqual(events.values, ["desktop-true", "daemon-restart"])
+        XCTAssertFalse(events.values.contains("desktop-restart"))
+        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertNil(store.codexDesktopError)
+    }
+
+    func testPendingMigrationRechecksDesktopBeforeStoppingDaemon() async {
+        let events = EventRecorder()
+        let desktopRunning = SharingFlag()
+        let migrationRequired = SharingFlag()
+        migrationRequired.set(true)
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: {
+                Self.codexDesktopSnapshot(
+                    enabled: true,
+                    appInstalled: true,
+                    appRunning: desktopRunning.value
+                )
+            },
+            bootstrap: {
+                Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: false)
+            },
+            setEnabled: { _, _ in
+                Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: false)
+            },
+            restartAndApply: {
+                events.append("desktop-restart")
+                return Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: true)
+            }
+        )
+        let store = makeStore(
+            configExists: true,
+            status: {
+                Self.statusWithCodex(
+                    shared: true,
+                    daemonRestartRequired: migrationRequired.value
+                )
+            },
+            restartCodexSharing: {
+                events.append("daemon-restart")
+                migrationRequired.set(false)
+            },
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        XCTAssertTrue(store.canRestartCodexDesktop)
+
+        // 设置页仍缓存为 stopped，但用户已从 Dock 重新打开 Desktop。
+        desktopRunning.set(true)
+        await store.restartCodexDesktop()
+
+        XCTAssertEqual(events.values, ["daemon-restart", "desktop-restart"])
+        XCTAssertNil(store.codexDesktopError)
+    }
+
     func testEnableDesktopFailureRollsBackBackendChangedBySameOperation() async {
         let events = EventRecorder()
         let sharing = SharingFlag()
@@ -1497,6 +1660,7 @@ final class HostStoreTests: XCTestCase {
         configureCodexSharing: @escaping @Sendable (Bool) async throws -> CodexSharingConfigurationResult = { enabled in
             CodexSharingConfigurationResult(enabled: enabled)
         },
+        restartCodexSharing: @escaping @Sendable () async throws -> Void = {},
         setLANAccess: @escaping @Sendable (Bool) async throws -> NetworkConfigurationResult = {
             NetworkConfigurationResult(lanEnabled: $0, changed: false, restartRequired: false)
         },
@@ -1515,6 +1679,7 @@ final class HostStoreTests: XCTestCase {
             doctor: { _ in DoctorFixResults(fixes: [], results: doctor) },
             configureClaude: configureClaude,
             configureCodexSharing: configureCodexSharing,
+            restartCodexSharing: restartCodexSharing,
             setLANAccess: setLANAccess,
             pair: pair ?? { _ in Self.pairing },
             version: { readyStatus.version }
@@ -1629,7 +1794,10 @@ final class HostStoreTests: XCTestCase {
         )
     }
 
-    private nonisolated static func statusWithCodex(shared: Bool) -> AgentStatus {
+    private nonisolated static func statusWithCodex(
+        shared: Bool,
+        daemonRestartRequired: Bool = false
+    ) -> AgentStatus {
         AgentStatus(
             processOK: readyStatus.processOK,
             serviceOK: readyStatus.serviceOK,
@@ -1656,6 +1824,7 @@ final class HostStoreTests: XCTestCase {
                         rateLimits: nil,
                         transport: shared ? "unix" : "websocket",
                         shared: shared,
+                        daemonRestartRequired: shared ? daemonRestartRequired : nil,
                         codexHome: shared ? "/tmp/codex" : nil
                     ),
                 ]

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -594,6 +594,75 @@ final class HostStoreTests: XCTestCase {
         XCTAssertEqual(store.lifecycle, .migrationRequired)
     }
 
+    func testDoctorRestartsMacAgentAfterConfigurationRepair() async {
+        let events = EventRecorder()
+        var registrationState = ServiceRegistrationState.notRegistered
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            status: {
+                events.append("status")
+                return Self.readyStatus
+            },
+            doctor: { fix in
+                events.append("doctor-\(fix)")
+                return DoctorFixResults(
+                    fixes: ["已恢复 Codex CLI 路径"],
+                    results: Self.readyStatus.doctor,
+                    restartRequired: true
+                )
+            },
+            registerAgent: {
+                events.append("register-mac")
+                registrationState = .enabled
+            },
+            unregisterAgent: {
+                events.append("unregister-mac")
+                registrationState = .notRegistered
+            },
+            healthCheck: { _ in false }
+        )
+        await store.bootstrap()
+
+        await store.runDoctor(fix: true)
+
+        XCTAssertEqual(store.owner, .macApp)
+        XCTAssertEqual(store.lifecycle, .ready)
+        XCTAssertNil(store.lastError)
+        XCTAssertEqual(events.values, [
+            "register-mac", "status",
+            "doctor-true", "unregister-mac", "register-mac", "status",
+        ])
+    }
+
+    func testDoctorRestartsHomebrewAfterConfigurationRepair() async {
+        let events = EventRecorder()
+        let store = makeStore(
+            configExists: true,
+            homebrewLoaded: true,
+            doctor: { fix in
+                events.append("doctor-\(fix)")
+                return DoctorFixResults(
+                    fixes: ["已恢复 Codex CLI 路径"],
+                    results: Self.readyStatus.doctor,
+                    restartRequired: true
+                )
+            },
+            homebrewStart: { events.append("start-homebrew") },
+            homebrewStop: { events.append("stop-homebrew") }
+        )
+        await store.bootstrap()
+
+        await store.runDoctor(fix: true)
+
+        XCTAssertEqual(store.owner, .homebrew)
+        XCTAssertEqual(store.lifecycle, .migrationRequired)
+        XCTAssertNil(store.lastError)
+        XCTAssertEqual(events.values, [
+            "doctor-true", "stop-homebrew", "start-homebrew",
+        ])
+    }
+
     func testFailedHomebrewRestoreReturnsToMacAgent() async {
         let events = EventRecorder()
         let store = makeStore(
@@ -1321,6 +1390,260 @@ final class HostStoreTests: XCTestCase {
         XCTAssertNil(store.codexDesktopError)
     }
 
+    func testCommittedDaemonMigrationStillReopensDesktopWhenStatusRefreshFails() async {
+        let events = EventRecorder()
+        let migrationRequired = SharingFlag()
+        let failRefresh = SharingFlag()
+        migrationRequired.set(true)
+        let pending = CodexDesktopEnvironmentSnapshot(
+            hasLocalPreference: true,
+            enabled: true,
+            environmentValue: "1",
+            codexHome: "/tmp/codex",
+            appInstalled: true,
+            appRunning: true,
+            restartRequired: true
+        )
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: {
+                if failRefresh.value { throw TestError.expected }
+                return pending
+            },
+            bootstrap: { pending },
+            setEnabled: { _, _ in pending },
+            restartAndApply: {
+                events.append("desktop-restart")
+                return Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: true)
+            }
+        )
+        let store = makeStore(
+            configExists: true,
+            status: {
+                if failRefresh.value { throw TestError.expected }
+                return Self.statusWithCodex(
+                    shared: true,
+                    daemonRestartRequired: migrationRequired.value
+                )
+            },
+            restartCodexSharing: {
+                events.append("daemon-restart")
+                migrationRequired.set(false)
+                failRefresh.set(true)
+            },
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        await store.restartCodexDesktop()
+
+        XCTAssertEqual(events.values, ["daemon-restart", "desktop-restart"])
+        XCTAssertNil(store.codexDesktopError)
+        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertFalse(store.canRestartCodexDesktop)
+    }
+
+    func testCommittedDaemonMigrationWithStoppedDesktopIgnoresPostCommitInspectFailure() async {
+        let events = EventRecorder()
+        let migrationRequired = SharingFlag()
+        let failRefresh = SharingFlag()
+        migrationRequired.set(true)
+        let stopped = Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: false)
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: {
+                if failRefresh.value { throw TestError.expected }
+                return stopped
+            },
+            bootstrap: { stopped },
+            setEnabled: { _, _ in stopped },
+            restartAndApply: {
+                events.append("desktop-restart")
+                return stopped
+            }
+        )
+        let store = makeStore(
+            configExists: true,
+            status: {
+                if failRefresh.value { throw TestError.expected }
+                return Self.statusWithCodex(
+                    shared: true,
+                    daemonRestartRequired: migrationRequired.value
+                )
+            },
+            restartCodexSharing: {
+                events.append("daemon-restart")
+                migrationRequired.set(false)
+                failRefresh.set(true)
+            },
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        await store.restartCodexDesktop()
+
+        XCTAssertEqual(events.values, ["daemon-restart"])
+        XCTAssertNil(store.codexDesktopError)
+        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertFalse(store.canRestartCodexDesktop)
+    }
+
+    func testCommittedDaemonMigrationDoesNotHideNewAuthoritativePendingMarker() async {
+        let migrationRequired = SharingFlag()
+        let failRefresh = SharingFlag()
+        migrationRequired.set(true)
+        let pending = Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: true)
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: {
+                if failRefresh.value { throw TestError.expected }
+                return pending
+            },
+            bootstrap: { pending },
+            setEnabled: { _, _ in pending },
+            restartAndApply: { pending }
+        )
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            status: {
+                if failRefresh.value { throw TestError.expected }
+                return Self.statusWithCodex(
+                    shared: true,
+                    daemonRestartRequired: migrationRequired.value
+                )
+            },
+            restartCodexSharing: {
+                migrationRequired.set(false)
+                failRefresh.set(true)
+            },
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        await store.restartCodexDesktop()
+        XCTAssertFalse(store.canRestartCodexDesktop)
+
+        // 提交后的首次刷新失败，随后服务端重新检测到 unmanaged owner 并生成
+        // 新 marker。下一份权威 true 必须重新显示 pending，不能被本地成功标记遮蔽。
+        migrationRequired.set(true)
+        failRefresh.set(false)
+        await store.refresh()
+
+        XCTAssertEqual(store.codexDesktopStatusTitle, "需要重启")
+        XCTAssertTrue(store.canRestartCodexDesktop)
+    }
+
+    func testPreCommitStatusResponseCannotOverwritePostCommitMigrationState() async {
+        let gate = SuspendedStatusGate()
+        let statusCalls = CallCounter()
+        let pendingStatus = Self.statusWithCodex(shared: true, daemonRestartRequired: true)
+        let committedStatus = Self.statusWithCodex(shared: true, daemonRestartRequired: false)
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: {
+                Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: false)
+            },
+            bootstrap: {
+                Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: false)
+            },
+            setEnabled: { _, _ in
+                Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: false)
+            },
+            restartAndApply: {
+                Self.codexDesktopSnapshot(enabled: true, appInstalled: true, appRunning: false)
+            }
+        )
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            status: {
+                switch statusCalls.increment() {
+                case 1:
+                    return pendingStatus
+                case 2:
+                    return await gate.suspendReturning(pendingStatus)
+                default:
+                    return committedStatus
+                }
+            },
+            restartCodexSharing: {},
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        XCTAssertTrue(store.canRestartCodexDesktop)
+
+        let staleRefresh = Task { await store.refresh() }
+        await gate.waitUntilSuspended()
+        await store.restartCodexDesktop()
+        XCTAssertFalse(store.canRestartCodexDesktop)
+
+        gate.resume()
+        await staleRefresh.value
+
+        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertFalse(store.canRestartCodexDesktop)
+    }
+
+    func testPreCommitStatusResponseCannotWinWhileDesktopReopens() async {
+        let statusGate = SuspendedStatusGate()
+        let reopenGate = SuspendedStatusGate()
+        let statusCalls = CallCounter()
+        let pendingStatus = Self.statusWithCodex(shared: true, daemonRestartRequired: true)
+        let committedStatus = Self.statusWithCodex(shared: true, daemonRestartRequired: false)
+        let running = Self.codexDesktopSnapshot(
+            enabled: true,
+            appInstalled: true,
+            appRunning: true
+        )
+        let desktop = CodexDesktopIntegrationClient(
+            inspect: { running },
+            bootstrap: { running },
+            setEnabled: { _, _ in running },
+            restartAndApply: { running },
+            restartAndApplyWithPreparation: { preparation in
+                // 模拟 live client 已经退出旧 Desktop、提交 daemon 迁移，随后
+                // application.open 仍在等待。迁移前的 status=true 会在此时迟到。
+                try await preparation()
+                return await reopenGate.suspendReturning(running)
+            }
+        )
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            status: {
+                switch statusCalls.increment() {
+                case 1:
+                    return pendingStatus
+                case 2:
+                    return await statusGate.suspendReturning(pendingStatus)
+                default:
+                    return committedStatus
+                }
+            },
+            restartCodexSharing: {},
+            codexDesktop: desktop
+        )
+
+        await store.bootstrap()
+        XCTAssertTrue(store.canRestartCodexDesktop)
+
+        let staleRefresh = Task { await store.refresh() }
+        await statusGate.waitUntilSuspended()
+        let restart = Task { await store.restartCodexDesktop() }
+        await reopenGate.waitUntilSuspended()
+
+        // daemon 已提交但 Desktop 仍在 open。旧的 pending=true 此时返回，
+        // 必须因提交点分配的新序号被丢弃，不能清掉本地 committed 状态。
+        statusGate.resume()
+        await staleRefresh.value
+        XCTAssertFalse(store.canRestartCodexDesktop)
+
+        reopenGate.resume()
+        await restart.value
+
+        XCTAssertNil(store.codexDesktopError)
+        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertFalse(store.canRestartCodexDesktop)
+    }
+
     func testEnableWithDesktopStoppedKeepsDaemonMigrationPendingUntilUserConfirms() async {
         let events = EventRecorder()
         let sharing = SharingFlag()
@@ -1642,6 +1965,9 @@ final class HostStoreTests: XCTestCase {
         status: @escaping @Sendable () async throws -> AgentStatus = {
             HostStoreTests.readyStatus
         },
+        doctor: @escaping @Sendable (Bool) async throws -> DoctorFixResults = { _ in
+            DoctorFixResults(fixes: [], results: HostStoreTests.readyStatus.doctor)
+        },
         registerAgent: @escaping @MainActor () throws -> Void = {},
         unregisterAgent: @escaping @MainActor () async throws -> Void = {},
         homebrewStart: @escaping @Sendable () async throws -> Void = {},
@@ -1670,13 +1996,12 @@ final class HostStoreTests: XCTestCase {
         terminateApplication: @escaping @MainActor () -> Void = {}
     ) -> HostStore {
         let readyStatus = Self.readyStatus
-        let doctor = readyStatus.doctor
         let agent = AgentCommandClient(
             configExists: { configExists },
             setup: { _ in Self.pairing },
             status: status,
             statusAt: { _ in readyStatus },
-            doctor: { _ in DoctorFixResults(fixes: [], results: doctor) },
+            doctor: doctor,
             configureClaude: configureClaude,
             configureCodexSharing: configureCodexSharing,
             restartCodexSharing: restartCodexSharing,
@@ -1938,6 +2263,47 @@ private final class CallCounter: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return value
+    }
+}
+
+private final class SuspendedStatusGate: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var suspended = false
+    private var released = false
+
+    func suspendReturning<T: Sendable>(_ value: T) async -> T {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async { [self] in
+                condition.lock()
+                suspended = true
+                condition.broadcast()
+                while !released {
+                    condition.wait()
+                }
+                condition.unlock()
+                continuation.resume(returning: value)
+            }
+        }
+    }
+
+    func waitUntilSuspended() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async { [self] in
+                condition.lock()
+                while !suspended {
+                    condition.wait()
+                }
+                condition.unlock()
+                continuation.resume()
+            }
+        }
+    }
+
+    func resume() {
+        condition.lock()
+        released = true
+        condition.broadcast()
+        condition.unlock()
     }
 }
 

--- a/scripts/check-source-size.sh
+++ b/scripts/check-source-size.sh
@@ -33,6 +33,18 @@ exception_reason() {
     internal/httpapi/appserver_gateway_test.go)
       printf '%s' 'App Server 网关回归矩阵，后续按鉴权、会话和历史消息场景拆分'
       ;;
+    internal/httpapi/appserver_gateway_policy_test.go)
+      printf '%s' '共享 App Server writer 与反向响应策略回归矩阵，后续按请求和响应策略拆分'
+      ;;
+    ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift)
+      printf '%s' 'Codex App Server 协议兼容回归矩阵，后续按传输与反向请求职责拆分'
+      ;;
+    ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift)
+      printf '%s' '直接 Runtime 会话与拒绝恢复回归矩阵，后续按审批和会话生命周期拆分'
+      ;;
+    cmd/agentd/main.go)
+      printf '%s' 'agentd 启动与共享 Runtime 状态编排入口，后续按 serve 和状态检查职责拆分'
+      ;;
     internal/httpapi/router_test.go)
       printf '%s' 'HTTP 路由回归矩阵，后续按配对、项目和运行时端点拆分'
       ;;


### PR DESCRIPTION
## 目标

让 Mimi iPhone / iPad 与 Codex Desktop 共用同一个官方 App Server，在保持 Mac Codex 原生流程、TCC 权限归因和单 writer 约束的前提下，实现已有会话实时观察与空闲后无缝续写。

关联 Linear：[MIM-157](https://linear.app/code89757/issue/MIM-157/codex-desktop-读取文件被归因到-agentd-并触发-mimi-权限)

## 根因

旧共享方案由 `agentd` 直接启动 Codex local daemon。macOS 会沿进程创建链传播 responsible process，导致 Desktop 经共享 daemon 访问文件时可能被归因到 Mimi/agentd；同时 Codex 原生 SSH bootstrap 可能先占用同一个 Unix socket，但该进程不在官方 daemon 的 pid backend 账本中，不能用普通 `daemon stop` 安全接管。

## 完整实现

- 用持久 `launchd` LaunchAgent 作为稳定 owner，直接调用官方 `codex app-server daemon start`；`agentd` 不再成为共享 daemon 的直接父进程。
- 初次启用只安装 `RunAtLoad=false` 的 manual owner 并保留 migration marker。日常 agentd 启动、gateway recovery、Doctor 修复均不能越过 pending 状态或触碰 Codex Desktop。
- 只有 Mac App 设置页显式确认后才执行迁移：普通退出 Desktop → 核实 backend/进程身份 → 停止旧 listener → 单次 kickstart → 完整握手和 lifecycle 校验 → 提升 auto owner → 按原运行状态决定是否重开 Desktop。
- unmanaged takeover 原生绑定 Unix peer PID/UID，并复核 executable、argv、进程启动时间和 Desktop bundle 状态；只向唯一匹配 PID 发一次 `SIGTERM`，不用 `pkill`、进程组信号、`SIGKILL`、后台循环或 `launchctl submit`。
- 新 daemon 必须通过 initialize、`CODEX_HOME`、版本、standalone path 和 lifecycle `backend=pid` 校验后才清 marker；任何失败都 fail closed，不自动重试、不擅自重开 Desktop。
- shared Unix gateway 对 Desktop active turn、observer 不可用和反向 response 缺失 thread scope 全部只读保护；pending request 只有在 guard 和重写成功后才消费。iOS 收到拒绝通知后恢复审批/补充输入卡片。
- enable / disable / setup / Doctor / runtime recovery 统一 daemon → config 锁序、同源 raw snapshot 和 CAS；覆盖崩溃恢复、stale Router、custom profile、大小写不敏感卷、Windows/Linux 编译边界以及 token/config 路径别名。
- Mac App 用单调 status sequence 防止迁移前旧响应覆盖提交后状态；迁移提交后 status/inspect 只做 best-effort，不阻止 Desktop 正常重开。

## 用户效果

- Mac 与 iPad 看到同一会话和同一事件流。
- Mac Turn 运行时 iPad 显示“观察”并保持只读；Turn 空闲后可直接在 iPad 续写同一会话。
- 两端不同会话可独立工作，新建会话会同步到另一端。
- 普通 Mimi 启动、重载或网络恢复不会退出、重开或接管 Codex Desktop；稳定 owner 迁移必须由用户明确确认。

## 最终本地验证（commit `4d4a56a7`）

- `go test ./...`：通过
- `go test -race ./internal/config ./internal/setup ./internal/appserver ./internal/httpapi`：通过
- `go vet ./...`：通过
- Linux / Windows `internal/appserver`、`internal/setup` 交叉编译：通过
- `git diff --check`：通过
- Mimi Remote Mac XCTest：100 passed，0 failed，0 skipped
- iOS 固定 `iPad Pro 13-inch (M5)` Simulator：1328 tests executed，3 skipped；18 个失败均为仓库既有视觉快照基线差异，本 PR 新增 Runtime / reverse-response 逻辑用例通过
- Codex 两个独立审查流、Claude Code 与 ChatGPT Pro：均为 GO，未发现剩余 P0–P2
- ChatGPT Pro 报告的唯一非阻断 P3 已修复：显式 daemon 迁移不再因无关 `scan_roots` 离线而在 Desktop 退出后中止
- 真机阶段性验收：iPad 能实时加载 Mac 会话、Mac 执行时显示“观察”、空闲后可从 iPad 续写；两端均可新建并同步会话

## Draft 阶段剩余验收

- Claude Code 已对最终提交完成只读复审：GO，无 P0–P2。
- ChatGPT Pro 已完成最终静态终审：GO；唯一 P3 已按建议修复并由本地完整 Go/race/vet 回归验证。
- 最终提交尚未重新部署到 Mac / iPad；待三方代码审查都通过后，再执行一次稳定 owner 迁移、Mac 登录冷启动和正式签名 TCC 归因验证。

## 安全边界

- 不修改 Codex Desktop 本体。
- 不把 CLI 双 flag 当作授权；它只是防误触。真正的用户确认入口仍在 Mac App。
- 正式签名 App 的 TCC / 受保护目录归因属于最终运行态验收，不能由单元测试代替。
