### PR TITLE
MIM-160 修复新版 app-server 下自动审批无法发送

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -90,7 +90,9 @@ fn claude_permission_mode(params: &p::TurnStartParams) -> &'static str {
     if params.sandbox_policy.as_ref().is_some_and(is_read_only) {
         return "plan";
     }
-    if matches!(params.approval_policy, Some(p::AskForApproval::OnFailure))
+    // 新版客户端用 on-request + auto_review 表示自动审批；旧的 on-failure
+    // 已从 Codex 协议移除，不能再作为 Claude 自动权限模式的触发条件。
+    if matches!(params.approval_policy, Some(p::AskForApproval::OnRequest))
         && matches!(
             params.approvals_reviewer,
             Some(p::ApprovalsReviewer::AutoReview)
@@ -1549,9 +1551,12 @@ mod tests {
         assert_eq!(claude_permission_mode(&params), "plan");
 
         params.sandbox_policy = Some(serde_json::json!({"type": "workspaceWrite"}));
-        params.approval_policy = Some(p::AskForApproval::OnFailure);
+        params.approval_policy = Some(p::AskForApproval::OnRequest);
         params.approvals_reviewer = Some(p::ApprovalsReviewer::AutoReview);
         assert_eq!(claude_permission_mode(&params), "auto");
+
+        params.approval_policy = Some(p::AskForApproval::OnFailure);
+        assert_eq!(claude_permission_mode(&params), "default");
 
         params.approval_policy = Some(p::AskForApproval::Never);
         assert_eq!(claude_permission_mode(&params), "default");

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -77,7 +77,7 @@ agentd restart --no-pair
 
 - 官方 daemon 冷启动需要 `$CODEX_HOME/packages/standalone/current/codex`。已有健康 socket 但 standalone 缺失时，启用操作也会阻断，避免本次看似成功、Mac 重启后 agentd 持续拉起失败；Mimi Remote 不会静默执行 `curl | sh`，只给出官方安装指引。
 - 共享架构把两端的会话一致性放在同一个官方 app-server 上，因此该 server 自身崩溃时 Codex Desktop 与 Mimi 会同时短暂失去后端。稳定 owner 只在 server 已不可连时尝试恢复它，不会为了恢复而退出或重开 Codex Desktop。
-- Desktop 必须支持 local daemon，当前最低兼容 app-server 版本为 `0.141.0`。版本、socket 类型、目录权限、socket 权限和返回的 `codexHome` 都会在启用前校验。
+- Desktop 必须支持 local daemon，当前最低启动基线仍为 app-server `0.141.0`。这个版本检查只证明共享 daemon transport 可用，不代表更高版本的每个协议枚举都向后兼容；客户端请求仍必须跟随当前 app-server schema。发布回归至少覆盖 `0.141.x` 基线和当前支持版本，自动审批固定使用 `approvalPolicy=on-request`、`approvalsReviewer=auto_review` 与 `workspaceWrite`，不再发送已删除的 `on-failure`。版本、socket 类型、目录权限、socket 权限和返回的 `codexHome` 都会在启用前校验。
 - Desktop 的自定义 CLI、强制 CLI 或资源覆盖可能让它回退到独立 stdio。Mac App 会确认 agentd 已连接共享 daemon，并明确要求完全重启 Desktop；Desktop 是否采用 daemon 仍要通过下面的跨端验收验证，不能只根据环境变量推断成功。
 - 稳定 LaunchAgent 的 `PATH` 会固定 Apple Silicon / Intel Homebrew 与系统工具目录，并在首次安装时追加调用进程可见的绝对用户工具目录；相对路径会被拒绝。之后 resident agentd 会复用已安装值，避免 MCP/plugin 路径随启动入口反复变化；需要完全自定义时可显式配置 `codex.env.PATH`。
 - 为了让 Dock / Finder 启动同样生效，Mac App 使用当前 GUI 用户的 `launchctl` 环境。它只管理自己写入的两个官方键，并用第三个随机 marker 区分当前登录会话的 ownership；禁用时仅在三者仍匹配时恢复原值。agentd 启动 Codex 子进程时会过滤 Desktop 专属 transport 开关与 marker，`CODEX_HOME` 则刻意保持一致。该设置不会默认开启。

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -466,7 +466,7 @@ func (r *Router) appServerChannels(req *http.Request) []appServerChannel {
 			ExternalActivity: true,
 		},
 		Policy: appServerChannelPolicy{
-			ApprovalPolicies: []string{"on-request", "on-failure"},
+			ApprovalPolicies: []string{"on-request"},
 			SandboxModes:     []string{"read-only", "workspace-write", "danger-full-access"},
 			NetworkAccess:    false,
 			CWDScope:         "agentd_allowlist",
@@ -510,7 +510,7 @@ func (r *Router) appServerChannels(req *http.Request) []appServerChannel {
 				RateLimits:       claudeRateLimitsAvailable,
 			},
 			Policy: appServerChannelPolicy{
-				ApprovalPolicies: []string{"on-request", "on-failure"},
+				ApprovalPolicies: []string{"on-request"},
 				SandboxModes:     []string{"read-only", "workspace-write"},
 				NetworkAccess:    false,
 				CWDScope:         "agentd_allowlist",

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -1150,8 +1150,9 @@ func sanitizedGatewayThreadParams(runtimeID string, method string, params map[st
 			safe["initialTurnsPage"] = sanitizedGatewayInitialTurnsPage(page)
 		}
 	}
-	safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params)
 	safe["sandbox"] = sanitizedGatewayThreadSandbox(runtimeID, params)
+	workspaceWrite := normalizePolicyValue(safe["sandbox"].(string)) == "workspacewrite"
+	safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params, workspaceWrite)
 	return safe
 }
 
@@ -1198,8 +1199,10 @@ func sanitizedGatewayTurnParams(runtimeID string, params map[string]any, cwd str
 	if collaborationMode, ok := sanitizedGatewayCollaborationMode(params["collaborationMode"]); ok {
 		safe["collaborationMode"] = collaborationMode
 	}
-	safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params)
 	safe["sandboxPolicy"] = sanitizedGatewaySandboxPolicy(runtimeID, params["sandboxPolicy"], cwd)
+	sandboxPolicy := safe["sandboxPolicy"].(map[string]any)
+	workspaceWrite := normalizePolicyValue(sandboxPolicy["type"].(string)) == "workspacewrite"
+	safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params, workspaceWrite)
 	// 默认模型必须交给 app-server 按账号 rollout 决定；gateway 只透传用户显式选择的 model。
 	if effort, ok := gatewayStringParam(safe, "effort"); !ok || strings.TrimSpace(effort) == "" {
 		safe["effort"] = defaultCodexReasoningEffort
@@ -1371,13 +1374,14 @@ func sanitizedGatewayCollaborationMode(raw any) (map[string]any, bool) {
 	}, true
 }
 
-func sanitizedGatewayApproval(params map[string]any) (string, string) {
+func sanitizedGatewayApproval(params map[string]any, workspaceWrite bool) (string, string) {
 	policy, _ := gatewayStringParam(params, "approvalPolicy")
 	reviewer, _ := gatewayStringParam(params, "approvalsReviewer")
-	// 移动端只放行一个有限自动审批组合：失败时交给 auto_review。
+	// 自动审批只允许在归一化后的 workspace-write 沙盒中生效。审批与沙盒在这里强绑定，
+	// 防止已认证客户端拼出 auto_review + danger-full-access 绕过用户确认。
 	// never / networkAccess 仍由 validateGatewayPolicyParams 统一拦截。
-	if normalizePolicyValue(policy) == "onfailure" && reviewer == "auto_review" {
-		return "on-failure", reviewer
+	if workspaceWrite && normalizePolicyValue(policy) == "onrequest" && reviewer == "auto_review" {
+		return "on-request", reviewer
 	}
 	return "on-request", "user"
 }

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -598,11 +598,11 @@ func TestAppServerGatewayRewritesMissingSafeDefaults(t *testing.T) {
 	}
 	gotTurnStart := readUpstreamFrame(t, received)
 	turnParams := decodeGatewayParamsForTest(t, gotTurnStart)
-	if turnParams["approvalPolicy"] != "on-failure" {
-		t.Fatalf("turn/start 应保留安全自动审批 approvalPolicy=on-failure：%s", gotTurnStart)
+	if turnParams["approvalPolicy"] != "on-request" {
+		t.Fatalf("turn/start 应把旧 approvalPolicy 安全降级为 on-request：%s", gotTurnStart)
 	}
-	if turnParams["approvalsReviewer"] != "auto_review" {
-		t.Fatalf("turn/start 应保留安全自动审批 approvalsReviewer=auto_review：%s", gotTurnStart)
+	if turnParams["approvalsReviewer"] != "user" {
+		t.Fatalf("turn/start 旧 approvalPolicy 不应继续携带 auto_review：%s", gotTurnStart)
 	}
 	if turnParams["effort"] != "xhigh" {
 		t.Fatalf("turn/start 应补默认推理强度：%s", gotTurnStart)
@@ -629,14 +629,33 @@ func TestAppServerGatewayRewritesMissingSafeDefaults(t *testing.T) {
 	if _, ok := sandbox["writableRoots"]; ok {
 		t.Fatalf("dangerFullAccess 默认不应携带 writableRoots：%v", sandbox)
 	}
+
+	autoTurnStart := []byte(fmt.Sprintf(
+		`{"id":52,"method":"turn/start","params":{"threadId":"thread-safe-default","cwd":%q,"input":[{"type":"text","text":"auto"}],"approvalPolicy":"on-request","approvalsReviewer":"auto_review","sandboxPolicy":{"type":"workspaceWrite","writableRoots":[%q],"networkAccess":false}}}`,
+		projectDir,
+		projectDir,
+	))
+	if err := conn.WriteMessage(websocket.TextMessage, autoTurnStart); err != nil {
+		t.Fatal(err)
+	}
+	gotAutoTurnStart := readUpstreamFrame(t, received)
+	autoTurnParams := decodeGatewayParamsForTest(t, gotAutoTurnStart)
+	if autoTurnParams["approvalPolicy"] != "on-request" || autoTurnParams["approvalsReviewer"] != "auto_review" {
+		t.Fatalf("turn/start 应保留 workspaceWrite 内的安全自动审批组合：%s", gotAutoTurnStart)
+	}
+	autoSandbox, ok := autoTurnParams["sandboxPolicy"].(map[string]any)
+	if !ok || autoSandbox["type"] != "workspaceWrite" || autoSandbox["networkAccess"] != false {
+		t.Fatalf("自动审批必须保持 workspaceWrite 且禁用网络：%v", autoTurnParams["sandboxPolicy"])
+	}
 }
 
 func TestSanitizedGatewayApprovalAllowsOnlySafeAutoReview(t *testing.T) {
 	tests := []struct {
-		name         string
-		params       map[string]any
-		wantPolicy   string
-		wantReviewer string
+		name           string
+		params         map[string]any
+		workspaceWrite bool
+		wantPolicy     string
+		wantReviewer   string
 	}{
 		{
 			name:         "default",
@@ -647,36 +666,116 @@ func TestSanitizedGatewayApprovalAllowsOnlySafeAutoReview(t *testing.T) {
 		{
 			name: "safe auto review",
 			params: map[string]any{
+				"approvalPolicy":    "on-request",
+				"approvalsReviewer": "auto_review",
+			},
+			workspaceWrite: true,
+			wantPolicy:     "on-request",
+			wantReviewer:   "auto_review",
+		},
+		{
+			name: "legacy auto review falls back",
+			params: map[string]any{
 				"approvalPolicy":    "on-failure",
 				"approvalsReviewer": "auto_review",
 			},
-			wantPolicy:   "on-failure",
-			wantReviewer: "auto_review",
+			workspaceWrite: true,
+			wantPolicy:     "on-request",
+			wantReviewer:   "user",
 		},
 		{
 			name: "reviewer alone is not enough",
 			params: map[string]any{
 				"approvalsReviewer": "auto_review",
 			},
-			wantPolicy:   "on-request",
-			wantReviewer: "user",
+			workspaceWrite: true,
+			wantPolicy:     "on-request",
+			wantReviewer:   "user",
 		},
 		{
 			name: "unknown reviewer falls back",
 			params: map[string]any{
-				"approvalPolicy":    "on-failure",
+				"approvalPolicy":    "on-request",
 				"approvalsReviewer": "somebody_else",
 			},
-			wantPolicy:   "on-request",
-			wantReviewer: "user",
+			workspaceWrite: true,
+			wantPolicy:     "on-request",
+			wantReviewer:   "user",
+		},
+		{
+			name: "auto review cannot escape workspace sandbox",
+			params: map[string]any{
+				"approvalPolicy":    "on-request",
+				"approvalsReviewer": "auto_review",
+			},
+			workspaceWrite: false,
+			wantPolicy:     "on-request",
+			wantReviewer:   "user",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPolicy, gotReviewer := sanitizedGatewayApproval(tt.params)
+			gotPolicy, gotReviewer := sanitizedGatewayApproval(tt.params, tt.workspaceWrite)
 			if gotPolicy != tt.wantPolicy || gotReviewer != tt.wantReviewer {
 				t.Fatalf("got %s/%s, want %s/%s", gotPolicy, gotReviewer, tt.wantPolicy, tt.wantReviewer)
+			}
+		})
+	}
+}
+
+func TestGatewayAutoReviewRequiresWorkspaceWriteSandbox(t *testing.T) {
+	tests := []struct {
+		name          string
+		threadSandbox string
+		turnSandbox   string
+		wantReviewer  string
+	}{
+		{
+			name:          "workspace write keeps auto review",
+			threadSandbox: "workspace-write",
+			turnSandbox:   "workspaceWrite",
+			wantReviewer:  "auto_review",
+		},
+		{
+			name:          "read only requires user review",
+			threadSandbox: "read-only",
+			turnSandbox:   "readOnly",
+			wantReviewer:  "user",
+		},
+		{
+			name:          "full access requires user review",
+			threadSandbox: "danger-full-access",
+			turnSandbox:   "dangerFullAccess",
+			wantReviewer:  "user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, method := range []string{"thread/start", "thread/resume", "thread/fork"} {
+				threadParams := sanitizedGatewayThreadParams("codex", method, map[string]any{
+					"threadId":          "thread-safe",
+					"approvalPolicy":    "on-request",
+					"approvalsReviewer": "auto_review",
+					"sandbox":           tt.threadSandbox,
+				})
+				if threadParams["approvalPolicy"] != "on-request" || threadParams["approvalsReviewer"] != tt.wantReviewer {
+					t.Fatalf("%s 审批组合异常：%v", method, threadParams)
+				}
+			}
+
+			turnParams := sanitizedGatewayTurnParams("codex", map[string]any{
+				"threadId":          "thread-safe",
+				"approvalPolicy":    "on-request",
+				"approvalsReviewer": "auto_review",
+				"sandboxPolicy": map[string]any{
+					"type":          tt.turnSandbox,
+					"networkAccess": false,
+				},
+			}, "/tmp/project")
+			if turnParams["approvalPolicy"] != "on-request" || turnParams["approvalsReviewer"] != tt.wantReviewer {
+				t.Fatalf("turn/start 审批组合异常：%v", turnParams)
 			}
 		})
 	}
@@ -981,9 +1080,9 @@ func TestAppServerGatewaySanitizesParamsForAllAllowedMethods(t *testing.T) {
 		threadStartParams["serviceTier"] != "priority" ||
 		threadStartParams["personality"] != "friendly" ||
 		threadStartParams["approvalPolicy"] != "on-request" ||
-		threadStartParams["approvalsReviewer"] != "user" ||
+		threadStartParams["approvalsReviewer"] != "auto_review" ||
 		threadStartParams["sandbox"] != "workspace-write" {
-		t.Fatalf("thread/start 应过滤线程级模型并保留安全参数：%v", threadStartParams)
+		t.Fatalf("thread/start 应过滤线程级模型并保留安全自动审批参数：%v", threadStartParams)
 	}
 
 	threadList := []byte(fmt.Sprintf(

--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -556,10 +556,32 @@ private enum CodexAppServerDefaults {
 
 enum CodexAppServerApprovalPolicy: String, Codable, CaseIterable, Hashable, Identifiable {
     case untrusted
-    case onFailure = "on-failure"
     case onRequest = "on-request"
 
     var id: String { rawValue }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        switch rawValue {
+        case Self.untrusted.rawValue:
+            self = .untrusted
+        case Self.onRequest.rawValue, "on-failure":
+            // 旧版 Mimi 会把自动审批持久化为 on-failure。新版 app-server 已删除该值，
+            // 因此只在本地解码时迁移，任何后续持久化和请求都统一写回 on-request。
+            self = .onRequest
+        default:
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported approval policy: \(rawValue)"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
 }
 
 enum CodexAppServerSandboxMode: String, Codable, CaseIterable, Hashable, Identifiable {
@@ -761,7 +783,7 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
         if sanitized.sandboxMode == .readOnly {
             sanitized.approvalPolicy = .onRequest
             sanitized.approvalsReviewer = "user"
-        } else if sanitized.approvalPolicy == .onFailure, reviewer == "auto_review" {
+        } else if sanitized.approvalPolicy == .onRequest, reviewer == "auto_review" {
             sanitized.sandboxMode = .workspaceWrite
             sanitized.approvalsReviewer = "auto_review"
         } else {
@@ -785,7 +807,7 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
             approvalsReviewer = "user"
             return
         }
-        if approvalPolicy == .onFailure, reviewer == "auto_review" {
+        if approvalPolicy == .onRequest, reviewer == "auto_review" {
             approvalsReviewer = reviewer
             sandboxMode = .workspaceWrite
             return

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -365,7 +365,7 @@ enum ComposerPermissionMode: String, CaseIterable, Identifiable {
             self = .readOnly
         } else if options.sandboxMode == .dangerFullAccess {
             self = .fullAccess
-        } else if options.approvalPolicy == .onFailure, reviewer == Self.autoReviewer {
+        } else if options.approvalPolicy == .onRequest, reviewer == Self.autoReviewer {
             self = .autoApprove
         } else {
             self = .requestApproval
@@ -426,10 +426,8 @@ enum ComposerPermissionMode: String, CaseIterable, Identifiable {
 
     var approvalPolicy: CodexAppServerApprovalPolicy {
         switch self {
-        case .requestApproval, .readOnly, .fullAccess:
+        case .requestApproval, .readOnly, .autoApprove, .fullAccess:
             return .onRequest
-        case .autoApprove:
-            return .onFailure
         }
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -806,6 +806,55 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(decoded.modelSelectionPolicy, .catalogOnly)
     }
 
+    func testTurnOptionsMigratesLegacyAutoApprovalAndWritesCurrentProtocolValue() throws {
+        let legacy = Data(#"{"approval_policy":"on-failure","approvals_reviewer":"auto_review","sandbox_mode":"workspaceWrite","network_access":false}"#.utf8)
+        let decoded = try JSONDecoder().decode(CodexAppServerTurnOptions.self, from: legacy)
+
+        XCTAssertEqual(decoded.approvalPolicy, .onRequest)
+        XCTAssertEqual(decoded.approvalsReviewer, "auto_review")
+        XCTAssertEqual(decoded.sandboxMode, .workspaceWrite)
+
+        let encoded = try JSONEncoder().encode(decoded)
+        let persisted = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        XCTAssertEqual(persisted["approval_policy"] as? String, "on-request")
+        XCTAssertEqual(persisted["approvals_reviewer"] as? String, "auto_review")
+        XCTAssertEqual(persisted["sandbox_mode"] as? String, "workspaceWrite")
+
+        let project = AgentProject(id: "repo", name: "Repo", path: "/Users/me/repo")
+        let builder = CodexAppServerRequestBuilder(allowlistedProjects: [project])
+        let threadRequest = try builder.threadStart(projectID: project.id, options: decoded)
+        let threadParams = try XCTUnwrap(threadRequest.params?.objectValue)
+        XCTAssertEqual(threadParams["approvalPolicy"]?.stringValue, "on-request")
+        XCTAssertEqual(threadParams["approvalsReviewer"]?.stringValue, "auto_review")
+        XCTAssertEqual(threadParams["sandbox"]?.stringValue, "workspace-write")
+
+        let request = try builder.turnStart(
+            threadID: "thread-legacy",
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "迁移后发送", options: decoded)
+        )
+        let params = try XCTUnwrap(request.params?.objectValue)
+        XCTAssertEqual(params["approvalPolicy"]?.stringValue, "on-request")
+        XCTAssertEqual(params["approvalsReviewer"]?.stringValue, "auto_review")
+        let sandbox = try XCTUnwrap(params["sandboxPolicy"]?.objectValue)
+        XCTAssertEqual(sandbox["type"]?.stringValue, "workspaceWrite")
+        XCTAssertEqual(sandbox["networkAccess"]?.boolValue, false)
+    }
+
+    func testApprovalPolicyRejectsUnsupportedPersistedValues() {
+        for value in ["never", "granular", "unknown"] {
+            XCTAssertThrowsError(
+                try JSONDecoder().decode(
+                    CodexAppServerApprovalPolicy.self,
+                    from: Data("\"\(value)\"".utf8)
+                ),
+                "Mimi 不应静默接受未开放的审批策略：\(value)"
+            )
+        }
+    }
+
     func testTurnStartBuilderUsesDefaultCollaborationModeForGoalTurns() throws {
         let project = AgentProject(id: "repo", name: "Repo", path: "/Users/me/repo")
         let builder = CodexAppServerRequestBuilder(allowlistedProjects: [project])
@@ -860,7 +909,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         options.serviceTier = "priority"
         options.reasoningEffort = .high
         options.reasoningSummary = .detailed
-        options.approvalPolicy = .onFailure
+        options.approvalPolicy = .onRequest
         options.sandboxMode = .readOnly
         options.personality = .friendly
         options.config = .object(["feature": .bool(true)])
@@ -876,7 +925,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(threadParams["model"]?.stringValue, "gpt-5-codex")
         XCTAssertEqual(threadParams["modelProvider"]?.stringValue, "openai")
         XCTAssertEqual(threadParams["serviceTier"]?.stringValue, "priority")
-        XCTAssertEqual(threadParams["approvalPolicy"]?.stringValue, "on-failure")
+        XCTAssertEqual(threadParams["approvalPolicy"]?.stringValue, "on-request")
         XCTAssertEqual(threadParams["sandbox"]?.stringValue, "read-only")
         XCTAssertEqual(threadParams["config"]?.objectValue?["feature"]?.boolValue, true)
         XCTAssertEqual(threadParams["baseInstructions"]?.stringValue, "base")
@@ -898,7 +947,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(turnParams["serviceTier"]?.stringValue, "priority")
         XCTAssertEqual(turnParams["effort"]?.stringValue, "high")
         XCTAssertEqual(turnParams["summary"]?.stringValue, "detailed")
-        XCTAssertEqual(turnParams["approvalPolicy"]?.stringValue, "on-failure")
+        XCTAssertEqual(turnParams["approvalPolicy"]?.stringValue, "on-request")
         XCTAssertEqual(turnParams["clientUserMessageId"]?.stringValue, "client-rich")
         XCTAssertNil(turnParams["modelProvider"])
         XCTAssertNil(turnParams["runtimeProvider"])

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -190,7 +190,7 @@ extension ConversationDataFlowTests {
         composerState.turnOptions.reasoningEffort = .high
         composerState.turnOptions.reasoningSummary = .detailed
         composerState.turnOptions.personality = .friendly
-        composerState.turnOptions.approvalPolicy = .onFailure
+        composerState.turnOptions.approvalPolicy = .onRequest
         composerState.turnOptions.approvalsReviewer = "auto_review"
         composerState.turnOptions.sandboxMode = .readOnly
         composerState.turnOptions.networkAccess = true
@@ -242,7 +242,7 @@ extension ConversationDataFlowTests {
         ))
         let options = submitted.payload.options
 
-        XCTAssertEqual(options.approvalPolicy, .onFailure)
+        XCTAssertEqual(options.approvalPolicy, .onRequest)
         XCTAssertEqual(options.approvalsReviewer, "auto_review")
         XCTAssertEqual(options.sandboxMode, .workspaceWrite)
         XCTAssertFalse(options.networkAccess)
@@ -362,7 +362,7 @@ extension ConversationDataFlowTests {
         let cases: [(mode: ComposerPermissionMode, policy: CodexAppServerApprovalPolicy, reviewer: String, sandbox: CodexAppServerSandboxMode)] = [
             (.readOnly, .onRequest, "user", .readOnly),
             (.requestApproval, .onRequest, "user", .workspaceWrite),
-            (.autoApprove, .onFailure, "auto_review", .workspaceWrite),
+            (.autoApprove, .onRequest, "auto_review", .workspaceWrite),
             (.fullAccess, .onRequest, "user", .dangerFullAccess)
         ]
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -3045,7 +3045,7 @@ final class ConversationDataFlowTests: XCTestCase {
 
         composerState.applyPermissionMode(.autoApprove)
         XCTAssertEqual(composerState.permissionMode, .autoApprove)
-        XCTAssertEqual(composerState.turnOptions.approvalPolicy, .onFailure)
+        XCTAssertEqual(composerState.turnOptions.approvalPolicy, .onRequest)
         XCTAssertEqual(composerState.turnOptions.approvalsReviewer, "auto_review")
         XCTAssertEqual(composerState.turnOptions.sandboxMode, .workspaceWrite)
         XCTAssertFalse(composerState.turnOptions.networkAccess)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
@@ -2031,7 +2031,7 @@ extension ConversationDataFlowTests {
         options.modelProvider = "openai"
         options.serviceTier = "priority"
         options.reasoningEffort = .high
-        options.approvalPolicy = .onFailure
+        options.approvalPolicy = .onRequest
         options.sandboxMode = .readOnly
         options.baseInstructions = "base"
         options.developerInstructions = "dev"
@@ -2064,7 +2064,7 @@ extension ConversationDataFlowTests {
         XCTAssertNil(threadParams["model"]?.stringValue)
         XCTAssertNil(threadParams["modelProvider"])
         XCTAssertEqual(threadParams["serviceTier"]?.stringValue, "priority")
-        XCTAssertEqual(threadParams["approvalPolicy"]?.stringValue, "on-failure")
+        XCTAssertEqual(threadParams["approvalPolicy"]?.stringValue, "on-request")
         XCTAssertEqual(threadParams["sandbox"]?.stringValue, "read-only")
         XCTAssertEqual(threadParams["baseInstructions"]?.stringValue, "base")
         XCTAssertEqual(threadParams["developerInstructions"]?.stringValue, "dev")
@@ -2079,7 +2079,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(turnParams["model"]?.stringValue, "gpt-5.1-codex")
         XCTAssertEqual(turnParams["serviceTier"]?.stringValue, "priority")
         XCTAssertEqual(turnParams["effort"]?.stringValue, "high")
-        XCTAssertEqual(turnParams["approvalPolicy"]?.stringValue, "on-failure")
+        XCTAssertEqual(turnParams["approvalPolicy"]?.stringValue, "on-request")
         XCTAssertNil(turnParams["modelProvider"])
         XCTAssertNil(turnParams["baseInstructions"])
         let input = try XCTUnwrap(turnParams["input"]?.arrayValue)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -1256,7 +1256,7 @@ extension ConversationDataFlowTests {
         var options = CodexAppServerTurnOptions.default
         options.model = "gpt-5-codex"
         options.serviceTier = "priority"
-        options.approvalPolicy = .onFailure
+        options.approvalPolicy = .onRequest
         let payload = CodexAppServerTurnPayload(input: [
             .text("分析截图"),
             .image(url: "data:image/png;base64,AA==", detail: .high),
@@ -1273,7 +1273,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(sent.input, payload.input)
         XCTAssertEqual(sent.turnOptions.model, "gpt-5-codex")
         XCTAssertEqual(sent.turnOptions.serviceTier, "priority")
-        XCTAssertEqual(sent.turnOptions.approvalPolicy, .onFailure)
+        XCTAssertEqual(sent.turnOptions.approvalPolicy, .onRequest)
 
         client.resolveCreate(with: .success(try makeCreateSessionResponse(session: created)))
         let accepted = await sendTask.value


### PR DESCRIPTION
## 目标

修复新版 Codex app-server 删除 `approvalPolicy=on-failure` 后，Mimi iOS 选择“自动审批”无法发送消息的问题。

Linear：MIM-160

## 根因

- iOS 仍把自动审批序列化为 `on-failure`，Codex app-server `0.143.0+` 会在解析 `thread/start` / `turn/start` 时拒绝该枚举。
- agentd gateway 同样只识别旧的 `on-failure + auto_review` 组合；即使 iOS 单独修正，也会被 gateway 降级成用户审批。

## 改动

- 自动审批统一使用 `on-request + auto_review + workspaceWrite`，继续强制 `networkAccess=false`。
- 旧本地 `on-failure` 仅在解码时迁移，重新持久化和请求不再输出旧值。
- iOS 对 `never`、`granular` 和未知审批策略保持 fail-closed。
- gateway 能力声明移除 `on-failure`，旧客户端请求安全降级为 `on-request + user`。
- gateway 将 `auto_review` 与最终归一化后的 `workspace-write` 强绑定；只读和完整访问必须由用户审批。
- 更新协议、运行流、安全边界测试及 app-server 版本兼容说明。

## 用户影响

- 新版 app-server 下选择“自动审批”可以正常创建会话并发送消息。
- 自动审批仍限制在当前工作区，不扩大网络或完整文件系统权限。

## 验证

- `git diff --check`
- `go test ./internal/httpapi`：通过（54.000s）
- 相关 5 个 Swift 测试套件：856 tests，3 skipped，0 failures
- `CodexAppServerProtocolTests`：81 tests，3 skipped，0 failures
- 独立权限边界复审：`ship`，无阻断 / 高 / 中严重度发现

全量 iOS 回归的协议、数据流和运行流测试通过；另有 15 个视觉快照测试在 iOS 27 / Xcode 27 Beta 下与既有图片基线不匹配，本 PR 未修改 UI。

## 残余风险

尚未用真实 app-server `0.141.x` 与当前支持版本分别完成经 agentd 的跨版本端到端自动审批联调。
