### PR TITLE
MIM-158 / MIM-159 修复共享 Codex daemon 的 FD 与 Browser 运行时身份

### DIFF
--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -49,6 +49,8 @@ Mac App 执行迁移的短命 `agentd` 控制命令有明确超时。超时后�
 
 `runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
 
+官方 `daemon start` 完成 detached listener 交接后，部分版本仍报告 `pid` backend，但不会继续返回 listener PID。只有 stable owner 已提交、socket 路径一致且 backend 仍为 `pid` 时，才标记为 `owner_claimed_unverified` warning；缺少 backend 的旧 SSH/CLI listener 仍视为 unmanaged。该 warning 既不把当前 listener 误报为已验证 stable，也不把 owner 的目标上限当成 listener 已实际继承。
+
 移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；对 app-server 发给客户端的审批、补充输入和 MCP elicitation，移动端返回的反向 JSON-RPC response 也执行相同 guard，拒绝时保留 pending request 并恢复移动端卡片。`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读、观测器缺失或反向 request 缺少 thread scope 时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
 
 命令行等价操作：

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -17,10 +17,7 @@ Codex App Server 新版对 thread writer 增加了跨进程互斥。同一个 th
 macOS 上显式启用 Codex 官方 local daemon：
 
 ```text
-launchd LaunchAgent ──> OpenAI 签名 node launcher（一次性）
-                                  │ detached
-                                  ▼
-                         OpenAI 签名 node supervisor
+launchd LaunchAgent ──> OpenAI 签名 node supervisor（前台常驻）
                                   │ foreground child
                                   ▼
                          OpenAI 签名 codex app-server
@@ -34,7 +31,7 @@ iPhone / iPad 通过 /api/app-server/ws 继续经过鉴权、cwd 和方法策略
 
 Desktop 使用官方 `CODEX_APP_SERVER_USE_LOCAL_DAEMON=1` 开关连接 Unix Socket；`agentd` 使用 WebSocket-over-UDS 连接同一 socket。writer 仍然是单写者，但所有客户端位于同一个 app-server 进程内，因此空闲 thread 的 `thread/resume` 会复用已加载实例，不再触发跨进程锁冲突。
 
-Browser 原生授权读取的三级进程链必须是 `node_repl → codex app-server → node supervisor`。旧 `codex app-server daemon start` 会把 listener 脱离成 `PPID=1`，第三级落到 `launchd`，即使共享 socket 和新会话都正常，Browser 仍会拒绝。新 owner 使用 Codex Desktop bundle 内的签名 Node 保持为 app-server 直接父进程；Mimi、shell 和 launcher 都不进入这三级。落盘前验证 bundle、Node 与 codex 的 Developer ID requirement，运行后再从真实 socket peer 沿 PPID 读取内核 `csops` 的 signing identifier、Team ID 和 hardened-runtime 状态，不能只信 plist、路径或 `codesign -d` metadata。
+Browser 原生授权读取的三级进程链必须是 `node_repl → codex app-server → node supervisor`。旧 `codex app-server daemon start` 会把 listener 脱离成 `PPID=1`，第三级落到 `launchd`，即使共享 socket 和新会话都正常，Browser 仍会拒绝。新 owner 使用 Codex Desktop bundle 内的签名 Node 保持为 app-server 直接父进程；Mimi、shell 和 launchd 都位于这三级之外。落盘前验证实际执行的 Node 与 codex 叶子程序的 Developer ID requirement，并要求 Node 位于可信 Desktop bundle 边界；运行后再从真实 socket peer 沿 PPID 读取内核 `csops` 的 signing identifier、Team ID 和 hardened-runtime 状态，不能只信 plist、路径或 `codesign -d` metadata。
 
 默认仍保留独立 loopback WebSocket，避免没有安装官方 standalone daemon 的机器在升级后无法启动。共享功能只能由用户在 Mimi Remote Mac 设置中显式开启，或使用命令行开启。
 
@@ -45,19 +42,19 @@ Browser 原生授权读取的三级进程链必须是 `node_repl → codex app-s
 Mac App 的“Codex Desktop → 共享本地 app-server 会话”会按以下顺序执行：
 
 1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket；已有 listener 必须完成 `initialize` / `initialized` 握手，stale socket 文件不算就绪；
-2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行 Codex Desktop bundle 内的签名 Node；一次性 launcher 创建 detached 的同签名 Node supervisor，supervisor 再以前台 child 启动 `codex app-server --listen unix://`。不经过 shell、不使用 `daemon start`，也不托管自定义二进制。job 使用 `KeepAlive=false`、`AbandonProcessGroup=true`，并显式设置 `SoftResourceLimits/NumberOfFiles=8192`；上限由 launcher、supervisor、app-server 和 Browser/MCP 子进程逐级继承，不覆盖 hard limit。`NODE_OPTIONS`、`NODE_PATH` 等可改变 Node 启动代码的变量会被清空。此时绝不启动新 Unix daemon；
-3. 对 Desktop App、内置 Node 与 standalone codex 分别执行严格 Developer ID requirement 验证，要求固定 Team `2DC432GLL2`、对应 signing identifier 和 hardened runtime；codex 与 Node 的符号链接会固定到已经验证的真实版本路径。全新启用还会写入私有 durable intent；任一提交前条件不完整都直接失败并清理本次 owner，配置与 Desktop 环境均不修改；
+2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接以前台方式执行 Codex Desktop bundle 内的签名 Node supervisor，supervisor 再以前台 child 启动 `codex app-server --listen unix://`。不经过 shell、不使用 `daemon start`，也不托管自定义二进制。job 使用 `KeepAlive=false`，不设置 `AbandonProcessGroup`，并显式设置 `SoftResourceLimits/NumberOfFiles=8192`；上限由 supervisor、app-server 和 Browser/MCP 子进程逐级继承，不覆盖 hard limit。child 退出后 supervisor 同步退出，后续只由已有 gateway recovery 在真实连接失败时受控 kickstart。`NODE_OPTIONS`、`NODE_PATH` 等可改变 Node 启动代码的变量会被清空。此时绝不启动新 Unix daemon；
+3. 对内置 Node 与配置解析出的 codex 叶子程序分别执行严格 Developer ID requirement 验证，要求固定 Team `2DC432GLL2`、对应 signing identifier 和 hardened runtime；Node 还必须位于 Codex Desktop bundle 的可信路径边界，codex 与 Node 的符号链接会固定到已经验证的真实版本路径。全新启用还会写入私有 durable intent；任一提交前条件不完整都直接失败并清理本次 owner，配置与 Desktop 环境均不修改；
 4. 在 shared-daemon 操作锁内再次复核同一份原始配置，并用所有 Mimi 配置写入者共用的跨进程 CAS 锁，原子保存当前 `app_server` transport 为 `shared_fallback`、再切换到 `unix://`。只有配置 rename 已成功且启用前没有旧 listener，manual job 才会显式 `kickstart` 并校验完整协议、`CODEX_HOME`、standalone 路径、版本以及真实 `listener → signed node supervisor` 父链；foreground app-server 的 lifecycle `backend=nil` 在完整签名父链成立时是正常状态，不会被无条件放开。即使冷启动全部通过，也继续保留 marker 与 `RunAtLoad=false`，因为 kickstart 与 socket 建立之间不能原子证明是谁赢得 listener。durable intent 只用于恢复“rename 已完成但首次冷启动尚未完成”的崩溃窗口，第一次完整签名拓扑校验通过后立即消费，不能被后续普通 recovery 重用。首次启用和接管既有 listener 都必须经过第 7 步的用户确认，才清 marker 并提升为 `RunAtLoad=true`。配置提交后的启动失败会作为“已提交、待恢复”结果返回，Mac App 会重新加载状态；若进程在 rename 与 kickstart 之间退出，下一次 shared agentd 会在锁内复核配置身份后继续该 durable intent，但仍不会自动完成 owner 迁移；
 5. 重启并确认 agentd 的 runtime 状态为 `transport=unix`、`shared=true`、daemon 可连接；
 6. 经 ownership 检查后，为 GUI 用户会话写入官方 daemon 开关、相同的 canonical `CODEX_HOME` 和 Mimi 私有的随机会话 marker，确保从 Dock / Finder 启动也生效；三键按事务写入，任一失败都会按相反顺序恢复，外部已有值不会被覆盖；
 7. 首次启用或启用前已有 daemon 时，owner 都会持久标记为“待迁移”，并把磁盘 plist 固定为 `RunAtLoad=false`，不会静默中断既有进程，也不会在注销、登录或 Mac 重启后自动完成迁移。旧 `pid` backend、SSH/CLI 直启 listener 或签名父链不成立的 listener 都只能保持 attach 并收敛到 pending，不能因为它们来自官方 codex 就冒充 Browser 可用的 stable 状态；只有真实 socket peer 的签名 supervisor 拓扑通过才算 stable。普通 ensure 在每个 `bootout/bootstrap` 前都会重新探测 socket：即使 listener 在 codesign 或 plist 落盘期间才出现，也会立刻把 owner 降成 manual+marker，绝不对活跃 launchd coalition 执行 bootout。仅 durable fresh-enable intent 且 socket 尚未创建时允许 manual job 恢复一次冷启动，恢复后仍保持 pending；其他 pending 掉线只等待用户再次确认。
 
-   用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 `pid` backend 管理时执行官方 `daemon stop`；直接 listener（包括旧 SSH bootstrap 和已签名 supervisor child）只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` argv、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 listener 发送一次 `SIGTERM`，supervisor 会逐次转发 `SIGHUP/SIGTERM/SIGINT` 且不使用 `SIGKILL`。等待旧 socket 持续拒绝连接 500 ms 且原 listener 的 PID/启动时间证据确认进程已经退出后，才 `bootout` 旧的 one-shot 定义、`bootstrap` 磁盘上的 manual 新定义并 `kickstart` 一次。新进程必须完成协议、版本和运行态签名父链验证，全部通过后才清 intent/marker、把 plist 恢复为 `RunAtLoad=true`。上次已启动新签名 supervisor、但恰好在清 marker 前崩溃时，重试会直接提交健康进程，不再中断一次。任意失败都保留 manual+marker，不自动重试、强杀或打开 Desktop；
-8. 在没有待迁移 marker 的正常已提交状态下，如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与显式迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。新安装或 reload 的 `RunAtLoad` launcher 已经触发时只等待其 socket，不会再 kickstart 第二套；登录时 launcher 已退出而 supervisor 尚在冷启动，也会先等待一秒 grace。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
+   用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 `pid` backend 管理时执行官方 `daemon stop`；直接 listener（包括旧 SSH bootstrap 和已签名 supervisor child）只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` argv、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 listener 发送一次 `SIGTERM`，supervisor 会逐次转发 `SIGHUP/SIGTERM/SIGINT` 且不使用 `SIGKILL`。等待旧 socket 持续拒绝连接 500 ms 且原 listener 的 PID/启动时间证据确认进程已经退出后，才 `bootout` 旧的已加载定义、`bootstrap` 磁盘上的 manual 新定义并 `kickstart` 一次。新进程必须完成协议、版本和运行态签名父链验证，全部通过后才清 intent/marker、把 plist 恢复为 `RunAtLoad=true`。上次已启动新签名 supervisor、但恰好在清 marker 前崩溃时，重试会直接提交健康进程，不再中断一次。任意失败都保留 manual+marker，不自动重试、强杀或打开 Desktop；
+8. 在没有待迁移 marker 的正常已提交状态下，如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与显式迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。新安装或 reload 的 `RunAtLoad` job 已经启动 supervisor 时只等待其 socket，不会再 kickstart 第二套；登录时 job 已运行但 app-server socket 尚在冷启动，也会先等待一秒 grace。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
 
 Mac App 执行迁移的短命 `agentd` 控制命令有明确超时。超时后先发送普通 `SIGTERM`，两秒仍未退出才只回收该 control CLI；不会因此向共享 Codex daemon 发送 `SIGKILL`。manual plist 与迁移 marker 会继续保留，设置页退出“正在更新”并显示可重试错误，避免控制命令异常时无限卡住。
 
-`runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
+`runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。稳定 owner 的这一未知项作为正常信息展示，不制造无法消除的 WARN；将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
 
 旧 `daemon start` 的 `pid` backend 无论是否返回精确 listener PID，都只标记为 `owner_claimed_unverified`；它证明官方 lifecycle 与 socket 对得上，但不能证明签名 Node 父链或实际继承的 FD soft limit。缺少 backend 且签名拓扑失败的旧 SSH/CLI listener 仍视为 unmanaged。两者都会等待显式迁移，不会被诊断误报成 Browser 可用的 stable。
 
@@ -80,7 +77,7 @@ Go 端仍会实时复核 marker、owner 和 Desktop 状态。同一用户下的�
 
 ### 关闭与回滚
 
-关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file，并删除 Mimi 的磁盘 LaunchAgent 与待迁移标记；不会停止当前 daemon，因为 Desktop 可能仍在使用它。已加载的 one-shot job 会保留到当前 GUI 会话注销：`bootout` 没有“不影响 launchd coalition 后代”的契约，删除未来登录入口已经足够阻止下次自动启动。即使进程在“plist 已删、marker 尚未清”之间崩溃，立即重试也会幂等清理 marker/intent，不要求先注销。事务顺序固定为：先把 owner 降为 manual 并移除未来启动入口，再 CAS 提交非共享配置。这样进程在任意一步退出，最多留下 `shared + 无 owner/manual owner`，不会形成 `WS + RunAtLoad=true`。owner 删除失败时配置不提交并保留 fail-closed 的 manual 状态；配置已被其他 writer 改动或提交失败时也不恢复可能已经失权的 auto owner，下一次明确操作再幂等收敛。`setup --force`、sharing、Claude、network 与 repair 写入共用配置提交锁；只有平台默认配置可以拥有或清理当前用户全局 LaunchAgent，自定义 `--config` profile 不会触碰默认服务的 owner。完整 stable-owner 共享目前只在 macOS 开放；非 macOS 升级后仍允许执行 disable 回退旧配置。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，启用时只 attach 已经可握手的 socket，缺失时明确失败且绝不启动；禁用时只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
+关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file，并删除 Mimi 的磁盘 LaunchAgent 与待迁移标记；不会停止当前 daemon，因为 Desktop 可能仍在使用它。已加载的 job registration 会保留到当前 GUI 会话注销：`bootout` 没有“不影响 launchd coalition 后代”的契约，删除未来登录入口已经足够阻止下次自动启动。即使进程在“plist 已删、marker 尚未清”之间崩溃，立即重试也会幂等清理 marker/intent，不要求先注销。事务顺序固定为：先把 owner 降为 manual 并移除未来启动入口，再 CAS 提交非共享配置。这样进程在任意一步退出，最多留下 `shared + 无 owner/manual owner`，不会形成 `WS + RunAtLoad=true`。owner 删除失败时配置不提交并保留 fail-closed 的 manual 状态；配置已被其他 writer 改动或提交失败时也不恢复可能已经失权的 auto owner，下一次明确操作再幂等收敛。`setup --force`、sharing、Claude、network 与 repair 写入共用配置提交锁；只有平台默认配置可以拥有或清理当前用户全局 LaunchAgent，自定义 `--config` profile 不会触碰默认服务的 owner。完整 stable-owner 共享目前只在 macOS 开放；非 macOS 升级后仍允许执行 disable 回退旧配置。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，启用时只 attach 已经可握手的 socket，缺失时明确失败且绝不启动；禁用时只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
 
 ```bash
 agentd runtime --codex-sharing=disabled --json
@@ -91,7 +88,8 @@ agentd restart --no-pair
 
 ## 风险与优化
 
-- 签名 supervisor 冷启动需要 `$CODEX_HOME/packages/standalone/current/codex` 与 Codex Desktop bundle 内置 Node。已有健康 socket 但任一材料缺失或签名不符时，owner 更新也会阻断，避免本次看似成功、Mac 重启后持续拉起失败；Mimi Remote 不会静默下载替代二进制，只给出官方安装指引。
+- 签名 supervisor 冷启动需要配置解析出的 codex 与 Codex Desktop bundle 内置 Node。已有健康 socket 但任一材料缺失或签名不符时，owner 更新也会阻断，避免本次看似成功、Mac 重启后持续拉起失败；Mimi Remote 不会静默下载替代二进制，只给出官方安装指引。
+- 安全校验会把 `standalone/current/codex` 的符号链接固定到已验签的真实版本，避免验签与执行之间被替换。升级使 `current` 指向新版本且旧 listener 仍在运行时，新 plist 会进入 manual+marker，用户需要显式“应用待处理设置”；若当时没有 listener，则可安全自动 reload。使用 Desktop bundle 内稳定 codex 路径的安装不受该版本目录变化影响。
 - 共享架构把两端的会话一致性放在同一个官方 app-server 上，因此该 server 自身崩溃时 Codex Desktop 与 Mimi 会同时短暂失去后端。稳定 owner 只在 server 已不可连时尝试恢复它，不会为了恢复而退出或重开 Codex Desktop。
 - 8192 是防止过低 launchd soft limit 把资源累积过早放大成全能力故障，不是对子进程或 FD 泄漏的掩盖。Doctor 同时展示真实 FD 与直接子进程水位；持续上涨仍需定位 Codex/MCP 上游的回收责任。本方案不基于不完整的 external activity 证据自动 recycle 健康 daemon。
 - Desktop 必须支持 local daemon，当前最低兼容 app-server 版本为 `0.141.0`。版本、socket 类型、目录权限、socket 权限和返回的 `codexHome` 都会在启用前校验。
@@ -101,7 +99,7 @@ agentd restart --no-pair
 - `launchctl` 环境会在注销后消失；Mac App 只会为已经显式启用、backend 再次确认共享且三键均为空的用户生成新 marker 并恢复环境，不会借登录启动替新用户自动开启功能。新会话里其他程序即使写入相同的官方值，没有匹配 marker 也不会被 Mimi 认领。若 Desktop 比 Mimi 更早启动，设置页会保持“需要重启”，由用户确认后正常退出并重开。
 - Unix Socket 的安全边界是当前用户私有目录与 `0600` socket；它不会暴露到 TCP，也不复用 iPad 的 Bearer Token 或旧 app-server capability token。
 - Mimi 自己的配置写入通过用户私有的跨进程文件锁与同源 raw snapshot CAS 串行；不遵守该协议的外部编辑器无法被强制加锁，因此最终 rename 前仍会复核 bytes 并在可检测冲突时 fail closed，但不会宣称能对任意第三方写入提供数据库级事务。
-- LaunchAgent plist 可能包含为 Codex/MCP 配置的运行环境，因此固定为 `0600`，日志目录/文件也按当前用户私有权限创建；Desktop 专属 transport/ownership 变量与 Node 代码注入变量由 job 的空值覆盖。稳定运行链固定为 `launchd → detached signed node supervisor → signed codex`，一次性 launcher 不进入 Browser 的三级授权链。
+- LaunchAgent plist 可能包含为 Codex/MCP 配置的运行环境，因此固定为 `0600`，日志目录/文件也按当前用户私有权限创建；Desktop 专属 transport/ownership 变量与 Node 代码注入变量由 job 的空值覆盖。稳定运行链固定为 `launchd → signed node supervisor → signed codex`；launchd 位于 Browser 读取的 `node_repl → codex → node` 三级授权链之外。
 - LaunchAgent 已安装、socket 可握手、版本一致和内核签名父链验证仍只证明本地结构闭环；Browser 的内部授权实现不是公开协议，正式发布必须用真实 Codex Desktop 新会话调用一次 Browser，并同时验证 Mimi/手机仍连接同一 socket。Doctor 和单元测试不能冒充这项端到端证明。
 - `thread/unsubscribe` 只取消当前连接订阅，不释放 writer；没有公开的单 thread takeover/unload RPC，因此不要重新叠加客户端 idle 猜测或自动抢占逻辑。
 

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -37,13 +37,17 @@ Desktop 使用官方 `CODEX_APP_SERVER_USE_LOCAL_DAEMON=1` 开关连接 Unix Soc
 Mac App 的“Codex Desktop → 共享本地 app-server 会话”会按以下顺序执行：
 
 1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket；已有 listener 必须完成 `initialize` / `initialized` 握手，stale socket 文件不算就绪；
-2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；此时绝不启动新 Unix daemon；
+2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；job 显式设置 `SoftResourceLimits/NumberOfFiles=8192`，避免用户域 launchd 常见的 256 soft limit 让长期共享 daemon 同时丢失 Browser、Skills、MCP、Shell 与网络能力；不覆盖 hard limit。此时绝不启动新 Unix daemon；
 3. 验证官方 standalone 可执行文件与 daemon lifecycle 冷启动能力。全新启用还会写入私有 durable intent；任一提交前条件不完整都直接失败并清理本次 owner，配置与 Desktop 环境均不修改；
 4. 在 shared-daemon 操作锁内再次复核同一份原始配置，并用所有 Mimi 配置写入者共用的跨进程 CAS 锁，原子保存当前 `app_server` transport 为 `shared_fallback`、再切换到 `unix://`。只有配置 rename 已成功且启用前没有旧 listener，manual job 才会显式 `kickstart` 并校验完整协议、官方 pid backend、`CODEX_HOME`、standalone 路径和版本；即使冷启动全部通过，也继续保留 marker 与 `RunAtLoad=false`，因为 kickstart 与 socket 建立之间不能原子证明是谁赢得 listener。durable intent 只用于恢复“rename 已完成但首次冷启动尚未完成”的崩溃窗口，第一次完整 managed 校验通过后立即消费，不能被后续普通 recovery 重用。首次启用和接管既有 listener 都必须经过第 7 步的用户确认，才清 marker 并提升为 `RunAtLoad=true`。配置提交后的启动失败会作为“已提交、待恢复”结果返回，Mac App 会重新加载状态；若进程在 rename 与 kickstart 之间退出，下一次 shared agentd 会在锁内复核配置身份后继续该 durable intent，但仍不会自动完成 owner 迁移；
 5. 重启并确认 agentd 的 runtime 状态为 `transport=unix`、`shared=true`、daemon 可连接；
 6. 经 ownership 检查后，为 GUI 用户会话写入官方 daemon 开关、相同的 canonical `CODEX_HOME` 和 Mimi 私有的随机会话 marker，确保从 Dock / Finder 启动也生效；三键按事务写入，任一失败都会按相反顺序恢复，外部已有值不会被覆盖；
 7. 首次启用或启用前已有 daemon 时，owner 都会持久标记为“待迁移”，并把磁盘 plist 固定为 `RunAtLoad=false`，不会静默中断既有进程，也不会在注销、登录或 Mac 重启后自动完成迁移。稳定 owner 已安装后，如果未来又由 Codex 原生 SSH bootstrap 先抢到 socket，agentd 仍会在完成协议、版本、`CODEX_HOME` 和 standalone 路径验证后保持 attach，并把 owner 收敛回同一 pending 状态；socket 仍可连接时普通启动只 attach；仅 durable fresh-enable intent 且 socket 尚未创建时允许 manual job 恢复一次冷启动，恢复后仍保持 pending。其他 socket 不可连接场景下普通启动和 gateway recovery 直接返回 pending，既不 `kickstart` 也不清 marker。该标记独立于五分钟 runtime 缓存，每次状态请求都实时读取，因此用户取消确认或先退出 Desktop 后入口仍保留。用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 pid backend 管理时执行官方 `daemon stop`；旧 server 是 Codex 原生 SSH bootstrap 直启链时，只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` 命令行、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 PID 发送一次 `SIGTERM`。官方 stop 与新 daemon kickstart 各自在副作用前按固定 bundle ID 最终复核 Desktop，App 已重开或 LaunchServices 查询失败都立即停止迁移。不使用进程组信号、`SIGKILL`、模糊进程名或自动重试。等待最长 15 秒，且旧 socket 持续拒绝连接 500 ms 后，才由 LaunchAgent 拉起一次并完成协议/生命周期/版本验证；全部通过后才清 intent/marker、把 plist 恢复为 `RunAtLoad=true`，并按实际执行时的 Desktop 状态决定是否重新打开 App。任意检查或启动失败均保留 manual plist 与待迁移标记，不自动打开 Desktop；若旧进程在等待超时后才完成退出，用户稍后重试不会再发送第二次信号。两种情况都会短暂中断连接该 daemon 的手机、SSH 或 CLI；
 8. 在没有待迁移 marker 的正常已提交状态下，如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与显式迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
+
+Mac App 执行迁移的短命 `agentd` 控制命令有明确超时。超时后先发送普通 `SIGTERM`，两秒仍未退出才只回收该 control CLI；不会因此向共享 Codex daemon 发送 `SIGKILL`。manual plist 与迁移 marker 会继续保留，设置页退出“正在更新”并显示可重试错误，避免控制命令异常时无限卡住。
+
+`runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
 
 移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；对 app-server 发给客户端的审批、补充输入和 MCP elicitation，移动端返回的反向 JSON-RPC response 也执行相同 guard，拒绝时保留 pending request 并恢复移动端卡片。`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读、观测器缺失或反向 request 缺少 thread scope 时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
 
@@ -77,6 +81,7 @@ agentd restart --no-pair
 
 - 官方 daemon 冷启动需要 `$CODEX_HOME/packages/standalone/current/codex`。已有健康 socket 但 standalone 缺失时，启用操作也会阻断，避免本次看似成功、Mac 重启后 agentd 持续拉起失败；Mimi Remote 不会静默执行 `curl | sh`，只给出官方安装指引。
 - 共享架构把两端的会话一致性放在同一个官方 app-server 上，因此该 server 自身崩溃时 Codex Desktop 与 Mimi 会同时短暂失去后端。稳定 owner 只在 server 已不可连时尝试恢复它，不会为了恢复而退出或重开 Codex Desktop。
+- 8192 是防止过低 launchd soft limit 把资源累积过早放大成全能力故障，不是对子进程或 FD 泄漏的掩盖。Doctor 同时展示真实 FD 与直接子进程水位；持续上涨仍需定位 Codex/MCP 上游的回收责任。本方案不基于不完整的 external activity 证据自动 recycle 健康 daemon。
 - Desktop 必须支持 local daemon，当前最低兼容 app-server 版本为 `0.141.0`。版本、socket 类型、目录权限、socket 权限和返回的 `codexHome` 都会在启用前校验。
 - Desktop 的自定义 CLI、强制 CLI 或资源覆盖可能让它回退到独立 stdio。Mac App 会确认 agentd 已连接共享 daemon，并明确要求完全重启 Desktop；Desktop 是否采用 daemon 仍要通过下面的跨端验收验证，不能只根据环境变量推断成功。
 - 稳定 LaunchAgent 的 `PATH` 会固定 Apple Silicon / Intel Homebrew 与系统工具目录，并在首次安装时追加调用进程可见的绝对用户工具目录；相对路径会被拒绝。之后 resident agentd 会复用已安装值，避免 MCP/plugin 路径随启动入口反复变化；需要完全自定义时可显式配置 `codex.env.PATH`。

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -17,16 +17,24 @@ Codex App Server 新版对 thread writer 增加了跨进程互斥。同一个 th
 macOS 上显式启用 Codex 官方 local daemon：
 
 ```text
-launchd LaunchAgent ──> 官方 codex daemon start ──> local daemon
-                                                    │
-Codex Desktop ──────────────────────────────────────┤
-Mimi agentd ────────────────────────────────────────┘
+launchd LaunchAgent ──> OpenAI 签名 node launcher（一次性）
+                                  │ detached
+                                  ▼
+                         OpenAI 签名 node supervisor
+                                  │ foreground child
+                                  ▼
+                         OpenAI 签名 codex app-server
+                                  │
+Codex Desktop ────────────────────┤
+Mimi agentd ──────────────────────┘
                     $CODEX_HOME/app-server-control/app-server-control.sock
        ↑
 iPhone / iPad 通过 /api/app-server/ws 继续经过鉴权、cwd 和方法策略
 ```
 
 Desktop 使用官方 `CODEX_APP_SERVER_USE_LOCAL_DAEMON=1` 开关连接 Unix Socket；`agentd` 使用 WebSocket-over-UDS 连接同一 socket。writer 仍然是单写者，但所有客户端位于同一个 app-server 进程内，因此空闲 thread 的 `thread/resume` 会复用已加载实例，不再触发跨进程锁冲突。
+
+Browser 原生授权读取的三级进程链必须是 `node_repl → codex app-server → node supervisor`。旧 `codex app-server daemon start` 会把 listener 脱离成 `PPID=1`，第三级落到 `launchd`，即使共享 socket 和新会话都正常，Browser 仍会拒绝。新 owner 使用 Codex Desktop bundle 内的签名 Node 保持为 app-server 直接父进程；Mimi、shell 和 launcher 都不进入这三级。落盘前验证 bundle、Node 与 codex 的 Developer ID requirement，运行后再从真实 socket peer 沿 PPID 读取内核 `csops` 的 signing identifier、Team ID 和 hardened-runtime 状态，不能只信 plist、路径或 `codesign -d` metadata。
 
 默认仍保留独立 loopback WebSocket，避免没有安装官方 standalone daemon 的机器在升级后无法启动。共享功能只能由用户在 Mimi Remote Mac 设置中显式开启，或使用命令行开启。
 
@@ -37,19 +45,21 @@ Desktop 使用官方 `CODEX_APP_SERVER_USE_LOCAL_DAEMON=1` 开关连接 Unix Soc
 Mac App 的“Codex Desktop → 共享本地 app-server 会话”会按以下顺序执行：
 
 1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket；已有 listener 必须完成 `initialize` / `initialized` 握手，stale socket 文件不算就绪；
-2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；job 显式设置 `SoftResourceLimits/NumberOfFiles=8192`，避免用户域 launchd 常见的 256 soft limit 让长期共享 daemon 同时丢失 Browser、Skills、MCP、Shell 与网络能力；不覆盖 hard limit。此时绝不启动新 Unix daemon；
-3. 验证官方 standalone 可执行文件与 daemon lifecycle 冷启动能力。全新启用还会写入私有 durable intent；任一提交前条件不完整都直接失败并清理本次 owner，配置与 Desktop 环境均不修改；
-4. 在 shared-daemon 操作锁内再次复核同一份原始配置，并用所有 Mimi 配置写入者共用的跨进程 CAS 锁，原子保存当前 `app_server` transport 为 `shared_fallback`、再切换到 `unix://`。只有配置 rename 已成功且启用前没有旧 listener，manual job 才会显式 `kickstart` 并校验完整协议、官方 pid backend、`CODEX_HOME`、standalone 路径和版本；即使冷启动全部通过，也继续保留 marker 与 `RunAtLoad=false`，因为 kickstart 与 socket 建立之间不能原子证明是谁赢得 listener。durable intent 只用于恢复“rename 已完成但首次冷启动尚未完成”的崩溃窗口，第一次完整 managed 校验通过后立即消费，不能被后续普通 recovery 重用。首次启用和接管既有 listener 都必须经过第 7 步的用户确认，才清 marker 并提升为 `RunAtLoad=true`。配置提交后的启动失败会作为“已提交、待恢复”结果返回，Mac App 会重新加载状态；若进程在 rename 与 kickstart 之间退出，下一次 shared agentd 会在锁内复核配置身份后继续该 durable intent，但仍不会自动完成 owner 迁移；
+2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行 Codex Desktop bundle 内的签名 Node；一次性 launcher 创建 detached 的同签名 Node supervisor，supervisor 再以前台 child 启动 `codex app-server --listen unix://`。不经过 shell、不使用 `daemon start`，也不托管自定义二进制。job 使用 `KeepAlive=false`、`AbandonProcessGroup=true`，并显式设置 `SoftResourceLimits/NumberOfFiles=8192`；上限由 launcher、supervisor、app-server 和 Browser/MCP 子进程逐级继承，不覆盖 hard limit。`NODE_OPTIONS`、`NODE_PATH` 等可改变 Node 启动代码的变量会被清空。此时绝不启动新 Unix daemon；
+3. 对 Desktop App、内置 Node 与 standalone codex 分别执行严格 Developer ID requirement 验证，要求固定 Team `2DC432GLL2`、对应 signing identifier 和 hardened runtime；codex 与 Node 的符号链接会固定到已经验证的真实版本路径。全新启用还会写入私有 durable intent；任一提交前条件不完整都直接失败并清理本次 owner，配置与 Desktop 环境均不修改；
+4. 在 shared-daemon 操作锁内再次复核同一份原始配置，并用所有 Mimi 配置写入者共用的跨进程 CAS 锁，原子保存当前 `app_server` transport 为 `shared_fallback`、再切换到 `unix://`。只有配置 rename 已成功且启用前没有旧 listener，manual job 才会显式 `kickstart` 并校验完整协议、`CODEX_HOME`、standalone 路径、版本以及真实 `listener → signed node supervisor` 父链；foreground app-server 的 lifecycle `backend=nil` 在完整签名父链成立时是正常状态，不会被无条件放开。即使冷启动全部通过，也继续保留 marker 与 `RunAtLoad=false`，因为 kickstart 与 socket 建立之间不能原子证明是谁赢得 listener。durable intent 只用于恢复“rename 已完成但首次冷启动尚未完成”的崩溃窗口，第一次完整签名拓扑校验通过后立即消费，不能被后续普通 recovery 重用。首次启用和接管既有 listener 都必须经过第 7 步的用户确认，才清 marker 并提升为 `RunAtLoad=true`。配置提交后的启动失败会作为“已提交、待恢复”结果返回，Mac App 会重新加载状态；若进程在 rename 与 kickstart 之间退出，下一次 shared agentd 会在锁内复核配置身份后继续该 durable intent，但仍不会自动完成 owner 迁移；
 5. 重启并确认 agentd 的 runtime 状态为 `transport=unix`、`shared=true`、daemon 可连接；
 6. 经 ownership 检查后，为 GUI 用户会话写入官方 daemon 开关、相同的 canonical `CODEX_HOME` 和 Mimi 私有的随机会话 marker，确保从 Dock / Finder 启动也生效；三键按事务写入，任一失败都会按相反顺序恢复，外部已有值不会被覆盖；
-7. 首次启用或启用前已有 daemon 时，owner 都会持久标记为“待迁移”，并把磁盘 plist 固定为 `RunAtLoad=false`，不会静默中断既有进程，也不会在注销、登录或 Mac 重启后自动完成迁移。稳定 owner 已安装后，如果未来又由 Codex 原生 SSH bootstrap 先抢到 socket，agentd 仍会在完成协议、版本、`CODEX_HOME` 和 standalone 路径验证后保持 attach，并把 owner 收敛回同一 pending 状态；socket 仍可连接时普通启动只 attach；仅 durable fresh-enable intent 且 socket 尚未创建时允许 manual job 恢复一次冷启动，恢复后仍保持 pending。其他 socket 不可连接场景下普通启动和 gateway recovery 直接返回 pending，既不 `kickstart` 也不清 marker。该标记独立于五分钟 runtime 缓存，每次状态请求都实时读取，因此用户取消确认或先退出 Desktop 后入口仍保留。用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 pid backend 管理时执行官方 `daemon stop`；旧 server 是 Codex 原生 SSH bootstrap 直启链时，只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` 命令行、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 PID 发送一次 `SIGTERM`。官方 stop 与新 daemon kickstart 各自在副作用前按固定 bundle ID 最终复核 Desktop，App 已重开或 LaunchServices 查询失败都立即停止迁移。不使用进程组信号、`SIGKILL`、模糊进程名或自动重试。等待最长 15 秒，且旧 socket 持续拒绝连接 500 ms 后，才由 LaunchAgent 拉起一次并完成协议/生命周期/版本验证；全部通过后才清 intent/marker、把 plist 恢复为 `RunAtLoad=true`，并按实际执行时的 Desktop 状态决定是否重新打开 App。任意检查或启动失败均保留 manual plist 与待迁移标记，不自动打开 Desktop；若旧进程在等待超时后才完成退出，用户稍后重试不会再发送第二次信号。两种情况都会短暂中断连接该 daemon 的手机、SSH 或 CLI；
-8. 在没有待迁移 marker 的正常已提交状态下，如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与显式迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
+7. 首次启用或启用前已有 daemon 时，owner 都会持久标记为“待迁移”，并把磁盘 plist 固定为 `RunAtLoad=false`，不会静默中断既有进程，也不会在注销、登录或 Mac 重启后自动完成迁移。旧 `pid` backend、SSH/CLI 直启 listener 或签名父链不成立的 listener 都只能保持 attach 并收敛到 pending，不能因为它们来自官方 codex 就冒充 Browser 可用的 stable 状态；只有真实 socket peer 的签名 supervisor 拓扑通过才算 stable。普通 ensure 在每个 `bootout/bootstrap` 前都会重新探测 socket：即使 listener 在 codesign 或 plist 落盘期间才出现，也会立刻把 owner 降成 manual+marker，绝不对活跃 launchd coalition 执行 bootout。仅 durable fresh-enable intent 且 socket 尚未创建时允许 manual job 恢复一次冷启动，恢复后仍保持 pending；其他 pending 掉线只等待用户再次确认。
+
+   用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 `pid` backend 管理时执行官方 `daemon stop`；直接 listener（包括旧 SSH bootstrap 和已签名 supervisor child）只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` argv、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 listener 发送一次 `SIGTERM`，supervisor 会逐次转发 `SIGHUP/SIGTERM/SIGINT` 且不使用 `SIGKILL`。等待旧 socket 持续拒绝连接 500 ms 且原 listener 的 PID/启动时间证据确认进程已经退出后，才 `bootout` 旧的 one-shot 定义、`bootstrap` 磁盘上的 manual 新定义并 `kickstart` 一次。新进程必须完成协议、版本和运行态签名父链验证，全部通过后才清 intent/marker、把 plist 恢复为 `RunAtLoad=true`。上次已启动新签名 supervisor、但恰好在清 marker 前崩溃时，重试会直接提交健康进程，不再中断一次。任意失败都保留 manual+marker，不自动重试、强杀或打开 Desktop；
+8. 在没有待迁移 marker 的正常已提交状态下，如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与显式迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。新安装或 reload 的 `RunAtLoad` launcher 已经触发时只等待其 socket，不会再 kickstart 第二套；登录时 launcher 已退出而 supervisor 尚在冷启动，也会先等待一秒 grace。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
 
 Mac App 执行迁移的短命 `agentd` 控制命令有明确超时。超时后先发送普通 `SIGTERM`，两秒仍未退出才只回收该 control CLI；不会因此向共享 Codex daemon 发送 `SIGKILL`。manual plist 与迁移 marker 会继续保留，设置页退出“正在更新”并显示可重试错误，避免控制命令异常时无限卡住。
 
 `runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
 
-官方 `daemon start` 完成 detached listener 交接后，部分版本仍报告 `pid` backend，但不会继续返回 listener PID。只有 stable owner 已提交、socket 路径一致且 backend 仍为 `pid` 时，才标记为 `owner_claimed_unverified` warning；缺少 backend 的旧 SSH/CLI listener 仍视为 unmanaged。该 warning 既不把当前 listener 误报为已验证 stable，也不把 owner 的目标上限当成 listener 已实际继承。
+旧 `daemon start` 的 `pid` backend 无论是否返回精确 listener PID，都只标记为 `owner_claimed_unverified`；它证明官方 lifecycle 与 socket 对得上，但不能证明签名 Node 父链或实际继承的 FD soft limit。缺少 backend 且签名拓扑失败的旧 SSH/CLI listener 仍视为 unmanaged。两者都会等待显式迁移，不会被诊断误报成 Browser 可用的 stable。
 
 移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；对 app-server 发给客户端的审批、补充输入和 MCP elicitation，移动端返回的反向 JSON-RPC response 也执行相同 guard，拒绝时保留 pending request 并恢复移动端卡片。`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读、观测器缺失或反向 request 缺少 thread scope 时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
 
@@ -70,7 +80,7 @@ Go 端仍会实时复核 marker、owner 和 Desktop 状态。同一用户下的�
 
 ### 关闭与回滚
 
-关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file，并卸载 Mimi 的 LaunchAgent 与待迁移标记；不会停止当前 daemon，因为 Desktop 可能仍在使用它。事务顺序固定为：先把 owner 降为 manual 并移除未来启动入口，再 CAS 提交非共享配置。这样进程在任意一步退出，最多留下 `shared + 无 owner/manual owner`，不会形成 `WS + RunAtLoad=true`。owner 卸载失败时配置不提交并保留 fail-closed 的 manual 状态；配置已被其他 writer 改动或提交失败时也不恢复可能已经失权的 auto owner，下一次明确操作再幂等收敛。`setup --force`、sharing、Claude、network 与 repair 写入共用配置提交锁；只有平台默认配置可以拥有或清理当前用户全局 LaunchAgent，自定义 `--config` profile 不会触碰默认服务的 owner。完整 stable-owner 共享目前只在 macOS 开放；非 macOS 升级后仍允许执行 disable 回退旧配置。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，启用时只 attach 已经可握手的 socket，缺失时明确失败且绝不启动；禁用时只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
+关闭共享会恢复 Mimi 在 `shared_fallback` 中保存的 transport、listen、managed 和 token file，并删除 Mimi 的磁盘 LaunchAgent 与待迁移标记；不会停止当前 daemon，因为 Desktop 可能仍在使用它。已加载的 one-shot job 会保留到当前 GUI 会话注销：`bootout` 没有“不影响 launchd coalition 后代”的契约，删除未来登录入口已经足够阻止下次自动启动。即使进程在“plist 已删、marker 尚未清”之间崩溃，立即重试也会幂等清理 marker/intent，不要求先注销。事务顺序固定为：先把 owner 降为 manual 并移除未来启动入口，再 CAS 提交非共享配置。这样进程在任意一步退出，最多留下 `shared + 无 owner/manual owner`，不会形成 `WS + RunAtLoad=true`。owner 删除失败时配置不提交并保留 fail-closed 的 manual 状态；配置已被其他 writer 改动或提交失败时也不恢复可能已经失权的 auto owner，下一次明确操作再幂等收敛。`setup --force`、sharing、Claude、network 与 repair 写入共用配置提交锁；只有平台默认配置可以拥有或清理当前用户全局 LaunchAgent，自定义 `--config` profile 不会触碰默认服务的 owner。完整 stable-owner 共享目前只在 macOS 开放；非 macOS 升级后仍允许执行 disable 回退旧配置。若当前 Unix backend 原本由用户或其他工具管理、没有 Mimi 的 fallback 账本，启用时只 attach 已经可握手的 socket，缺失时明确失败且绝不启动；禁用时只关闭 Desktop 环境并保留 backend，绝不虚构默认 WS 覆盖外部配置。配置更新后需要重启 agentd 与 Codex Desktop。
 
 ```bash
 agentd runtime --codex-sharing=disabled --json
@@ -81,7 +91,7 @@ agentd restart --no-pair
 
 ## 风险与优化
 
-- 官方 daemon 冷启动需要 `$CODEX_HOME/packages/standalone/current/codex`。已有健康 socket 但 standalone 缺失时，启用操作也会阻断，避免本次看似成功、Mac 重启后 agentd 持续拉起失败；Mimi Remote 不会静默执行 `curl | sh`，只给出官方安装指引。
+- 签名 supervisor 冷启动需要 `$CODEX_HOME/packages/standalone/current/codex` 与 Codex Desktop bundle 内置 Node。已有健康 socket 但任一材料缺失或签名不符时，owner 更新也会阻断，避免本次看似成功、Mac 重启后持续拉起失败；Mimi Remote 不会静默下载替代二进制，只给出官方安装指引。
 - 共享架构把两端的会话一致性放在同一个官方 app-server 上，因此该 server 自身崩溃时 Codex Desktop 与 Mimi 会同时短暂失去后端。稳定 owner 只在 server 已不可连时尝试恢复它，不会为了恢复而退出或重开 Codex Desktop。
 - 8192 是防止过低 launchd soft limit 把资源累积过早放大成全能力故障，不是对子进程或 FD 泄漏的掩盖。Doctor 同时展示真实 FD 与直接子进程水位；持续上涨仍需定位 Codex/MCP 上游的回收责任。本方案不基于不完整的 external activity 证据自动 recycle 健康 daemon。
 - Desktop 必须支持 local daemon，当前最低兼容 app-server 版本为 `0.141.0`。版本、socket 类型、目录权限、socket 权限和返回的 `codexHome` 都会在启用前校验。
@@ -91,8 +101,8 @@ agentd restart --no-pair
 - `launchctl` 环境会在注销后消失；Mac App 只会为已经显式启用、backend 再次确认共享且三键均为空的用户生成新 marker 并恢复环境，不会借登录启动替新用户自动开启功能。新会话里其他程序即使写入相同的官方值，没有匹配 marker 也不会被 Mimi 认领。若 Desktop 比 Mimi 更早启动，设置页会保持“需要重启”，由用户确认后正常退出并重开。
 - Unix Socket 的安全边界是当前用户私有目录与 `0600` socket；它不会暴露到 TCP，也不复用 iPad 的 Bearer Token 或旧 app-server capability token。
 - Mimi 自己的配置写入通过用户私有的跨进程文件锁与同源 raw snapshot CAS 串行；不遵守该协议的外部编辑器无法被强制加锁，因此最终 rename 前仍会复核 bytes 并在可检测冲突时 fail closed，但不会宣称能对任意第三方写入提供数据库级事务。
-- LaunchAgent plist 可能包含为 Codex/MCP 配置的运行环境，因此固定为 `0600`，日志目录/文件也按当前用户私有权限创建；Desktop 专属 transport/ownership 环境变量由 job 的空值覆盖，避免继承 GUI 用户域值，同时保持 `launchd -> codex` 的直接进程链。
-- LaunchAgent 已安装、socket 可握手和版本一致只能证明结构与协议闭环；macOS TCC 的最终文件权限归因必须用正式签名 App 做一次受保护目录读写验收，Doctor 会明确保留这项运行态要求，不把单元测试冒充为 TCC 证明。
+- LaunchAgent plist 可能包含为 Codex/MCP 配置的运行环境，因此固定为 `0600`，日志目录/文件也按当前用户私有权限创建；Desktop 专属 transport/ownership 变量与 Node 代码注入变量由 job 的空值覆盖。稳定运行链固定为 `launchd → detached signed node supervisor → signed codex`，一次性 launcher 不进入 Browser 的三级授权链。
+- LaunchAgent 已安装、socket 可握手、版本一致和内核签名父链验证仍只证明本地结构闭环；Browser 的内部授权实现不是公开协议，正式发布必须用真实 Codex Desktop 新会话调用一次 Browser，并同时验证 Mimi/手机仍连接同一 socket。Doctor 和单元测试不能冒充这项端到端证明。
 - `thread/unsubscribe` 只取消当前连接订阅，不释放 writer；没有公开的单 thread takeover/unload RPC，因此不要重新叠加客户端 idle 猜测或自动抢占逻辑。
 
 验收场景：
@@ -102,4 +112,6 @@ agentd restart --no-pair
 3. Desktop turn 完成并保持 thread 页面打开；手机再次发送，应成功。
 4. 禁用共享并重启两端；agentd 应恢复原 WS 配置，已有配对与 thread ID 不变。
 5. 在没有待迁移 marker 的正常已提交状态下杀掉共享 daemon，再从手机新建一次 gateway 连接，应由 LaunchAgent 自动恢复并只重试一次；pending 状态下同样操作必须保持 manual owner，等待用户再次确认。
-6. 用签名的 Mimi Remote Mac 与 Codex Desktop 分别访问一个受保护目录，确认系统权限提示/授权不再归因到 Mimi 的旧 App 路径；该项不能由无签名单测替代。
+6. 在 Codex Desktop 新建一个从未在手机/iPad 打开的会话，调用 Browser 打开页面；应成功识别 Browser，同时 socket peer 的父链为 `node_repl → codex → node`，三个运行进程都满足 OpenAI Team/identifier 要求。
+7. Browser 验收期间从 Mimi/手机继续同一共享会话，确认只有一个 app-server listener；重启 Codex Desktop、agentd 或 gateway 不应分叉成第二个 listener/supervisor。
+8. 用签名的 Mimi Remote Mac 与 Codex Desktop 分别访问一个受保护目录，确认系统权限提示/授权不再归因到 Mimi 的旧 App 路径；该项不能由无签名单测替代。

--- a/internal/appserver/local_daemon.go
+++ b/internal/appserver/local_daemon.go
@@ -245,9 +245,9 @@ func ensureLocalDaemonWithStableOwner(
 	if err != nil {
 		return LocalDaemonStatus{}, err
 	}
-	// RunAtLoad=true 的新/重载 owner 已由 bootstrap 异步触发 launcher。launcher
-	// 会在 app-server ready 前很快退出，因此不能再以 owner.Running=false 为由
-	// kickstart 第二套 supervisor；这里记住第一次 ensure 的启动事实并只等待。
+	// RunAtLoad=true 的新/重载 owner 已由 bootstrap 异步触发 supervisor。launchd
+	// 状态与 socket 建立之间仍有短窗口，不能再 kickstart 第二套 supervisor；
+	// 这里记住第一次 ensure 的启动事实并只等待。
 	ownerBootstrapped := owner.Changed && owner.RunAtLoad && !daemonPreexisting
 	if owner.MigrationRequired && !sharedDaemonSocketAcceptsConnectionMust(options) {
 		if prepared && options.ValidateStableOwner != nil && !options.PrepareOwnerForConfigCommit {

--- a/internal/appserver/local_daemon.go
+++ b/internal/appserver/local_daemon.go
@@ -235,6 +235,7 @@ func ensureLocalDaemonWithStableOwner(
 		return LocalDaemonStatus{}, preparedErr
 	}
 
+	bootstrapLogOffset := sharedDaemonLaunchAgentLogSize()
 	owner, err := ensureSharedDaemonOwner(
 		ctx,
 		options,
@@ -244,6 +245,10 @@ func ensureLocalDaemonWithStableOwner(
 	if err != nil {
 		return LocalDaemonStatus{}, err
 	}
+	// RunAtLoad=true 的新/重载 owner 已由 bootstrap 异步触发 launcher。launcher
+	// 会在 app-server ready 前很快退出，因此不能再以 owner.Running=false 为由
+	// kickstart 第二套 supervisor；这里记住第一次 ensure 的启动事实并只等待。
+	ownerBootstrapped := owner.Changed && owner.RunAtLoad && !daemonPreexisting
 	if owner.MigrationRequired && !sharedDaemonSocketAcceptsConnectionMust(options) {
 		if prepared && options.ValidateStableOwner != nil && !options.PrepareOwnerForConfigCommit {
 			// 上一次 fresh enable 可能在“shared 配置已 rename、manual owner 已
@@ -265,6 +270,10 @@ func ensureLocalDaemonWithStableOwner(
 	status, err := ensureLocalDaemon(ctx, options, localDaemonHooks{
 		probe: ProbeLocalDaemonInfo,
 		start: func(startCtx context.Context, startOptions LocalDaemonOptions) error {
+			if ownerBootstrapped {
+				startedByStableOwner = true
+				return waitForSharedDaemonSocket(startCtx, startOptions, bootstrapLogOffset)
+			}
 			var startErr error
 			if startOptions.PrepareOwnerForConfigCommit {
 				startedByStableOwner, startErr = startPreparedSharedDaemonWithStableOwnerTracked(startCtx, startOptions)
@@ -279,12 +288,16 @@ func ensureLocalDaemonWithStableOwner(
 		return LocalDaemonStatus{}, stableOwnerEnsureFailure(options, owner, err)
 	}
 	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
+	signedSupervisorValidated := false
 	if err == nil {
-		err = reconcileStableOwnerLifecycle(
+		signedRuntimeErr := sharedDaemonValidateSignedRuntime(ctx, options, status.SocketPath)
+		signedSupervisorValidated = signedRuntimeErr == nil
+		err = reconcileStableOwnerLifecycleWithSignedRuntime(
 			lifecycle,
 			status,
 			&owner,
 			startedByStableOwner,
+			signedSupervisorValidated,
 			func() error {
 				// 现有 SSH bootstrap 重新抢到 socket 时，不只写 marker；还要把
 				// 登录启动持久化为 manual，保证下次登录不会绕过用户确认。
@@ -306,7 +319,7 @@ func ensureLocalDaemonWithStableOwner(
 	status.OwnerRollback = owner.Rollback
 	status.StartedByStableOwner = startedByStableOwner
 	status.LifecycleValidated = true
-	if prepared && lifecycle.Backend != nil {
+	if prepared && (lifecycle.Backend != nil || signedSupervisorValidated) {
 		// 上次进程可能在 manual kickstart 已成功、但 post-commit helper 尚未
 		// 消费 intent 时崩溃。本次普通 Ensure 已在同一 operation lock 内完成
 		// managed lifecycle + probe 校验，必须在返回前消费这份“一次性恢复权”；
@@ -340,22 +353,60 @@ func reconcileStableOwnerLifecycle(
 	startedByStableOwner bool,
 	markMigrationRequired func() error,
 ) error {
+	return reconcileStableOwnerLifecycleWithSignedRuntime(
+		lifecycle,
+		status,
+		owner,
+		startedByStableOwner,
+		false,
+		markMigrationRequired,
+	)
+}
+
+func reconcileStableOwnerLifecycleWithSignedRuntime(
+	lifecycle LocalDaemonLifecycleStatus,
+	status LocalDaemonStatus,
+	owner *SharedDaemonOwnerStatus,
+	startedByStableOwner bool,
+	signedSupervisorValidated bool,
+	markMigrationRequired func() error,
+) error {
 	if err := ValidateLocalDaemonLifecycle(lifecycle, status.SocketPath); err != nil {
 		return err
 	}
 	if err := ValidateLocalDaemonProbeVersion(lifecycle, status.Version); err != nil {
 		return err
 	}
-	// 任何已声明的 backend 都必须是官方 pid。未知的未来 backend
-	// 不能借旧 marker 绕过校验。
+	// foreground app-server 不使用官方 pid backend。只有从真实 socket peer 反查
+	// 到 listener -> OpenAI node supervisor 的完整父链后，才把 Backend=nil 认作
+	// Mimi 的稳定 owner；单凭 plist 或本次 kickstart 都不够。
+	if signedSupervisorValidated {
+		return nil
+	}
+	// 任何已声明的 backend 都必须先通过官方 pid 校验。它仍属于旧 runtime：
+	// Browser 需要的签名 node 父链并不存在，所以日常路径只保持 attach 并恢复
+	// pending，不能把“官方 daemon”误当成新的 stable supervisor。
 	if lifecycle.Backend != nil {
-		return ValidateManagedLocalDaemonLifecycle(lifecycle, status.SocketPath)
+		if err := ValidateManagedLocalDaemonLifecycle(lifecycle, status.SocketPath); err != nil {
+			return err
+		}
+		if startedByStableOwner {
+			return fmt.Errorf("稳定 owner 启动后得到旧 pid backend，签名 supervisor 未生效")
+		}
+		return reconcileSharedDaemonMigrationMarker(owner, markMigrationRequired)
 	}
 	// 本次明确执行了稳定 owner kickstart，却仍看不到 backend，说明
 	// 启动结果不能归因给该 owner，必须 fail closed。
 	if startedByStableOwner {
 		return ValidateManagedLocalDaemonLifecycle(lifecycle, status.SocketPath)
 	}
+	return reconcileSharedDaemonMigrationMarker(owner, markMigrationRequired)
+}
+
+func reconcileSharedDaemonMigrationMarker(
+	owner *SharedDaemonOwnerStatus,
+	markMigrationRequired func() error,
+) error {
 	if owner == nil || !owner.Installed || !owner.Loaded || !owner.Secure {
 		return fmt.Errorf("非 daemon 管理的 Codex app-server 缺少安全稳定 owner")
 	}

--- a/internal/appserver/local_daemon_test.go
+++ b/internal/appserver/local_daemon_test.go
@@ -394,6 +394,59 @@ func TestReconcileStableOwnerLifecycleMarksDetectedUnmanagedBackend(t *testing.T
 	}
 }
 
+func TestReconcileStableOwnerLifecycleMarksLegacyPIDBackendForMigration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows 不支持 Codex Unix daemon")
+	}
+	codexHome := shortCodexHome(t)
+	socketPath := filepath.Join(codexHome, localDaemonSocketDir, localDaemonSocketName)
+	official := filepath.Join(codexHome, "packages", "standalone", "current", "codex")
+	if err := os.MkdirAll(filepath.Dir(official), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(official, []byte("test"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	version := "0.147.0"
+	backend := "pid"
+	lifecycle := LocalDaemonLifecycleStatus{
+		Status:              "running",
+		Backend:             &backend,
+		ManagedCodexPath:    official,
+		ManagedCodexVersion: &version,
+		SocketPath:          socketPath,
+		CLIVersion:          version,
+		AppServerVersion:    version,
+	}
+	status := LocalDaemonStatus{SocketPath: socketPath, Version: version}
+	owner := SharedDaemonOwnerStatus{Installed: true, Loaded: true, Secure: true}
+	markCalls := 0
+	if err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, false, func() error {
+		markCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("旧官方 pid backend 应保持 attach 并等待显式迁移：%v", err)
+	}
+	if !owner.MigrationRequired || markCalls != 1 {
+		t.Fatalf("旧 pid backend 不能冒充签名 supervisor：owner=%+v mark=%d", owner, markCalls)
+	}
+	if err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, false, func() error {
+		markCalls++
+		return nil
+	}); err != nil || markCalls != 1 {
+		t.Fatalf("已有 legacy marker 时必须幂等：err=%v mark=%d", err, markCalls)
+	}
+
+	owner.MigrationRequired = true
+	err := reconcileStableOwnerLifecycle(lifecycle, status, &owner, true, func() error {
+		markCalls++
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "旧 pid backend") || markCalls != 1 {
+		t.Fatalf("本次新 owner kickstart 得到 pid backend 必须 fail closed：err=%v mark=%d", err, markCalls)
+	}
+}
+
 func TestReconcileStableOwnerLifecycleRejectsUnmanagedAfterStableKickstart(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows 不支持 Codex Unix daemon")

--- a/internal/appserver/shared_daemon_codesign_darwin.go
+++ b/internal/appserver/shared_daemon_codesign_darwin.go
@@ -1,0 +1,114 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	darwinCSOpsStatus   = 0
+	darwinCSOpsIdentity = 11
+	darwinCSOpsTeamID   = 14
+	darwinCSValid       = 0x00000001
+	darwinCSRuntime     = 0x00010000
+)
+
+type sharedDaemonRunningCodeSignature struct {
+	Flags      uint32
+	Identifier string
+	TeamID     string
+}
+
+// sharedDaemonRunningCodeSignatureForPID 直接询问内核当前正在执行的 code
+// object，而不是只解析磁盘 Mach-O 的声明。这样 App 更新、路径替换或损坏签名
+// 不能借旧 metadata 通过最终父链验收。
+func sharedDaemonRunningCodeSignatureForPID(pid int) (sharedDaemonRunningCodeSignature, error) {
+	if pid <= 1 {
+		return sharedDaemonRunningCodeSignature{}, fmt.Errorf("代码签名 PID 无效")
+	}
+	var flags uint32
+	_, _, errno := unix.Syscall6(
+		unix.SYS_CSOPS,
+		uintptr(pid),
+		darwinCSOpsStatus,
+		uintptr(unsafe.Pointer(&flags)),
+		unsafe.Sizeof(flags),
+		0,
+		0,
+	)
+	runtime.KeepAlive(&flags)
+	if errno != 0 {
+		return sharedDaemonRunningCodeSignature{}, fmt.Errorf("读取运行中代码签名状态失败：%w", errno)
+	}
+	identifier, err := sharedDaemonCSOpsString(pid, darwinCSOpsIdentity)
+	if err != nil {
+		return sharedDaemonRunningCodeSignature{}, err
+	}
+	teamID, err := sharedDaemonCSOpsString(pid, darwinCSOpsTeamID)
+	if err != nil {
+		return sharedDaemonRunningCodeSignature{}, err
+	}
+	return sharedDaemonRunningCodeSignature{
+		Flags:      flags,
+		Identifier: identifier,
+		TeamID:     teamID,
+	}, nil
+}
+
+func sharedDaemonCSOpsString(pid int, operation uintptr) (string, error) {
+	buffer := make([]byte, 256)
+	_, _, errno := unix.Syscall6(
+		unix.SYS_CSOPS,
+		uintptr(pid),
+		operation,
+		uintptr(unsafe.Pointer(&buffer[0])),
+		uintptr(len(buffer)),
+		0,
+		0,
+	)
+	runtime.KeepAlive(buffer)
+	if errno != 0 {
+		return "", fmt.Errorf("读取运行中代码签名身份失败：%w", errno)
+	}
+	return parseSharedDaemonCSOpsStringBlob(buffer)
+}
+
+func parseSharedDaemonCSOpsStringBlob(buffer []byte) (string, error) {
+	// CS_OPS_IDENTITY/TEAMID 返回 cs_blob：两个 big-endian uint32 header，
+	// 第二项是 header + NUL payload 的总长度。
+	if len(buffer) < 9 {
+		return "", fmt.Errorf("运行中代码签名身份长度无效")
+	}
+	if binary.BigEndian.Uint32(buffer[0:4]) != 0 {
+		return "", fmt.Errorf("运行中代码签名身份 header 无效")
+	}
+	total := int(binary.BigEndian.Uint32(buffer[4:8]))
+	if total < 9 || total > len(buffer) {
+		return "", fmt.Errorf("运行中代码签名身份 metadata 无效")
+	}
+	payload := buffer[8:total]
+	nul := bytes.IndexByte(payload, 0)
+	if nul <= 0 || nul != len(payload)-1 {
+		return "", fmt.Errorf("运行中代码签名身份没有规范 NUL 结尾")
+	}
+	return string(payload[:nul]), nil
+}
+
+func validateSharedDaemonRunningCodeSignature(pid int, expectedIdentifier string) error {
+	signature, err := sharedDaemonRunningCodeSignatureForPID(pid)
+	if err != nil {
+		return err
+	}
+	if signature.Flags&darwinCSValid == 0 || signature.Flags&darwinCSRuntime == 0 ||
+		signature.Identifier != expectedIdentifier || signature.TeamID != sharedDaemonOpenAITeamIdentifier {
+		return fmt.Errorf("运行中进程不是受支持的 OpenAI hardened runtime")
+	}
+	return nil
+}

--- a/internal/appserver/shared_daemon_codesign_darwin_test.go
+++ b/internal/appserver/shared_daemon_codesign_darwin_test.go
@@ -1,0 +1,76 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func sharedDaemonTestCSOpsStringBlob(payload []byte) []byte {
+	buffer := make([]byte, 8+len(payload)+1)
+	binary.BigEndian.PutUint32(buffer[4:8], uint32(len(buffer)))
+	copy(buffer[8:], payload)
+	buffer[len(buffer)-1] = 0
+	return buffer
+}
+
+func TestParseSharedDaemonCSOpsStringBlobAcceptsCanonicalNULTermination(t *testing.T) {
+	want := "com.openai.codex"
+	got, err := parseSharedDaemonCSOpsStringBlob(sharedDaemonTestCSOpsStringBlob([]byte(want)))
+	if err != nil {
+		t.Fatalf("规范 CSOPS string blob 应通过：%v", err)
+	}
+	if got != want {
+		t.Fatalf("CSOPS string blob 解析错误：got=%q want=%q", got, want)
+	}
+}
+
+func TestParseSharedDaemonCSOpsStringBlobRejectsInvalidLength(t *testing.T) {
+	valid := sharedDaemonTestCSOpsStringBlob([]byte("codex"))
+	tests := map[string][]byte{
+		"short header": valid[:8],
+		"unexpected header type": func() []byte {
+			candidate := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint32(candidate[0:4], 1)
+			return candidate
+		}(),
+		"total shorter than header and NUL": func() []byte {
+			candidate := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint32(candidate[4:8], 8)
+			return candidate
+		}(),
+		"total exceeds buffer": func() []byte {
+			candidate := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint32(candidate[4:8], uint32(len(candidate)+1))
+			return candidate
+		}(),
+	}
+	for name, candidate := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseSharedDaemonCSOpsStringBlob(candidate); err == nil {
+				t.Fatal("非法 CSOPS blob 长度必须 fail closed")
+			}
+		})
+	}
+}
+
+func TestParseSharedDaemonCSOpsStringBlobRejectsNonCanonicalNUL(t *testing.T) {
+	valid := sharedDaemonTestCSOpsStringBlob([]byte("codex"))
+	tests := map[string][]byte{
+		"missing final NUL": func() []byte {
+			candidate := append([]byte(nil), valid...)
+			candidate[len(candidate)-1] = 'x'
+			return candidate
+		}(),
+		"embedded NUL":  sharedDaemonTestCSOpsStringBlob([]byte{'c', 0, 'd', 'e', 'x'}),
+		"empty payload": sharedDaemonTestCSOpsStringBlob(nil),
+	}
+	for name, candidate := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseSharedDaemonCSOpsStringBlob(candidate); err == nil {
+				t.Fatal("非规范 CSOPS blob NUL 必须 fail closed")
+			}
+		})
+	}
+}

--- a/internal/appserver/shared_daemon_diagnostics.go
+++ b/internal/appserver/shared_daemon_diagnostics.go
@@ -12,6 +12,7 @@ const (
 	SharedDaemonOwnerStateStable            SharedDaemonOwnerState = "stable"
 	SharedDaemonOwnerStateMigrationPending  SharedDaemonOwnerState = "migration_pending"
 	SharedDaemonOwnerStateUnavailable       SharedDaemonOwnerState = "owner_unavailable"
+	SharedDaemonOwnerStateClaimedUnverified SharedDaemonOwnerState = "owner_claimed_unverified"
 	SharedDaemonOwnerStateUnmanagedListener SharedDaemonOwnerState = "unmanaged_listener"
 	SharedDaemonOwnerStateListenerMismatch  SharedDaemonOwnerState = "listener_mismatch"
 )

--- a/internal/appserver/shared_daemon_diagnostics.go
+++ b/internal/appserver/shared_daemon_diagnostics.go
@@ -1,0 +1,65 @@
+package appserver
+
+import "time"
+
+const sharedDaemonSoftFileLimit = 8192
+
+type SharedDaemonOwnerState string
+
+const (
+	SharedDaemonOwnerStateUnknown           SharedDaemonOwnerState = "unknown"
+	SharedDaemonOwnerStateExternal          SharedDaemonOwnerState = "external"
+	SharedDaemonOwnerStateStable            SharedDaemonOwnerState = "stable"
+	SharedDaemonOwnerStateMigrationPending  SharedDaemonOwnerState = "migration_pending"
+	SharedDaemonOwnerStateUnavailable       SharedDaemonOwnerState = "owner_unavailable"
+	SharedDaemonOwnerStateUnmanagedListener SharedDaemonOwnerState = "unmanaged_listener"
+	SharedDaemonOwnerStateListenerMismatch  SharedDaemonOwnerState = "listener_mismatch"
+)
+
+type SharedDaemonResourceState string
+
+const (
+	SharedDaemonResourceStateUnknown  SharedDaemonResourceState = "unknown"
+	SharedDaemonResourceStateHealthy  SharedDaemonResourceState = "healthy"
+	SharedDaemonResourceStateDegraded SharedDaemonResourceState = "degraded"
+	SharedDaemonResourceStateCritical SharedDaemonResourceState = "critical"
+)
+
+// SharedDaemonDiagnostics 只暴露进程资源与 owner 对账所需的脱敏字段。
+// 不返回命令行、环境变量或路径，避免 runtime status / doctor 扩大敏感信息范围。
+type SharedDaemonDiagnostics struct {
+	Supported            bool
+	ListenerPID          int
+	ListenerStartedAt    time.Time
+	OpenFileDescriptors  int
+	DirectChildProcesses int
+	// OwnerTargetFDSoftLimit 是 stable owner 下一次启动时的目标配置，不代表
+	// 当前 listener 已实际继承。只有 EffectiveFDSoftLimit 有可靠取证时，
+	// 才能计算百分比并判断阈值，避免把手工启动的低上限进程误报为健康。
+	OwnerTargetFDSoftLimit *int
+	EffectiveFDSoftLimit   *int
+	FDUsagePercent         *float64
+	OwnerState             SharedDaemonOwnerState
+	ResourceState          SharedDaemonResourceState
+}
+
+func applySharedDaemonResourceState(status *SharedDaemonDiagnostics) {
+	if status == nil {
+		return
+	}
+	status.ResourceState = SharedDaemonResourceStateUnknown
+	status.FDUsagePercent = nil
+	if status.EffectiveFDSoftLimit == nil || *status.EffectiveFDSoftLimit <= 0 {
+		return
+	}
+	usage := float64(status.OpenFileDescriptors) * 100 / float64(*status.EffectiveFDSoftLimit)
+	status.FDUsagePercent = &usage
+	switch {
+	case usage >= 90:
+		status.ResourceState = SharedDaemonResourceStateCritical
+	case usage >= 70:
+		status.ResourceState = SharedDaemonResourceStateDegraded
+	default:
+		status.ResourceState = SharedDaemonResourceStateHealthy
+	}
+}

--- a/internal/appserver/shared_daemon_diagnostics_darwin.go
+++ b/internal/appserver/shared_daemon_diagnostics_darwin.go
@@ -1,0 +1,194 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	darwinProcInfoCallPIDInfo = 2
+	darwinProcPIDListFDs      = 1
+)
+
+// darwinProcFDInfo 与 Darwin 的 proc_fdinfo ABI 保持一致。PROC_PIDLISTFDS
+// 返回的每一项都对应一个实际打开的描述符；不能使用 proc_bsdinfo.pbi_nfiles，
+// 后者在实机上反映文件表容量，可能恰好等于 256 而不是当前打开数。
+type darwinProcFDInfo struct {
+	FD   int32
+	Type uint32
+}
+
+// InspectSharedDaemonDiagnostics 从当前 Unix socket 的真实 peer PID 开始取证，
+// 不信任 plist、缓存 PID 或进程名。诊断只读，不会启动、停止或迁移 daemon。
+func InspectSharedDaemonDiagnostics(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (SharedDaemonDiagnostics, error) {
+	status := SharedDaemonDiagnostics{
+		Supported:     true,
+		OwnerState:    SharedDaemonOwnerStateUnknown,
+		ResourceState: SharedDaemonResourceStateUnknown,
+	}
+	if err := ctx.Err(); err != nil {
+		return status, err
+	}
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return status, err
+	}
+	process, err := inspectSharedDaemonListenerIdentity(ctx, socketPath)
+	if err != nil {
+		return status, fmt.Errorf("读取共享 daemon listener 失败：%w", err)
+	}
+	openFiles, err := sharedDaemonProcessOpenFileCount(process.PID)
+	if err != nil {
+		return status, err
+	}
+	children, err := sharedDaemonDirectChildCount(process.PID)
+	if err != nil {
+		return status, err
+	}
+
+	status.ListenerPID = process.PID
+	status.ListenerStartedAt = time.Unix(process.StartSec, int64(process.StartUsec)*int64(time.Microsecond)).UTC()
+	status.OpenFileDescriptors = openFiles
+	status.DirectChildProcesses = children
+	status.OwnerState = inspectSharedDaemonOwnerState(ctx, options, socketPath, process.PID)
+	if status.OwnerState == SharedDaemonOwnerStateStable {
+		limit := sharedDaemonSoftFileLimit
+		status.OwnerTargetFDSoftLimit = &limit
+	}
+	applySharedDaemonResourceState(&status)
+	return status, nil
+}
+
+// inspectSharedDaemonListenerIdentity 只读取资源诊断实际需要的身份字段。
+// 不读取命令行或环境变量，避免把接管校验的敏感取证面带入常规状态刷新。
+func inspectSharedDaemonListenerIdentity(
+	ctx context.Context,
+	socketPath string,
+) (sharedDaemonListenerProcess, error) {
+	pid, peerUID, err := sharedDaemonSocketPeer(ctx, socketPath)
+	if err != nil {
+		return sharedDaemonListenerProcess{}, err
+	}
+	kinfo, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || int(kinfo.Proc.P_pid) != pid {
+		return sharedDaemonListenerProcess{}, fmt.Errorf("读取 socket owner 进程身份失败")
+	}
+	if int(kinfo.Eproc.Ucred.Uid) != peerUID {
+		return sharedDaemonListenerProcess{}, fmt.Errorf("socket peer UID 与进程 UID 不一致")
+	}
+	return sharedDaemonListenerProcess{
+		PID:       pid,
+		UID:       peerUID,
+		StartSec:  kinfo.Proc.P_starttime.Sec,
+		StartUsec: kinfo.Proc.P_starttime.Usec,
+	}, nil
+}
+
+func inspectSharedDaemonOwnerState(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	socketPath string,
+	listenerPID int,
+) SharedDaemonOwnerState {
+	if !options.StableOwner {
+		return SharedDaemonOwnerStateExternal
+	}
+	owner, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return SharedDaemonOwnerStateUnknown
+	}
+	if !owner.Installed || !owner.Loaded || !owner.Secure {
+		return SharedDaemonOwnerStateUnavailable
+	}
+	if owner.MigrationRequired || !owner.RunAtLoad {
+		return SharedDaemonOwnerStateMigrationPending
+	}
+	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
+	if err != nil || !strings.EqualFold(strings.TrimSpace(lifecycle.Status), "running") {
+		return SharedDaemonOwnerStateUnknown
+	}
+	if lifecycle.Backend == nil || lifecycle.PID == nil {
+		return SharedDaemonOwnerStateUnmanagedListener
+	}
+	if !strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid") ||
+		!sameCanonicalPath(lifecycle.SocketPath, socketPath) ||
+		int(*lifecycle.PID) != listenerPID {
+		return SharedDaemonOwnerStateListenerMismatch
+	}
+	return SharedDaemonOwnerStateStable
+}
+
+func sharedDaemonProcessOpenFileCount(pid int) (int, error) {
+	if pid <= 1 {
+		return 0, fmt.Errorf("共享 daemon PID 无效")
+	}
+	entrySize := unsafe.Sizeof(darwinProcFDInfo{})
+	required, _, errno := unix.Syscall6(
+		unix.SYS_PROC_INFO,
+		darwinProcInfoCallPIDInfo,
+		uintptr(pid),
+		darwinProcPIDListFDs,
+		0,
+		0,
+		0,
+	)
+	if errno != 0 {
+		return 0, fmt.Errorf("读取共享 daemon FD 数失败：%w", errno)
+	}
+	if required == 0 {
+		return 0, nil
+	}
+	// 在 size query 与实际读取之间目标可能打开新 FD；额外预留 32 项，并在
+	// 内核仍填满缓冲区时放大重试，避免把瞬时增长截断成偏低水位。
+	capacity := int(required/entrySize) + 32
+	for attempt := 0; attempt < 3; attempt++ {
+		entries := make([]darwinProcFDInfo, capacity)
+		written, _, readErrno := unix.Syscall6(
+			unix.SYS_PROC_INFO,
+			darwinProcInfoCallPIDInfo,
+			uintptr(pid),
+			darwinProcPIDListFDs,
+			0,
+			uintptr(unsafe.Pointer(&entries[0])),
+			uintptr(len(entries))*entrySize,
+		)
+		if readErrno != 0 {
+			return 0, fmt.Errorf("读取共享 daemon FD 列表失败：%w", readErrno)
+		}
+		if written%entrySize != 0 {
+			return 0, fmt.Errorf("共享 daemon FD 列表元数据不完整")
+		}
+		count := int(written / entrySize)
+		if count < len(entries) {
+			return count, nil
+		}
+		capacity *= 2
+	}
+	return 0, fmt.Errorf("共享 daemon FD 列表持续增长，无法取得稳定水位")
+}
+
+func sharedDaemonDirectChildCount(pid int) (int, error) {
+	// Darwin 不提供稳定的 kern.proc.ppid sysctl selector；读取一次内核进程表
+	// 后按 PPID 过滤，仍然不需要 fork ps/pgrep，daemon 接近 EMFILE 时也可用。
+	processes, err := unix.SysctlKinfoProcSlice("kern.proc.all")
+	if err != nil {
+		return 0, fmt.Errorf("读取共享 daemon 子进程数失败：%w", err)
+	}
+	count := 0
+	for index := range processes {
+		if int(processes[index].Eproc.Ppid) == pid && processes[index].Proc.P_pid > 0 {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/internal/appserver/shared_daemon_diagnostics_darwin.go
+++ b/internal/appserver/shared_daemon_diagnostics_darwin.go
@@ -117,12 +117,19 @@ func inspectSharedDaemonOwnerState(
 	if err != nil || !strings.EqualFold(strings.TrimSpace(lifecycle.Status), "running") {
 		return SharedDaemonOwnerStateUnknown
 	}
-	if lifecycle.Backend == nil || lifecycle.PID == nil {
+	// 没有 backend 仍是旧 SSH/CLI 直启进程，不能因为 owner 已安装就冒充官方托管。
+	if lifecycle.Backend == nil {
 		return SharedDaemonOwnerStateUnmanagedListener
 	}
-	if !strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid") ||
-		!sameCanonicalPath(lifecycle.SocketPath, socketPath) ||
-		int(*lifecycle.PID) != listenerPID {
+	backendIsPID := strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid")
+	socketMatches := sameCanonicalPath(lifecycle.SocketPath, socketPath)
+	// 官方 0.147.0 的 daemon start 在完成 detached listener 交接后，会保留 pid
+	// backend 但不再返回 PID。此时 stable owner 已提交且 socket 路径一致，仍不能
+	// 证明 listener 的启动来源；保留只读 warning，不误报 unmanaged 或 healthy。
+	if backendIsPID && socketMatches && lifecycle.PID == nil {
+		return SharedDaemonOwnerStateClaimedUnverified
+	}
+	if lifecycle.PID == nil || !backendIsPID || !socketMatches || int(*lifecycle.PID) != listenerPID {
 		return SharedDaemonOwnerStateListenerMismatch
 	}
 	return SharedDaemonOwnerStateStable

--- a/internal/appserver/shared_daemon_diagnostics_darwin.go
+++ b/internal/appserver/shared_daemon_diagnostics_darwin.go
@@ -113,6 +113,11 @@ func inspectSharedDaemonOwnerState(
 	if owner.MigrationRequired || !owner.RunAtLoad {
 		return SharedDaemonOwnerStateMigrationPending
 	}
+	// foreground app-server 的官方 daemon JSON 没有 pid backend。先从真实 socket
+	// peer 沿 PPID 验证 OpenAI node supervisor；只有完整链成立才是新的 stable。
+	if err := sharedDaemonValidateSignedRuntime(ctx, options, socketPath); err == nil {
+		return SharedDaemonOwnerStateStable
+	}
 	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
 	if err != nil || !strings.EqualFold(strings.TrimSpace(lifecycle.Status), "running") {
 		return SharedDaemonOwnerStateUnknown
@@ -123,16 +128,14 @@ func inspectSharedDaemonOwnerState(
 	}
 	backendIsPID := strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid")
 	socketMatches := sameCanonicalPath(lifecycle.SocketPath, socketPath)
-	// 官方 0.147.0 的 daemon start 在完成 detached listener 交接后，会保留 pid
-	// backend 但不再返回 PID。此时 stable owner 已提交且 socket 路径一致，仍不能
-	// 证明 listener 的启动来源；保留只读 warning，不误报 unmanaged 或 healthy。
-	if backendIsPID && socketMatches && lifecycle.PID == nil {
+	// 旧 daemon start 即使返回了精确 PID，也只能证明官方 pid backend 管理着
+	// listener，不能证明它来自新的签名 node supervisor，更不能断言继承了 8192。
+	// 保留 warning，等待普通 ensure 收敛为 pending 后由用户显式迁移。
+	if backendIsPID && socketMatches &&
+		(lifecycle.PID == nil || int(*lifecycle.PID) == listenerPID) {
 		return SharedDaemonOwnerStateClaimedUnverified
 	}
-	if lifecycle.PID == nil || !backendIsPID || !socketMatches || int(*lifecycle.PID) != listenerPID {
-		return SharedDaemonOwnerStateListenerMismatch
-	}
-	return SharedDaemonOwnerStateStable
+	return SharedDaemonOwnerStateListenerMismatch
 }
 
 func sharedDaemonProcessOpenFileCount(pid int) (int, error) {

--- a/internal/appserver/shared_daemon_diagnostics_darwin_test.go
+++ b/internal/appserver/shared_daemon_diagnostics_darwin_test.go
@@ -1,0 +1,97 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+)
+
+func TestDarwinProcFDInfoLayout(t *testing.T) {
+	// proc_info 是 ABI，不经过 Go 类型检查；布局变化必须在测试中显式暴露。
+	if got := unsafe.Sizeof(darwinProcFDInfo{}); got != 8 {
+		t.Fatalf("proc_fdinfo 布局大小异常：got=%d want=8", got)
+	}
+}
+
+func TestSharedDaemonProcessMetricsReadCurrentProcess(t *testing.T) {
+	before, err := sharedDaemonProcessOpenFileCount(os.Getpid())
+	if err != nil {
+		t.Fatalf("读取当前进程 FD 数失败：%v", err)
+	}
+	if before <= 0 {
+		t.Fatalf("当前进程 FD 数必须大于 0：%d", before)
+	}
+	opened := make([]*os.File, 0, 3)
+	for range 3 {
+		file, openErr := os.Open("/dev/null")
+		if openErr != nil {
+			t.Fatal(openErr)
+		}
+		opened = append(opened, file)
+	}
+	t.Cleanup(func() {
+		for _, file := range opened {
+			_ = file.Close()
+		}
+	})
+	after, err := sharedDaemonProcessOpenFileCount(os.Getpid())
+	if err != nil {
+		t.Fatalf("打开文件后读取当前进程 FD 数失败：%v", err)
+	}
+	if after < before+len(opened) {
+		t.Fatalf("PROC_PIDLISTFDS 必须反映实际新增 FD：before=%d after=%d opened=%d", before, after, len(opened))
+	}
+	children, err := sharedDaemonDirectChildCount(os.Getpid())
+	if err != nil {
+		t.Fatalf("读取当前进程直接子进程数失败：%v", err)
+	}
+	if children < 0 {
+		t.Fatalf("直接子进程数不能为负数：%d", children)
+	}
+}
+
+func TestInspectSharedDaemonDiagnosticsUsesSocketPeerAndKeepsExternalLimitUnknown(t *testing.T) {
+	// Unix socket 路径有固定长度上限；系统测试临时目录在 macOS 上可能很深。
+	codexHome, err := os.MkdirTemp("/tmp", "mimi-daemon-diag-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(codexHome) })
+	socketPath, err := LocalDaemonSocketPath(map[string]string{"CODEX_HOME": codexHome})
+	if err != nil {
+		t.Fatalf("解析临时 socket 失败：%v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		t.Fatalf("创建临时 socket 目录失败：%v", err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("创建临时 Unix listener 失败：%v", err)
+	}
+	defer listener.Close()
+
+	status, err := InspectSharedDaemonDiagnostics(context.Background(), LocalDaemonOptions{
+		Env: map[string]string{"CODEX_HOME": codexHome},
+	})
+	if err != nil {
+		t.Fatalf("共享 daemon 诊断失败：%v", err)
+	}
+	if status.ListenerPID != os.Getpid() {
+		t.Fatalf("必须以 socket 的真实 peer PID 为准：got=%d want=%d", status.ListenerPID, os.Getpid())
+	}
+	if status.OpenFileDescriptors <= 0 || status.ListenerStartedAt.IsZero() {
+		t.Fatalf("进程资源证据不完整：%+v", status)
+	}
+	if status.OwnerState != SharedDaemonOwnerStateExternal {
+		t.Fatalf("非 StableOwner 配置必须标记为 external：%+v", status)
+	}
+	if status.OwnerTargetFDSoftLimit != nil || status.FDUsagePercent != nil ||
+		status.ResourceState != SharedDaemonResourceStateUnknown {
+		t.Fatalf("外部 owner 的上限未知，不能套用 Mimi 配置：%+v", status)
+	}
+}

--- a/internal/appserver/shared_daemon_diagnostics_other.go
+++ b/internal/appserver/shared_daemon_diagnostics_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+
+package appserver
+
+import "context"
+
+func InspectSharedDaemonDiagnostics(
+	context.Context,
+	LocalDaemonOptions,
+) (SharedDaemonDiagnostics, error) {
+	return SharedDaemonDiagnostics{
+		Supported:     false,
+		OwnerState:    SharedDaemonOwnerStateUnknown,
+		ResourceState: SharedDaemonResourceStateUnknown,
+	}, nil
+}

--- a/internal/appserver/shared_daemon_diagnostics_test.go
+++ b/internal/appserver/shared_daemon_diagnostics_test.go
@@ -1,0 +1,56 @@
+package appserver
+
+import "testing"
+
+func TestApplySharedDaemonResourceStateRequiresEffectiveLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		openFiles int
+		limit     *int
+		wantState SharedDaemonResourceState
+		wantUsage *float64
+	}{
+		{name: "limit unknown", openFiles: 200, wantState: SharedDaemonResourceStateUnknown},
+		{name: "healthy", openFiles: 4096, limit: intPointer(8192), wantState: SharedDaemonResourceStateHealthy, wantUsage: floatPointer(50)},
+		{name: "degraded boundary", openFiles: 5735, limit: intPointer(8192), wantState: SharedDaemonResourceStateDegraded},
+		{name: "critical boundary", openFiles: 7373, limit: intPointer(8192), wantState: SharedDaemonResourceStateCritical},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			status := SharedDaemonDiagnostics{
+				OpenFileDescriptors:  testCase.openFiles,
+				EffectiveFDSoftLimit: testCase.limit,
+			}
+			applySharedDaemonResourceState(&status)
+			if status.ResourceState != testCase.wantState {
+				t.Fatalf("资源状态错误：got=%s want=%s", status.ResourceState, testCase.wantState)
+			}
+			if testCase.wantUsage == nil {
+				if status.FDUsagePercent != nil && testCase.limit == nil {
+					t.Fatalf("上限未知时不能推测 FD 使用率：%v", *status.FDUsagePercent)
+				}
+				return
+			}
+			if status.FDUsagePercent == nil || *status.FDUsagePercent != *testCase.wantUsage {
+				t.Fatalf("FD 使用率错误：got=%v want=%v", status.FDUsagePercent, *testCase.wantUsage)
+			}
+		})
+	}
+}
+
+func TestApplySharedDaemonResourceStateDoesNotAssumeConfiguredLimitIsEffective(t *testing.T) {
+	configured := 8192
+	status := SharedDaemonDiagnostics{
+		OpenFileDescriptors:    8000,
+		OwnerTargetFDSoftLimit: &configured,
+	}
+	applySharedDaemonResourceState(&status)
+	if status.ResourceState != SharedDaemonResourceStateUnknown || status.FDUsagePercent != nil {
+		t.Fatalf("仅有 owner 配置时不能推测当前 listener 的资源水位：%+v", status)
+	}
+}
+
+func intPointer(value int) *int { return &value }
+
+func floatPointer(value float64) *float64 { return &value }

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -22,9 +23,9 @@ import (
 )
 
 const (
-	// SharedDaemonLaunchAgentLabel 是 Mimi 安装的 LaunchAgent 标签。它只负责“请
-	// launchd 以官方 codex 身份创建共享 daemon”，不代表 Mimi 拥有该 daemon 的
-	// 生命周期：job 本身执行完 `daemon start` 就退出，daemon 继续独立运行。
+	// SharedDaemonLaunchAgentLabel 是 Mimi 安装的 LaunchAgent 标签。job 只执行
+	// OpenAI 签名的 node launcher；launcher 创建 detached node supervisor 后退出，
+	// Mimi/agentd 不进入 Browser 原生 peer 校验所读取的三级父链。
 	SharedDaemonLaunchAgentLabel = "com.gaixianggeng.mimi.codex-shared-daemon"
 
 	sharedDaemonLaunchAgentLogName         = "codex-shared-daemon.log"
@@ -35,6 +36,7 @@ const (
 	sharedDaemonStartTimeoutForLocalEnsure = sharedDaemonStartTimeout
 	sharedDaemonStopTimeout                = 15 * time.Second
 	sharedDaemonStoppedConfirmationWindow  = 500 * time.Millisecond
+	sharedDaemonRunAtLoadGrace             = time.Second
 	sharedDaemonSocketPollInterval         = 100 * time.Millisecond
 	launchctlTimeout                       = 10 * time.Second
 	sharedDaemonMaxLogBytes                = 1 << 20
@@ -49,6 +51,7 @@ func SupportsStableSharedDaemonOwner() bool { return true }
 
 type sharedDaemonListenerProcess struct {
 	PID        int
+	ParentPID  int
 	UID        int
 	StartSec   int64
 	StartUsec  int32
@@ -63,8 +66,8 @@ type unmanagedSharedDaemonHooks struct {
 	currentUID     func() int
 }
 
-// SharedDaemonOwnerStatus 描述 Mimi 为官方 daemon 安装的稳定启动入口。它只证明
-// launchd job 的安装状态；TCC 的最终责任主体仍需在真实签名 App 上做运行态验收。
+// SharedDaemonOwnerStatus 描述 Mimi 为共享 app-server 安装的稳定启动入口。它只
+// 证明 launchd job 的安装状态；Browser/TCC 仍需对真实 socket peer 父链验收。
 type SharedDaemonOwnerStatus struct {
 	Supported         bool
 	Installed         bool
@@ -88,6 +91,13 @@ var sharedDaemonStrippedEnvKeys = []string{
 	LocalDaemonEnvironmentKey,
 	"CODEX_APP_SERVER_WS_URL",
 	"MIMI_REMOTE_CODEX_DESKTOP_OWNERSHIP_EPOCH",
+	// supervisor 通过 node -e 执行固定内联脚本。继承 NODE_OPTIONS/require
+	// 等控制面会允许用户环境在脚本前加载额外代码，必须以空值覆盖。
+	"NODE_OPTIONS",
+	"NODE_PATH",
+	"NODE_REPL_EXTERNAL_MODULE",
+	"NODE_REDIRECT_WARNINGS",
+	"NODE_V8_COVERAGE",
 }
 
 var sharedDaemonRequiredToolPaths = []string{
@@ -219,34 +229,37 @@ func resolveSharedDaemonCodexBin(configured string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("解析 codex 路径失败：%w", err)
 	}
-	info, err := os.Stat(absolute)
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("解析 codex 真实路径失败：%w", err)
+	}
+	canonical = filepath.Clean(canonical)
+	info, err := os.Stat(canonical)
 	if err != nil {
 		return "", fmt.Errorf("检查 codex 可执行文件失败：%w", err)
 	}
 	if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
-		return "", fmt.Errorf("codex 路径不是可执行文件：%s", absolute)
+		return "", fmt.Errorf("codex 路径不是可执行文件：%s", canonical)
 	}
-	return absolute, nil
+	// plist 固定到已验证版本的真实路径，避免 `current`/用户 bin symlink 在
+	// codesign 检查与 launchd 执行之间被换到另一份未验证程序。
+	return canonical, nil
 }
 
-// renderSharedDaemonLaunchAgent 生成 plist。ProgramArguments 直接执行官方 codex，
-// 不引入 shell 责任主体；Desktop 专属变量由 job 环境中的空值覆盖。TCC 最终归因
-// 仍必须由签名 App 做运行态验收，不能由 plist 结构或单元测试代替。
+// renderSharedDaemonLaunchAgent 生成 plist。ProgramArguments 直接执行 Codex
+// Desktop 内置的签名 node，不引入 shell 或 Mimi 可执行文件。node launcher 只负责
+// 创建 detached node supervisor；最终仍需以 socket peer 父链做运行态验收。
 func renderSharedDaemonLaunchAgent(
+	nodeBin string,
 	codexBin string,
 	env map[string]string,
 	logPath string,
 	runAtLoadOption ...bool,
 ) ([]byte, error) {
-	if strings.TrimSpace(codexBin) == "" {
-		return nil, fmt.Errorf("codex 路径不能为空")
+	if strings.TrimSpace(nodeBin) == "" || strings.TrimSpace(codexBin) == "" {
+		return nil, fmt.Errorf("node supervisor 与 codex 路径不能为空")
 	}
-	arguments := []string{
-		codexBin,
-		"app-server",
-		"daemon",
-		"start",
-	}
+	arguments := sharedDaemonSupervisorProgramArguments(nodeBin, codexBin)
 	runAtLoad := true
 	if len(runAtLoadOption) > 0 {
 		runAtLoad = runAtLoadOption[0]
@@ -297,9 +310,15 @@ func renderSharedDaemonLaunchAgent(
 	} else {
 		buf.WriteString("\t<false/>\n")
 	}
-	// job 是一次性控制命令，退出属于正常结束，不能让 launchd 反复重启。
+	// launcher 是一次性控制命令。真正的 supervisor 已进入独立 session；launcher
+	// 退出属于成功，不能让 launchd 因其退出反复创建 socket 竞争者。
 	buf.WriteString("\t<key>KeepAlive</key>\n\t<false/>\n")
+	// 明确告诉 launchd 不要在 one-shot launcher 退出时按进程组清理已 detached
+	// 的 supervisor。bootout 的 coalition 行为仍不作安全假设，活跃 socket 路径
+	// 会完全避开 bootout。
+	buf.WriteString("\t<key>AbandonProcessGroup</key>\n\t<true/>\n")
 	buf.WriteString("\t<key>ThrottleInterval</key>\n\t<integer>1</integer>\n")
+	buf.WriteString("\t<key>ExitTimeOut</key>\n\t<integer>20</integer>\n")
 	// 077 的十进制是 63；确保 launchd 创建的 stdout/stderr 日志仅当前用户可读。
 	buf.WriteString("\t<key>Umask</key>\n\t<integer>63</integer>\n")
 	if strings.TrimSpace(logPath) != "" {
@@ -323,7 +342,7 @@ func sharedDaemonLaunchAgentEnv(env map[string]string) map[string]string {
 	}
 	values["PATH"] = normalizedSharedDaemonToolingPath(values["PATH"], os.Getenv("PATH"))
 	// EnvironmentVariables 会覆盖 launchctl setenv 的用户域值。直接 ProgramArguments
-	// 因此无需借 shell 执行 unset，进程树固定为 launchd -> codex。
+	// 因此无需借 shell 执行 unset，启动链固定为 launchd -> node launcher。
 	for _, key := range sharedDaemonStrippedEnvKeys {
 		values[key] = ""
 	}
@@ -463,6 +482,13 @@ func planSharedDaemonLaunchAgent(
 	if err != nil {
 		return sharedDaemonLaunchAgentPlan{}, err
 	}
+	nodeBin, err := sharedDaemonResolveSupervisorNode(codexBin)
+	if err != nil {
+		return sharedDaemonLaunchAgentPlan{}, err
+	}
+	if err := sharedDaemonValidateSupervisor(nodeBin, codexBin); err != nil {
+		return sharedDaemonLaunchAgentPlan{}, err
+	}
 	logPath, err := sharedDaemonLaunchAgentLogPath()
 	if err != nil {
 		return sharedDaemonLaunchAgentPlan{}, err
@@ -516,7 +542,7 @@ func planSharedDaemonLaunchAgent(
 	} else if !os.IsNotExist(statErr) {
 		return sharedDaemonLaunchAgentPlan{}, fmt.Errorf("检查共享 daemon LaunchAgent 失败：%w", statErr)
 	}
-	desired, err := renderSharedDaemonLaunchAgent(codexBin, effectiveEnv, logPath, runAtLoad)
+	desired, err := renderSharedDaemonLaunchAgent(nodeBin, codexBin, effectiveEnv, logPath, runAtLoad)
 	if err != nil {
 		return sharedDaemonLaunchAgentPlan{}, err
 	}
@@ -790,42 +816,107 @@ func ensureSharedDaemonOwner(
 		return SharedDaemonOwnerStatus{}, err
 	}
 	autoChanged := !autoPlan.existingPresent || !bytes.Equal(autoPlan.existing, autoPlan.desired)
+	manualDesired, err := sharedDaemonManualPlist(autoPlan.desired)
+	if err != nil {
+		return SharedDaemonOwnerStatus{}, err
+	}
 	pending := before.MigrationRequired || forcePending ||
 		(daemonPreexisting && (autoChanged || !before.Loaded))
 	plan := autoPlan
 	if pending {
-		plan, err = planSharedDaemonLaunchAgent(options, false)
-		if err != nil {
-			return SharedDaemonOwnerStatus{}, err
-		}
+		// node/codex 的完整 Developer ID 校验最昂贵，也会 fork codesign。manual
+		// 与 auto 只差 RunAtLoad，直接从同一份已验证 plan 派生，避免同次 ensure
+		// 重复 6 个签名/metadata 子进程并扩大 socket 竞态窗口。
+		plan.desired = manualDesired
 	}
 	fileChanged, err := applySharedDaemonLaunchAgentPlan(plan)
 	if err != nil {
 		return SharedDaemonOwnerStatus{}, err
 	}
 	created := !before.Installed
+	launchctlChanged := false
 	rollback := func(cause error) (SharedDaemonOwnerStatus, error) {
 		rollbackCtx, cancel := context.WithTimeout(context.Background(), 2*launchctlTimeout)
 		defer cancel()
-		if rollbackErr := restoreSharedDaemonOwner(rollbackCtx, before, previousPlist); rollbackErr != nil {
+		var rollbackErr error
+		if launchctlChanged && !sharedDaemonSocketAcceptsConnectionMust(options) {
+			rollbackErr = restoreSharedDaemonOwner(rollbackCtx, before, previousPlist)
+		} else {
+			rollbackErr = restoreSharedDaemonOwnerFilesOnly(before, previousPlist)
+		}
+		if rollbackErr != nil {
 			return SharedDaemonOwnerStatus{}, fmt.Errorf("%w；恢复原 daemon owner 也失败：%v", cause, rollbackErr)
 		}
 		return SharedDaemonOwnerStatus{}, fmt.Errorf("%w；已恢复原 daemon owner", cause)
 	}
-	if pending && !before.MigrationRequired {
-		if err := writeSharedDaemonMigrationFlag(); err != nil {
-			return rollback(err)
+	markerPresent := before.MigrationRequired
+	ensurePendingMarker := func() error {
+		if !pending || markerPresent {
+			return nil
 		}
+		if err := writeSharedDaemonMigrationFlag(); err != nil {
+			return err
+		}
+		markerPresent = true
+		return nil
+	}
+	// 入口探测到“无 listener”不构成跨越 codesign/落盘窗口的租约。每个
+	// launchctl 副作用前重新探测；一旦 socket 已出现，就把刚写的 auto plist
+	// 收敛为 manual+marker，并保留当前 loaded job，绝不 bootout 活跃 coalition。
+	stagePendingIfListenerAppeared := func() (bool, error) {
+		if !sharedDaemonSocketAcceptsConnectionMust(options) {
+			return false, nil
+		}
+		if !pending {
+			manualPlan := autoPlan
+			manualPlan.desired = manualDesired
+			changed, applyErr := applySharedDaemonLaunchAgentPlan(manualPlan)
+			if applyErr != nil {
+				return true, applyErr
+			}
+			fileChanged = fileChanged || changed
+			pending = true
+		}
+		if err := ensurePendingMarker(); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+	if err := ensurePendingMarker(); err != nil {
+		return rollback(err)
 	}
 	loaded := before.Loaded
-	if fileChanged && loaded {
+	listenerActive := daemonPreexisting
+	if fileChanged || !loaded {
+		observedActive, stageErr := stagePendingIfListenerAppeared()
+		if stageErr != nil {
+			return rollback(stageErr)
+		}
+		listenerActive = listenerActive || observedActive
+	}
+	// 已有 listener 时只 stage 新的 manual plist + marker，不能在用户确认前
+	// bootout 当前 job。虽然旧官方 daemon 通常已经 detached，launchd 仍可能按
+	// service coalition 回收后代；显式迁移会在 socket 完全停止后再 reload。
+	deferReloadUntilMigration := fileChanged && loaded && (daemonPreexisting || listenerActive)
+	if fileChanged && loaded && !deferReloadUntilMigration {
+		listenerActive, err = stagePendingIfListenerAppeared()
+		if err != nil {
+			return rollback(err)
+		}
+		deferReloadUntilMigration = listenerActive
+	}
+	if fileChanged && loaded && !deferReloadUntilMigration {
 		if _, bootoutErr := sharedDaemonLaunchctl(ctx, "bootout", launchAgentServiceTarget()); bootoutErr != nil &&
 			!isLaunchctlNotLoaded(bootoutErr) {
 			return rollback(bootoutErr)
 		}
 		loaded = false
+		launchctlChanged = true
 	}
 	if !loaded {
+		if _, stageErr := stagePendingIfListenerAppeared(); stageErr != nil {
+			return rollback(stageErr)
+		}
 		path, pathErr := SharedDaemonLaunchAgentPath()
 		if pathErr != nil {
 			return rollback(pathErr)
@@ -835,6 +926,7 @@ func ensureSharedDaemonOwner(
 		if _, bootstrapErr := sharedDaemonLaunchctl(ctx, "bootstrap", launchAgentDomainTarget(), path); bootstrapErr != nil {
 			return rollback(bootstrapErr)
 		}
+		launchctlChanged = true
 	}
 	changed := fileChanged || !before.Loaded || markerRepaired
 	status, err := InspectSharedDaemonOwner(ctx)
@@ -873,7 +965,10 @@ func ensureSharedDaemonOwner(
 					currentStatus.MigrationRequired != appliedMigrationRequired {
 					return fmt.Errorf("共享 daemon owner 状态已被其他进程修改，拒绝覆盖")
 				}
-				return restoreSharedDaemonOwner(rollbackCtx, before, previousPlist)
+				if launchctlChanged && !sharedDaemonSocketAcceptsConnectionMust(options) {
+					return restoreSharedDaemonOwner(rollbackCtx, before, previousPlist)
+				}
+				return restoreSharedDaemonOwnerFilesOnly(before, previousPlist)
 			},
 		}
 	}
@@ -893,7 +988,8 @@ func RollbackSharedDaemonOwnerChange(ctx context.Context, rollback *SharedDaemon
 }
 
 // restoreSharedDaemonOwner 把 plist、launchd 加载状态和迁移标记一起恢复到调用前。
-// job 是一次性官方控制命令，回滚不会 stop 已运行的 app-server daemon。
+// 只允许用于本事务已在“无既有 listener”条件下修改过 launchctl 的路径；已有
+// listener 的 stage/rollback 必须走 files-only，不能依赖 bootout 的 coalition 行为。
 func restoreSharedDaemonOwner(
 	ctx context.Context,
 	before SharedDaemonOwnerStatus,
@@ -921,6 +1017,29 @@ func restoreSharedDaemonOwner(
 			if _, err := sharedDaemonLaunchctl(ctx, "bootstrap", launchAgentDomainTarget(), path); err != nil {
 				return err
 			}
+		}
+	} else if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("删除本次新建 LaunchAgent 失败：%w", err)
+	}
+	if before.MigrationRequired {
+		return writeSharedDaemonMigrationFlag()
+	}
+	return clearSharedDaemonMigrationFlag()
+}
+
+// restoreSharedDaemonOwnerFilesOnly 用于只 stage 了磁盘 plist/marker、尚未触碰
+// launchctl 的事务回滚。此路径绝不能为了恢复文件而 bootout 仍在服务的旧 job。
+func restoreSharedDaemonOwnerFilesOnly(
+	before SharedDaemonOwnerStatus,
+	previousPlist []byte,
+) error {
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		return err
+	}
+	if before.Installed {
+		if err := writeSharedDaemonPrivateFileAtomically(path, previousPlist); err != nil {
+			return fmt.Errorf("恢复原 LaunchAgent 文件失败：%w", err)
 		}
 	} else if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("删除本次新建 LaunchAgent 失败：%w", err)
@@ -1057,22 +1176,13 @@ func clearSharedDaemonMigrationFlag() error {
 	return nil
 }
 
-// RemoveSharedDaemonLaunchAgent 关闭共享时卸载 job 并删除 plist。不停止已经在运行
-// 的 daemon：那会打断仍在使用它的 Desktop 或移动端任务。
+// RemoveSharedDaemonLaunchAgent 关闭共享时只删除未来登录的启动入口。one-shot job
+// 可能仍通过 launchd coalition 关联着当前 listener；即使 job 自己已经 exited，
+// bootout 也没有“不影响后代”的系统契约，因此本会话保留已加载但不可自启的定义。
 func RemoveSharedDaemonLaunchAgent(ctx context.Context) error {
 	path, err := SharedDaemonLaunchAgentPath()
 	if err != nil {
 		return err
-	}
-	loaded, _, inspectErr := inspectLaunchAgentState(ctx)
-	if inspectErr != nil {
-		return inspectErr
-	}
-	if loaded {
-		if _, bootoutErr := sharedDaemonLaunchctl(ctx, "bootout", launchAgentServiceTarget()); bootoutErr != nil &&
-			!isLaunchctlNotLoaded(bootoutErr) {
-			return bootoutErr
-		}
 	}
 	if err := sharedDaemonRemoveLaunchAgentFile(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("删除 LaunchAgent 失败：%w", err)
@@ -1098,20 +1208,16 @@ func removeSharedDaemonOwnerUnlocked(ctx context.Context) error {
 }
 
 // removeSharedDaemonOwnerForTransactionUnlocked 在调用方持有 operation lock 时
-// 移除 owner。先把磁盘 plist 降为 manual，再 bootout/delete；因此删除任一步
-// 失败也不会留下可在下次登录自动启动的 owner。返回值保留兼容签名，但禁用
-// 事务不再恢复 auto owner：配置可能已被锁外编辑器改成 WS，恢复会越权。
+// 移除 owner。先把磁盘 plist 降为 manual，再删除未来登录入口；当前会话里已
+// 加载的 one-shot 定义保留到注销，避免 bootout 误伤 coalition 中的 listener。
+// 返回值保留兼容签名，但禁用事务不再恢复 auto owner：配置可能已被锁外编辑器
+// 改成 WS，恢复会越权。
 func removeSharedDaemonOwnerForTransactionUnlocked(
 	ctx context.Context,
 ) (func(context.Context) error, error) {
 	before, err := InspectSharedDaemonOwner(ctx)
 	if err != nil {
 		return nil, err
-	}
-	if before.Loaded && !before.Installed {
-		// 没有磁盘 plist 就无法在失败时重新 bootstrap 同一个 job。先于 bootout
-		// 拒绝这种外部/残缺状态，保证后面的删除事务始终可完整回滚。
-		return nil, fmt.Errorf("共享 daemon LaunchAgent 已加载但磁盘 plist 缺失，拒绝卸载")
 	}
 	var previousPlist []byte
 	if before.Installed {
@@ -1192,6 +1298,23 @@ func startLocalDaemonWithStableOwnerTracked(
 		// job 尚未退出时再 kickstart，直接等待本次启动完成。
 		return false, waitForSharedDaemonSocket(ctx, options, logOffset)
 	}
+	if owner.RunAtLoad {
+		// 登录时 RunAtLoad launcher 可能已经退出，但 detached supervisor 仍在
+		// 启动 app-server。先给这条既有链一个短窗口，避免立即 kickstart 第二套
+		// supervisor；真正崩溃的恢复最多只增加这一秒。
+		graceCtx, cancelGrace := context.WithTimeout(ctx, sharedDaemonRunAtLoadGrace)
+		graceErr := waitForSharedDaemonSocket(graceCtx, options, logOffset)
+		cancelGrace()
+		if graceErr == nil {
+			return false, nil
+		}
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		if sharedDaemonSocketAcceptsConnectionMust(options) {
+			return false, nil
+		}
+	}
 	// job 已注册：显式 kickstart 一次，不依赖刚才 bootstrap 的异步 RunAtLoad。
 	if _, kickErr := sharedDaemonLaunchctl(ctx, "kickstart", launchAgentServiceTarget()); kickErr != nil {
 		return false, kickErr
@@ -1258,11 +1381,14 @@ func startPreparedSharedDaemonAfterConfigCommit(
 	if err != nil {
 		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 启动后生命周期检查失败：%w", err)
 	}
-	if err := ValidateManagedLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
+	if err := ValidateLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
 		return LocalDaemonStatus{}, err
 	}
 	if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
 		return LocalDaemonStatus{}, err
+	}
+	if err := sharedDaemonValidateSignedRuntime(ctx, options, socketPath); err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 启动后签名父链检查失败：%w", err)
 	}
 	status := localDaemonStatus(socketPath, startedByOwner, probe.Version, os.Stat)
 	status.StartedByStableOwner = startedByOwner
@@ -1326,6 +1452,29 @@ func restartSharedDaemonWithStableOwner(
 	if err := clearSharedDaemonEnablePrepared(); err != nil {
 		return LocalDaemonStatus{}, err
 	}
+	// 上一次显式迁移可能已经启动并完整验证了新 supervisor，却在清 marker 前
+	// 崩溃。若当前 socket 仍能从真实 peer 证明就是目标签名父链，直接提交 auto；
+	// 不为了修复持久状态再中断一次健康会话。
+	if owner.MigrationRequired && preexistingErr == nil {
+		probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
+		probe, probeErr := ProbeLocalDaemonInfo(probeCtx, socketPath)
+		cancel()
+		if probeErr == nil {
+			lifecycle, lifecycleErr := InspectLocalDaemonLifecycle(ctx, options)
+			if lifecycleErr == nil &&
+				ValidateLocalDaemonLifecycle(lifecycle, socketPath) == nil &&
+				ValidateLocalDaemonProbeVersion(lifecycle, probe.Version) == nil &&
+				sharedDaemonValidateSignedRuntime(ctx, options, socketPath) == nil {
+				if err := commitSharedDaemonMigration(options); err != nil {
+					return LocalDaemonStatus{}, err
+				}
+				status := localDaemonStatus(socketPath, false, probe.Version, os.Stat)
+				status.OwnerInstalled = true
+				status.LifecycleValidated = true
+				return status, nil
+			}
+		}
+	}
 	if !owner.MigrationRequired {
 		probeCtx, cancel := context.WithTimeout(ctx, localDaemonProbeTimeout)
 		probe, probeErr := ProbeLocalDaemonInfo(probeCtx, socketPath)
@@ -1335,22 +1484,45 @@ func restartSharedDaemonWithStableOwner(
 			if lifecycleErr != nil {
 				return LocalDaemonStatus{}, fmt.Errorf("确认现有共享 daemon 生命周期失败：%w", lifecycleErr)
 			}
-			if lifecycleErr := ValidateManagedLocalDaemonLifecycle(lifecycle, socketPath); lifecycleErr != nil {
+			if lifecycleErr := ValidateLocalDaemonLifecycle(lifecycle, socketPath); lifecycleErr != nil {
 				return LocalDaemonStatus{}, lifecycleErr
 			}
 			if identityErr := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); identityErr != nil {
 				return LocalDaemonStatus{}, identityErr
+			}
+			if identityErr := sharedDaemonValidateSignedRuntime(ctx, options, socketPath); identityErr != nil {
+				return LocalDaemonStatus{}, fmt.Errorf("现有共享 daemon 缺少签名 supervisor 父链：%w", identityErr)
 			}
 			status := localDaemonStatus(socketPath, false, probe.Version, os.Stat)
 			status.OwnerInstalled = true
 			return status, nil
 		}
 	}
+	var listenerBeforeStop *sharedDaemonListenerProcess
+	if sharedDaemonSocketAcceptsConnection(socketPath) {
+		identity, identityErr := inspectSharedDaemonListenerProcess(ctx, socketPath)
+		if identityErr != nil {
+			return LocalDaemonStatus{}, fmt.Errorf("记录旧共享 daemon 身份失败：%w", identityErr)
+		}
+		listenerBeforeStop = &identity
+	}
 	if err := stopSharedDaemon(ctx, options, owner); err != nil {
 		return LocalDaemonStatus{}, err
 	}
-	if err := waitForSharedDaemonStopped(ctx, socketPath); err != nil {
+	var stoppedIdentities []sharedDaemonListenerProcess
+	if listenerBeforeStop != nil {
+		stoppedIdentities = append(stoppedIdentities, *listenerBeforeStop)
+	}
+	if err := waitForSharedDaemonStopped(ctx, socketPath, stoppedIdentities...); err != nil {
 		return LocalDaemonStatus{}, err
+	}
+	// 已有 listener 时 Ensure 只把新 plist stage 到磁盘，launchd 内仍可能
+	// 注册着旧的 `daemon start` 定义。只有用户明确确认、旧 socket 已稳定断开
+	// 后，才把当前 manual plist 重新加载；否则随后 kickstart 仍会拉起旧拓扑。
+	if owner.MigrationRequired {
+		if err := reloadSharedDaemonLaunchAgentForMigration(ctx); err != nil {
+			return LocalDaemonStatus{}, err
+		}
 	}
 	logOffset := sharedDaemonLaunchAgentLogSize()
 	if err := kickstartSharedDaemon(ctx); err != nil {
@@ -1369,11 +1541,14 @@ func restartSharedDaemonWithStableOwner(
 	if err != nil {
 		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 重启后生命周期检查失败：%w", err)
 	}
-	if err := ValidateManagedLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
+	if err := ValidateLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
 		return LocalDaemonStatus{}, err
 	}
 	if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
 		return LocalDaemonStatus{}, err
+	}
+	if err := sharedDaemonValidateSignedRuntime(ctx, options, socketPath); err != nil {
+		return LocalDaemonStatus{}, fmt.Errorf("共享 daemon 重启后签名父链检查失败：%w", err)
 	}
 	if err := commitSharedDaemonMigration(options); err != nil {
 		return LocalDaemonStatus{}, err
@@ -1381,6 +1556,41 @@ func restartSharedDaemonWithStableOwner(
 	status := localDaemonStatus(socketPath, true, probe.Version, os.Stat)
 	status.OwnerInstalled = true
 	return status, nil
+}
+
+func reloadSharedDaemonLaunchAgentForMigration(ctx context.Context) error {
+	if err := requireCodexDesktopStopped(ctx, "重新加载共享 daemon owner 前"); err != nil {
+		return err
+	}
+	owner, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return fmt.Errorf("确认待迁移共享 daemon owner 失败：%w", err)
+	}
+	if !owner.Installed || !owner.Secure || owner.RunAtLoad || !owner.MigrationRequired {
+		return fmt.Errorf("待迁移共享 daemon owner 不是安全的 manual 状态")
+	}
+	if owner.Loaded {
+		if _, err := sharedDaemonLaunchctl(ctx, "bootout", launchAgentServiceTarget()); err != nil &&
+			!isLaunchctlNotLoaded(err) {
+			return fmt.Errorf("卸载旧共享 daemon owner 失败：%w", err)
+		}
+	}
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		return err
+	}
+	if _, err := sharedDaemonLaunchctl(ctx, "bootstrap", launchAgentDomainTarget(), path); err != nil {
+		return fmt.Errorf("加载新共享 daemon owner 失败：%w", err)
+	}
+	confirmed, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return fmt.Errorf("复核新共享 daemon owner 失败：%w", err)
+	}
+	if !confirmed.Installed || !confirmed.Loaded || confirmed.Running || !confirmed.Secure ||
+		confirmed.RunAtLoad || !confirmed.MigrationRequired {
+		return fmt.Errorf("新共享 daemon owner 未保持可显式启动的 manual 状态")
+	}
+	return nil
 }
 
 func kickstartSharedDaemon(ctx context.Context) error {
@@ -1412,7 +1622,11 @@ func commitSharedDaemonMigration(options LocalDaemonOptions) error {
 	return nil
 }
 
-func waitForSharedDaemonStopped(ctx context.Context, socketPath string) error {
+func waitForSharedDaemonStopped(
+	ctx context.Context,
+	socketPath string,
+	identities ...sharedDaemonListenerProcess,
+) error {
 	deadline := time.Now().Add(sharedDaemonStopTimeout)
 	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
 		deadline = ctxDeadline
@@ -1425,7 +1639,20 @@ func waitForSharedDaemonStopped(ctx context.Context, socketPath string) error {
 		} else if disconnectedSince.IsZero() {
 			disconnectedSince = now
 		} else if now.Sub(disconnectedSince) >= sharedDaemonStoppedConfirmationWindow {
-			return nil
+			allExited := true
+			for _, identity := range identities {
+				alive, identityErr := sharedDaemonProcessIdentityStillAlive(identity)
+				if identityErr != nil {
+					return identityErr
+				}
+				if alive {
+					allExited = false
+					break
+				}
+			}
+			if allExited {
+				return nil
+			}
 		}
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -1435,6 +1662,24 @@ func waitForSharedDaemonStopped(ctx context.Context, socketPath string) error {
 		}
 		time.Sleep(sharedDaemonSocketPollInterval)
 	}
+}
+
+func sharedDaemonProcessIdentityStillAlive(identity sharedDaemonListenerProcess) (bool, error) {
+	if identity.PID <= 1 {
+		return false, fmt.Errorf("旧共享 daemon PID 无效")
+	}
+	kinfo, err := unix.SysctlKinfoProc("kern.proc.pid", identity.PID)
+	if err != nil {
+		if errors.Is(err, unix.ESRCH) || errors.Is(err, unix.ENOENT) {
+			return false, nil
+		}
+		return false, fmt.Errorf("复核旧共享 daemon 是否退出失败：%w", err)
+	}
+	if int(kinfo.Proc.P_pid) != identity.PID || int(kinfo.Eproc.Ucred.Uid) != identity.UID {
+		return false, nil
+	}
+	return kinfo.Proc.P_starttime.Sec == identity.StartSec &&
+		kinfo.Proc.P_starttime.Usec == identity.StartUsec, nil
 }
 
 func stopSharedDaemon(
@@ -1675,12 +1920,17 @@ func inspectSharedDaemonListenerProcess(
 	if err != nil {
 		return sharedDaemonListenerProcess{}, err
 	}
+	return inspectSharedDaemonProcessIdentity(pid, peerUID)
+}
+
+func inspectSharedDaemonProcessIdentity(pid int, expectedUID int) (sharedDaemonListenerProcess, error) {
 	kinfo, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
 	if err != nil || int(kinfo.Proc.P_pid) != pid {
-		return sharedDaemonListenerProcess{}, fmt.Errorf("读取 socket owner 进程身份失败")
+		return sharedDaemonListenerProcess{}, fmt.Errorf("读取共享 daemon 进程身份失败")
 	}
-	if int(kinfo.Eproc.Ucred.Uid) != peerUID {
-		return sharedDaemonListenerProcess{}, fmt.Errorf("socket peer UID 与进程 UID 不一致")
+	uid := int(kinfo.Eproc.Ucred.Uid)
+	if uid != expectedUID {
+		return sharedDaemonListenerProcess{}, fmt.Errorf("共享 daemon 进程 UID 与预期不一致")
 	}
 	executable, arguments, err := sharedDaemonProcessArguments(pid)
 	if err != nil {
@@ -1688,7 +1938,8 @@ func inspectSharedDaemonListenerProcess(
 	}
 	return sharedDaemonListenerProcess{
 		PID:        pid,
-		UID:        peerUID,
+		ParentPID:  int(kinfo.Eproc.Ppid),
+		UID:        uid,
 		StartSec:   kinfo.Proc.P_starttime.Sec,
 		StartUsec:  kinfo.Proc.P_starttime.Usec,
 		Command:    strings.Join(arguments, "\x00"),
@@ -1804,8 +2055,8 @@ func signalSharedDaemonProcessTERM(pid int) error {
 	return process.Signal(syscall.SIGTERM)
 }
 
-// waitForSharedDaemonSocket 把 launchd 的异步启动重新变成同步语义：官方
-// `daemon start` 原本是阻塞的，调用方依赖“返回即已就绪”。
+// waitForSharedDaemonSocket 把 launchd/node supervisor 的异步启动重新变成同步
+// 语义，调用方依赖“返回即已就绪”。
 func waitForSharedDaemonSocket(ctx context.Context, options LocalDaemonOptions, logOffset int64) error {
 	socketPath, err := LocalDaemonSocketPath(options.Env)
 	if err != nil {

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	// SharedDaemonLaunchAgentLabel 是 Mimi 安装的 LaunchAgent 标签。job 只执行
-	// OpenAI 签名的 node launcher；launcher 创建 detached node supervisor 后退出，
-	// Mimi/agentd 不进入 Browser 原生 peer 校验所读取的三级父链。
+	// SharedDaemonLaunchAgentLabel 是 Mimi 安装的 LaunchAgent 标签。job 直接执行
+	// OpenAI 签名的 node supervisor；Mimi/agentd 不进入 Browser 原生 peer 校验
+	// 所读取的三级父链。
 	SharedDaemonLaunchAgentLabel = "com.gaixianggeng.mimi.codex-shared-daemon"
 
 	sharedDaemonLaunchAgentLogName         = "codex-shared-daemon.log"
@@ -65,6 +65,14 @@ type unmanagedSharedDaemonHooks struct {
 	signalTERM     func(int) error
 	currentUID     func() int
 }
+
+// SysctlKinfoProc 在进程刚退出的极窄窗口里可能返回 EIO，而不是 ESRCH。
+// 这里保留 seam 让退出复核能够覆盖该真实 Darwin 行为；signal 0 只用于确认
+// PID 是否已经消失，不能替代启动时间与 UID 的完整身份校验。
+var (
+	sharedDaemonStoppedKinfoProc = unix.SysctlKinfoProc
+	sharedDaemonSignalZero       = func(pid int) error { return unix.Kill(pid, 0) }
+)
 
 // SharedDaemonOwnerStatus 描述 Mimi 为共享 app-server 安装的稳定启动入口。它只
 // 证明 launchd job 的安装状态；Browser/TCC 仍需对真实 socket peer 父链验收。
@@ -247,8 +255,8 @@ func resolveSharedDaemonCodexBin(configured string) (string, error) {
 }
 
 // renderSharedDaemonLaunchAgent 生成 plist。ProgramArguments 直接执行 Codex
-// Desktop 内置的签名 node，不引入 shell 或 Mimi 可执行文件。node launcher 只负责
-// 创建 detached node supervisor；最终仍需以 socket peer 父链做运行态验收。
+// Desktop 内置的签名 node，不引入 shell 或 Mimi 可执行文件。node 作为持久
+// supervisor 直接拉起 app-server；最终仍需以 socket peer 父链做运行态验收。
 func renderSharedDaemonLaunchAgent(
 	nodeBin string,
 	codexBin string,
@@ -310,13 +318,9 @@ func renderSharedDaemonLaunchAgent(
 	} else {
 		buf.WriteString("\t<false/>\n")
 	}
-	// launcher 是一次性控制命令。真正的 supervisor 已进入独立 session；launcher
-	// 退出属于成功，不能让 launchd 因其退出反复创建 socket 竞争者。
+	// supervisor 随 app-server 一并退出；KeepAlive=false 禁止 launchd 在 socket
+	// 冲突或 child 崩溃时形成无界重启风暴，恢复仍由现有 gateway 路径触发。
 	buf.WriteString("\t<key>KeepAlive</key>\n\t<false/>\n")
-	// 明确告诉 launchd 不要在 one-shot launcher 退出时按进程组清理已 detached
-	// 的 supervisor。bootout 的 coalition 行为仍不作安全假设，活跃 socket 路径
-	// 会完全避开 bootout。
-	buf.WriteString("\t<key>AbandonProcessGroup</key>\n\t<true/>\n")
 	buf.WriteString("\t<key>ThrottleInterval</key>\n\t<integer>1</integer>\n")
 	buf.WriteString("\t<key>ExitTimeOut</key>\n\t<integer>20</integer>\n")
 	// 077 的十进制是 63；确保 launchd 创建的 stdout/stderr 日志仅当前用户可读。
@@ -342,7 +346,7 @@ func sharedDaemonLaunchAgentEnv(env map[string]string) map[string]string {
 	}
 	values["PATH"] = normalizedSharedDaemonToolingPath(values["PATH"], os.Getenv("PATH"))
 	// EnvironmentVariables 会覆盖 launchctl setenv 的用户域值。直接 ProgramArguments
-	// 因此无需借 shell 执行 unset，启动链固定为 launchd -> node launcher。
+	// 因此无需借 shell 执行 unset，启动链固定为 launchd -> node supervisor。
 	for _, key := range sharedDaemonStrippedEnvKeys {
 		values[key] = ""
 	}
@@ -1176,9 +1180,9 @@ func clearSharedDaemonMigrationFlag() error {
 	return nil
 }
 
-// RemoveSharedDaemonLaunchAgent 关闭共享时只删除未来登录的启动入口。one-shot job
-// 可能仍通过 launchd coalition 关联着当前 listener；即使 job 自己已经 exited，
-// bootout 也没有“不影响后代”的系统契约，因此本会话保留已加载但不可自启的定义。
+// RemoveSharedDaemonLaunchAgent 关闭共享时只删除未来登录的启动入口。当前 job
+// 可能仍通过 launchd coalition 关联着 listener；bootout 没有“不影响服务进程”
+// 的系统契约，因此本会话保留已加载且 KeepAlive=false 的定义。
 func RemoveSharedDaemonLaunchAgent(ctx context.Context) error {
 	path, err := SharedDaemonLaunchAgentPath()
 	if err != nil {
@@ -1209,7 +1213,7 @@ func removeSharedDaemonOwnerUnlocked(ctx context.Context) error {
 
 // removeSharedDaemonOwnerForTransactionUnlocked 在调用方持有 operation lock 时
 // 移除 owner。先把磁盘 plist 降为 manual，再删除未来登录入口；当前会话里已
-// 加载的 one-shot 定义保留到注销，避免 bootout 误伤 coalition 中的 listener。
+// 加载的定义保留到注销，避免 bootout 误伤 coalition 中的 listener。
 // 返回值保留兼容签名，但禁用事务不再恢复 auto owner：配置可能已被锁外编辑器
 // 改成 WS，恢复会越权。
 func removeSharedDaemonOwnerForTransactionUnlocked(
@@ -1299,9 +1303,9 @@ func startLocalDaemonWithStableOwnerTracked(
 		return false, waitForSharedDaemonSocket(ctx, options, logOffset)
 	}
 	if owner.RunAtLoad {
-		// 登录时 RunAtLoad launcher 可能已经退出，但 detached supervisor 仍在
-		// 启动 app-server。先给这条既有链一个短窗口，避免立即 kickstart 第二套
-		// supervisor；真正崩溃的恢复最多只增加这一秒。
+		// 登录时 launchd 的 running 状态与 app-server socket 建立并非原子更新。
+		// 先给既有 supervisor 一个短窗口，避免立即 kickstart 第二套；真正崩溃
+		// 的恢复最多只增加这一秒。
 		graceCtx, cancelGrace := context.WithTimeout(ctx, sharedDaemonRunAtLoadGrace)
 		graceErr := waitForSharedDaemonSocket(graceCtx, options, logOffset)
 		cancelGrace()
@@ -1668,10 +1672,23 @@ func sharedDaemonProcessIdentityStillAlive(identity sharedDaemonListenerProcess)
 	if identity.PID <= 1 {
 		return false, fmt.Errorf("旧共享 daemon PID 无效")
 	}
-	kinfo, err := unix.SysctlKinfoProc("kern.proc.pid", identity.PID)
+	kinfo, err := sharedDaemonStoppedKinfoProc("kern.proc.pid", identity.PID)
 	if err != nil {
 		if errors.Is(err, unix.ESRCH) || errors.Is(err, unix.ENOENT) {
 			return false, nil
+		}
+		if errors.Is(err, unix.EIO) {
+			// Darwin 可能在进程退出但 kinfo 尚未稳定的瞬间返回 EIO。只有
+			// kill(pid, 0)=ESRCH 才足以证明旧 PID 已消失；PID 仍存在或
+			// 无法判断时继续 fail closed，避免把 PID reuse 当成已退出。
+			signalErr := sharedDaemonSignalZero(identity.PID)
+			if errors.Is(signalErr, unix.ESRCH) {
+				return false, nil
+			}
+			if signalErr == nil {
+				return false, fmt.Errorf("复核旧共享 daemon 是否退出失败：%w（PID 仍存在）", err)
+			}
+			return false, fmt.Errorf("复核旧共享 daemon 是否退出失败：%w（signal 0：%v）", err, signalErr)
 		}
 		return false, fmt.Errorf("复核旧共享 daemon 是否退出失败：%w", err)
 	}

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -265,6 +265,13 @@ func renderSharedDaemonLaunchAgent(
 	}
 	buf.WriteString("\t</array>\n")
 
+	// launchd 用户域的默认 maxfiles 可能只有 256；daemon 需要为多路客户端和
+	// MCP 连接预留余量，因此只把 soft limit 受控提升到 8192。不设置 hard limit，
+	// 避免 plist 绕过系统策略获得无限制的文件描述符权限。
+	buf.WriteString("\t<key>SoftResourceLimits</key>\n\t<dict>\n")
+	fmt.Fprintf(&buf, "\t\t<key>NumberOfFiles</key>\n\t\t<integer>%d</integer>\n", sharedDaemonSoftFileLimit)
+	buf.WriteString("\t</dict>\n")
+
 	if values := sharedDaemonLaunchAgentEnv(env); len(values) > 0 {
 		buf.WriteString("\t<key>EnvironmentVariables</key>\n\t<dict>\n")
 		keys := make([]string, 0, len(values))

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -1679,14 +1679,14 @@ func sharedDaemonProcessIdentityStillAlive(identity sharedDaemonListenerProcess)
 		}
 		if errors.Is(err, unix.EIO) {
 			// Darwin 可能在进程退出但 kinfo 尚未稳定的瞬间返回 EIO。只有
-			// kill(pid, 0)=ESRCH 才足以证明旧 PID 已消失；PID 仍存在或
-			// 无法判断时继续 fail closed，避免把 PID reuse 当成已退出。
+			// kill(pid, 0)=ESRCH 才足以证明旧 PID 已消失；PID 仍存在时
+			// 返回 alive 让外层继续轮询，无法判断时仍 fail closed。
 			signalErr := sharedDaemonSignalZero(identity.PID)
 			if errors.Is(signalErr, unix.ESRCH) {
 				return false, nil
 			}
 			if signalErr == nil {
-				return false, fmt.Errorf("复核旧共享 daemon 是否退出失败：%w（PID 仍存在）", err)
+				return true, nil
 			}
 			return false, fmt.Errorf("复核旧共享 daemon 是否退出失败：%w（signal 0：%v）", err, signalErr)
 		}

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -88,8 +88,37 @@ func TestSharedDaemonProcessIdentityStillAliveHandlesDarwinExitEIO(t *testing.T)
 	}
 
 	sharedDaemonSignalZero = func(int) error { return nil }
-	if alive, err := sharedDaemonProcessIdentityStillAlive(identity); err == nil || alive {
-		t.Fatalf("kinfo=EIO 但 PID 仍存在时必须 fail closed：alive=%t err=%v", alive, err)
+	if alive, err := sharedDaemonProcessIdentityStillAlive(identity); err != nil || !alive {
+		t.Fatalf("kinfo=EIO 但 PID 仍存在时应继续等待：alive=%t err=%v", alive, err)
+	}
+}
+
+func TestWaitForSharedDaemonStoppedRetriesTransientDarwinExitEIO(t *testing.T) {
+	previousKinfo := sharedDaemonStoppedKinfoProc
+	previousSignalZero := sharedDaemonSignalZero
+	t.Cleanup(func() {
+		sharedDaemonStoppedKinfoProc = previousKinfo
+		sharedDaemonSignalZero = previousSignalZero
+	})
+
+	kinfoCalls := 0
+	sharedDaemonStoppedKinfoProc = func(string, ...int) (*unix.KinfoProc, error) {
+		kinfoCalls++
+		if kinfoCalls == 1 {
+			return nil, unix.EIO
+		}
+		return nil, unix.ESRCH
+	}
+	sharedDaemonSignalZero = func(int) error { return nil }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	identity := sharedDaemonListenerProcess{PID: 4242, UID: os.Getuid()}
+	if err := waitForSharedDaemonStopped(ctx, filepath.Join(t.TempDir(), "missing.sock"), identity); err != nil {
+		t.Fatalf("瞬时 EIO 后应继续轮询直到确认旧 PID 退出：%v", err)
+	}
+	if kinfoCalls < 2 {
+		t.Fatalf("瞬时 EIO 后没有继续复核进程身份：calls=%d", kinfoCalls)
 	}
 }
 

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -15,6 +15,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func writeFakeCodexBin(t *testing.T, dir string, name string) string {
@@ -67,6 +69,30 @@ func allowTestSignedSharedDaemonRuntime(t *testing.T) {
 	t.Cleanup(func() { sharedDaemonValidateSignedRuntime = previous })
 }
 
+func TestSharedDaemonProcessIdentityStillAliveHandlesDarwinExitEIO(t *testing.T) {
+	previousKinfo := sharedDaemonStoppedKinfoProc
+	previousSignalZero := sharedDaemonSignalZero
+	t.Cleanup(func() {
+		sharedDaemonStoppedKinfoProc = previousKinfo
+		sharedDaemonSignalZero = previousSignalZero
+	})
+	sharedDaemonStoppedKinfoProc = func(string, ...int) (*unix.KinfoProc, error) {
+		return nil, unix.EIO
+	}
+	identity := sharedDaemonListenerProcess{PID: 4242, UID: os.Getuid()}
+
+	sharedDaemonSignalZero = func(int) error { return unix.ESRCH }
+	alive, err := sharedDaemonProcessIdentityStillAlive(identity)
+	if err != nil || alive {
+		t.Fatalf("kinfo=EIO 且 signal0=ESRCH 应确认旧 PID 已退出：alive=%t err=%v", alive, err)
+	}
+
+	sharedDaemonSignalZero = func(int) error { return nil }
+	if alive, err := sharedDaemonProcessIdentityStillAlive(identity); err == nil || alive {
+		t.Fatalf("kinfo=EIO 但 PID 仍存在时必须 fail closed：alive=%t err=%v", alive, err)
+	}
+}
+
 func TestValidateSharedDaemonCodeSignatureMetadataForNodeAndCodex(t *testing.T) {
 	metadataFor := func(identifier string) string {
 		return strings.Join([]string{
@@ -105,7 +131,7 @@ func TestValidateSharedDaemonCodeSignatureMetadataForNodeAndCodex(t *testing.T) 
 	}
 }
 
-func TestRenderSharedDaemonLaunchAgentUsesSignedNodeLauncher(t *testing.T) {
+func TestRenderSharedDaemonLaunchAgentUsesSignedNodeSupervisor(t *testing.T) {
 	nodeBin := "/opt/ChatGPT.app/Contents/Resources/cua_node/bin/node"
 	codexBin := "/opt/codex bin/codex"
 	rendered, err := renderSharedDaemonLaunchAgent(
@@ -130,20 +156,23 @@ func TestRenderSharedDaemonLaunchAgentUsesSignedNodeLauncher(t *testing.T) {
 	for _, argument := range sharedDaemonSupervisorProgramArguments(nodeBin, codexBin) {
 		var escaped bytes.Buffer
 		if err := xml.EscapeText(&escaped, []byte(argument)); err != nil {
-			t.Fatalf("转义 launcher 参数失败：%v", err)
+			t.Fatalf("转义 supervisor 参数失败：%v", err)
 		}
 		if !strings.Contains(content, "<string>"+escaped.String()+"</string>") {
-			t.Fatalf("plist 缺少 signed node launcher 参数 %q：\n%s", argument, content)
+			t.Fatalf("plist 缺少 signed node supervisor 参数 %q：\n%s", argument, content)
 		}
 	}
 	if !strings.Contains(content, "<key>RunAtLoad</key>\n\t<true/>") {
 		t.Fatalf("plist 必须覆盖登录冷启动：\n%s", content)
 	}
 	if !strings.Contains(content, "<key>KeepAlive</key>\n\t<false/>") {
-		t.Fatalf("一次性控制命令不能被 launchd 反复重启：\n%s", content)
+		t.Fatalf("supervisor 退出后不能被 launchd 反复重启：\n%s", content)
 	}
-	if !strings.Contains(content, "<key>AbandonProcessGroup</key>\n\t<true/>") {
-		t.Fatalf("one-shot launcher 必须显式放弃已 detached 的 process group：\n%s", content)
+	if strings.Contains(content, "<key>AbandonProcessGroup</key>") {
+		t.Fatalf("持久 supervisor 不应放弃 app-server 所在进程组：\n%s", content)
+	}
+	if strings.Contains(content, "detached: true") || strings.Contains(content, ".unref()") {
+		t.Fatalf("plist 不能再包含不可观测的 detached launcher：\n%s", content)
 	}
 	if !strings.Contains(content, "<key>Umask</key>\n\t<integer>63</integer>") {
 		t.Fatalf("LaunchAgent 日志必须只允许当前用户读取：\n%s", content)
@@ -159,7 +188,7 @@ func TestRenderSharedDaemonLaunchAgentUsesSignedNodeLauncher(t *testing.T) {
 		}
 	}
 	if value := sharedDaemonPlistStringValue(rendered, "NODE_OPTIONS"); value != "" {
-		t.Fatalf("launcher 必须清空继承的 NODE_OPTIONS，实际=%q", value)
+		t.Fatalf("supervisor 必须清空继承的 NODE_OPTIONS，实际=%q", value)
 	}
 }
 
@@ -967,7 +996,7 @@ func TestRunAtLoadGraceAvoidsDuplicateKickstartWhileSocketStarts(t *testing.T) {
 		t.Fatalf("RunAtLoad supervisor 在 grace 内建立 socket 应直接复用：%v", err)
 	}
 	if started || kickstartCalls != 0 {
-		t.Fatalf("launcher 已退出但 supervisor 正启动时不能创建第二套：started=%t kickstart=%d", started, kickstartCalls)
+		t.Fatalf("RunAtLoad supervisor 正启动时不能创建第二套：started=%t kickstart=%d", started, kickstartCalls)
 	}
 }
 

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -85,6 +85,25 @@ func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
 	}
 }
 
+func TestRenderSharedDaemonLaunchAgentSetsControlledSoftFileLimit(t *testing.T) {
+	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/codex/bin/codex",
+		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("渲染 plist 失败：%v", err)
+	}
+	content := string(rendered)
+	want := "<key>SoftResourceLimits</key>\n\t<dict>\n\t\t<key>NumberOfFiles</key>\n\t\t<integer>8192</integer>\n\t</dict>"
+	if !strings.Contains(content, want) {
+		t.Fatalf("LaunchAgent 必须设置受控的文件描述符 soft limit 8192：\n%s", content)
+	}
+	if strings.Contains(content, "<key>HardResourceLimits</key>") {
+		t.Fatalf("LaunchAgent 不应设置 hard 文件描述符限制：\n%s", content)
+	}
+}
+
 func TestRenderSharedDaemonLaunchAgentPendingDisablesRunAtLoad(t *testing.T) {
 	rendered, err := renderSharedDaemonLaunchAgent(
 		"/opt/codex/bin/codex",

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -5,6 +5,7 @@ package appserver
 import (
 	"bytes"
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"net"
@@ -29,10 +30,27 @@ func writeFakeCodexBin(t *testing.T, dir string, name string) string {
 // CODEX_HOME 要满足生产代码的“目录已存在”约束。
 func sharedDaemonTestHome(t *testing.T) string {
 	t.Helper()
+	previousResolver := sharedDaemonResolveSupervisorNode
+	previousValidator := sharedDaemonValidateSupervisor
+	previousRuntimeValidator := sharedDaemonValidateSignedRuntime
 	home, err := os.MkdirTemp("/tmp", "mimi-owner-")
 	if err != nil {
 		t.Fatalf("创建短测试 Home 失败：%v", err)
 	}
+	// 测试只注入路径解析和签名校验 seam，不依赖真实 ChatGPT.app 或真实
+	// codesign 输出；owner 的两阶段/文件权限测试仍走完整生产流程。
+	nodePath := filepath.Join(home, "node")
+	if err := os.WriteFile(nodePath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("写入假 node supervisor 失败：%v", err)
+	}
+	sharedDaemonResolveSupervisorNode = func(string) (string, error) { return nodePath, nil }
+	sharedDaemonValidateSupervisor = func(string, string) error { return nil }
+	sharedDaemonValidateSignedRuntime = func(context.Context, LocalDaemonOptions, string) error {
+		return fmt.Errorf("test listener lacks signed supervisor evidence")
+	}
+	t.Cleanup(func() { sharedDaemonResolveSupervisorNode = previousResolver })
+	t.Cleanup(func() { sharedDaemonValidateSupervisor = previousValidator })
+	t.Cleanup(func() { sharedDaemonValidateSignedRuntime = previousRuntimeValidator })
 	t.Cleanup(func() { os.RemoveAll(home) })
 	for _, name := range []string{".codex", "other-codex"} {
 		if err := os.MkdirAll(filepath.Join(home, name), 0o700); err != nil {
@@ -42,9 +60,57 @@ func sharedDaemonTestHome(t *testing.T) string {
 	return home
 }
 
-func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
+func allowTestSignedSharedDaemonRuntime(t *testing.T) {
+	t.Helper()
+	previous := sharedDaemonValidateSignedRuntime
+	sharedDaemonValidateSignedRuntime = func(context.Context, LocalDaemonOptions, string) error { return nil }
+	t.Cleanup(func() { sharedDaemonValidateSignedRuntime = previous })
+}
+
+func TestValidateSharedDaemonCodeSignatureMetadataForNodeAndCodex(t *testing.T) {
+	metadataFor := func(identifier string) string {
+		return strings.Join([]string{
+			"Executable=/Applications/ChatGPT.app/Contents/Resources/" + identifier,
+			"Identifier=" + identifier,
+			"CodeDirectory v=20500 flags=0x10000(runtime)",
+			"TeamIdentifier=2DC432GLL2",
+		}, "\n")
+	}
+	for _, identifier := range []string{"node", "codex"} {
+		t.Run(identifier, func(t *testing.T) {
+			valid := metadataFor(identifier)
+			if err := validateSharedDaemonCodeSignatureMetadata(valid, identifier); err != nil {
+				t.Fatalf("OpenAI 签名的 hardened %s 应通过：%v", identifier, err)
+			}
+			tests := map[string]string{
+				"wrong identifier": strings.Replace(valid, "Identifier="+identifier, "Identifier=foreign", 1),
+				"wrong team":       strings.Replace(valid, "TeamIdentifier=2DC432GLL2", "TeamIdentifier=OTHER", 1),
+				"no runtime":       strings.Replace(valid, "(runtime)", "", 1),
+			}
+			for name, candidate := range tests {
+				t.Run(name, func(t *testing.T) {
+					if err := validateSharedDaemonCodeSignatureMetadata(candidate, identifier); err == nil {
+						t.Fatal("不可信 supervisor metadata 必须 fail closed")
+					}
+				})
+			}
+			otherIdentifier := "node"
+			if identifier == "node" {
+				otherIdentifier = "codex"
+			}
+			if err := validateSharedDaemonCodeSignatureMetadata(valid, otherIdentifier); err == nil {
+				t.Fatalf("%s metadata 不能冒充 %s 签名", identifier, otherIdentifier)
+			}
+		})
+	}
+}
+
+func TestRenderSharedDaemonLaunchAgentUsesSignedNodeLauncher(t *testing.T) {
+	nodeBin := "/opt/ChatGPT.app/Contents/Resources/cua_node/bin/node"
+	codexBin := "/opt/codex bin/codex"
 	rendered, err := renderSharedDaemonLaunchAgent(
-		"/opt/codex bin/codex",
+		nodeBin,
+		codexBin,
 		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
 		"/Users/tester/Library/Logs/mimi-remote/codex-shared-daemon.log",
 	)
@@ -53,15 +119,21 @@ func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
 	}
 	content := string(rendered)
 
-	if strings.Contains(content, "<string>/bin/sh</string>") || strings.Contains(content, "exec &#34;") {
-		t.Fatalf("plist 不能引入 shell 责任主体：\n%s", content)
+	if strings.Contains(content, "<string>/bin/sh</string>") || strings.Contains(content, "exec &#34;") ||
+		strings.Contains(content, "<string>daemon</string>") || strings.Contains(content, "<string>start</string>") {
+		t.Fatalf("plist 不能引入 shell 或旧 daemon start 责任主体：\n%s", content)
 	}
-	if !strings.Contains(content, "<string>/opt/codex bin/codex</string>") {
+	if !strings.Contains(content, "<string>"+nodeBin+"</string>") ||
+		!strings.Contains(content, "<string>"+codexBin+"</string>") {
 		t.Fatalf("plist 必须使用绝对 codex 路径：\n%s", content)
 	}
-	for _, argument := range []string{"app-server", "daemon", "start"} {
-		if !strings.Contains(content, "<string>"+argument+"</string>") {
-			t.Fatalf("plist 缺少官方 daemon 参数 %s：\n%s", argument, content)
+	for _, argument := range sharedDaemonSupervisorProgramArguments(nodeBin, codexBin) {
+		var escaped bytes.Buffer
+		if err := xml.EscapeText(&escaped, []byte(argument)); err != nil {
+			t.Fatalf("转义 launcher 参数失败：%v", err)
+		}
+		if !strings.Contains(content, "<string>"+escaped.String()+"</string>") {
+			t.Fatalf("plist 缺少 signed node launcher 参数 %q：\n%s", argument, content)
 		}
 	}
 	if !strings.Contains(content, "<key>RunAtLoad</key>\n\t<true/>") {
@@ -69,6 +141,9 @@ func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
 	}
 	if !strings.Contains(content, "<key>KeepAlive</key>\n\t<false/>") {
 		t.Fatalf("一次性控制命令不能被 launchd 反复重启：\n%s", content)
+	}
+	if !strings.Contains(content, "<key>AbandonProcessGroup</key>\n\t<true/>") {
+		t.Fatalf("one-shot launcher 必须显式放弃已 detached 的 process group：\n%s", content)
 	}
 	if !strings.Contains(content, "<key>Umask</key>\n\t<integer>63</integer>") {
 		t.Fatalf("LaunchAgent 日志必须只允许当前用户读取：\n%s", content)
@@ -83,10 +158,14 @@ func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
 			t.Fatalf("plist 必须以空值覆盖 Desktop 专属变量 %s：\n%s", key, content)
 		}
 	}
+	if value := sharedDaemonPlistStringValue(rendered, "NODE_OPTIONS"); value != "" {
+		t.Fatalf("launcher 必须清空继承的 NODE_OPTIONS，实际=%q", value)
+	}
 }
 
 func TestRenderSharedDaemonLaunchAgentSetsControlledSoftFileLimit(t *testing.T) {
 	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/ChatGPT.app/Contents/Resources/cua_node/bin/node",
 		"/opt/codex/bin/codex",
 		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
 		"",
@@ -106,6 +185,7 @@ func TestRenderSharedDaemonLaunchAgentSetsControlledSoftFileLimit(t *testing.T) 
 
 func TestRenderSharedDaemonLaunchAgentPendingDisablesRunAtLoad(t *testing.T) {
 	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/ChatGPT.app/Contents/Resources/cua_node/bin/node",
 		"/opt/codex/bin/codex",
 		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
 		"",
@@ -123,6 +203,7 @@ func TestRenderSharedDaemonLaunchAgentPendingDisablesRunAtLoad(t *testing.T) {
 
 func TestRenderSharedDaemonLaunchAgentEscapesXML(t *testing.T) {
 	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/ChatGPT.app/Contents/Resources/cua_node/bin/node",
 		"/tmp/a&b/codex",
 		map[string]string{"CODEX_HOME": "/tmp/<home>"},
 		"",
@@ -140,8 +221,37 @@ func TestRenderSharedDaemonLaunchAgentEscapesXML(t *testing.T) {
 }
 
 func TestRenderSharedDaemonLaunchAgentRejectsEmptyBin(t *testing.T) {
-	if _, err := renderSharedDaemonLaunchAgent("  ", nil, ""); err == nil {
+	if _, err := renderSharedDaemonLaunchAgent("  ", "/opt/codex/bin/codex", nil, ""); err == nil {
+		t.Fatal("空 node supervisor 路径必须报错")
+	}
+	if _, err := renderSharedDaemonLaunchAgent("/opt/node", "  ", nil, ""); err == nil {
 		t.Fatal("空 codex 路径必须报错")
+	}
+}
+
+func TestEnsureSharedDaemonLaunchAgentRejectsUntrustedSupervisorBeforeWrite(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexBin := writeFakeCodexBin(t, t.TempDir(), "codex")
+	previousValidator := sharedDaemonValidateSupervisor
+	sharedDaemonValidateSupervisor = func(string, string) error {
+		return fmt.Errorf("共享 daemon supervisor 不是受支持的 OpenAI 签名 codex")
+	}
+	t.Cleanup(func() { sharedDaemonValidateSupervisor = previousValidator })
+
+	_, err := EnsureSharedDaemonLaunchAgent(LocalDaemonOptions{
+		CodexBin: codexBin,
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	})
+	if err == nil || !strings.Contains(err.Error(), "OpenAI 签名") {
+		t.Fatalf("不可信 supervisor 必须在写 plist 前拒绝：%v", err)
+	}
+	path, pathErr := SharedDaemonLaunchAgentPath()
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("签名失败不能落盘 LaunchAgent：%v", statErr)
 	}
 }
 
@@ -351,6 +461,76 @@ func TestEnsureSharedDaemonOwnerMarksPreexistingDaemonForExplicitMigration(t *te
 	}
 	if _, err := os.Stat(flagPath); !os.IsNotExist(err) {
 		t.Fatalf("迁移标记应被删除：%v", err)
+	}
+}
+
+func TestEnsureSharedDaemonOwnerRechecksListenerBeforeBootout(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	loaded := false
+	bootstrapCalls := 0
+	bootoutCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "bootstrap":
+			bootstrapCalls++
+			loaded = true
+			return "", nil
+		case "bootout":
+			bootoutCalls++
+			loaded = false
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	oldOptions := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex-old"),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	if _, err := EnsureSharedDaemonOwner(context.Background(), oldOptions, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// 入口快照仍是“无 listener”，但在新 plan 的签名校验期间模拟另一条
+	// Codex 启动链赢得 socket。bootout 前的二次取证必须把 owner 改成 manual。
+	originalValidator := sharedDaemonValidateSupervisor
+	var stopServer func()
+	sharedDaemonValidateSupervisor = func(string, string) error {
+		if stopServer == nil {
+			_, _, stopServer = startLocalDaemonTestServer(
+				t,
+				codexHome,
+				"Codex Desktop/0.147.0 (Mac OS; arm64)",
+			)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		sharedDaemonValidateSupervisor = originalValidator
+		if stopServer != nil {
+			stopServer()
+		}
+	})
+
+	status, err := EnsureSharedDaemonOwner(context.Background(), LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex-new"),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}, false)
+	if err != nil {
+		t.Fatalf("bootout 前出现 listener 应安全收敛为 pending：%v", err)
+	}
+	if !status.MigrationRequired || status.RunAtLoad || !loaded || bootoutCalls != 0 || bootstrapCalls != 1 {
+		t.Fatalf("活跃 listener 不能被 bootout/rebootstrap：status=%+v loaded=%t bootout=%d bootstrap=%d", status, loaded, bootoutCalls, bootstrapCalls)
 	}
 }
 
@@ -725,6 +905,72 @@ func TestPreparedIntentCreatesManualOwnerBeforeFirstBootstrap(t *testing.T) {
 	}
 }
 
+func TestRunAtLoadGraceAvoidsDuplicateKickstartWhileSocketStarts(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	codexHome := filepath.Join(home, ".codex")
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": codexHome},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, true); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := true
+	kickstartCalls := 0
+	originalLaunchctl := sharedDaemonLaunchctl
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = { state = exited }", nil
+			}
+			return "", fmt.Errorf("not loaded")
+		case "kickstart":
+			kickstartCalls++
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
+
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	type listenResult struct {
+		listener net.Listener
+		err      error
+	}
+	result := make(chan listenResult, 1)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		listener, listenErr := net.Listen("unix", socketPath)
+		result <- listenResult{listener: listener, err: listenErr}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	started, err := startLocalDaemonWithStableOwnerTracked(ctx, options)
+	listenerResult := <-result
+	if listenerResult.listener != nil {
+		t.Cleanup(func() { _ = listenerResult.listener.Close() })
+	}
+	if listenerResult.err != nil {
+		t.Fatal(listenerResult.err)
+	}
+	if err != nil {
+		t.Fatalf("RunAtLoad supervisor 在 grace 内建立 socket 应直接复用：%v", err)
+	}
+	if started || kickstartCalls != 0 {
+		t.Fatalf("launcher 已退出但 supervisor 正启动时不能创建第二套：started=%t kickstart=%d", started, kickstartCalls)
+	}
+}
+
 func TestFailedExplicitMigrationCannotReuseFreshEnableIntent(t *testing.T) {
 	home := sharedDaemonTestHome(t)
 	t.Setenv("HOME", home)
@@ -780,6 +1026,81 @@ func TestFailedExplicitMigrationCannotReuseFreshEnableIntent(t *testing.T) {
 	}
 	if kickstartCalls != beforeEnsure {
 		t.Fatalf("普通 Ensure 不能复用旧 intent 静默启动：before=%d after=%d", beforeEnsure, kickstartCalls)
+	}
+}
+
+func TestReloadSharedDaemonLaunchAgentForMigrationReloadsManualOwner(t *testing.T) {
+	home := sharedDaemonTestHome(t)
+	t.Setenv("HOME", home)
+	options := LocalDaemonOptions{
+		CodexBin: writeFakeCodexBin(t, t.TempDir(), "codex"),
+		Env:      map[string]string{"CODEX_HOME": filepath.Join(home, ".codex")},
+	}
+	if _, err := ensureSharedDaemonLaunchAgent(options, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSharedDaemonMigrationFlag(); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := true
+	commands := make([][]string, 0, 4)
+	originalLaunchctl := sharedDaemonLaunchctl
+	originalDesktop := sharedDaemonDesktopRunning
+	sharedDaemonDesktopRunning = func(context.Context) (bool, error) { return false, nil }
+	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
+		commands = append(commands, append([]string(nil), arguments...))
+		switch arguments[0] {
+		case "print":
+			if loaded {
+				return "service = {\n\tstate = exited\n}", nil
+			}
+			return "", errors.New("not loaded")
+		case "bootout":
+			if !loaded {
+				return "", errors.New("not loaded")
+			}
+			loaded = false
+			return "", nil
+		case "bootstrap":
+			loaded = true
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl command: %v", arguments)
+		}
+	}
+	t.Cleanup(func() {
+		sharedDaemonLaunchctl = originalLaunchctl
+		sharedDaemonDesktopRunning = originalDesktop
+	})
+
+	if err := reloadSharedDaemonLaunchAgentForMigration(context.Background()); err != nil {
+		t.Fatalf("manual owner 应先 reload 再允许 kickstart：%v", err)
+	}
+	if !loaded {
+		t.Fatal("reload 后 owner 必须重新 loaded")
+	}
+	if len(commands) != 4 || commands[0][0] != "print" || commands[1][0] != "bootout" ||
+		commands[2][0] != "bootstrap" || commands[3][0] != "print" {
+		t.Fatalf("迁移 reload 必须执行 print→bootout→bootstrap→print：%v", commands)
+	}
+	path, err := SharedDaemonLaunchAgentPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runAtLoad, ok := sharedDaemonPlistBoolValue(content, "RunAtLoad"); !ok || runAtLoad {
+		t.Fatalf("reload 期间 owner 必须保持 manual：ok=%t runAtLoad=%t", ok, runAtLoad)
+	}
+	owner, err := InspectSharedDaemonOwner(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !owner.Installed || !owner.Loaded || owner.Running || !owner.Secure || owner.RunAtLoad || !owner.MigrationRequired {
+		t.Fatalf("reload 后必须复核 loaded/manual/pending owner：%+v", owner)
 	}
 }
 
@@ -1131,6 +1452,7 @@ func TestCommitSharedDaemonDisableDoesNotRestoreAutoOwnerAfterConfigConflict(t *
 
 	loaded := true
 	bootstrapCalls := 0
+	bootoutCalls := 0
 	originalLaunchctl := sharedDaemonLaunchctl
 	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
 		switch arguments[0] {
@@ -1140,6 +1462,7 @@ func TestCommitSharedDaemonDisableDoesNotRestoreAutoOwnerAfterConfigConflict(t *
 			}
 			return "", fmt.Errorf("not loaded")
 		case "bootout":
+			bootoutCalls++
 			loaded = false
 			return "", nil
 		case "bootstrap":
@@ -1169,8 +1492,8 @@ func TestCommitSharedDaemonDisableDoesNotRestoreAutoOwnerAfterConfigConflict(t *
 	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
 		t.Fatalf("配置失权后不能恢复旧 auto owner：%v", statErr)
 	}
-	if loaded || bootstrapCalls != 0 {
-		t.Fatalf("配置冲突后不能重新加载旧 job：loaded=%t bootstrap=%d", loaded, bootstrapCalls)
+	if !loaded || bootstrapCalls != 0 || bootoutCalls != 0 {
+		t.Fatalf("配置冲突后不能重新加载或 bootout 旧 job：loaded=%t bootstrap=%d bootout=%d", loaded, bootstrapCalls, bootoutCalls)
 	}
 }
 
@@ -1249,6 +1572,7 @@ func TestCommitSharedDaemonEnableKeepsOwnerManualUntilConfigCommit(t *testing.T)
 
 func TestCommittedFreshEnableRecoversAfterCrashBeforeKickstart(t *testing.T) {
 	home := sharedDaemonTestHome(t)
+	allowTestSignedSharedDaemonRuntime(t)
 	t.Setenv("HOME", home)
 	codexHome := filepath.Join(home, ".codex")
 	options := LocalDaemonOptions{
@@ -1378,6 +1702,7 @@ func TestPrepareSharedDaemonOwnerRejectsConnectableListenerWithoutHandshake(t *t
 
 func TestCommitSharedDaemonEnableKeepsManualUntilExplicitMigration(t *testing.T) {
 	home := sharedDaemonTestHome(t)
+	allowTestSignedSharedDaemonRuntime(t)
 	t.Setenv("HOME", home)
 	codexHome := filepath.Join(home, ".codex")
 	options := LocalDaemonOptions{
@@ -1589,11 +1914,19 @@ func TestStableOwnerConfigurationRestoresPreviousOwnerWhenSocketDropsAfterInstal
 	loaded := false
 	bootstrapCalls := 0
 	bootoutCalls := 0
+	printCalls := 0
 	var stopSocket func()
 	originalLaunchctl := sharedDaemonLaunchctl
 	sharedDaemonLaunchctl = func(_ context.Context, arguments ...string) (string, error) {
 		switch arguments[0] {
 		case "print":
+			printCalls++
+			// live listener 下的新 plist 只 stage 到磁盘，不发生 bootout/bootstrap。
+			// 第四次 print 是新 owner 的 post-stage 复核；在它返回后模拟 socket
+			// 竞态退出，外层应走 files-only rollback。
+			if printCalls == 4 && stopSocket != nil {
+				stopSocket()
+			}
 			if loaded {
 				return "service = { state = exited }", nil
 			}
@@ -1601,11 +1934,6 @@ func TestStableOwnerConfigurationRestoresPreviousOwnerWhenSocketDropsAfterInstal
 		case "bootstrap":
 			bootstrapCalls++
 			loaded = true
-			// 第二次 bootstrap 已经写入 manual owner；模拟旧 SSH socket
-			// 正好在此时退出，覆盖 owner 安装与二次检查之间的竞态。
-			if bootstrapCalls == 2 && stopSocket != nil {
-				stopSocket()
-			}
 			return "", nil
 		case "bootout":
 			bootoutCalls++
@@ -1644,8 +1972,8 @@ func TestStableOwnerConfigurationRestoresPreviousOwnerWhenSocketDropsAfterInstal
 	if readErr != nil || !bytes.Equal(before, after) {
 		t.Fatalf("设置未提交时必须逐字恢复原 plist：read=%v", readErr)
 	}
-	if !loaded || bootstrapCalls != 3 || bootoutCalls != 2 {
-		t.Fatalf("设置未提交时必须恢复原 loaded owner：loaded=%t bootstrap=%d bootout=%d", loaded, bootstrapCalls, bootoutCalls)
+	if !loaded || bootstrapCalls != 1 || bootoutCalls != 0 {
+		t.Fatalf("live listener 的 stage/rollback 只能恢复磁盘 owner：loaded=%t bootstrap=%d bootout=%d", loaded, bootstrapCalls, bootoutCalls)
 	}
 	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || required {
 		t.Fatalf("设置未提交时必须恢复原 marker：required=%t err=%v", required, markerErr)
@@ -1715,6 +2043,7 @@ func testRemoveSharedDaemonOwnerFailureIsManual(t *testing.T, stage string, inje
 	path, _ := SharedDaemonLaunchAgentPath()
 
 	loaded := true
+	bootoutCalls := 0
 	originalLaunchctl := sharedDaemonLaunchctl
 	originalRemove := sharedDaemonRemoveLaunchAgentFile
 	originalClear := sharedDaemonClearMigrationForRemoval
@@ -1726,6 +2055,7 @@ func testRemoveSharedDaemonOwnerFailureIsManual(t *testing.T, stage string, inje
 			}
 			return "", fmt.Errorf("not loaded")
 		case "bootout":
+			bootoutCalls++
 			loaded = false
 			return "", nil
 		case "bootstrap":
@@ -1757,17 +2087,23 @@ func testRemoveSharedDaemonOwnerFailureIsManual(t *testing.T, stage string, inje
 	} else if !os.IsNotExist(readErr) {
 		t.Fatalf("marker clear 失败时 auto 入口必须已删除：%v", readErr)
 	}
-	if loaded {
-		t.Fatalf("%s 失败后 job 不能重新 bootstrap", stage)
+	if !loaded || bootoutCalls != 0 {
+		t.Fatalf("%s 失败后当前 loaded job 不应被 bootout：loaded=%t bootout=%d", stage, loaded, bootoutCalls)
 	}
 	if required, markerErr := SharedDaemonMigrationRequired(); markerErr != nil || !required {
 		t.Fatalf("%s 失败后 marker 必须保持 fail-closed：required=%t err=%v", stage, required, markerErr)
 	}
 }
 
-func TestRemoveSharedDaemonOwnerRejectsLoadedJobWithoutRecoverablePlist(t *testing.T) {
+func TestRemoveSharedDaemonOwnerRecoversLoadedJobWithoutPlist(t *testing.T) {
 	home := sharedDaemonTestHome(t)
 	t.Setenv("HOME", home)
+	if err := writeSharedDaemonMigrationFlag(); err != nil {
+		t.Fatal(err)
+	}
+	if err := markSharedDaemonEnablePrepared(); err != nil {
+		t.Fatal(err)
+	}
 	loaded := true
 	bootoutCalls := 0
 	originalLaunchctl := sharedDaemonLaunchctl
@@ -1788,9 +2124,17 @@ func TestRemoveSharedDaemonOwnerRejectsLoadedJobWithoutRecoverablePlist(t *testi
 	}
 	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })
 
-	err := removeSharedDaemonOwnerUnlocked(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "plist 缺失") || bootoutCalls != 0 || !loaded {
-		t.Fatalf("无法回滚的孤立 loaded job 必须在 bootout 前拒绝：err=%v bootout=%d loaded=%t", err, bootoutCalls, loaded)
+	if err := removeSharedDaemonOwnerUnlocked(context.Background()); err != nil {
+		t.Fatalf("plist 已删后的禁用重试应幂等完成：%v", err)
+	}
+	if bootoutCalls != 0 || !loaded {
+		t.Fatalf("孤立 loaded job 必须保留到注销：bootout=%d loaded=%t", bootoutCalls, loaded)
+	}
+	if required, err := SharedDaemonMigrationRequired(); err != nil || required {
+		t.Fatalf("幂等禁用必须清理 marker：required=%t err=%v", required, err)
+	}
+	if prepared, err := sharedDaemonEnablePrepared(); err != nil || prepared {
+		t.Fatalf("幂等禁用必须清理 fresh-enable intent：prepared=%t err=%v", prepared, err)
 	}
 }
 
@@ -1885,7 +2229,7 @@ func TestInspectLaunchAgentStateDistinguishesLoadedFromRunning(t *testing.T) {
 	}
 }
 
-func TestRemoveSharedDaemonLaunchAgentBootsOutLoadedJobWithoutPlist(t *testing.T) {
+func TestRemoveSharedDaemonLaunchAgentKeepsLoadedJobWithoutPlist(t *testing.T) {
 	home := sharedDaemonTestHome(t)
 	t.Setenv("HOME", home)
 	loaded := true
@@ -1911,8 +2255,8 @@ func TestRemoveSharedDaemonLaunchAgentBootsOutLoadedJobWithoutPlist(t *testing.T
 	if err := RemoveSharedDaemonLaunchAgent(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if loaded || bootoutCalls != 1 {
-		t.Fatalf("磁盘 plist 缺失也必须清理已加载 job：loaded=%t bootoutCalls=%d", loaded, bootoutCalls)
+	if !loaded || bootoutCalls != 0 {
+		t.Fatalf("磁盘 plist 缺失时只删除未来入口，不能 bootout 当前 job：loaded=%t bootoutCalls=%d", loaded, bootoutCalls)
 	}
 }
 
@@ -1934,8 +2278,12 @@ func TestResolveSharedDaemonCodexBinRequiresExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("解析可执行 codex 失败：%v", err)
 	}
-	if resolved != executable {
-		t.Fatalf("解析结果不一致：%s", resolved)
+	expected, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		t.Fatalf("解析测试 codex 真实路径失败：%v", err)
+	}
+	if resolved != expected {
+		t.Fatalf("解析结果不一致：got=%s want=%s", resolved, expected)
 	}
 }
 

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -162,6 +162,9 @@ func TestRenderSharedDaemonLaunchAgentUsesSignedNodeSupervisor(t *testing.T) {
 			t.Fatalf("plist 缺少 signed node supervisor 参数 %q：\n%s", argument, content)
 		}
 	}
+	if strings.Contains(content, "&#xA;") {
+		t.Fatalf("ProgramArguments 不能包含会被 launchctl 截断的换行实体：\n%s", content)
+	}
 	if !strings.Contains(content, "<key>RunAtLoad</key>\n\t<true/>") {
 		t.Fatalf("plist 必须覆盖登录冷启动：\n%s", content)
 	}

--- a/internal/appserver/shared_daemon_owner_other.go
+++ b/internal/appserver/shared_daemon_owner_other.go
@@ -139,3 +139,9 @@ func startPreparedSharedDaemonWithStableOwnerTracked(
 }
 
 func sharedDaemonSocketAcceptsConnectionMust(LocalDaemonOptions) bool { return false }
+
+func sharedDaemonLaunchAgentLogSize() int64 { return 0 }
+
+func waitForSharedDaemonSocket(context.Context, LocalDaemonOptions, int64) error {
+	return fmt.Errorf("稳定共享 daemon owner 仅支持 macOS")
+}

--- a/internal/appserver/shared_daemon_supervisor_darwin.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin.go
@@ -13,13 +13,12 @@ import (
 )
 
 const (
-	sharedDaemonOpenAITeamIdentifier     = "2DC432GLL2"
-	sharedDaemonCodexSigningIdentifier   = "codex"
-	sharedDaemonNodeSigningIdentifier    = "node"
-	sharedDaemonDesktopSigningIdentifier = "com.openai.codex"
-	sharedDaemonCodeSignRetryAttempts    = 16
-	sharedDaemonCodeSignRetryInterval    = time.Second
-	sharedDaemonCodeSignTimeout          = 20 * time.Second
+	sharedDaemonOpenAITeamIdentifier   = "2DC432GLL2"
+	sharedDaemonCodexSigningIdentifier = "codex"
+	sharedDaemonNodeSigningIdentifier  = "node"
+	sharedDaemonCodeSignRetryAttempts  = 16
+	sharedDaemonCodeSignRetryInterval  = time.Second
+	sharedDaemonCodeSignTimeout        = 20 * time.Second
 
 	// launcher 只负责把真正的 node supervisor 放进独立 session 后退出。这样
 	// LaunchAgent 仍是一条 one-shot job，普通 launcher 退出不会按同一进程组清理
@@ -73,6 +72,12 @@ var (
 	sharedDaemonValidateSupervisor    = validateSharedDaemonSupervisorBinaries
 	sharedDaemonValidateSignedRuntime = validateSignedSharedDaemonRuntime
 )
+
+type sharedDaemonCodeSigningTarget struct {
+	path       string
+	identifier string
+	name       string
+}
 
 func resolveSharedDaemonSupervisorNode(codexBin string) (string, error) {
 	candidates := make([]string, 0, 5)
@@ -139,24 +144,16 @@ func sharedDaemonDesktopBundleForNode(nodePath string) (string, error) {
 }
 
 func validateSharedDaemonSupervisorBinaries(nodePath string, codexPath string) error {
-	bundlePath, err := sharedDaemonDesktopBundleForNode(nodePath)
+	targets, err := sharedDaemonSupervisorSigningTargets(nodePath, codexPath)
 	if err != nil {
 		return err
 	}
-	for _, target := range []struct {
-		path       string
-		identifier string
-		name       string
-	}{
-		{path: bundlePath, identifier: sharedDaemonDesktopSigningIdentifier, name: "Codex Desktop"},
-		{path: nodePath, identifier: sharedDaemonNodeSigningIdentifier, name: "node supervisor"},
-		{path: codexPath, identifier: sharedDaemonCodexSigningIdentifier, name: "Codex app-server"},
-	} {
+	for _, target := range targets {
 		// `codesign -d` 只会展示签名声明，即使页哈希已经损坏也可能输出看似
 		// 正确的 TeamIdentifier。必须先用指定 requirement 验证真实签名，再把
 		// metadata 作为 hardened-runtime 的补充约束。
 		if verifyErr := verifySharedDaemonCodeSignature(target.path, target.identifier); verifyErr != nil {
-			return fmt.Errorf("%s 代码签名验证失败", target.name)
+			return fmt.Errorf("%s 代码签名验证失败：%w", target.name, verifyErr)
 		}
 		metadata, metadataErr := sharedDaemonCodeSigningMetadata(target.path)
 		if metadataErr != nil {
@@ -169,6 +166,21 @@ func validateSharedDaemonSupervisorBinaries(nodePath string, codexPath string) e
 	return nil
 }
 
+func sharedDaemonSupervisorSigningTargets(nodePath string, codexPath string) ([]sharedDaemonCodeSigningTarget, error) {
+	if _, err := sharedDaemonDesktopBundleForNode(nodePath); err != nil {
+		return nil, err
+	}
+	// Browser 的 peer authorization 和 LaunchAgent 真正执行的只有 node 与
+	// codex 两个叶子程序。对 ChatGPT.app 整包执行 codesign 会递归扫描插件；
+	// Desktop 正常退出时该扫描可能长期阻塞，反而让显式迁移永远无法开始。
+	// 这里验证实际执行文件的 Developer ID、Team、identifier 与 hardened
+	// runtime，并继续用 bundle 边界、规范路径及运行态 csops 父链防止替换。
+	return []sharedDaemonCodeSigningTarget{
+		{path: nodePath, identifier: sharedDaemonNodeSigningIdentifier, name: "node supervisor"},
+		{path: codexPath, identifier: sharedDaemonCodexSigningIdentifier, name: "Codex app-server"},
+	}, nil
+}
+
 func verifySharedDaemonCodeSignature(path string, expectedIdentifier string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), sharedDaemonCodeSignTimeout)
 	defer cancel()
@@ -177,7 +189,7 @@ func verifySharedDaemonCodeSignature(path string, expectedIdentifier string) err
 		expectedIdentifier,
 		sharedDaemonOpenAITeamIdentifier,
 	)
-	return retrySharedDaemonCodeSignature(
+	err := retrySharedDaemonCodeSignature(
 		ctx,
 		sharedDaemonCodeSignRetryAttempts,
 		sharedDaemonCodeSignRetryInterval,
@@ -196,6 +208,10 @@ func verifySharedDaemonCodeSignature(path string, expectedIdentifier string) err
 		},
 		waitForSharedDaemonCodeSignatureRetry,
 	)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("代码签名校验超时：%w", ctxErr)
+	}
+	return err
 }
 
 func retrySharedDaemonCodeSignature(

--- a/internal/appserver/shared_daemon_supervisor_darwin.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin.go
@@ -4,6 +4,7 @@ package appserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,10 +184,19 @@ func verifySharedDaemonCodeSignature(path string, expectedIdentifier string) err
 		},
 		waitForSharedDaemonCodeSignatureRetry,
 	)
-	if ctxErr := ctx.Err(); ctxErr != nil {
+	return sharedDaemonCodeSignatureResult(err, ctx.Err())
+}
+
+// 超时只描述重试为什么停止，不能覆盖最后一次真实的 codesign 失败；同时保留
+// 两条 error chain，排障时才能区分权限、签名损坏和单纯的截止时间耗尽。
+func sharedDaemonCodeSignatureResult(verifyErr error, ctxErr error) error {
+	if ctxErr == nil {
+		return verifyErr
+	}
+	if verifyErr == nil {
 		return fmt.Errorf("代码签名校验超时：%w", ctxErr)
 	}
-	return err
+	return fmt.Errorf("代码签名校验超时：%w", errors.Join(ctxErr, verifyErr))
 }
 
 func retrySharedDaemonCodeSignature(
@@ -210,7 +220,10 @@ func retrySharedDaemonCodeSignature(
 			break
 		}
 		if err := wait(ctx, interval); err != nil {
-			return fmt.Errorf("等待代码签名稳定失败：%w", err)
+			return fmt.Errorf(
+				"等待代码签名稳定失败：%w",
+				errors.Join(err, fmt.Errorf("最后一次代码签名验证失败：%w", lastErr)),
+			)
 		}
 	}
 	return lastErr

--- a/internal/appserver/shared_daemon_supervisor_darwin.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin.go
@@ -17,6 +17,9 @@ const (
 	sharedDaemonCodexSigningIdentifier   = "codex"
 	sharedDaemonNodeSigningIdentifier    = "node"
 	sharedDaemonDesktopSigningIdentifier = "com.openai.codex"
+	sharedDaemonCodeSignRetryAttempts    = 16
+	sharedDaemonCodeSignRetryInterval    = time.Second
+	sharedDaemonCodeSignTimeout          = 20 * time.Second
 
 	// launcher 只负责把真正的 node supervisor 放进独立 session 后退出。这样
 	// LaunchAgent 仍是一条 one-shot job，普通 launcher 退出不会按同一进程组清理
@@ -167,24 +170,70 @@ func validateSharedDaemonSupervisorBinaries(nodePath string, codexPath string) e
 }
 
 func verifySharedDaemonCodeSignature(path string, expectedIdentifier string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), sharedDaemonCodeSignTimeout)
 	defer cancel()
 	requirement := fmt.Sprintf(
 		`=identifier %q and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = %q`,
 		expectedIdentifier,
 		sharedDaemonOpenAITeamIdentifier,
 	)
-	cmd := exec.CommandContext(
+	return retrySharedDaemonCodeSignature(
 		ctx,
-		"/usr/bin/codesign",
-		"--verify",
-		"--strict",
-		"--test-requirement",
-		requirement,
-		path,
+		sharedDaemonCodeSignRetryAttempts,
+		sharedDaemonCodeSignRetryInterval,
+		func() error {
+			cmd := exec.CommandContext(
+				ctx,
+				"/usr/bin/codesign",
+				"--verify",
+				"--strict",
+				"--test-requirement",
+				requirement,
+				path,
+			)
+			configureManagedCommand(cmd)
+			return cmd.Run()
+		},
+		waitForSharedDaemonCodeSignatureRetry,
 	)
-	configureManagedCommand(cmd)
-	return cmd.Run()
+}
+
+func retrySharedDaemonCodeSignature(
+	ctx context.Context,
+	attempts int,
+	interval time.Duration,
+	verify func() error,
+	wait func(context.Context, time.Duration) error,
+) error {
+	if attempts < 1 {
+		return fmt.Errorf("代码签名校验重试次数必须大于零")
+	}
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if err := verify(); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if attempt == attempts {
+			break
+		}
+		if err := wait(ctx, interval); err != nil {
+			return fmt.Errorf("等待代码签名稳定失败：%w", err)
+		}
+	}
+	return lastErr
+}
+
+func waitForSharedDaemonCodeSignatureRetry(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func sharedDaemonCodeSigningMetadata(path string) (string, error) {

--- a/internal/appserver/shared_daemon_supervisor_darwin.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin.go
@@ -20,29 +20,11 @@ const (
 	sharedDaemonCodeSignRetryInterval  = time.Second
 	sharedDaemonCodeSignTimeout        = 20 * time.Second
 
-	// launcher 只负责把真正的 node supervisor 放进独立 session 后退出。这样
-	// LaunchAgent 仍是一条 one-shot job，普通 launcher 退出不会按同一进程组清理
-	// supervisor；bootout 的 coalition 行为不作假设，活跃 socket 路径会避开它。
-	// Browser 读取到的三级保持为 node_repl -> codex -> node。
-	sharedDaemonNodeLauncherScript = `'use strict';
-const { spawn } = require('node:child_process');
-const argv = process.argv.slice(1);
-if (argv.length < 5) process.exit(64);
-const node = argv.shift();
-const supervisor = spawn(node, ['-e', argv.shift(), '--', ...argv], {
-  detached: true,
-  env: process.env,
-  stdio: ['ignore', 'inherit', 'inherit']
-});
-supervisor.once('error', () => process.exit(70));
-supervisor.once('spawn', () => {
-  supervisor.unref();
-  process.exit(0);
-});`
-
-	// supervisor 必须保持为 app-server 的直接父进程。它不做自动重启或强杀；
-	// child 退出后 supervisor 一并退出，由现有 gateway recovery 再次 kickstart
-	// one-shot LaunchAgent，避免 socket 冲突时形成隐藏重启风暴。
+	// LaunchAgent 本身就是 OpenAI 签名的 node supervisor，并始终保持为
+	// app-server 的直接父进程。这样不依赖 detached 后代能否逃离 launchd 的
+	// service coalition，Browser 读取到的三级仍是 node_repl -> codex -> node。
+	// supervisor 不做自动重启或强杀；child 退出后它一并退出，KeepAlive=false
+	// 保证 socket 冲突不会形成隐藏重启风暴，由现有 gateway recovery 再 kickstart。
 	sharedDaemonNodeSupervisorScript = `'use strict';
 const { spawn } = require('node:child_process');
 const argv = process.argv.slice(1);
@@ -292,10 +274,8 @@ func sharedDaemonSupervisorProgramArguments(nodePath string, codexPath string) [
 	return []string{
 		nodePath,
 		"-e",
-		sharedDaemonNodeLauncherScript,
-		"--",
-		nodePath,
 		sharedDaemonNodeSupervisorScript,
+		"--",
 		codexPath,
 		"app-server",
 		"--listen",

--- a/internal/appserver/shared_daemon_supervisor_darwin.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin.go
@@ -1,0 +1,360 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	sharedDaemonOpenAITeamIdentifier     = "2DC432GLL2"
+	sharedDaemonCodexSigningIdentifier   = "codex"
+	sharedDaemonNodeSigningIdentifier    = "node"
+	sharedDaemonDesktopSigningIdentifier = "com.openai.codex"
+
+	// launcher 只负责把真正的 node supervisor 放进独立 session 后退出。这样
+	// LaunchAgent 仍是一条 one-shot job，普通 launcher 退出不会按同一进程组清理
+	// supervisor；bootout 的 coalition 行为不作假设，活跃 socket 路径会避开它。
+	// Browser 读取到的三级保持为 node_repl -> codex -> node。
+	sharedDaemonNodeLauncherScript = `'use strict';
+const { spawn } = require('node:child_process');
+const argv = process.argv.slice(1);
+if (argv.length < 5) process.exit(64);
+const node = argv.shift();
+const supervisor = spawn(node, ['-e', argv.shift(), '--', ...argv], {
+  detached: true,
+  env: process.env,
+  stdio: ['ignore', 'inherit', 'inherit']
+});
+supervisor.once('error', () => process.exit(70));
+supervisor.once('spawn', () => {
+  supervisor.unref();
+  process.exit(0);
+});`
+
+	// supervisor 必须保持为 app-server 的直接父进程。它不做自动重启或强杀；
+	// child 退出后 supervisor 一并退出，由现有 gateway recovery 再次 kickstart
+	// one-shot LaunchAgent，避免 socket 冲突时形成隐藏重启风暴。
+	sharedDaemonNodeSupervisorScript = `'use strict';
+const { spawn } = require('node:child_process');
+const argv = process.argv.slice(1);
+if (argv.length < 4) process.exit(64);
+const child = spawn(argv[0], argv.slice(1), {
+  detached: false,
+  env: process.env,
+  stdio: 'inherit'
+});
+for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+  process.on(signal, () => {
+    // ChildProcess.killed 只表示“曾成功发送过信号”，不表示进程已经退出。
+    // 以 exitCode/signalCode 判断，允许 SIGHUP 后仍继续转发真正的 stop。
+    if (child.exitCode === null && child.signalCode === null) child.kill(signal);
+  });
+}
+child.once('error', () => process.exit(70));
+child.once('exit', (code, signal) => {
+  process.exitCode = Number.isInteger(code) ? code : (signal ? 1 : 70);
+});`
+)
+
+var (
+	// 测试替换 resolver/validator 后可以使用临时可执行文件，不依赖本机安装
+	// ChatGPT.app，也不会伪造系统 codesign 输出。
+	sharedDaemonResolveSupervisorNode = resolveSharedDaemonSupervisorNode
+	sharedDaemonValidateSupervisor    = validateSharedDaemonSupervisorBinaries
+	sharedDaemonValidateSignedRuntime = validateSignedSharedDaemonRuntime
+)
+
+func resolveSharedDaemonSupervisorNode(codexBin string) (string, error) {
+	candidates := make([]string, 0, 5)
+	resources := filepath.Dir(filepath.Clean(codexBin))
+	if filepath.Base(resources) == "Resources" && filepath.Base(codexBin) == "codex" {
+		candidates = append(candidates, filepath.Join(resources, "cua_node", "bin", "node"))
+	}
+	candidates = append(candidates,
+		"/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node",
+		"/Applications/Codex.app/Contents/Resources/cua_node/bin/node",
+	)
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, "Applications", "ChatGPT.app", "Contents", "Resources", "cua_node", "bin", "node"),
+			filepath.Join(home, "Applications", "Codex.app", "Contents", "Resources", "cua_node", "bin", "node"),
+		)
+	}
+
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		absolute, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		absolute = filepath.Clean(absolute)
+		if _, exists := seen[absolute]; exists {
+			continue
+		}
+		seen[absolute] = struct{}{}
+		info, err := os.Stat(absolute)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+			continue
+		}
+		if _, err := sharedDaemonDesktopBundleForNode(absolute); err != nil {
+			continue
+		}
+		canonical, err := filepath.EvalSymlinks(absolute)
+		if err != nil {
+			continue
+		}
+		return filepath.Clean(canonical), nil
+	}
+	return "", fmt.Errorf("未找到 Codex Desktop 内置的签名 node supervisor")
+}
+
+func sharedDaemonDesktopBundleForNode(nodePath string) (string, error) {
+	canonical, err := filepath.EvalSymlinks(nodePath)
+	if err != nil {
+		return "", fmt.Errorf("解析 node supervisor 路径失败")
+	}
+	canonical = filepath.Clean(canonical)
+	wantSuffix := filepath.Join("Contents", "Resources", "cua_node", "bin", "node")
+	if !strings.HasSuffix(canonical, string(filepath.Separator)+wantSuffix) {
+		return "", fmt.Errorf("node supervisor 不在 Codex Desktop bundle 内")
+	}
+	bundle := canonical
+	for range 5 {
+		bundle = filepath.Dir(bundle)
+	}
+	if filepath.Ext(bundle) != ".app" {
+		return "", fmt.Errorf("node supervisor 缺少 App bundle 边界")
+	}
+	return bundle, nil
+}
+
+func validateSharedDaemonSupervisorBinaries(nodePath string, codexPath string) error {
+	bundlePath, err := sharedDaemonDesktopBundleForNode(nodePath)
+	if err != nil {
+		return err
+	}
+	for _, target := range []struct {
+		path       string
+		identifier string
+		name       string
+	}{
+		{path: bundlePath, identifier: sharedDaemonDesktopSigningIdentifier, name: "Codex Desktop"},
+		{path: nodePath, identifier: sharedDaemonNodeSigningIdentifier, name: "node supervisor"},
+		{path: codexPath, identifier: sharedDaemonCodexSigningIdentifier, name: "Codex app-server"},
+	} {
+		// `codesign -d` 只会展示签名声明，即使页哈希已经损坏也可能输出看似
+		// 正确的 TeamIdentifier。必须先用指定 requirement 验证真实签名，再把
+		// metadata 作为 hardened-runtime 的补充约束。
+		if verifyErr := verifySharedDaemonCodeSignature(target.path, target.identifier); verifyErr != nil {
+			return fmt.Errorf("%s 代码签名验证失败", target.name)
+		}
+		metadata, metadataErr := sharedDaemonCodeSigningMetadata(target.path)
+		if metadataErr != nil {
+			return fmt.Errorf("%s 缺少可读取的代码签名", target.name)
+		}
+		if metadataErr = validateSharedDaemonCodeSignatureMetadata(metadata, target.identifier); metadataErr != nil {
+			return fmt.Errorf("%s 不是受支持的 OpenAI 签名程序", target.name)
+		}
+	}
+	return nil
+}
+
+func verifySharedDaemonCodeSignature(path string, expectedIdentifier string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	requirement := fmt.Sprintf(
+		`=identifier %q and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = %q`,
+		expectedIdentifier,
+		sharedDaemonOpenAITeamIdentifier,
+	)
+	cmd := exec.CommandContext(
+		ctx,
+		"/usr/bin/codesign",
+		"--verify",
+		"--strict",
+		"--test-requirement",
+		requirement,
+		path,
+	)
+	configureManagedCommand(cmd)
+	return cmd.Run()
+}
+
+func sharedDaemonCodeSigningMetadata(path string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/usr/bin/codesign", "-d", "--verbose=4", path)
+	configureManagedCommand(cmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+// Browser 原生 peer authorization 使用运行中进程的 TeamIdentifier 与
+// signingIdentifier。这里对落盘候选执行同一组 metadata 约束；真正提交 stable
+// owner 前还会从 socket peer 反查 PID/PPID/argv/真实可执行文件并二次验证。
+func validateSharedDaemonCodeSignatureMetadata(metadata string, expectedIdentifier string) error {
+	hasIdentifier := false
+	hasTeam := false
+	hasHardenedRuntime := false
+	for _, line := range strings.Split(metadata, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "Identifier="+expectedIdentifier:
+			hasIdentifier = true
+		case line == "TeamIdentifier="+sharedDaemonOpenAITeamIdentifier:
+			hasTeam = true
+		case strings.HasPrefix(line, "CodeDirectory ") && strings.Contains(line, "(runtime)"):
+			hasHardenedRuntime = true
+		}
+	}
+	if !hasIdentifier || !hasTeam || !hasHardenedRuntime {
+		return fmt.Errorf("代码签名 metadata 不符合共享 daemon 约束")
+	}
+	return nil
+}
+
+func sharedDaemonSupervisorProgramArguments(nodePath string, codexPath string) []string {
+	return []string{
+		nodePath,
+		"-e",
+		sharedDaemonNodeLauncherScript,
+		"--",
+		nodePath,
+		sharedDaemonNodeSupervisorScript,
+		codexPath,
+		"app-server",
+		"--listen",
+		"unix://",
+	}
+}
+
+func validateSignedSharedDaemonRuntime(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	socketPath string,
+) error {
+	codexPath, err := resolveSharedDaemonCodexBin(options.CodexBin)
+	if err != nil {
+		return err
+	}
+	nodePath, err := sharedDaemonResolveSupervisorNode(codexPath)
+	if err != nil {
+		return err
+	}
+
+	listener, err := inspectSharedDaemonListenerProcess(ctx, socketPath)
+	if err != nil {
+		return err
+	}
+	if listener.ParentPID <= 1 {
+		return fmt.Errorf("共享 daemon listener 缺少签名 node supervisor")
+	}
+	supervisor, err := inspectSharedDaemonProcessIdentity(listener.ParentPID, os.Getuid())
+	if err != nil {
+		return err
+	}
+	if err := validateSignedSharedDaemonProcessChain(
+		listener,
+		supervisor,
+		os.Getuid(),
+		nodePath,
+		codexPath,
+		validateSharedDaemonRunningCodeSignature,
+	); err != nil {
+		return err
+	}
+
+	// PID、启动时间和命令行在两次取证间任一变化都 fail closed，避免把 PID
+	// 复用或 socket 竞争赢家错误归因给刚安装的 supervisor。
+	confirmedListener, err := inspectSharedDaemonListenerProcess(ctx, socketPath)
+	if err != nil || confirmedListener != listener {
+		return fmt.Errorf("共享 daemon listener 在身份复核期间发生变化")
+	}
+	confirmedSupervisor, err := inspectSharedDaemonProcessIdentity(supervisor.PID, os.Getuid())
+	if err != nil || confirmedSupervisor != supervisor {
+		return fmt.Errorf("共享 daemon supervisor 在身份复核期间发生变化")
+	}
+	return nil
+}
+
+func validateSignedSharedDaemonProcessChain(
+	listener sharedDaemonListenerProcess,
+	supervisor sharedDaemonListenerProcess,
+	expectedUID int,
+	nodePath string,
+	codexPath string,
+	validateSignature func(int, string) error,
+) error {
+	if listener.ParentPID <= 1 || listener.ParentPID != supervisor.PID {
+		return fmt.Errorf("共享 daemon listener 父进程与 node supervisor 不一致")
+	}
+	if err := validateSharedDaemonListenerProcess(listener, expectedUID, codexPath); err != nil {
+		return err
+	}
+	if validateSignature == nil {
+		return fmt.Errorf("共享 daemon 缺少运行态签名验证器")
+	}
+	if err := validateSignature(listener.PID, sharedDaemonCodexSigningIdentifier); err != nil {
+		return fmt.Errorf("共享 daemon listener 运行态签名无效：%w", err)
+	}
+	if supervisor.UID != expectedUID {
+		return fmt.Errorf("共享 daemon supervisor 不属于当前用户")
+	}
+	if err := validateSharedDaemonNodeSupervisorProcess(supervisor, nodePath, codexPath); err != nil {
+		return err
+	}
+	if err := validateSignature(supervisor.PID, sharedDaemonNodeSigningIdentifier); err != nil {
+		return fmt.Errorf("共享 daemon supervisor 运行态签名无效：%w", err)
+	}
+	return nil
+}
+
+func validateSharedDaemonNodeSupervisorProcess(
+	process sharedDaemonListenerProcess,
+	nodePath string,
+	codexPath string,
+) error {
+	if process.PID <= 1 || process.UID != os.Getuid() {
+		return fmt.Errorf("共享 daemon supervisor 进程身份无效")
+	}
+	if strings.TrimSpace(process.Executable) == "" || !sameCanonicalPath(process.Executable, nodePath) {
+		return fmt.Errorf("共享 daemon supervisor 不是 Codex Desktop 内置 node")
+	}
+	fields := sharedDaemonCommandFields(process.Command)
+	if len(fields) < 7 || !sameCanonicalPath(fields[0], nodePath) || fields[1] != "-e" ||
+		fields[2] != sharedDaemonNodeSupervisorScript {
+		return fmt.Errorf("共享 daemon supervisor 命令行不符合预期")
+	}
+	index := 3
+	if fields[index] == "--" {
+		index++
+	}
+	if len(fields) != index+4 || !sameCanonicalPath(fields[index], codexPath) ||
+		fields[index+1] != "app-server" || fields[index+2] != "--listen" || fields[index+3] != "unix://" {
+		return fmt.Errorf("共享 daemon supervisor child 参数不符合预期")
+	}
+	return nil
+}
+
+func sharedDaemonCommandFields(command string) []string {
+	if strings.Contains(command, "\x00") {
+		fields := make([]string, 0, 8)
+		for _, field := range strings.Split(command, "\x00") {
+			if field != "" {
+				fields = append(fields, field)
+			}
+		}
+		return fields
+	}
+	return strings.Fields(strings.TrimSpace(command))
+}

--- a/internal/appserver/shared_daemon_supervisor_darwin.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin.go
@@ -25,26 +25,19 @@ const (
 	// service coalition，Browser 读取到的三级仍是 node_repl -> codex -> node。
 	// supervisor 不做自动重启或强杀；child 退出后它一并退出，KeepAlive=false
 	// 保证 socket 冲突不会形成隐藏重启风暴，由现有 gateway recovery 再 kickstart。
-	sharedDaemonNodeSupervisorScript = `'use strict';
-const { spawn } = require('node:child_process');
-const argv = process.argv.slice(1);
-if (argv.length < 4) process.exit(64);
-const child = spawn(argv[0], argv.slice(1), {
-  detached: false,
-  env: process.env,
-  stdio: 'inherit'
-});
-for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
-  process.on(signal, () => {
-    // ChildProcess.killed 只表示“曾成功发送过信号”，不表示进程已经退出。
-    // 以 exitCode/signalCode 判断，允许 SIGHUP 后仍继续转发真正的 stop。
-    if (child.exitCode === null && child.signalCode === null) child.kill(signal);
-  });
-}
-child.once('error', () => process.exit(70));
-child.once('exit', (code, signal) => {
-  process.exitCode = Number.isInteger(code) ? code : (signal ? 1 : 70);
-});`
+	// 必须保持为单行：encoding/xml 会把换行编码为 &#xA;，而 launchctl
+	// bootstrap 会把这种 ProgramArguments 字符串截断在第一处换行实体。中文解释
+	// 留在 Go 注释中，运行时脚本只保留最小、可逐字校验的责任边界。
+	sharedDaemonNodeSupervisorScript = `'use strict';` +
+		`const{spawn}=require('node:child_process');` +
+		`const argv=process.argv.slice(1);` +
+		`if(argv.length<4)process.exit(64);` +
+		`const child=spawn(argv[0],argv.slice(1),{detached:false,env:process.env,stdio:'inherit'});` +
+		`for(const signal of['SIGTERM','SIGINT','SIGHUP'])process.on(signal,()=>{` +
+		`if(child.exitCode===null&&child.signalCode===null)child.kill(signal);` +
+		`});` +
+		`child.once('error',()=>process.exit(70));` +
+		`child.once('exit',(code,signal)=>{process.exitCode=Number.isInteger(code)?code:(signal?1:70);});`
 )
 
 var (

--- a/internal/appserver/shared_daemon_supervisor_darwin_test.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin_test.go
@@ -7,10 +7,37 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestSharedDaemonSupervisorSigningTargetsValidateOnlyExecutedBinaries(t *testing.T) {
+	bundlePath := filepath.Join(t.TempDir(), "ChatGPT.app")
+	nodePath := filepath.Join(bundlePath, "Contents", "Resources", "cua_node", "bin", "node")
+	codexPath := filepath.Join(bundlePath, "Contents", "Resources", "codex")
+	if err := os.MkdirAll(filepath.Dir(nodePath), 0o700); err != nil {
+		t.Fatalf("创建 node 目录失败：%v", err)
+	}
+	for _, path := range []string{nodePath, codexPath} {
+		if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
+			t.Fatalf("创建签名目标 fixture 失败：%v", err)
+		}
+	}
+
+	targets, err := sharedDaemonSupervisorSigningTargets(nodePath, codexPath)
+	if err != nil {
+		t.Fatalf("解析签名目标失败：%v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("只能验证实际执行的 node/codex，不能递归验证 Desktop bundle：%+v", targets)
+	}
+	if targets[0].path != nodePath || targets[0].identifier != sharedDaemonNodeSigningIdentifier ||
+		targets[1].path != codexPath || targets[1].identifier != sharedDaemonCodexSigningIdentifier {
+		t.Fatalf("签名目标错误：%+v", targets)
+	}
+}
 
 func TestRetrySharedDaemonCodeSignatureWaitsForTransientShutdownWindow(t *testing.T) {
 	verifyCalls := 0

--- a/internal/appserver/shared_daemon_supervisor_darwin_test.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin_test.go
@@ -3,11 +3,66 @@
 package appserver
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestRetrySharedDaemonCodeSignatureWaitsForTransientShutdownWindow(t *testing.T) {
+	verifyCalls := 0
+	waitCalls := 0
+	err := retrySharedDaemonCodeSignature(
+		context.Background(),
+		4,
+		time.Second,
+		func() error {
+			verifyCalls++
+			if verifyCalls < 3 {
+				return errors.New("temporary codesign failure")
+			}
+			return nil
+		},
+		func(context.Context, time.Duration) error {
+			waitCalls++
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("退出阶段的瞬时签名失败应在稳定后恢复：%v", err)
+	}
+	if verifyCalls != 3 || waitCalls != 2 {
+		t.Fatalf("签名退避次数错误：verify=%d wait=%d", verifyCalls, waitCalls)
+	}
+}
+
+func TestRetrySharedDaemonCodeSignatureFailsClosedAfterBound(t *testing.T) {
+	wantErr := errors.New("invalid signature")
+	verifyCalls := 0
+	waitCalls := 0
+	err := retrySharedDaemonCodeSignature(
+		context.Background(),
+		3,
+		0,
+		func() error {
+			verifyCalls++
+			return wantErr
+		},
+		func(context.Context, time.Duration) error {
+			waitCalls++
+			return nil
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("持续无效签名必须 fail closed：%v", err)
+	}
+	if verifyCalls != 3 || waitCalls != 2 {
+		t.Fatalf("必须严格遵守重试上限：verify=%d wait=%d", verifyCalls, waitCalls)
+	}
+}
 
 func TestValidateSignedSharedDaemonProcessChainRequiresExactSignedParent(t *testing.T) {
 	nodePath := "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"

--- a/internal/appserver/shared_daemon_supervisor_darwin_test.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin_test.go
@@ -1,0 +1,192 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestValidateSignedSharedDaemonProcessChainRequiresExactSignedParent(t *testing.T) {
+	nodePath := "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
+	codexPath := "/Applications/ChatGPT.app/Contents/Resources/codex"
+	listener := sharedDaemonListenerProcess{
+		PID:        4242,
+		ParentPID:  4343,
+		UID:        os.Getuid(),
+		Executable: codexPath,
+		Command:    strings.Join([]string{codexPath, "app-server", "--listen", "unix://"}, "\x00"),
+	}
+	supervisor := sharedDaemonListenerProcess{
+		PID:        4343,
+		ParentPID:  1,
+		UID:        os.Getuid(),
+		Executable: nodePath,
+		Command: strings.Join([]string{
+			nodePath, "-e", sharedDaemonNodeSupervisorScript, "--",
+			codexPath, "app-server", "--listen", "unix://",
+		}, "\x00"),
+	}
+	var signatureChecks []string
+	validateSignature := func(pid int, identifier string) error {
+		signatureChecks = append(signatureChecks, fmt.Sprintf("%d:%s", pid, identifier))
+		return nil
+	}
+	if err := validateSignedSharedDaemonProcessChain(
+		listener,
+		supervisor,
+		os.Getuid(),
+		nodePath,
+		codexPath,
+		validateSignature,
+	); err != nil {
+		t.Fatalf("完整签名父链应通过：%v", err)
+	}
+	if got := strings.Join(signatureChecks, ","); got != "4242:codex,4343:node" {
+		t.Fatalf("必须分别验证 listener 与 supervisor 的运行态签名：%s", got)
+	}
+
+	tests := map[string]func(*sharedDaemonListenerProcess, *sharedDaemonListenerProcess) func(int, string) error{
+		"parent mismatch": func(listener *sharedDaemonListenerProcess, _ *sharedDaemonListenerProcess) func(int, string) error {
+			listener.ParentPID++
+			return validateSignature
+		},
+		"listener signature": func(_ *sharedDaemonListenerProcess, _ *sharedDaemonListenerProcess) func(int, string) error {
+			return func(pid int, _ string) error {
+				if pid == listener.PID {
+					return fmt.Errorf("invalid listener signature")
+				}
+				return nil
+			}
+		},
+		"supervisor signature": func(_ *sharedDaemonListenerProcess, _ *sharedDaemonListenerProcess) func(int, string) error {
+			return func(pid int, _ string) error {
+				if pid == supervisor.PID {
+					return fmt.Errorf("invalid supervisor signature")
+				}
+				return nil
+			}
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateListener := listener
+			candidateSupervisor := supervisor
+			candidateValidator := mutate(&candidateListener, &candidateSupervisor)
+			if err := validateSignedSharedDaemonProcessChain(
+				candidateListener,
+				candidateSupervisor,
+				os.Getuid(),
+				nodePath,
+				codexPath,
+				candidateValidator,
+			); err == nil {
+				t.Fatal("不完整或无效的运行态签名父链必须 fail closed")
+			}
+		})
+	}
+}
+
+func TestValidateSharedDaemonNodeSupervisorProcessAcceptsSignedSupervisorArgv(t *testing.T) {
+	nodePath := "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
+	codexPath := "/Applications/ChatGPT.app/Contents/Resources/codex"
+	baseArgv := []string{
+		nodePath,
+		"-e",
+		sharedDaemonNodeSupervisorScript,
+		codexPath,
+		"app-server",
+		"--listen",
+		"unix://",
+	}
+
+	for _, withSeparator := range []bool{false, true} {
+		argv := append([]string(nil), baseArgv...)
+		if withSeparator {
+			argv = append(argv[:3], append([]string{"--"}, argv[3:]...)...)
+		}
+		process := sharedDaemonListenerProcess{
+			PID:        4242,
+			UID:        os.Getuid(),
+			Executable: nodePath,
+			Command:    strings.Join(argv, "\x00"),
+		}
+		if err := validateSharedDaemonNodeSupervisorProcess(process, nodePath, codexPath); err != nil {
+			t.Fatalf("带 separator=%t 的 supervisor argv 应通过：%v", withSeparator, err)
+		}
+	}
+}
+
+func TestValidateSharedDaemonNodeSupervisorProcessRejectsUnsafeArgv(t *testing.T) {
+	nodePath := "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
+	codexPath := "/Applications/ChatGPT.app/Contents/Resources/codex"
+	validArgv := []string{
+		nodePath,
+		"-e",
+		sharedDaemonNodeSupervisorScript,
+		codexPath,
+		"app-server",
+		"--listen",
+		"unix://",
+	}
+	newProcess := func(argv []string) sharedDaemonListenerProcess {
+		return sharedDaemonListenerProcess{
+			PID:        4242,
+			UID:        os.Getuid(),
+			Executable: nodePath,
+			Command:    strings.Join(argv, "\x00"),
+		}
+	}
+
+	tests := map[string]func(sharedDaemonListenerProcess) sharedDaemonListenerProcess{
+		"invalid pid": func(process sharedDaemonListenerProcess) sharedDaemonListenerProcess {
+			process.PID = 1
+			return process
+		},
+		"foreign uid": func(process sharedDaemonListenerProcess) sharedDaemonListenerProcess {
+			process.UID++
+			return process
+		},
+		"foreign executable": func(process sharedDaemonListenerProcess) sharedDaemonListenerProcess {
+			process.Executable = "/tmp/node"
+			return process
+		},
+		"wrong node script": func(process sharedDaemonListenerProcess) sharedDaemonListenerProcess {
+			argv := strings.Split(process.Command, "\x00")
+			argv[2] = "console.log('unexpected')"
+			process.Command = strings.Join(argv, "\x00")
+			return process
+		},
+		"shell style command": func(process sharedDaemonListenerProcess) sharedDaemonListenerProcess {
+			process.Command = strings.Join([]string{nodePath, "-e", sharedDaemonNodeSupervisorScript, codexPath, "daemon", "start"}, "\x00")
+			return process
+		},
+		"unexpected child argument": func(process sharedDaemonListenerProcess) sharedDaemonListenerProcess {
+			argv := append([]string(nil), validArgv...)
+			argv = append(argv, "unexpected")
+			process.Command = strings.Join(argv, "\x00")
+			return process
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := validateSharedDaemonNodeSupervisorProcess(mutate(newProcess(validArgv)), nodePath, codexPath); err == nil {
+				t.Fatal("不安全的 supervisor argv 必须 fail closed")
+			}
+		})
+	}
+}
+
+func TestSharedDaemonNodeSupervisorForwardsSignalsWithoutChildKilledState(t *testing.T) {
+	// Node 的 child.killed 只表示最近一次 kill 调用，不表示子进程仍然存活；
+	// supervisor 必须依据可观测退出状态决定是否转发信号，避免漏发终止信号。
+	if strings.Contains(sharedDaemonNodeSupervisorScript, "child.killed") {
+		t.Fatal("supervisor signal forwarding 不能把 child.killed 当作存活状态")
+	}
+	if !strings.Contains(sharedDaemonNodeSupervisorScript, "child.kill(signal)") {
+		t.Fatal("supervisor 必须把 SIGTERM/SIGINT/SIGHUP 转发给 app-server child")
+	}
+}

--- a/internal/appserver/shared_daemon_supervisor_darwin_test.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin_test.go
@@ -91,6 +91,35 @@ func TestRetrySharedDaemonCodeSignatureFailsClosedAfterBound(t *testing.T) {
 	}
 }
 
+func TestRetrySharedDaemonCodeSignaturePreservesLastFailureWhenWaitStops(t *testing.T) {
+	verifyErr := errors.New("invalid signature")
+	waitErr := context.DeadlineExceeded
+	err := retrySharedDaemonCodeSignature(
+		context.Background(),
+		3,
+		time.Second,
+		func() error { return verifyErr },
+		func(context.Context, time.Duration) error { return waitErr },
+	)
+	if !errors.Is(err, verifyErr) || !errors.Is(err, waitErr) {
+		t.Fatalf("等待中止时必须同时保留截止时间和最后一次验签错误：%v", err)
+	}
+	if !strings.Contains(err.Error(), "最后一次代码签名验证失败") {
+		t.Fatalf("错误信息缺少最后一次验签上下文：%v", err)
+	}
+}
+
+func TestSharedDaemonCodeSignatureResultPreservesTimeoutAndVerificationFailure(t *testing.T) {
+	verifyErr := errors.New("invalid signature")
+	err := sharedDaemonCodeSignatureResult(verifyErr, context.DeadlineExceeded)
+	if !errors.Is(err, verifyErr) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("超时不能覆盖真实验签错误：%v", err)
+	}
+	if !strings.Contains(err.Error(), "代码签名校验超时") || !strings.Contains(err.Error(), "invalid signature") {
+		t.Fatalf("超时错误缺少可操作的验签上下文：%v", err)
+	}
+}
+
 func TestValidateSignedSharedDaemonProcessChainRequiresExactSignedParent(t *testing.T) {
 	nodePath := "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
 	codexPath := "/Applications/ChatGPT.app/Contents/Resources/codex"

--- a/internal/appserver/shared_daemon_supervisor_darwin_test.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin_test.go
@@ -286,3 +286,14 @@ func TestSharedDaemonNodeSupervisorForwardsSignalsWithoutChildKilledState(t *tes
 		t.Fatal("supervisor 必须把 SIGTERM/SIGINT/SIGHUP 转发给 app-server child")
 	}
 }
+
+func TestSharedDaemonNodeSupervisorScriptHasNoPlistLineBreaks(t *testing.T) {
+	// encoding/xml 会把换行编码为 &#xA;；launchctl bootstrap 对
+	// ProgramArguments 的这种实体会只保留第一行，最终让 node 正常退出但不拉起 child。
+	if strings.ContainsAny(sharedDaemonNodeSupervisorScript, "\r\n") {
+		t.Fatal("node supervisor inline script 必须保持为单行")
+	}
+	if !strings.HasSuffix(sharedDaemonNodeSupervisorScript, "});") {
+		t.Fatal("node supervisor inline script 缺少 child exit 尾部哨兵")
+	}
+}

--- a/internal/appserver/shared_daemon_supervisor_darwin_test.go
+++ b/internal/appserver/shared_daemon_supervisor_darwin_test.go
@@ -201,6 +201,20 @@ func TestValidateSharedDaemonNodeSupervisorProcessAcceptsSignedSupervisorArgv(t 
 	}
 }
 
+func TestGeneratedSharedDaemonProgramArgumentsMatchRuntimeValidator(t *testing.T) {
+	nodePath := "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
+	codexPath := "/Applications/ChatGPT.app/Contents/Resources/codex"
+	process := sharedDaemonListenerProcess{
+		PID:        4242,
+		UID:        os.Getuid(),
+		Executable: nodePath,
+		Command:    strings.Join(sharedDaemonSupervisorProgramArguments(nodePath, codexPath), "\x00"),
+	}
+	if err := validateSharedDaemonNodeSupervisorProcess(process, nodePath, codexPath); err != nil {
+		t.Fatalf("LaunchAgent 生成的 supervisor argv 必须通过同一份运行态校验：%v", err)
+	}
+}
+
 func TestValidateSharedDaemonNodeSupervisorProcessRejectsUnsafeArgv(t *testing.T) {
 	nodePath := "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
 	codexPath := "/Applications/ChatGPT.app/Contents/Resources/codex"

--- a/internal/appserver/shared_daemon_supervisor_other.go
+++ b/internal/appserver/shared_daemon_supervisor_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package appserver
+
+import (
+	"context"
+	"fmt"
+)
+
+var sharedDaemonValidateSignedRuntime = validateSignedSharedDaemonRuntime
+
+func validateSignedSharedDaemonRuntime(
+	context.Context,
+	LocalDaemonOptions,
+	string,
+) error {
+	return fmt.Errorf("签名 node supervisor 仅支持 macOS")
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -535,8 +535,12 @@ func sharedDaemonRuntimeDiagnosticCheck(
 		case appserver.SharedDaemonResourceStateCritical:
 			check.Message = "共享 daemon FD 接近耗尽；" + summary
 		default:
-			check.Level = "warning"
-			check.Message = "共享 daemon owner 正常，但 FD soft limit 尚不可确认；" + summary
+			// macOS 没有可靠的非特权接口读取另一个进程的 RLIMIT_NOFILE。
+			// 已验证稳定 owner 时保留事实提示，但不制造一条用户永远无法消除的 WARN；
+			// 真正的迁移、owner 不匹配和已取证的高水位仍由其他分支告警。
+			check.OK = true
+			check.Message = "共享 daemon owner 正常；FD soft limit 尚不可独立确认；" + summary
+			check.Fix = ""
 		}
 	case appserver.SharedDaemonOwnerStateMigrationPending:
 		check.Message = "共享 daemon 正在等待显式迁移，新 FD 上限尚未作用于当前 listener；" + summary

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -445,12 +445,7 @@ func (c *Checker) sharedDaemonOwnerCheck(ctx context.Context) Check {
 	}
 	status, err := appserver.InspectSharedDaemonOwner(ctx)
 	if err != nil {
-		return Check{
-			Name:    "codex-daemon-owner",
-			OK:      false,
-			Message: "无法检查共享 Codex daemon 的 launchd owner",
-			Fix:     err.Error(),
-		}
+		return sharedDaemonOwnerInspectionFailureCheck(err)
 	}
 	if !status.Supported {
 		return Check{}
@@ -474,6 +469,17 @@ func (c *Checker) sharedDaemonOwnerCheck(ctx context.Context) Check {
 		check.Fix = ""
 	}
 	return check
+}
+
+// 共享 owner 检查的底层错误可能包含 LaunchAgent 或 socket 绝对路径；Doctor
+// 结果会进入状态接口和远端 UI，因此只返回固定的可执行提示，不传播原始错误。
+func sharedDaemonOwnerInspectionFailureCheck(_ error) Check {
+	return Check{
+		Name:    "codex-daemon-owner",
+		OK:      false,
+		Message: "无法检查共享 Codex daemon 的 launchd owner",
+		Fix:     "确认共享 Codex daemon 已启用，并检查当前用户对 LaunchAgent 和进程信息的读取权限后重试",
+	}
 }
 
 func (c *Checker) sharedDaemonRuntimeCheck(ctx context.Context) Check {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -25,6 +25,7 @@ type Checker struct {
 	cfg                        config.Config
 	registry                   *projects.Registry
 	configPath                 string
+	sharedDaemonDiagnostics    func(context.Context, appserver.LocalDaemonOptions) (appserver.SharedDaemonDiagnostics, error)
 	fileAccessMu               sync.RWMutex
 	fileAccessPreflightStarted bool
 	fileAccessPreflight        Check
@@ -49,7 +50,12 @@ type Check struct {
 }
 
 func NewChecker(version string, cfg config.Config, registry *projects.Registry, configPath ...string) *Checker {
-	checker := &Checker{version: version, cfg: cfg, registry: registry}
+	checker := &Checker{
+		version:                 version,
+		cfg:                     cfg,
+		registry:                registry,
+		sharedDaemonDiagnostics: appserver.InspectSharedDaemonDiagnostics,
+	}
 	// variadic 参数保持现有嵌入方兼容；CLI 传入真实路径后才启用配置文件权限检查。
 	if len(configPath) > 0 {
 		checker.configPath = expandConfigPath(configPath[0])
@@ -109,6 +115,9 @@ func (c *Checker) Run(ctx context.Context, checkPort bool) Results {
 	if check := c.sharedDaemonOwnerCheck(ctx); check.Name != "" {
 		checks = append(checks, check)
 	}
+	if check := c.sharedDaemonRuntimeCheck(ctx); check.Name != "" {
+		checks = append(checks, check)
+	}
 	checks = append(checks, c.claudeBridgeCheck(ctx))
 	if check := c.appServerGatewayCheck(ctx); check.Name != "" {
 		checks = append(checks, check)
@@ -153,7 +162,7 @@ func (c *Checker) results(checks []Check) Results {
 			checks[i].Level = "ok"
 			continue
 		}
-		if isWarningOnlyCheck(checks[i].Name) {
+		if strings.EqualFold(strings.TrimSpace(checks[i].Level), "warning") || isWarningOnlyCheck(checks[i].Name) {
 			if checks[i].Name == "tailscale" {
 				checks[i].Message = "未检测到 Tailscale 命令，本机访问仍可使用"
 			}
@@ -465,6 +474,99 @@ func (c *Checker) sharedDaemonOwnerCheck(ctx context.Context) Check {
 		check.Fix = ""
 	}
 	return check
+}
+
+func (c *Checker) sharedDaemonRuntimeCheck(ctx context.Context) Check {
+	if !strings.EqualFold(strings.TrimSpace(c.cfg.AppServer.Transport), "unix") {
+		return Check{}
+	}
+	inspect := c.sharedDaemonDiagnostics
+	if inspect == nil {
+		inspect = appserver.InspectSharedDaemonDiagnostics
+	}
+	status, err := inspect(ctx, appserver.LocalDaemonOptions{
+		CodexBin:    c.cfg.Codex.Bin,
+		Env:         c.cfg.Codex.Env,
+		StableOwner: c.cfg.AppServer.SharedFallback != nil,
+	})
+	return sharedDaemonRuntimeDiagnosticCheck(status, err)
+}
+
+func sharedDaemonRuntimeDiagnosticCheck(
+	status appserver.SharedDaemonDiagnostics,
+	err error,
+) Check {
+	check := Check{
+		Name: "codex-daemon-resources",
+		Fix:  "先保存所有活跃任务；若资源继续上涨，使用受控迁移恢复 owner，不要直接强杀进程",
+	}
+	if err != nil {
+		check.Level = "warning"
+		check.Message = "无法读取共享 Codex daemon 的 FD / 子进程水位"
+		// 底层 Unix dial 错误可能包含 CODEX_HOME/socket 绝对路径；Doctor
+		// 只返回固定操作建议，不把原始错误扩大到状态输出或日志。
+		check.Fix = "确认共享 Codex daemon 正在运行，并允许 Mimi 读取当前用户的进程信息"
+		return check
+	}
+	if !status.Supported {
+		return Check{}
+	}
+	summary := sharedDaemonResourceSummary(status)
+	switch status.OwnerState {
+	case appserver.SharedDaemonOwnerStateExternal:
+		check.OK = true
+		check.Message = "共享 daemon 由外部 owner 管理；" + summary + "；FD soft limit 由外部 owner 负责"
+		check.Fix = ""
+	case appserver.SharedDaemonOwnerStateStable:
+		switch status.ResourceState {
+		case appserver.SharedDaemonResourceStateHealthy:
+			check.OK = true
+			check.Message = "共享 daemon 资源水位正常；" + summary
+			check.Fix = ""
+		case appserver.SharedDaemonResourceStateDegraded:
+			check.Level = "warning"
+			check.Message = "共享 daemon FD 水位偏高；" + summary
+		case appserver.SharedDaemonResourceStateCritical:
+			check.Message = "共享 daemon FD 接近耗尽；" + summary
+		default:
+			check.Level = "warning"
+			check.Message = "共享 daemon owner 正常，但 FD soft limit 尚不可确认；" + summary
+		}
+	case appserver.SharedDaemonOwnerStateMigrationPending:
+		check.Message = "共享 daemon 正在等待显式迁移，新 FD 上限尚未作用于当前 listener；" + summary
+		check.Fix = "保存任务后，在 Mimi Remote Mac 中点击“应用待处理设置”并确认"
+	case appserver.SharedDaemonOwnerStateUnavailable:
+		check.Message = "共享 daemon listener 可用，但稳定 LaunchAgent owner 不可用；" + summary
+		check.Fix = "在 Mimi Remote Mac 中关闭后重新开启共享，恢复稳定 owner"
+	case appserver.SharedDaemonOwnerStateUnmanagedListener:
+		check.Message = "共享 daemon listener 尚未由官方 pid daemon 管理；" + summary
+		check.Fix = "保存任务并退出 Codex Desktop 后，在 Mimi Remote Mac 中应用待处理设置"
+	case appserver.SharedDaemonOwnerStateListenerMismatch:
+		check.Message = "共享 daemon lifecycle PID 与真实 socket listener 不一致；" + summary
+		check.Fix = "不要直接终止进程；保存任务后使用显式受控迁移重新对账 owner"
+	default:
+		check.Level = "warning"
+		check.Message = "共享 daemon owner 状态暂时无法确认；" + summary
+	}
+	return check
+}
+
+func sharedDaemonResourceSummary(status appserver.SharedDaemonDiagnostics) string {
+	fd := fmt.Sprintf("打开 FD %d", status.OpenFileDescriptors)
+	if status.EffectiveFDSoftLimit != nil {
+		fd = fmt.Sprintf("打开 FD %d/%d", status.OpenFileDescriptors, *status.EffectiveFDSoftLimit)
+		if status.FDUsagePercent != nil {
+			fd += fmt.Sprintf("（%.1f%%）", *status.FDUsagePercent)
+		}
+	} else if status.OwnerTargetFDSoftLimit != nil {
+		fd += fmt.Sprintf("；owner 目标上限 %d（当前进程未验证）", *status.OwnerTargetFDSoftLimit)
+	}
+	return fmt.Sprintf(
+		"listener PID %d，%s，直接子进程 %d",
+		status.ListenerPID,
+		fd,
+		status.DirectChildProcesses,
+	)
 }
 
 func (c *Checker) claudeBridgeCheck(ctx context.Context) Check {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -538,6 +538,10 @@ func sharedDaemonRuntimeDiagnosticCheck(
 	case appserver.SharedDaemonOwnerStateUnavailable:
 		check.Message = "共享 daemon listener 可用，但稳定 LaunchAgent owner 不可用；" + summary
 		check.Fix = "在 Mimi Remote Mac 中关闭后重新开启共享，恢复稳定 owner"
+	case appserver.SharedDaemonOwnerStateClaimedUnverified:
+		check.Level = "warning"
+		check.Message = "共享 daemon 的稳定 owner 已提交，但官方 lifecycle 未返回 listener PID；" + summary
+		check.Fix = "继续观察真实 FD 与子进程水位；不要仅凭 owner 配置推测当前进程上限"
 	case appserver.SharedDaemonOwnerStateUnmanagedListener:
 		check.Message = "共享 daemon listener 尚未由官方 pid daemon 管理；" + summary
 		check.Fix = "保存任务并退出 Codex Desktop 后，在 Mimi Remote Mac 中应用待处理设置"

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -123,6 +123,26 @@ func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *t
 	}
 }
 
+func TestSharedDaemonOwnerInspectionFailureDoesNotLeakRawError(t *testing.T) {
+	rawErr := errors.New("读取 /Users/secret/Library/LaunchAgents/com.example.codex.plist 失败：permission denied")
+	check := sharedDaemonOwnerInspectionFailureCheck(rawErr)
+
+	if check.OK || check.Name != "codex-daemon-owner" {
+		t.Fatalf("owner 检查失败应保留阻断检查语义：%+v", check)
+	}
+	for field, value := range map[string]string{
+		"message": check.Message,
+		"fix":     check.Fix,
+	} {
+		if strings.Contains(value, "/Users/secret") || strings.Contains(value, rawErr.Error()) {
+			t.Fatalf("owner 检查不应把底层错误写入 %s：%q", field, value)
+		}
+	}
+	if !strings.Contains(check.Fix, "共享 Codex daemon") || !strings.Contains(check.Fix, "权限") {
+		t.Fatalf("owner 检查失败应给出共享功能和权限方向的固定修复建议：%+v", check)
+	}
+}
+
 func TestCheckerRunAndPrintDoNotLeakToken(t *testing.T) {
 	binDir := t.TempDir()
 	codexPath := filepath.Join(binDir, "codex")

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -76,13 +76,13 @@ func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *t
 			wantLevel: "error", wantText: "尚未作用",
 		},
 		{
-			name: "configured owner limit is not effective limit",
+			name: "stable unknown effective limit stays informational",
 			status: appserver.SharedDaemonDiagnostics{
 				Supported: true, ListenerPID: 106, OpenFileDescriptors: 7800,
 				OwnerTargetFDSoftLimit: &limit, OwnerState: appserver.SharedDaemonOwnerStateStable,
 				ResourceState: appserver.SharedDaemonResourceStateUnknown,
 			},
-			wantLevel: "warning", wantText: "当前进程未验证",
+			wantOK: true, wantText: "当前进程未验证",
 		},
 		{
 			name: "claimed owner without lifecycle pid is warning",

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -85,6 +85,14 @@ func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *t
 			wantLevel: "warning", wantText: "当前进程未验证",
 		},
 		{
+			name: "claimed owner without lifecycle pid is warning",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 107, OpenFileDescriptors: 82,
+				OwnerState: appserver.SharedDaemonOwnerStateClaimedUnverified,
+			},
+			wantLevel: "warning", wantText: "未返回 listener PID",
+		},
+		{
 			name: "observation failure is warning",
 			err:  errors.New("dial unix /Users/secret/.codex/app-server.sock: permission denied"), wantLevel: "warning", wantText: "无法读取",
 		},

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -11,10 +12,108 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/claudebridge"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 	"github.com/gaixianggeng/mimi-remote/internal/projects"
 )
+
+func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *testing.T) {
+	limit := 8192
+	usage := 75.0
+	tests := []struct {
+		name      string
+		status    appserver.SharedDaemonDiagnostics
+		err       error
+		wantOK    bool
+		wantLevel string
+		wantText  string
+	}{
+		{
+			name: "healthy stable owner",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 100, OpenFileDescriptors: 80,
+				DirectChildProcesses: 2, EffectiveFDSoftLimit: &limit,
+				OwnerState:    appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateHealthy,
+			},
+			wantOK: true, wantText: "80/8192",
+		},
+		{
+			name: "degraded is warning",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 101, OpenFileDescriptors: 6144,
+				DirectChildProcesses: 9, EffectiveFDSoftLimit: &limit,
+				FDUsagePercent: &usage, OwnerState: appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateDegraded,
+			},
+			wantLevel: "warning", wantText: "75.0%",
+		},
+		{
+			name: "critical blocks doctor",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 102, OpenFileDescriptors: 7800,
+				EffectiveFDSoftLimit: &limit, OwnerState: appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateCritical,
+			},
+			wantLevel: "error", wantText: "接近耗尽",
+		},
+		{
+			name: "external owner stays informational",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 103, OpenFileDescriptors: 90,
+				OwnerState:    appserver.SharedDaemonOwnerStateExternal,
+				ResourceState: appserver.SharedDaemonResourceStateUnknown,
+			},
+			wantOK: true, wantText: "外部 owner",
+		},
+		{
+			name: "migration pending blocks doctor",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 104, OpenFileDescriptors: 200,
+				OwnerState: appserver.SharedDaemonOwnerStateMigrationPending,
+			},
+			wantLevel: "error", wantText: "尚未作用",
+		},
+		{
+			name: "configured owner limit is not effective limit",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 106, OpenFileDescriptors: 7800,
+				OwnerTargetFDSoftLimit: &limit, OwnerState: appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateUnknown,
+			},
+			wantLevel: "warning", wantText: "当前进程未验证",
+		},
+		{
+			name: "observation failure is warning",
+			err:  errors.New("dial unix /Users/secret/.codex/app-server.sock: permission denied"), wantLevel: "warning", wantText: "无法读取",
+		},
+	}
+
+	checker := &Checker{}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			check := sharedDaemonRuntimeDiagnosticCheck(testCase.status, testCase.err)
+			results := checker.results([]Check{check})
+			got := results.Checks[0]
+			if got.OK != testCase.wantOK || got.Level != testCase.wantLevel && testCase.wantLevel != "" {
+				t.Fatalf("诊断等级错误：%+v", got)
+			}
+			if !strings.Contains(got.Message, testCase.wantText) {
+				t.Fatalf("诊断文案缺少 %q：%+v", testCase.wantText, got)
+			}
+			if strings.Contains(got.Fix, "/Users/secret") {
+				t.Fatalf("Doctor 修复建议泄露了底层 socket 路径：%+v", got)
+			}
+			if testCase.wantLevel == "error" && results.OK {
+				t.Fatalf("阻断状态必须让 doctor 失败：%+v", results)
+			}
+			if testCase.wantLevel == "warning" && !results.OK {
+				t.Fatalf("warning 不应让 doctor 失败：%+v", results)
+			}
+		})
+	}
+}
 
 func TestCheckerRunAndPrintDoNotLeakToken(t *testing.T) {
 	binDir := t.TempDir()

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -60,6 +60,9 @@ type Router struct {
 	// sharedDaemonMigrationRequired 只读取 Mimi owner 的持久迁移标记。单独注入
 	// 让 runtime cache 保持昂贵账号探测缓存，同时每次请求仍返回实时迁移状态。
 	sharedDaemonMigrationRequired func() (bool, error)
+	// sharedDaemonDiagnostics 以 Unix socket 的真实 peer PID 为起点读取资源水位。
+	// 它只进入低频 runtime 快照，不参与 readiness，也不会触发迁移或重启。
+	sharedDaemonDiagnostics func(context.Context) (appserver.SharedDaemonDiagnostics, error)
 	// tailscalePathLookup 只在连接验证/测速时读取一次本机 Tailscale 状态。
 	// 使用可注入函数既避免常驻轮询，也让无 Tailscale 环境下的接口行为可测试。
 	tailscalePathLookup tailscaleNetworkPathLookup
@@ -222,6 +225,16 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 		gitTestFlightJobs:           map[string]*gitTestFlightReleaseJob{},
 		accountTokenUsageCacheTTL:   defaultAccountTokenUsageCacheTTL,
 		claudeBridge:                newClaudeBridgeSupervisor(),
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") {
+		diagnosticOptions := appserver.LocalDaemonOptions{
+			CodexBin:    cfg.Codex.Bin,
+			Env:         cfg.Codex.Env,
+			StableOwner: cfg.AppServer.SharedFallback != nil,
+		}
+		r.sharedDaemonDiagnostics = func(ctx context.Context) (appserver.SharedDaemonDiagnostics, error) {
+			return appserver.InspectSharedDaemonDiagnostics(ctx, diagnosticOptions)
+		}
 	}
 	if strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") &&
 		cfg.AppServer.SharedFallback != nil {

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -210,20 +210,35 @@ func (r *Router) storeClaudeRuntimeQuota(limits *runtimeRateLimits) {
 // runtimeAccountStatus 只包含菜单栏需要的脱敏状态。账号邮箱、Token、Keychain
 // 内容和上游原始错误都不能进入这个结构，避免 status CLI 或日志扩大凭据暴露面。
 type runtimeAccountStatus struct {
-	ID                    string                 `json:"id"`
-	Title                 string                 `json:"title"`
-	Enabled               bool                   `json:"enabled"`
-	State                 runtimeConnectionState `json:"state"`
-	Transport             string                 `json:"transport,omitempty"`
-	Shared                bool                   `json:"shared,omitempty"`
-	DaemonRestartRequired *bool                  `json:"daemon_restart_required,omitempty"`
-	CodexHome             string                 `json:"codex_home,omitempty"`
-	Version               string                 `json:"version,omitempty"`
-	StartedAt             *time.Time             `json:"started_at,omitempty"`
-	AuthMode              string                 `json:"auth_mode,omitempty"`
-	PlanType              string                 `json:"plan_type,omitempty"`
-	Reason                string                 `json:"reason,omitempty"`
-	RateLimits            *runtimeRateLimits     `json:"rate_limits,omitempty"`
+	ID                    string                     `json:"id"`
+	Title                 string                     `json:"title"`
+	Enabled               bool                       `json:"enabled"`
+	State                 runtimeConnectionState     `json:"state"`
+	Transport             string                     `json:"transport,omitempty"`
+	Shared                bool                       `json:"shared,omitempty"`
+	DaemonRestartRequired *bool                      `json:"daemon_restart_required,omitempty"`
+	CodexHome             string                     `json:"codex_home,omitempty"`
+	Version               string                     `json:"version,omitempty"`
+	StartedAt             *time.Time                 `json:"started_at,omitempty"`
+	AuthMode              string                     `json:"auth_mode,omitempty"`
+	PlanType              string                     `json:"plan_type,omitempty"`
+	Reason                string                     `json:"reason,omitempty"`
+	RateLimits            *runtimeRateLimits         `json:"rate_limits,omitempty"`
+	SharedDaemon          *runtimeSharedDaemonStatus `json:"shared_daemon,omitempty"`
+}
+
+// runtimeSharedDaemonStatus 只提供定位资源耗尽所需的数值与枚举。命令行、环境、
+// socket/owner 路径均不进入本机状态接口，避免为了可观测性扩大敏感信息面。
+type runtimeSharedDaemonStatus struct {
+	ListenerPID            int        `json:"listener_pid"`
+	ListenerStartedAt      *time.Time `json:"listener_started_at,omitempty"`
+	OpenFileDescriptors    int        `json:"open_file_descriptors"`
+	DirectChildProcesses   int        `json:"direct_child_processes"`
+	OwnerTargetFDSoftLimit *int       `json:"owner_target_fd_soft_limit,omitempty"`
+	EffectiveFDSoftLimit   *int       `json:"effective_fd_soft_limit,omitempty"`
+	FDUsagePercent         *float64   `json:"fd_usage_percent,omitempty"`
+	OwnerState             string     `json:"owner_state"`
+	ResourceState          string     `json:"resource_state"`
 }
 
 type runtimeRateLimits struct {
@@ -399,8 +414,8 @@ func runtimeStatusLoopbackRequest(req *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
-	status := runtimeAccountStatus{
+func (r *Router) probeCodexRuntime(ctx context.Context) (status runtimeAccountStatus) {
+	status = runtimeAccountStatus{
 		ID:        "codex",
 		Title:     "Codex",
 		Enabled:   true,
@@ -409,6 +424,18 @@ func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
 		Shared:    strings.EqualFold(strings.TrimSpace(r.cfg.AppServer.Transport), "unix"),
 		StartedAt: r.codexRuntimeStartTime(),
 		Reason:    "upstream_unavailable",
+	}
+	var diagnostics <-chan sharedDaemonDiagnosticsResult
+	if status.Shared && r.sharedDaemonDiagnostics != nil {
+		result := make(chan sharedDaemonDiagnosticsResult, 1)
+		diagnostics = result
+		go func() {
+			value, err := r.sharedDaemonDiagnostics(ctx)
+			result <- sharedDaemonDiagnosticsResult{value: value, err: err}
+		}()
+		defer func() {
+			status.SharedDaemon = awaitRuntimeSharedDaemonDiagnostics(ctx, diagnostics)
+		}()
 	}
 	if status.Shared {
 		if socketPath, pathErr := appserver.LocalDaemonSocketPath(r.cfg.Codex.Env); pathErr == nil {
@@ -469,6 +496,54 @@ func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
 		status.Reason = "quota_refresh_in_progress"
 	}
 	return status
+}
+
+type sharedDaemonDiagnosticsResult struct {
+	value appserver.SharedDaemonDiagnostics
+	err   error
+}
+
+func awaitRuntimeSharedDaemonDiagnostics(
+	ctx context.Context,
+	results <-chan sharedDaemonDiagnosticsResult,
+) *runtimeSharedDaemonStatus {
+	if results == nil {
+		return nil
+	}
+	// 账号和资源探测并行执行；这里只给内核/launchctl 取证一个很短的收尾窗口，
+	// 不能让可选诊断拖垮原有 runtime 状态刷新。
+	timer := time.NewTimer(500 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case result := <-results:
+		if result.err != nil || !result.value.Supported {
+			return nil
+		}
+		return newRuntimeSharedDaemonStatus(result.value)
+	case <-ctx.Done():
+		return nil
+	case <-timer.C:
+		return nil
+	}
+}
+
+func newRuntimeSharedDaemonStatus(value appserver.SharedDaemonDiagnostics) *runtimeSharedDaemonStatus {
+	var startedAt *time.Time
+	if !value.ListenerStartedAt.IsZero() {
+		copy := value.ListenerStartedAt.UTC()
+		startedAt = &copy
+	}
+	return &runtimeSharedDaemonStatus{
+		ListenerPID:            value.ListenerPID,
+		ListenerStartedAt:      startedAt,
+		OpenFileDescriptors:    value.OpenFileDescriptors,
+		DirectChildProcesses:   value.DirectChildProcesses,
+		OwnerTargetFDSoftLimit: value.OwnerTargetFDSoftLimit,
+		EffectiveFDSoftLimit:   value.EffectiveFDSoftLimit,
+		FDUsagePercent:         value.FDUsagePercent,
+		OwnerState:             string(value.OwnerState),
+		ResourceState:          string(value.ResourceState),
+	}
 }
 
 func applyCodexAccount(status *runtimeAccountStatus, response runtimeAccountResponse) {

--- a/internal/httpapi/runtime_status_test.go
+++ b/internal/httpapi/runtime_status_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 )
 
@@ -94,6 +95,49 @@ func TestRuntimeStatusOverlaysLiveSharedDaemonMigrationMarker(t *testing.T) {
 	unknown := router.withLiveSharedDaemonMigrationStatus(cached)
 	if unknown.Runtimes[0].DaemonRestartRequired != nil {
 		t.Fatal("标记读取失败必须保持未知，不能授权迁移")
+	}
+}
+
+func TestRuntimeSharedDaemonDiagnosticsAreSanitized(t *testing.T) {
+	limit := 8192
+	effectiveLimit := 4096
+	usage := 12.5
+	startedAt := time.Date(2026, time.August, 14, 0, 20, 20, 0, time.UTC)
+	diagnostic := newRuntimeSharedDaemonStatus(appserver.SharedDaemonDiagnostics{
+		Supported:              true,
+		ListenerPID:            10306,
+		ListenerStartedAt:      startedAt,
+		OpenFileDescriptors:    1024,
+		DirectChildProcesses:   3,
+		OwnerTargetFDSoftLimit: &limit,
+		EffectiveFDSoftLimit:   &effectiveLimit,
+		FDUsagePercent:         &usage,
+		OwnerState:             appserver.SharedDaemonOwnerStateStable,
+		ResourceState:          appserver.SharedDaemonResourceStateHealthy,
+	})
+	if diagnostic.ListenerPID != 10306 || diagnostic.OpenFileDescriptors != 1024 ||
+		diagnostic.OwnerTargetFDSoftLimit == nil || *diagnostic.OwnerTargetFDSoftLimit != 8192 ||
+		diagnostic.EffectiveFDSoftLimit == nil || *diagnostic.EffectiveFDSoftLimit != 4096 ||
+		diagnostic.OwnerState != "stable" || diagnostic.ResourceState != "healthy" {
+		t.Fatalf("共享 daemon 诊断映射错误：%+v", diagnostic)
+	}
+	raw, err := json.Marshal(diagnostic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialized := string(raw)
+	for _, sensitive := range []string{"socket", "command", "environment", "/Users/tester"} {
+		if strings.Contains(strings.ToLower(serialized), strings.ToLower(sensitive)) {
+			t.Fatalf("runtime daemon 诊断不能泄露 %q：%s", sensitive, serialized)
+		}
+	}
+}
+
+func TestRuntimeSharedDaemonDiagnosticsFailureIsOmitted(t *testing.T) {
+	results := make(chan sharedDaemonDiagnosticsResult, 1)
+	results <- sharedDaemonDiagnosticsResult{err: fmt.Errorf("permission denied")}
+	if status := awaitRuntimeSharedDaemonDiagnostics(context.Background(), results); status != nil {
+		t.Fatalf("可选资源诊断失败时必须省略字段：%+v", status)
 	}
 }
 

--- a/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
@@ -43,13 +43,15 @@ extension AgentCommandClient {
             binary: URL,
             arguments: [String],
             allowFailure: Bool = false,
-            timeout: Duration = .seconds(15)
+            timeout: Duration = .seconds(15),
+            forceKillAfterTimeout: Bool = false
         ) async throws -> CommandResult {
             let result = try await executor.run(
                 executable: binary,
                 arguments: arguments,
                 timeout: timeout,
-                environment: environment
+                environment: environment,
+                forceKillAfterTimeout: forceKillAfterTimeout
             )
             if result.status != 0 && !allowFailure {
                 throw AgentClientError.commandFailed(
@@ -145,7 +147,10 @@ extension AgentCommandClient {
                 _ = try await execute(
                     binary: binary,
                     arguments: codexSharingRestartArguments(),
-                    timeout: .seconds(50)
+                    timeout: .seconds(50),
+                    // 迁移的 agentd 是短命 control CLI；超时后只回收它本身，
+                    // 不触碰共享 Codex daemon。其他通用命令保持普通 TERM 语义。
+                    forceKillAfterTimeout: true
                 )
             },
             setLANAccess: { enabled in

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -1,4 +1,5 @@
 @preconcurrency import Foundation
+import Darwin
 
 struct CommandResult: Equatable, Sendable {
     let status: Int32
@@ -53,7 +54,8 @@ actor ProcessExecutor {
         arguments: [String],
         timeout: Duration = .seconds(15),
         outputLimit: Int = 1_048_576,
-        environment: [String: String]? = nil
+        environment: [String: String]? = nil,
+        forceKillAfterTimeout: Bool = false
     ) async throws -> CommandResult {
         let process = Process()
         process.executableURL = executable
@@ -79,7 +81,15 @@ actor ProcessExecutor {
             try? await Task.sleep(for: timeout)
             guard !Task.isCancelled, process.isRunning else { return }
             timeoutState.set()
+            // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
+            // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
+            // “正在更新”。两秒后只强制回收这个短命 control CLI，不触碰共享
+            // Codex daemon；后端 marker/manual plist 仍保留，可安全重试。
             process.terminate()
+            guard forceKillAfterTimeout else { return }
+            try? await Task.sleep(for: .seconds(2))
+            guard process.isRunning else { return }
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
         }
 
         let status = await withTaskCancellationHandler {

--- a/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
@@ -114,4 +114,26 @@ final class AgentCommandClientTests: XCTestCase {
             "committed"
         )
     }
+
+    func testProcessTimeoutReapsControlCommandThatIgnoresTerminate() async {
+        let executor = ProcessExecutor()
+        let startedAt = ContinuousClock.now
+        do {
+            _ = try await executor.run(
+                executable: URL(filePath: "/bin/sh"),
+                arguments: ["-c", "trap '' TERM; while :; do sleep 1; done"],
+                timeout: .milliseconds(100),
+                forceKillAfterTimeout: true
+            )
+            XCTFail("忽略 SIGTERM 的 control command 必须超时")
+        } catch ProcessExecutorError.timedOut {
+            XCTAssertLessThan(
+                startedAt.duration(to: .now),
+                .seconds(4),
+                "timeout 后必须在 grace period 内回收 control command，不能让 UI 永久 busy"
+            )
+        } catch {
+            XCTFail("超时应保留 timedOut 语义，实际为 \(error)")
+        }
+    }
 }


### PR DESCRIPTION
## 目标

在保持单一共享 Codex App Server 的前提下，修复长时间运行后的 FD 资源耗尽，以及 Codex Desktop 无法挂载 Browser backend 的问题。

关联 Linear：MIM-158、MIM-159。

## 根因

- 共享 daemon 没有显式提升 `RLIMIT_NOFILE`，长时间运行后可能耗尽 FD，继而丢失 Browser / MCP 能力。
- `codex app-server daemon start` 会让 listener 脱离为 launchd 子进程，Browser 原生授权看到 `node_repl → codex → launchd`，无法验证完整的 OpenAI 签名父链。
- 首版 Node supervisor 使用多行 `node -e` 参数；plist XML 将换行写成 `&#xA;` 后，launchctl 只导入第一行，Node 会正常退出但不启动 App Server。

## 方案

- LaunchAgent 设置 soft `NumberOfFiles=8192`，并增加只读 FD/子进程诊断与 Doctor/API 状态。
- 使用 ChatGPT.app 内置、OpenAI 签名的 Node 作为持久 supervisor，前台托管官方 `codex app-server --listen unix://`。
- supervisor 参数改为编译期拼接的单行脚本，避免 launchctl 参数截断，并转发 TERM/INT/HUP；child 退出后 supervisor 同步退出，不做内部无限重启。
- 从真实 Unix socket peer 向上校验 Codex/Node 的路径、argv、UID、start time、父子关系、Developer ID、Team ID、identifier 与 hardened runtime。
- 保留两阶段迁移：普通 Ensure 不打断现有 listener；显式确认后才执行 stop → wait → reload → kickstart → handshake/signature validation → commit。
- 活跃 listener 期间禁止 bootout；失败保留 manual plist 与 pending marker，继续 fail closed。

## 用户影响

- Codex Desktop 与 Mimi Mac/iPhone/iPad 继续共用同一个 App Server 和会话数据。
- Codex Browser 恢复原生运行时身份，可在新会话和恢复会话中挂载并调用。
- LaunchAgent 的 FD soft limit 目标提升到 8192；Doctor/API 展示真实 FD 数，但不会把无法独立读取的当前进程 RLIMIT 冒充为已验证值，也不使用高水位自动重启打断活跃连接。

## 验证

- `git diff --check origin/main...HEAD`
- `go test ./... -count=1`
- `go vet ./...`
- `xcodebuild test -project macos/MimiRemoteMac/MimiRemoteMac.xcodeproj -scheme MimiRemoteMac -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/mim159-pr-deriveddata CODE_SIGNING_ALLOWED=NO`
  - 101 tests，0 failures
- Build 22 深度 codesign 与本机安装验证通过。
- 真实 Browser E2E：打开 `https://example.com/` 并读取 `Example Domain`。
- Browser 调用后共享 listener FD 约 `72`；Doctor 总体通过，资源项明确展示“owner 目标 8192、当前进程未验证”，不再制造无法消除的 WARN。
- iPhone 实际回归：config/version/status/capabilities 返回 200，App Server WebSocket 返回 101。
- 审查回归：文档已统一为 launchd 直接托管前台 Node supervisor；Darwin 退出阶段的瞬时 EIO 会继续轮询；验签超时同时保留最后一次真实 `codesign` 错误。

## 风险与边界

- 依赖 ChatGPT.app 内置 Node/Codex 的路径与签名身份；上游发生不兼容变化时会进入 pending，而不是运行未知二进制。
- 显式迁移或 daemon 重启会断开现有 WebSocket，客户端需要重连。
- 共享 App Server 不会自动把 Mimi 变成 Codex Desktop 的插件宿主；Desktop 专属 Browser/Connector 授权仍由 Codex Desktop 管理。
