### PR TITLE
MIM-158 提升共享 Codex daemon FD 上限并增加资源诊断

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -21,7 +21,10 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: macos-26
-    timeout-minutes: 20
+    # GitHub 的全新 macOS runner 首次编译 Swift、Go 与 Rust bridge 已连续两次
+    # 超过 20 分钟；本地增量构建不能代表 CI 冷构建耗时。保留有限上限，同时
+    # 给完整 Scheme 测试足够的收尾时间。
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -21,10 +21,9 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: macos-26
-    # GitHub 的全新 macOS runner 首次编译 Swift、Go 与 Rust bridge 已连续两次
-    # 超过 20 分钟；本地增量构建不能代表 CI 冷构建耗时。保留有限上限，同时
-    # 给完整 Scheme 测试足够的收尾时间。
-    timeout-minutes: 35
+    # Debug 门禁复用 DerivedData 内缓存，且不再误用 Cargo release profile；
+    # 15 分钟为冷 runner 保留充足余量，同时避免异常构建再次黑盒等待半小时。
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -44,4 +43,7 @@ jobs:
       - name: Build and test Mac App
         env:
           MACOS_DERIVED_DATA_PATH: ${{ runner.temp }}/MimiRemoteMacDerivedData
+          # Build phase 总是执行；把 Go/Rust 增量产物放到 runner 临时目录，
+          # 同一 job 内可复用且不会污染 checkout。脚本仍会按配置/架构隔离。
+          MACOS_EMBED_CACHE_DIR: ${{ runner.temp }}/MimiRemoteMacEmbedCache
         run: bash ./scripts/test-macos-app.sh

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -47,7 +47,7 @@ Mac App 的“Codex Desktop → 共享本地 app-server 会话”会按以下顺
 
 Mac App 执行迁移的短命 `agentd` 控制命令有明确超时。超时后先发送普通 `SIGTERM`，两秒仍未退出才只回收该 control CLI；不会因此向共享 Codex daemon 发送 `SIGKILL`。manual plist 与迁移 marker 会继续保留，设置页退出“正在更新”并显示可重试错误，避免控制命令异常时无限卡住。
 
-`runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
+`runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。稳定 owner 的这一未知项作为正常信息展示，不制造无法消除的 WARN；将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
 
 官方 `daemon start` 完成 detached listener 交接后，部分版本仍报告 `pid` backend，但不会继续返回 listener PID。只有 stable owner 已提交、socket 路径一致且 backend 仍为 `pid` 时，才标记为 `owner_claimed_unverified` warning；缺少 backend 的旧 SSH/CLI listener 仍视为 unmanaged。该 warning 既不把当前 listener 误报为已验证 stable，也不把 owner 的目标上限当成 listener 已实际继承。
 

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -49,6 +49,8 @@ Mac App 执行迁移的短命 `agentd` 控制命令有明确超时。超时后�
 
 `runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
 
+官方 `daemon start` 完成 detached listener 交接后，部分版本仍报告 `pid` backend，但不会继续返回 listener PID。只有 stable owner 已提交、socket 路径一致且 backend 仍为 `pid` 时，才标记为 `owner_claimed_unverified` warning；缺少 backend 的旧 SSH/CLI listener 仍视为 unmanaged。该 warning 既不把当前 listener 误报为已验证 stable，也不把 owner 的目标上限当成 listener 已实际继承。
+
 移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；对 app-server 发给客户端的审批、补充输入和 MCP elicitation，移动端返回的反向 JSON-RPC response 也执行相同 guard，拒绝时保留 pending request 并恢复移动端卡片。`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读、观测器缺失或反向 request 缺少 thread scope 时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
 
 命令行等价操作：

--- a/docs/codex-shared-daemon.md
+++ b/docs/codex-shared-daemon.md
@@ -37,13 +37,17 @@ Desktop 使用官方 `CODEX_APP_SERVER_USE_LOCAL_DAEMON=1` 开关连接 Unix Soc
 Mac App 的“Codex Desktop → 共享本地 app-server 会话”会按以下顺序执行：
 
 1. 使用配置中的同一 `CODEX_HOME` 探测官方 Unix Socket；已有 listener 必须完成 `initialize` / `initialized` 握手，stale socket 文件不算就绪；
-2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；此时绝不启动新 Unix daemon；
+2. 先把 `com.gaixianggeng.mimi.codex-shared-daemon` 用户 LaunchAgent 准备成 `RunAtLoad=false` 的 manual owner。`ProgramArguments` 直接执行官方 `codex app-server daemon start`，不经过 shell，也不托管自定义 daemon；job 显式设置 `SoftResourceLimits/NumberOfFiles=8192`，避免用户域 launchd 常见的 256 soft limit 让长期共享 daemon 同时丢失 Browser、Skills、MCP、Shell 与网络能力；不覆盖 hard limit。此时绝不启动新 Unix daemon；
 3. 验证官方 standalone 可执行文件与 daemon lifecycle 冷启动能力。全新启用还会写入私有 durable intent；任一提交前条件不完整都直接失败并清理本次 owner，配置与 Desktop 环境均不修改；
 4. 在 shared-daemon 操作锁内再次复核同一份原始配置，并用所有 Mimi 配置写入者共用的跨进程 CAS 锁，原子保存当前 `app_server` transport 为 `shared_fallback`、再切换到 `unix://`。只有配置 rename 已成功且启用前没有旧 listener，manual job 才会显式 `kickstart` 并校验完整协议、官方 pid backend、`CODEX_HOME`、standalone 路径和版本；即使冷启动全部通过，也继续保留 marker 与 `RunAtLoad=false`，因为 kickstart 与 socket 建立之间不能原子证明是谁赢得 listener。durable intent 只用于恢复“rename 已完成但首次冷启动尚未完成”的崩溃窗口，第一次完整 managed 校验通过后立即消费，不能被后续普通 recovery 重用。首次启用和接管既有 listener 都必须经过第 7 步的用户确认，才清 marker 并提升为 `RunAtLoad=true`。配置提交后的启动失败会作为“已提交、待恢复”结果返回，Mac App 会重新加载状态；若进程在 rename 与 kickstart 之间退出，下一次 shared agentd 会在锁内复核配置身份后继续该 durable intent，但仍不会自动完成 owner 迁移；
 5. 重启并确认 agentd 的 runtime 状态为 `transport=unix`、`shared=true`、daemon 可连接；
 6. 经 ownership 检查后，为 GUI 用户会话写入官方 daemon 开关、相同的 canonical `CODEX_HOME` 和 Mimi 私有的随机会话 marker，确保从 Dock / Finder 启动也生效；三键按事务写入，任一失败都会按相反顺序恢复，外部已有值不会被覆盖；
 7. 首次启用或启用前已有 daemon 时，owner 都会持久标记为“待迁移”，并把磁盘 plist 固定为 `RunAtLoad=false`，不会静默中断既有进程，也不会在注销、登录或 Mac 重启后自动完成迁移。稳定 owner 已安装后，如果未来又由 Codex 原生 SSH bootstrap 先抢到 socket，agentd 仍会在完成协议、版本、`CODEX_HOME` 和 standalone 路径验证后保持 attach，并把 owner 收敛回同一 pending 状态；socket 仍可连接时普通启动只 attach；仅 durable fresh-enable intent 且 socket 尚未创建时允许 manual job 恢复一次冷启动，恢复后仍保持 pending。其他 socket 不可连接场景下普通启动和 gateway recovery 直接返回 pending，既不 `kickstart` 也不清 marker。该标记独立于五分钟 runtime 缓存，每次状态请求都实时读取，因此用户取消确认或先退出 Desktop 后入口仍保留。用户确认后，Desktop 正在运行时先请求它正常退出。旧 server 已由官方 pid backend 管理时执行官方 `daemon stop`；旧 server 是 Codex 原生 SSH bootstrap 直启链时，只有在同一私有 socket、当前用户、官方 standalone 真实路径、直接 `app-server --listen unix://` 命令行、PID 启动时间及 Desktop 最终退出状态全部两次匹配时，才向该唯一 PID 发送一次 `SIGTERM`。官方 stop 与新 daemon kickstart 各自在副作用前按固定 bundle ID 最终复核 Desktop，App 已重开或 LaunchServices 查询失败都立即停止迁移。不使用进程组信号、`SIGKILL`、模糊进程名或自动重试。等待最长 15 秒，且旧 socket 持续拒绝连接 500 ms 后，才由 LaunchAgent 拉起一次并完成协议/生命周期/版本验证；全部通过后才清 intent/marker、把 plist 恢复为 `RunAtLoad=true`，并按实际执行时的 Desktop 状态决定是否重新打开 App。任意检查或启动失败均保留 manual plist 与待迁移标记，不自动打开 Desktop；若旧进程在等待超时后才完成退出，用户稍后重试不会再发送第二次信号。两种情况都会短暂中断连接该 daemon 的手机、SSH 或 CLI；
 8. 在没有待迁移 marker 的正常已提交状态下，如果共享 daemon 后续异常退出，只有一次真实的移动端 gateway 连接失败后才会通过同一 LaunchAgent 恢复并重试；跨连接恢复串行且缓存最近 30 秒结果，恢复与显式迁移还共用用户级文件锁，避免在 `stop/start` 中间被另一进程插入。永久故障不会堆积成多倍启动超时，高频 readiness 也不会拉起进程。
+
+Mac App 执行迁移的短命 `agentd` 控制命令有明确超时。超时后先发送普通 `SIGTERM`，两秒仍未退出才只回收该 control CLI；不会因此向共享 Codex daemon 发送 `SIGKILL`。manual plist 与迁移 marker 会继续保留，设置页退出“正在更新”并显示可重试错误，避免控制命令异常时无限卡住。
+
+`runtime status` 与 Doctor 会从 Unix socket 的真实 peer PID 取证，不信任缓存 PID 或进程名；Darwin 上直接读取内核的打开 FD 数、启动时间和进程表中的直接子进程数，不额外启动 `lsof`、`ps` 或 `pgrep`。stable owner 的 `8192` 只标记为下一次启动的目标值，不冒充当前 listener 的实际 `RLIMIT_NOFILE`；macOS 无法可靠读取另一进程的实际 soft limit 时，百分比与资源等级保持 unknown，只展示绝对 FD 数和“当前进程未验证”。将来只有取得实际生效上限后才按 70%/90% 阈值判断。AttachOnly / 外部 owner 同样不套用 Mimi 的上限，也不阻断转发。状态接口只返回 PID、计数、时间和枚举，不暴露命令行、环境、原始错误或 owner/socket 路径。
 
 移动端写入前，gateway 还会复用现有 external activity 的精确 Thread / Turn ownership 证据：同一 thread 确认由 Codex Desktop 运行时，`turn/start`、`turn/steer`、中断和其他写操作会在转发前返回 `accepted=false`；对 app-server 发给客户端的审批、补充输入和 MCP elicitation，移动端返回的反向 JSON-RPC response 也执行相同 guard，拒绝时保留 pending request 并恢复移动端卡片。`thread/resume` 与读取接口仍可用于只读观察。Desktop 仅打开空闲 thread 不会被当成占用。共享 Unix 模式下状态库不可读、观测器缺失或反向 request 缺少 thread scope 时会 fail-closed，暂时拒绝写入但继续允许读取；默认独立 WS 没有共同 writer，仍保持原有可用性策略。
 
@@ -77,6 +81,7 @@ agentd restart --no-pair
 
 - 官方 daemon 冷启动需要 `$CODEX_HOME/packages/standalone/current/codex`。已有健康 socket 但 standalone 缺失时，启用操作也会阻断，避免本次看似成功、Mac 重启后 agentd 持续拉起失败；Mimi Remote 不会静默执行 `curl | sh`，只给出官方安装指引。
 - 共享架构把两端的会话一致性放在同一个官方 app-server 上，因此该 server 自身崩溃时 Codex Desktop 与 Mimi 会同时短暂失去后端。稳定 owner 只在 server 已不可连时尝试恢复它，不会为了恢复而退出或重开 Codex Desktop。
+- 8192 是防止过低 launchd soft limit 把资源累积过早放大成全能力故障，不是对子进程或 FD 泄漏的掩盖。Doctor 同时展示真实 FD 与直接子进程水位；持续上涨仍需定位 Codex/MCP 上游的回收责任。本方案不基于不完整的 external activity 证据自动 recycle 健康 daemon。
 - Desktop 必须支持 local daemon，当前最低兼容 app-server 版本为 `0.141.0`。版本、socket 类型、目录权限、socket 权限和返回的 `codexHome` 都会在启用前校验。
 - Desktop 的自定义 CLI、强制 CLI 或资源覆盖可能让它回退到独立 stdio。Mac App 会确认 agentd 已连接共享 daemon，并明确要求完全重启 Desktop；Desktop 是否采用 daemon 仍要通过下面的跨端验收验证，不能只根据环境变量推断成功。
 - 稳定 LaunchAgent 的 `PATH` 会固定 Apple Silicon / Intel Homebrew 与系统工具目录，并在首次安装时追加调用进程可见的绝对用户工具目录；相对路径会被拒绝。之后 resident agentd 会复用已安装值，避免 MCP/plugin 路径随启动入口反复变化；需要完全自定义时可显式配置 `codex.env.PATH`。

--- a/internal/appserver/shared_daemon_diagnostics.go
+++ b/internal/appserver/shared_daemon_diagnostics.go
@@ -12,6 +12,7 @@ const (
 	SharedDaemonOwnerStateStable            SharedDaemonOwnerState = "stable"
 	SharedDaemonOwnerStateMigrationPending  SharedDaemonOwnerState = "migration_pending"
 	SharedDaemonOwnerStateUnavailable       SharedDaemonOwnerState = "owner_unavailable"
+	SharedDaemonOwnerStateClaimedUnverified SharedDaemonOwnerState = "owner_claimed_unverified"
 	SharedDaemonOwnerStateUnmanagedListener SharedDaemonOwnerState = "unmanaged_listener"
 	SharedDaemonOwnerStateListenerMismatch  SharedDaemonOwnerState = "listener_mismatch"
 )

--- a/internal/appserver/shared_daemon_diagnostics.go
+++ b/internal/appserver/shared_daemon_diagnostics.go
@@ -1,0 +1,65 @@
+package appserver
+
+import "time"
+
+const sharedDaemonSoftFileLimit = 8192
+
+type SharedDaemonOwnerState string
+
+const (
+	SharedDaemonOwnerStateUnknown           SharedDaemonOwnerState = "unknown"
+	SharedDaemonOwnerStateExternal          SharedDaemonOwnerState = "external"
+	SharedDaemonOwnerStateStable            SharedDaemonOwnerState = "stable"
+	SharedDaemonOwnerStateMigrationPending  SharedDaemonOwnerState = "migration_pending"
+	SharedDaemonOwnerStateUnavailable       SharedDaemonOwnerState = "owner_unavailable"
+	SharedDaemonOwnerStateUnmanagedListener SharedDaemonOwnerState = "unmanaged_listener"
+	SharedDaemonOwnerStateListenerMismatch  SharedDaemonOwnerState = "listener_mismatch"
+)
+
+type SharedDaemonResourceState string
+
+const (
+	SharedDaemonResourceStateUnknown  SharedDaemonResourceState = "unknown"
+	SharedDaemonResourceStateHealthy  SharedDaemonResourceState = "healthy"
+	SharedDaemonResourceStateDegraded SharedDaemonResourceState = "degraded"
+	SharedDaemonResourceStateCritical SharedDaemonResourceState = "critical"
+)
+
+// SharedDaemonDiagnostics 只暴露进程资源与 owner 对账所需的脱敏字段。
+// 不返回命令行、环境变量或路径，避免 runtime status / doctor 扩大敏感信息范围。
+type SharedDaemonDiagnostics struct {
+	Supported            bool
+	ListenerPID          int
+	ListenerStartedAt    time.Time
+	OpenFileDescriptors  int
+	DirectChildProcesses int
+	// OwnerTargetFDSoftLimit 是 stable owner 下一次启动时的目标配置，不代表
+	// 当前 listener 已实际继承。只有 EffectiveFDSoftLimit 有可靠取证时，
+	// 才能计算百分比并判断阈值，避免把手工启动的低上限进程误报为健康。
+	OwnerTargetFDSoftLimit *int
+	EffectiveFDSoftLimit   *int
+	FDUsagePercent         *float64
+	OwnerState             SharedDaemonOwnerState
+	ResourceState          SharedDaemonResourceState
+}
+
+func applySharedDaemonResourceState(status *SharedDaemonDiagnostics) {
+	if status == nil {
+		return
+	}
+	status.ResourceState = SharedDaemonResourceStateUnknown
+	status.FDUsagePercent = nil
+	if status.EffectiveFDSoftLimit == nil || *status.EffectiveFDSoftLimit <= 0 {
+		return
+	}
+	usage := float64(status.OpenFileDescriptors) * 100 / float64(*status.EffectiveFDSoftLimit)
+	status.FDUsagePercent = &usage
+	switch {
+	case usage >= 90:
+		status.ResourceState = SharedDaemonResourceStateCritical
+	case usage >= 70:
+		status.ResourceState = SharedDaemonResourceStateDegraded
+	default:
+		status.ResourceState = SharedDaemonResourceStateHealthy
+	}
+}

--- a/internal/appserver/shared_daemon_diagnostics_darwin.go
+++ b/internal/appserver/shared_daemon_diagnostics_darwin.go
@@ -1,0 +1,194 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	darwinProcInfoCallPIDInfo = 2
+	darwinProcPIDListFDs      = 1
+)
+
+// darwinProcFDInfo 与 Darwin 的 proc_fdinfo ABI 保持一致。PROC_PIDLISTFDS
+// 返回的每一项都对应一个实际打开的描述符；不能使用 proc_bsdinfo.pbi_nfiles，
+// 后者在实机上反映文件表容量，可能恰好等于 256 而不是当前打开数。
+type darwinProcFDInfo struct {
+	FD   int32
+	Type uint32
+}
+
+// InspectSharedDaemonDiagnostics 从当前 Unix socket 的真实 peer PID 开始取证，
+// 不信任 plist、缓存 PID 或进程名。诊断只读，不会启动、停止或迁移 daemon。
+func InspectSharedDaemonDiagnostics(
+	ctx context.Context,
+	options LocalDaemonOptions,
+) (SharedDaemonDiagnostics, error) {
+	status := SharedDaemonDiagnostics{
+		Supported:     true,
+		OwnerState:    SharedDaemonOwnerStateUnknown,
+		ResourceState: SharedDaemonResourceStateUnknown,
+	}
+	if err := ctx.Err(); err != nil {
+		return status, err
+	}
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return status, err
+	}
+	process, err := inspectSharedDaemonListenerIdentity(ctx, socketPath)
+	if err != nil {
+		return status, fmt.Errorf("读取共享 daemon listener 失败：%w", err)
+	}
+	openFiles, err := sharedDaemonProcessOpenFileCount(process.PID)
+	if err != nil {
+		return status, err
+	}
+	children, err := sharedDaemonDirectChildCount(process.PID)
+	if err != nil {
+		return status, err
+	}
+
+	status.ListenerPID = process.PID
+	status.ListenerStartedAt = time.Unix(process.StartSec, int64(process.StartUsec)*int64(time.Microsecond)).UTC()
+	status.OpenFileDescriptors = openFiles
+	status.DirectChildProcesses = children
+	status.OwnerState = inspectSharedDaemonOwnerState(ctx, options, socketPath, process.PID)
+	if status.OwnerState == SharedDaemonOwnerStateStable {
+		limit := sharedDaemonSoftFileLimit
+		status.OwnerTargetFDSoftLimit = &limit
+	}
+	applySharedDaemonResourceState(&status)
+	return status, nil
+}
+
+// inspectSharedDaemonListenerIdentity 只读取资源诊断实际需要的身份字段。
+// 不读取命令行或环境变量，避免把接管校验的敏感取证面带入常规状态刷新。
+func inspectSharedDaemonListenerIdentity(
+	ctx context.Context,
+	socketPath string,
+) (sharedDaemonListenerProcess, error) {
+	pid, peerUID, err := sharedDaemonSocketPeer(ctx, socketPath)
+	if err != nil {
+		return sharedDaemonListenerProcess{}, err
+	}
+	kinfo, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || int(kinfo.Proc.P_pid) != pid {
+		return sharedDaemonListenerProcess{}, fmt.Errorf("读取 socket owner 进程身份失败")
+	}
+	if int(kinfo.Eproc.Ucred.Uid) != peerUID {
+		return sharedDaemonListenerProcess{}, fmt.Errorf("socket peer UID 与进程 UID 不一致")
+	}
+	return sharedDaemonListenerProcess{
+		PID:       pid,
+		UID:       peerUID,
+		StartSec:  kinfo.Proc.P_starttime.Sec,
+		StartUsec: kinfo.Proc.P_starttime.Usec,
+	}, nil
+}
+
+func inspectSharedDaemonOwnerState(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	socketPath string,
+	listenerPID int,
+) SharedDaemonOwnerState {
+	if !options.StableOwner {
+		return SharedDaemonOwnerStateExternal
+	}
+	owner, err := InspectSharedDaemonOwner(ctx)
+	if err != nil {
+		return SharedDaemonOwnerStateUnknown
+	}
+	if !owner.Installed || !owner.Loaded || !owner.Secure {
+		return SharedDaemonOwnerStateUnavailable
+	}
+	if owner.MigrationRequired || !owner.RunAtLoad {
+		return SharedDaemonOwnerStateMigrationPending
+	}
+	lifecycle, err := InspectLocalDaemonLifecycle(ctx, options)
+	if err != nil || !strings.EqualFold(strings.TrimSpace(lifecycle.Status), "running") {
+		return SharedDaemonOwnerStateUnknown
+	}
+	if lifecycle.Backend == nil || lifecycle.PID == nil {
+		return SharedDaemonOwnerStateUnmanagedListener
+	}
+	if !strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid") ||
+		!sameCanonicalPath(lifecycle.SocketPath, socketPath) ||
+		int(*lifecycle.PID) != listenerPID {
+		return SharedDaemonOwnerStateListenerMismatch
+	}
+	return SharedDaemonOwnerStateStable
+}
+
+func sharedDaemonProcessOpenFileCount(pid int) (int, error) {
+	if pid <= 1 {
+		return 0, fmt.Errorf("共享 daemon PID 无效")
+	}
+	entrySize := unsafe.Sizeof(darwinProcFDInfo{})
+	required, _, errno := unix.Syscall6(
+		unix.SYS_PROC_INFO,
+		darwinProcInfoCallPIDInfo,
+		uintptr(pid),
+		darwinProcPIDListFDs,
+		0,
+		0,
+		0,
+	)
+	if errno != 0 {
+		return 0, fmt.Errorf("读取共享 daemon FD 数失败：%w", errno)
+	}
+	if required == 0 {
+		return 0, nil
+	}
+	// 在 size query 与实际读取之间目标可能打开新 FD；额外预留 32 项，并在
+	// 内核仍填满缓冲区时放大重试，避免把瞬时增长截断成偏低水位。
+	capacity := int(required/entrySize) + 32
+	for attempt := 0; attempt < 3; attempt++ {
+		entries := make([]darwinProcFDInfo, capacity)
+		written, _, readErrno := unix.Syscall6(
+			unix.SYS_PROC_INFO,
+			darwinProcInfoCallPIDInfo,
+			uintptr(pid),
+			darwinProcPIDListFDs,
+			0,
+			uintptr(unsafe.Pointer(&entries[0])),
+			uintptr(len(entries))*entrySize,
+		)
+		if readErrno != 0 {
+			return 0, fmt.Errorf("读取共享 daemon FD 列表失败：%w", readErrno)
+		}
+		if written%entrySize != 0 {
+			return 0, fmt.Errorf("共享 daemon FD 列表元数据不完整")
+		}
+		count := int(written / entrySize)
+		if count < len(entries) {
+			return count, nil
+		}
+		capacity *= 2
+	}
+	return 0, fmt.Errorf("共享 daemon FD 列表持续增长，无法取得稳定水位")
+}
+
+func sharedDaemonDirectChildCount(pid int) (int, error) {
+	// Darwin 不提供稳定的 kern.proc.ppid sysctl selector；读取一次内核进程表
+	// 后按 PPID 过滤，仍然不需要 fork ps/pgrep，daemon 接近 EMFILE 时也可用。
+	processes, err := unix.SysctlKinfoProcSlice("kern.proc.all")
+	if err != nil {
+		return 0, fmt.Errorf("读取共享 daemon 子进程数失败：%w", err)
+	}
+	count := 0
+	for index := range processes {
+		if int(processes[index].Eproc.Ppid) == pid && processes[index].Proc.P_pid > 0 {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/internal/appserver/shared_daemon_diagnostics_darwin.go
+++ b/internal/appserver/shared_daemon_diagnostics_darwin.go
@@ -117,12 +117,19 @@ func inspectSharedDaemonOwnerState(
 	if err != nil || !strings.EqualFold(strings.TrimSpace(lifecycle.Status), "running") {
 		return SharedDaemonOwnerStateUnknown
 	}
-	if lifecycle.Backend == nil || lifecycle.PID == nil {
+	// 没有 backend 仍是旧 SSH/CLI 直启进程，不能因为 owner 已安装就冒充官方托管。
+	if lifecycle.Backend == nil {
 		return SharedDaemonOwnerStateUnmanagedListener
 	}
-	if !strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid") ||
-		!sameCanonicalPath(lifecycle.SocketPath, socketPath) ||
-		int(*lifecycle.PID) != listenerPID {
+	backendIsPID := strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid")
+	socketMatches := sameCanonicalPath(lifecycle.SocketPath, socketPath)
+	// 官方 0.147.0 的 daemon start 在完成 detached listener 交接后，会保留 pid
+	// backend 但不再返回 PID。此时 stable owner 已提交且 socket 路径一致，仍不能
+	// 证明 listener 的启动来源；保留只读 warning，不误报 unmanaged 或 healthy。
+	if backendIsPID && socketMatches && lifecycle.PID == nil {
+		return SharedDaemonOwnerStateClaimedUnverified
+	}
+	if lifecycle.PID == nil || !backendIsPID || !socketMatches || int(*lifecycle.PID) != listenerPID {
 		return SharedDaemonOwnerStateListenerMismatch
 	}
 	return SharedDaemonOwnerStateStable

--- a/internal/appserver/shared_daemon_diagnostics_darwin_test.go
+++ b/internal/appserver/shared_daemon_diagnostics_darwin_test.go
@@ -1,0 +1,97 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+)
+
+func TestDarwinProcFDInfoLayout(t *testing.T) {
+	// proc_info 是 ABI，不经过 Go 类型检查；布局变化必须在测试中显式暴露。
+	if got := unsafe.Sizeof(darwinProcFDInfo{}); got != 8 {
+		t.Fatalf("proc_fdinfo 布局大小异常：got=%d want=8", got)
+	}
+}
+
+func TestSharedDaemonProcessMetricsReadCurrentProcess(t *testing.T) {
+	before, err := sharedDaemonProcessOpenFileCount(os.Getpid())
+	if err != nil {
+		t.Fatalf("读取当前进程 FD 数失败：%v", err)
+	}
+	if before <= 0 {
+		t.Fatalf("当前进程 FD 数必须大于 0：%d", before)
+	}
+	opened := make([]*os.File, 0, 3)
+	for range 3 {
+		file, openErr := os.Open("/dev/null")
+		if openErr != nil {
+			t.Fatal(openErr)
+		}
+		opened = append(opened, file)
+	}
+	t.Cleanup(func() {
+		for _, file := range opened {
+			_ = file.Close()
+		}
+	})
+	after, err := sharedDaemonProcessOpenFileCount(os.Getpid())
+	if err != nil {
+		t.Fatalf("打开文件后读取当前进程 FD 数失败：%v", err)
+	}
+	if after < before+len(opened) {
+		t.Fatalf("PROC_PIDLISTFDS 必须反映实际新增 FD：before=%d after=%d opened=%d", before, after, len(opened))
+	}
+	children, err := sharedDaemonDirectChildCount(os.Getpid())
+	if err != nil {
+		t.Fatalf("读取当前进程直接子进程数失败：%v", err)
+	}
+	if children < 0 {
+		t.Fatalf("直接子进程数不能为负数：%d", children)
+	}
+}
+
+func TestInspectSharedDaemonDiagnosticsUsesSocketPeerAndKeepsExternalLimitUnknown(t *testing.T) {
+	// Unix socket 路径有固定长度上限；系统测试临时目录在 macOS 上可能很深。
+	codexHome, err := os.MkdirTemp("/tmp", "mimi-daemon-diag-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(codexHome) })
+	socketPath, err := LocalDaemonSocketPath(map[string]string{"CODEX_HOME": codexHome})
+	if err != nil {
+		t.Fatalf("解析临时 socket 失败：%v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		t.Fatalf("创建临时 socket 目录失败：%v", err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("创建临时 Unix listener 失败：%v", err)
+	}
+	defer listener.Close()
+
+	status, err := InspectSharedDaemonDiagnostics(context.Background(), LocalDaemonOptions{
+		Env: map[string]string{"CODEX_HOME": codexHome},
+	})
+	if err != nil {
+		t.Fatalf("共享 daemon 诊断失败：%v", err)
+	}
+	if status.ListenerPID != os.Getpid() {
+		t.Fatalf("必须以 socket 的真实 peer PID 为准：got=%d want=%d", status.ListenerPID, os.Getpid())
+	}
+	if status.OpenFileDescriptors <= 0 || status.ListenerStartedAt.IsZero() {
+		t.Fatalf("进程资源证据不完整：%+v", status)
+	}
+	if status.OwnerState != SharedDaemonOwnerStateExternal {
+		t.Fatalf("非 StableOwner 配置必须标记为 external：%+v", status)
+	}
+	if status.OwnerTargetFDSoftLimit != nil || status.FDUsagePercent != nil ||
+		status.ResourceState != SharedDaemonResourceStateUnknown {
+		t.Fatalf("外部 owner 的上限未知，不能套用 Mimi 配置：%+v", status)
+	}
+}

--- a/internal/appserver/shared_daemon_diagnostics_other.go
+++ b/internal/appserver/shared_daemon_diagnostics_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+
+package appserver
+
+import "context"
+
+func InspectSharedDaemonDiagnostics(
+	context.Context,
+	LocalDaemonOptions,
+) (SharedDaemonDiagnostics, error) {
+	return SharedDaemonDiagnostics{
+		Supported:     false,
+		OwnerState:    SharedDaemonOwnerStateUnknown,
+		ResourceState: SharedDaemonResourceStateUnknown,
+	}, nil
+}

--- a/internal/appserver/shared_daemon_diagnostics_test.go
+++ b/internal/appserver/shared_daemon_diagnostics_test.go
@@ -1,0 +1,56 @@
+package appserver
+
+import "testing"
+
+func TestApplySharedDaemonResourceStateRequiresEffectiveLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		openFiles int
+		limit     *int
+		wantState SharedDaemonResourceState
+		wantUsage *float64
+	}{
+		{name: "limit unknown", openFiles: 200, wantState: SharedDaemonResourceStateUnknown},
+		{name: "healthy", openFiles: 4096, limit: intPointer(8192), wantState: SharedDaemonResourceStateHealthy, wantUsage: floatPointer(50)},
+		{name: "degraded boundary", openFiles: 5735, limit: intPointer(8192), wantState: SharedDaemonResourceStateDegraded},
+		{name: "critical boundary", openFiles: 7373, limit: intPointer(8192), wantState: SharedDaemonResourceStateCritical},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			status := SharedDaemonDiagnostics{
+				OpenFileDescriptors:  testCase.openFiles,
+				EffectiveFDSoftLimit: testCase.limit,
+			}
+			applySharedDaemonResourceState(&status)
+			if status.ResourceState != testCase.wantState {
+				t.Fatalf("资源状态错误：got=%s want=%s", status.ResourceState, testCase.wantState)
+			}
+			if testCase.wantUsage == nil {
+				if status.FDUsagePercent != nil && testCase.limit == nil {
+					t.Fatalf("上限未知时不能推测 FD 使用率：%v", *status.FDUsagePercent)
+				}
+				return
+			}
+			if status.FDUsagePercent == nil || *status.FDUsagePercent != *testCase.wantUsage {
+				t.Fatalf("FD 使用率错误：got=%v want=%v", status.FDUsagePercent, *testCase.wantUsage)
+			}
+		})
+	}
+}
+
+func TestApplySharedDaemonResourceStateDoesNotAssumeConfiguredLimitIsEffective(t *testing.T) {
+	configured := 8192
+	status := SharedDaemonDiagnostics{
+		OpenFileDescriptors:    8000,
+		OwnerTargetFDSoftLimit: &configured,
+	}
+	applySharedDaemonResourceState(&status)
+	if status.ResourceState != SharedDaemonResourceStateUnknown || status.FDUsagePercent != nil {
+		t.Fatalf("仅有 owner 配置时不能推测当前 listener 的资源水位：%+v", status)
+	}
+}
+
+func intPointer(value int) *int { return &value }
+
+func floatPointer(value float64) *float64 { return &value }

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -265,6 +265,13 @@ func renderSharedDaemonLaunchAgent(
 	}
 	buf.WriteString("\t</array>\n")
 
+	// launchd 用户域的默认 maxfiles 可能只有 256；daemon 需要为多路客户端和
+	// MCP 连接预留余量，因此只把 soft limit 受控提升到 8192。不设置 hard limit，
+	// 避免 plist 绕过系统策略获得无限制的文件描述符权限。
+	buf.WriteString("\t<key>SoftResourceLimits</key>\n\t<dict>\n")
+	fmt.Fprintf(&buf, "\t\t<key>NumberOfFiles</key>\n\t\t<integer>%d</integer>\n", sharedDaemonSoftFileLimit)
+	buf.WriteString("\t</dict>\n")
+
 	if values := sharedDaemonLaunchAgentEnv(env); len(values) > 0 {
 		buf.WriteString("\t<key>EnvironmentVariables</key>\n\t<dict>\n")
 		keys := make([]string, 0, len(values))

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -85,6 +85,25 @@ func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
 	}
 }
 
+func TestRenderSharedDaemonLaunchAgentSetsControlledSoftFileLimit(t *testing.T) {
+	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/codex/bin/codex",
+		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("渲染 plist 失败：%v", err)
+	}
+	content := string(rendered)
+	want := "<key>SoftResourceLimits</key>\n\t<dict>\n\t\t<key>NumberOfFiles</key>\n\t\t<integer>8192</integer>\n\t</dict>"
+	if !strings.Contains(content, want) {
+		t.Fatalf("LaunchAgent 必须设置受控的文件描述符 soft limit 8192：\n%s", content)
+	}
+	if strings.Contains(content, "<key>HardResourceLimits</key>") {
+		t.Fatalf("LaunchAgent 不应设置 hard 文件描述符限制：\n%s", content)
+	}
+}
+
 func TestRenderSharedDaemonLaunchAgentPendingDisablesRunAtLoad(t *testing.T) {
 	rendered, err := renderSharedDaemonLaunchAgent(
 		"/opt/codex/bin/codex",

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -85,25 +85,6 @@ func TestRenderSharedDaemonLaunchAgentExecsOfficialCodexDirectly(t *testing.T) {
 	}
 }
 
-func TestRenderSharedDaemonLaunchAgentSetsControlledSoftFileLimit(t *testing.T) {
-	rendered, err := renderSharedDaemonLaunchAgent(
-		"/opt/codex/bin/codex",
-		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
-		"",
-	)
-	if err != nil {
-		t.Fatalf("渲染 plist 失败：%v", err)
-	}
-	content := string(rendered)
-	want := "<key>SoftResourceLimits</key>\n\t<dict>\n\t\t<key>NumberOfFiles</key>\n\t\t<integer>8192</integer>\n\t</dict>"
-	if !strings.Contains(content, want) {
-		t.Fatalf("LaunchAgent 必须设置受控的文件描述符 soft limit 8192：\n%s", content)
-	}
-	if strings.Contains(content, "<key>HardResourceLimits</key>") {
-		t.Fatalf("LaunchAgent 不应设置 hard 文件描述符限制：\n%s", content)
-	}
-}
-
 func TestRenderSharedDaemonLaunchAgentPendingDisablesRunAtLoad(t *testing.T) {
 	rendered, err := renderSharedDaemonLaunchAgent(
 		"/opt/codex/bin/codex",

--- a/internal/appserver/shared_daemon_owner_resources_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_resources_darwin_test.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSharedDaemonLaunchAgentSetsControlledSoftFileLimit(t *testing.T) {
+	rendered, err := renderSharedDaemonLaunchAgent(
+		"/opt/codex/bin/codex",
+		map[string]string{"CODEX_HOME": "/Users/tester/.codex"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("渲染 plist 失败：%v", err)
+	}
+	content := string(rendered)
+	want := "<key>SoftResourceLimits</key>\n\t<dict>\n\t\t<key>NumberOfFiles</key>\n\t\t<integer>8192</integer>\n\t</dict>"
+	if !strings.Contains(content, want) {
+		t.Fatalf("LaunchAgent 必须设置受控的文件描述符 soft limit 8192：\n%s", content)
+	}
+	if strings.Contains(content, "<key>HardResourceLimits</key>") {
+		t.Fatalf("LaunchAgent 不应设置 hard 文件描述符限制：\n%s", content)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -529,8 +529,12 @@ func sharedDaemonRuntimeDiagnosticCheck(
 		case appserver.SharedDaemonResourceStateCritical:
 			check.Message = "共享 daemon FD 接近耗尽；" + summary
 		default:
-			check.Level = "warning"
-			check.Message = "共享 daemon owner 正常，但 FD soft limit 尚不可确认；" + summary
+			// macOS 没有可靠的非特权接口读取另一个进程的 RLIMIT_NOFILE。
+			// 已验证稳定 owner 时保留事实提示，但不制造一条用户永远无法消除的 WARN；
+			// 真正的迁移、owner 不匹配和已取证的高水位仍由其他分支告警。
+			check.OK = true
+			check.Message = "共享 daemon owner 正常；FD soft limit 尚不可独立确认；" + summary
+			check.Fix = ""
 		}
 	case appserver.SharedDaemonOwnerStateMigrationPending:
 		check.Message = "共享 daemon 正在等待显式迁移，新 FD 上限尚未作用于当前 listener；" + summary

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -439,8 +439,7 @@ func (c *Checker) localDaemonLifecycleCheck(ctx context.Context) Check {
 }
 
 func (c *Checker) sharedDaemonOwnerCheck(ctx context.Context) Check {
-	if !strings.EqualFold(strings.TrimSpace(c.cfg.AppServer.Transport), "unix") ||
-		c.cfg.AppServer.SharedFallback == nil {
+	if !usesStableSharedDaemonOwner(c.cfg.AppServer) {
 		return Check{}
 	}
 	status, err := appserver.InspectSharedDaemonOwner(ctx)
@@ -487,9 +486,18 @@ func (c *Checker) sharedDaemonRuntimeCheck(ctx context.Context) Check {
 	status, err := inspect(ctx, appserver.LocalDaemonOptions{
 		CodexBin:    c.cfg.Codex.Bin,
 		Env:         c.cfg.Codex.Env,
-		StableOwner: c.cfg.AppServer.SharedFallback != nil,
+		StableOwner: usesStableSharedDaemonOwner(c.cfg.AppServer),
 	})
 	return sharedDaemonRuntimeDiagnosticCheck(status, err)
+}
+
+// shared_fallback 只记录 Mimi 曾保存过的旧 transport，不能单独证明当前
+// Unix listener 仍由 Mimi 托管。managed=false 明确表示生命周期归外部 owner；
+// 此时 Doctor 只能做外部 listener 的只读诊断，不能检查 Mimi LaunchAgent。
+func usesStableSharedDaemonOwner(cfg config.AppServerConfig) bool {
+	return strings.EqualFold(strings.TrimSpace(cfg.Transport), "unix") &&
+		cfg.Managed &&
+		cfg.SharedFallback != nil
 }
 
 func sharedDaemonRuntimeDiagnosticCheck(

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -25,6 +25,7 @@ type Checker struct {
 	cfg                        config.Config
 	registry                   *projects.Registry
 	configPath                 string
+	sharedDaemonDiagnostics    func(context.Context, appserver.LocalDaemonOptions) (appserver.SharedDaemonDiagnostics, error)
 	fileAccessMu               sync.RWMutex
 	fileAccessPreflightStarted bool
 	fileAccessPreflight        Check
@@ -49,7 +50,12 @@ type Check struct {
 }
 
 func NewChecker(version string, cfg config.Config, registry *projects.Registry, configPath ...string) *Checker {
-	checker := &Checker{version: version, cfg: cfg, registry: registry}
+	checker := &Checker{
+		version:                 version,
+		cfg:                     cfg,
+		registry:                registry,
+		sharedDaemonDiagnostics: appserver.InspectSharedDaemonDiagnostics,
+	}
 	// variadic 参数保持现有嵌入方兼容；CLI 传入真实路径后才启用配置文件权限检查。
 	if len(configPath) > 0 {
 		checker.configPath = expandConfigPath(configPath[0])
@@ -109,6 +115,9 @@ func (c *Checker) Run(ctx context.Context, checkPort bool) Results {
 	if check := c.sharedDaemonOwnerCheck(ctx); check.Name != "" {
 		checks = append(checks, check)
 	}
+	if check := c.sharedDaemonRuntimeCheck(ctx); check.Name != "" {
+		checks = append(checks, check)
+	}
 	checks = append(checks, c.claudeBridgeCheck(ctx))
 	if check := c.appServerGatewayCheck(ctx); check.Name != "" {
 		checks = append(checks, check)
@@ -153,7 +162,7 @@ func (c *Checker) results(checks []Check) Results {
 			checks[i].Level = "ok"
 			continue
 		}
-		if isWarningOnlyCheck(checks[i].Name) {
+		if strings.EqualFold(strings.TrimSpace(checks[i].Level), "warning") || isWarningOnlyCheck(checks[i].Name) {
 			if checks[i].Name == "tailscale" {
 				checks[i].Message = "未检测到 Tailscale 命令，本机访问仍可使用"
 			}
@@ -465,6 +474,99 @@ func (c *Checker) sharedDaemonOwnerCheck(ctx context.Context) Check {
 		check.Fix = ""
 	}
 	return check
+}
+
+func (c *Checker) sharedDaemonRuntimeCheck(ctx context.Context) Check {
+	if !strings.EqualFold(strings.TrimSpace(c.cfg.AppServer.Transport), "unix") {
+		return Check{}
+	}
+	inspect := c.sharedDaemonDiagnostics
+	if inspect == nil {
+		inspect = appserver.InspectSharedDaemonDiagnostics
+	}
+	status, err := inspect(ctx, appserver.LocalDaemonOptions{
+		CodexBin:    c.cfg.Codex.Bin,
+		Env:         c.cfg.Codex.Env,
+		StableOwner: c.cfg.AppServer.SharedFallback != nil,
+	})
+	return sharedDaemonRuntimeDiagnosticCheck(status, err)
+}
+
+func sharedDaemonRuntimeDiagnosticCheck(
+	status appserver.SharedDaemonDiagnostics,
+	err error,
+) Check {
+	check := Check{
+		Name: "codex-daemon-resources",
+		Fix:  "先保存所有活跃任务；若资源继续上涨，使用受控迁移恢复 owner，不要直接强杀进程",
+	}
+	if err != nil {
+		check.Level = "warning"
+		check.Message = "无法读取共享 Codex daemon 的 FD / 子进程水位"
+		// 底层 Unix dial 错误可能包含 CODEX_HOME/socket 绝对路径；Doctor
+		// 只返回固定操作建议，不把原始错误扩大到状态输出或日志。
+		check.Fix = "确认共享 Codex daemon 正在运行，并允许 Mimi 读取当前用户的进程信息"
+		return check
+	}
+	if !status.Supported {
+		return Check{}
+	}
+	summary := sharedDaemonResourceSummary(status)
+	switch status.OwnerState {
+	case appserver.SharedDaemonOwnerStateExternal:
+		check.OK = true
+		check.Message = "共享 daemon 由外部 owner 管理；" + summary + "；FD soft limit 由外部 owner 负责"
+		check.Fix = ""
+	case appserver.SharedDaemonOwnerStateStable:
+		switch status.ResourceState {
+		case appserver.SharedDaemonResourceStateHealthy:
+			check.OK = true
+			check.Message = "共享 daemon 资源水位正常；" + summary
+			check.Fix = ""
+		case appserver.SharedDaemonResourceStateDegraded:
+			check.Level = "warning"
+			check.Message = "共享 daemon FD 水位偏高；" + summary
+		case appserver.SharedDaemonResourceStateCritical:
+			check.Message = "共享 daemon FD 接近耗尽；" + summary
+		default:
+			check.Level = "warning"
+			check.Message = "共享 daemon owner 正常，但 FD soft limit 尚不可确认；" + summary
+		}
+	case appserver.SharedDaemonOwnerStateMigrationPending:
+		check.Message = "共享 daemon 正在等待显式迁移，新 FD 上限尚未作用于当前 listener；" + summary
+		check.Fix = "保存任务后，在 Mimi Remote Mac 中点击“应用待处理设置”并确认"
+	case appserver.SharedDaemonOwnerStateUnavailable:
+		check.Message = "共享 daemon listener 可用，但稳定 LaunchAgent owner 不可用；" + summary
+		check.Fix = "在 Mimi Remote Mac 中关闭后重新开启共享，恢复稳定 owner"
+	case appserver.SharedDaemonOwnerStateUnmanagedListener:
+		check.Message = "共享 daemon listener 尚未由官方 pid daemon 管理；" + summary
+		check.Fix = "保存任务并退出 Codex Desktop 后，在 Mimi Remote Mac 中应用待处理设置"
+	case appserver.SharedDaemonOwnerStateListenerMismatch:
+		check.Message = "共享 daemon lifecycle PID 与真实 socket listener 不一致；" + summary
+		check.Fix = "不要直接终止进程；保存任务后使用显式受控迁移重新对账 owner"
+	default:
+		check.Level = "warning"
+		check.Message = "共享 daemon owner 状态暂时无法确认；" + summary
+	}
+	return check
+}
+
+func sharedDaemonResourceSummary(status appserver.SharedDaemonDiagnostics) string {
+	fd := fmt.Sprintf("打开 FD %d", status.OpenFileDescriptors)
+	if status.EffectiveFDSoftLimit != nil {
+		fd = fmt.Sprintf("打开 FD %d/%d", status.OpenFileDescriptors, *status.EffectiveFDSoftLimit)
+		if status.FDUsagePercent != nil {
+			fd += fmt.Sprintf("（%.1f%%）", *status.FDUsagePercent)
+		}
+	} else if status.OwnerTargetFDSoftLimit != nil {
+		fd += fmt.Sprintf("；owner 目标上限 %d（当前进程未验证）", *status.OwnerTargetFDSoftLimit)
+	}
+	return fmt.Sprintf(
+		"listener PID %d，%s，直接子进程 %d",
+		status.ListenerPID,
+		fd,
+		status.DirectChildProcesses,
+	)
 }
 
 func (c *Checker) claudeBridgeCheck(ctx context.Context) Check {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -538,6 +538,10 @@ func sharedDaemonRuntimeDiagnosticCheck(
 	case appserver.SharedDaemonOwnerStateUnavailable:
 		check.Message = "共享 daemon listener 可用，但稳定 LaunchAgent owner 不可用；" + summary
 		check.Fix = "在 Mimi Remote Mac 中关闭后重新开启共享，恢复稳定 owner"
+	case appserver.SharedDaemonOwnerStateClaimedUnverified:
+		check.Level = "warning"
+		check.Message = "共享 daemon 的稳定 owner 已提交，但官方 lifecycle 未返回 listener PID；" + summary
+		check.Fix = "继续观察真实 FD 与子进程水位；不要仅凭 owner 配置推测当前进程上限"
 	case appserver.SharedDaemonOwnerStateUnmanagedListener:
 		check.Message = "共享 daemon listener 尚未由官方 pid daemon 管理；" + summary
 		check.Fix = "保存任务并退出 Codex Desktop 后，在 Mimi Remote Mac 中应用待处理设置"

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -76,13 +76,13 @@ func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *t
 			wantLevel: "error", wantText: "尚未作用",
 		},
 		{
-			name: "configured owner limit is not effective limit",
+			name: "stable unknown effective limit stays informational",
 			status: appserver.SharedDaemonDiagnostics{
 				Supported: true, ListenerPID: 106, OpenFileDescriptors: 7800,
 				OwnerTargetFDSoftLimit: &limit, OwnerState: appserver.SharedDaemonOwnerStateStable,
 				ResourceState: appserver.SharedDaemonResourceStateUnknown,
 			},
-			wantLevel: "warning", wantText: "当前进程未验证",
+			wantOK: true, wantText: "当前进程未验证",
 		},
 		{
 			name: "claimed owner without lifecycle pid is warning",

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -85,6 +85,14 @@ func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *t
 			wantLevel: "warning", wantText: "当前进程未验证",
 		},
 		{
+			name: "claimed owner without lifecycle pid is warning",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 107, OpenFileDescriptors: 82,
+				OwnerState: appserver.SharedDaemonOwnerStateClaimedUnverified,
+			},
+			wantLevel: "warning", wantText: "未返回 listener PID",
+		},
+		{
 			name: "observation failure is warning",
 			err:  errors.New("dial unix /Users/secret/.codex/app-server.sock: permission denied"), wantLevel: "warning", wantText: "无法读取",
 		},

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -11,10 +12,108 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/claudebridge"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 	"github.com/gaixianggeng/mimi-remote/internal/projects"
 )
+
+func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *testing.T) {
+	limit := 8192
+	usage := 75.0
+	tests := []struct {
+		name      string
+		status    appserver.SharedDaemonDiagnostics
+		err       error
+		wantOK    bool
+		wantLevel string
+		wantText  string
+	}{
+		{
+			name: "healthy stable owner",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 100, OpenFileDescriptors: 80,
+				DirectChildProcesses: 2, EffectiveFDSoftLimit: &limit,
+				OwnerState:    appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateHealthy,
+			},
+			wantOK: true, wantText: "80/8192",
+		},
+		{
+			name: "degraded is warning",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 101, OpenFileDescriptors: 6144,
+				DirectChildProcesses: 9, EffectiveFDSoftLimit: &limit,
+				FDUsagePercent: &usage, OwnerState: appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateDegraded,
+			},
+			wantLevel: "warning", wantText: "75.0%",
+		},
+		{
+			name: "critical blocks doctor",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 102, OpenFileDescriptors: 7800,
+				EffectiveFDSoftLimit: &limit, OwnerState: appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateCritical,
+			},
+			wantLevel: "error", wantText: "接近耗尽",
+		},
+		{
+			name: "external owner stays informational",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 103, OpenFileDescriptors: 90,
+				OwnerState:    appserver.SharedDaemonOwnerStateExternal,
+				ResourceState: appserver.SharedDaemonResourceStateUnknown,
+			},
+			wantOK: true, wantText: "外部 owner",
+		},
+		{
+			name: "migration pending blocks doctor",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 104, OpenFileDescriptors: 200,
+				OwnerState: appserver.SharedDaemonOwnerStateMigrationPending,
+			},
+			wantLevel: "error", wantText: "尚未作用",
+		},
+		{
+			name: "configured owner limit is not effective limit",
+			status: appserver.SharedDaemonDiagnostics{
+				Supported: true, ListenerPID: 106, OpenFileDescriptors: 7800,
+				OwnerTargetFDSoftLimit: &limit, OwnerState: appserver.SharedDaemonOwnerStateStable,
+				ResourceState: appserver.SharedDaemonResourceStateUnknown,
+			},
+			wantLevel: "warning", wantText: "当前进程未验证",
+		},
+		{
+			name: "observation failure is warning",
+			err:  errors.New("dial unix /Users/secret/.codex/app-server.sock: permission denied"), wantLevel: "warning", wantText: "无法读取",
+		},
+	}
+
+	checker := &Checker{}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			check := sharedDaemonRuntimeDiagnosticCheck(testCase.status, testCase.err)
+			results := checker.results([]Check{check})
+			got := results.Checks[0]
+			if got.OK != testCase.wantOK || got.Level != testCase.wantLevel && testCase.wantLevel != "" {
+				t.Fatalf("诊断等级错误：%+v", got)
+			}
+			if !strings.Contains(got.Message, testCase.wantText) {
+				t.Fatalf("诊断文案缺少 %q：%+v", testCase.wantText, got)
+			}
+			if strings.Contains(got.Fix, "/Users/secret") {
+				t.Fatalf("Doctor 修复建议泄露了底层 socket 路径：%+v", got)
+			}
+			if testCase.wantLevel == "error" && results.OK {
+				t.Fatalf("阻断状态必须让 doctor 失败：%+v", results)
+			}
+			if testCase.wantLevel == "warning" && !results.OK {
+				t.Fatalf("warning 不应让 doctor 失败：%+v", results)
+			}
+		})
+	}
+}
 
 func TestCheckerRunAndPrintDoNotLeakToken(t *testing.T) {
 	binDir := t.TempDir()

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -123,6 +123,39 @@ func TestSharedDaemonRuntimeDiagnosticCheckClassifiesResourceAndOwnerStates(t *t
 	}
 }
 
+func TestSharedDaemonChecksTreatUnmanagedUnixFallbackAsExternal(t *testing.T) {
+	fallback := &config.AppServerFallbackConfig{Transport: "ws", Managed: true}
+	checker := &Checker{
+		cfg: config.Config{AppServer: config.AppServerConfig{
+			Transport:      "unix",
+			Managed:        false,
+			SharedFallback: fallback,
+		}},
+	}
+	if check := checker.sharedDaemonOwnerCheck(context.Background()); check.Name != "" {
+		t.Fatalf("外部 Unix listener 不应检查 Mimi LaunchAgent owner：%+v", check)
+	}
+
+	stableOwner := true
+	checker.sharedDaemonDiagnostics = func(
+		_ context.Context,
+		options appserver.LocalDaemonOptions,
+	) (appserver.SharedDaemonDiagnostics, error) {
+		stableOwner = options.StableOwner
+		return appserver.SharedDaemonDiagnostics{
+			Supported:  true,
+			OwnerState: appserver.SharedDaemonOwnerStateExternal,
+		}, nil
+	}
+	check := checker.sharedDaemonRuntimeCheck(context.Background())
+	if stableOwner {
+		t.Fatal("managed=false 时不能仅凭 shared_fallback 宣称 stable owner")
+	}
+	if !check.OK || !strings.Contains(check.Message, "外部 owner") {
+		t.Fatalf("外部 Unix listener 应保持只读信息诊断：%+v", check)
+	}
+}
+
 func TestCheckerRunAndPrintDoNotLeakToken(t *testing.T) {
 	binDir := t.TempDir()
 	codexPath := filepath.Join(binDir, "codex")

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -60,6 +60,9 @@ type Router struct {
 	// sharedDaemonMigrationRequired 只读取 Mimi owner 的持久迁移标记。单独注入
 	// 让 runtime cache 保持昂贵账号探测缓存，同时每次请求仍返回实时迁移状态。
 	sharedDaemonMigrationRequired func() (bool, error)
+	// sharedDaemonDiagnostics 以 Unix socket 的真实 peer PID 为起点读取资源水位。
+	// 它只进入低频 runtime 快照，不参与 readiness，也不会触发迁移或重启。
+	sharedDaemonDiagnostics func(context.Context) (appserver.SharedDaemonDiagnostics, error)
 	// tailscalePathLookup 只在连接验证/测速时读取一次本机 Tailscale 状态。
 	// 使用可注入函数既避免常驻轮询，也让无 Tailscale 环境下的接口行为可测试。
 	tailscalePathLookup tailscaleNetworkPathLookup
@@ -222,6 +225,16 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 		gitTestFlightJobs:           map[string]*gitTestFlightReleaseJob{},
 		accountTokenUsageCacheTTL:   defaultAccountTokenUsageCacheTTL,
 		claudeBridge:                newClaudeBridgeSupervisor(),
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") {
+		diagnosticOptions := appserver.LocalDaemonOptions{
+			CodexBin:    cfg.Codex.Bin,
+			Env:         cfg.Codex.Env,
+			StableOwner: cfg.AppServer.SharedFallback != nil,
+		}
+		r.sharedDaemonDiagnostics = func(ctx context.Context) (appserver.SharedDaemonDiagnostics, error) {
+			return appserver.InspectSharedDaemonDiagnostics(ctx, diagnosticOptions)
+		}
 	}
 	if strings.EqualFold(strings.TrimSpace(cfg.AppServer.Transport), "unix") &&
 		cfg.AppServer.SharedFallback != nil {

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -210,20 +210,35 @@ func (r *Router) storeClaudeRuntimeQuota(limits *runtimeRateLimits) {
 // runtimeAccountStatus 只包含菜单栏需要的脱敏状态。账号邮箱、Token、Keychain
 // 内容和上游原始错误都不能进入这个结构，避免 status CLI 或日志扩大凭据暴露面。
 type runtimeAccountStatus struct {
-	ID                    string                 `json:"id"`
-	Title                 string                 `json:"title"`
-	Enabled               bool                   `json:"enabled"`
-	State                 runtimeConnectionState `json:"state"`
-	Transport             string                 `json:"transport,omitempty"`
-	Shared                bool                   `json:"shared,omitempty"`
-	DaemonRestartRequired *bool                  `json:"daemon_restart_required,omitempty"`
-	CodexHome             string                 `json:"codex_home,omitempty"`
-	Version               string                 `json:"version,omitempty"`
-	StartedAt             *time.Time             `json:"started_at,omitempty"`
-	AuthMode              string                 `json:"auth_mode,omitempty"`
-	PlanType              string                 `json:"plan_type,omitempty"`
-	Reason                string                 `json:"reason,omitempty"`
-	RateLimits            *runtimeRateLimits     `json:"rate_limits,omitempty"`
+	ID                    string                     `json:"id"`
+	Title                 string                     `json:"title"`
+	Enabled               bool                       `json:"enabled"`
+	State                 runtimeConnectionState     `json:"state"`
+	Transport             string                     `json:"transport,omitempty"`
+	Shared                bool                       `json:"shared,omitempty"`
+	DaemonRestartRequired *bool                      `json:"daemon_restart_required,omitempty"`
+	CodexHome             string                     `json:"codex_home,omitempty"`
+	Version               string                     `json:"version,omitempty"`
+	StartedAt             *time.Time                 `json:"started_at,omitempty"`
+	AuthMode              string                     `json:"auth_mode,omitempty"`
+	PlanType              string                     `json:"plan_type,omitempty"`
+	Reason                string                     `json:"reason,omitempty"`
+	RateLimits            *runtimeRateLimits         `json:"rate_limits,omitempty"`
+	SharedDaemon          *runtimeSharedDaemonStatus `json:"shared_daemon,omitempty"`
+}
+
+// runtimeSharedDaemonStatus 只提供定位资源耗尽所需的数值与枚举。命令行、环境、
+// socket/owner 路径均不进入本机状态接口，避免为了可观测性扩大敏感信息面。
+type runtimeSharedDaemonStatus struct {
+	ListenerPID            int        `json:"listener_pid"`
+	ListenerStartedAt      *time.Time `json:"listener_started_at,omitempty"`
+	OpenFileDescriptors    int        `json:"open_file_descriptors"`
+	DirectChildProcesses   int        `json:"direct_child_processes"`
+	OwnerTargetFDSoftLimit *int       `json:"owner_target_fd_soft_limit,omitempty"`
+	EffectiveFDSoftLimit   *int       `json:"effective_fd_soft_limit,omitempty"`
+	FDUsagePercent         *float64   `json:"fd_usage_percent,omitempty"`
+	OwnerState             string     `json:"owner_state"`
+	ResourceState          string     `json:"resource_state"`
 }
 
 type runtimeRateLimits struct {
@@ -399,8 +414,8 @@ func runtimeStatusLoopbackRequest(req *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
-	status := runtimeAccountStatus{
+func (r *Router) probeCodexRuntime(ctx context.Context) (status runtimeAccountStatus) {
+	status = runtimeAccountStatus{
 		ID:        "codex",
 		Title:     "Codex",
 		Enabled:   true,
@@ -409,6 +424,18 @@ func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
 		Shared:    strings.EqualFold(strings.TrimSpace(r.cfg.AppServer.Transport), "unix"),
 		StartedAt: r.codexRuntimeStartTime(),
 		Reason:    "upstream_unavailable",
+	}
+	var diagnostics <-chan sharedDaemonDiagnosticsResult
+	if status.Shared && r.sharedDaemonDiagnostics != nil {
+		result := make(chan sharedDaemonDiagnosticsResult, 1)
+		diagnostics = result
+		go func() {
+			value, err := r.sharedDaemonDiagnostics(ctx)
+			result <- sharedDaemonDiagnosticsResult{value: value, err: err}
+		}()
+		defer func() {
+			status.SharedDaemon = awaitRuntimeSharedDaemonDiagnostics(ctx, diagnostics)
+		}()
 	}
 	if status.Shared {
 		if socketPath, pathErr := appserver.LocalDaemonSocketPath(r.cfg.Codex.Env); pathErr == nil {
@@ -469,6 +496,54 @@ func (r *Router) probeCodexRuntime(ctx context.Context) runtimeAccountStatus {
 		status.Reason = "quota_refresh_in_progress"
 	}
 	return status
+}
+
+type sharedDaemonDiagnosticsResult struct {
+	value appserver.SharedDaemonDiagnostics
+	err   error
+}
+
+func awaitRuntimeSharedDaemonDiagnostics(
+	ctx context.Context,
+	results <-chan sharedDaemonDiagnosticsResult,
+) *runtimeSharedDaemonStatus {
+	if results == nil {
+		return nil
+	}
+	// 账号和资源探测并行执行；这里只给内核/launchctl 取证一个很短的收尾窗口，
+	// 不能让可选诊断拖垮原有 runtime 状态刷新。
+	timer := time.NewTimer(500 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case result := <-results:
+		if result.err != nil || !result.value.Supported {
+			return nil
+		}
+		return newRuntimeSharedDaemonStatus(result.value)
+	case <-ctx.Done():
+		return nil
+	case <-timer.C:
+		return nil
+	}
+}
+
+func newRuntimeSharedDaemonStatus(value appserver.SharedDaemonDiagnostics) *runtimeSharedDaemonStatus {
+	var startedAt *time.Time
+	if !value.ListenerStartedAt.IsZero() {
+		copy := value.ListenerStartedAt.UTC()
+		startedAt = &copy
+	}
+	return &runtimeSharedDaemonStatus{
+		ListenerPID:            value.ListenerPID,
+		ListenerStartedAt:      startedAt,
+		OpenFileDescriptors:    value.OpenFileDescriptors,
+		DirectChildProcesses:   value.DirectChildProcesses,
+		OwnerTargetFDSoftLimit: value.OwnerTargetFDSoftLimit,
+		EffectiveFDSoftLimit:   value.EffectiveFDSoftLimit,
+		FDUsagePercent:         value.FDUsagePercent,
+		OwnerState:             string(value.OwnerState),
+		ResourceState:          string(value.ResourceState),
+	}
 }
 
 func applyCodexAccount(status *runtimeAccountStatus, response runtimeAccountResponse) {

--- a/internal/httpapi/runtime_status_test.go
+++ b/internal/httpapi/runtime_status_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 )
 
@@ -94,6 +95,49 @@ func TestRuntimeStatusOverlaysLiveSharedDaemonMigrationMarker(t *testing.T) {
 	unknown := router.withLiveSharedDaemonMigrationStatus(cached)
 	if unknown.Runtimes[0].DaemonRestartRequired != nil {
 		t.Fatal("标记读取失败必须保持未知，不能授权迁移")
+	}
+}
+
+func TestRuntimeSharedDaemonDiagnosticsAreSanitized(t *testing.T) {
+	limit := 8192
+	effectiveLimit := 4096
+	usage := 12.5
+	startedAt := time.Date(2026, time.August, 14, 0, 20, 20, 0, time.UTC)
+	diagnostic := newRuntimeSharedDaemonStatus(appserver.SharedDaemonDiagnostics{
+		Supported:              true,
+		ListenerPID:            10306,
+		ListenerStartedAt:      startedAt,
+		OpenFileDescriptors:    1024,
+		DirectChildProcesses:   3,
+		OwnerTargetFDSoftLimit: &limit,
+		EffectiveFDSoftLimit:   &effectiveLimit,
+		FDUsagePercent:         &usage,
+		OwnerState:             appserver.SharedDaemonOwnerStateStable,
+		ResourceState:          appserver.SharedDaemonResourceStateHealthy,
+	})
+	if diagnostic.ListenerPID != 10306 || diagnostic.OpenFileDescriptors != 1024 ||
+		diagnostic.OwnerTargetFDSoftLimit == nil || *diagnostic.OwnerTargetFDSoftLimit != 8192 ||
+		diagnostic.EffectiveFDSoftLimit == nil || *diagnostic.EffectiveFDSoftLimit != 4096 ||
+		diagnostic.OwnerState != "stable" || diagnostic.ResourceState != "healthy" {
+		t.Fatalf("共享 daemon 诊断映射错误：%+v", diagnostic)
+	}
+	raw, err := json.Marshal(diagnostic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialized := string(raw)
+	for _, sensitive := range []string{"socket", "command", "environment", "/Users/tester"} {
+		if strings.Contains(strings.ToLower(serialized), strings.ToLower(sensitive)) {
+			t.Fatalf("runtime daemon 诊断不能泄露 %q：%s", sensitive, serialized)
+		}
+	}
+}
+
+func TestRuntimeSharedDaemonDiagnosticsFailureIsOmitted(t *testing.T) {
+	results := make(chan sharedDaemonDiagnosticsResult, 1)
+	results <- sharedDaemonDiagnosticsResult{err: fmt.Errorf("permission denied")}
+	if status := awaitRuntimeSharedDaemonDiagnostics(context.Background(), results); status != nil {
+		t.Fatalf("可选资源诊断失败时必须省略字段：%+v", status)
 	}
 }
 

--- a/macos/MimiRemoteMac/Scripts/embed-agentd.sh
+++ b/macos/MimiRemoteMac/Scripts/embed-agentd.sh
@@ -9,6 +9,31 @@ agentd_output="$bundle_root/Resources/agentd"
 bridge_output="$bundle_root/Resources/alleycat-claude-bridge"
 launch_agent_output="$bundle_root/Library/LaunchAgents/com.gaixianggeng.mimi.mac.agentd.plist"
 launch_agent_source="$SRCROOT/Resources/LaunchAgents/com.gaixianggeng.mimi.mac.agentd.plist"
+configuration="${CONFIGURATION:-Debug}"
+
+log() {
+  printf '[embed-agentd %s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+# Build phase 被 Xcode 标记为 alwaysOutOfDate，因此这里必须复用稳定缓存。
+# 配置和 Rust target/profile 都进入目录层级，避免 Debug/Release 或 arm64/
+# x86_64 之间串用产物；默认路径仍在 DerivedData 内，CI 可显式传入 runner.temp。
+default_cache_root="${PROJECT_TEMP_DIR:-${BUILD_DIR:-$TARGET_BUILD_DIR}/../MimiRemoteMacEmbedCache}"
+cache_root="${MACOS_EMBED_CACHE_DIR:-$default_cache_root}"
+cache_root="${cache_root%/}/${configuration}"
+mkdir -p "$cache_root"
+
+case "$configuration" in
+  Debug|Debug-*)
+    rust_profile="debug"
+    ;;
+  *)
+    # Release 和 Archive 必须继续使用 release profile；未知配置也按发布安全默认处理。
+    rust_profile="release"
+    ;;
+esac
+
+log "开始构建内嵌 agentd/Claude bridge：configuration=${configuration} rust-profile=${rust_profile}"
 
 find_go() {
   local candidate
@@ -38,8 +63,6 @@ if [[ "$go_version" != go1.25.* ]]; then
 fi
 
 mkdir -p "$(dirname "$agentd_output")" "$(dirname "$launch_agent_output")"
-build_dir="$(mktemp -d "${TMPDIR:-/tmp}/mimi-agentd-build.XXXXXX")"
-trap 'rm -rf "$build_dir"' EXIT
 
 architectures=($ARCHS)
 outputs=()
@@ -58,14 +81,21 @@ for architecture in "${architectures[@]}"; do
       exit 1
       ;;
   esac
-  output="$build_dir/agentd-$architecture"
+  # 每个架构使用独立 Go 编译缓存和输出，既可复用又不会把交叉编译结果混在一起。
+  go_cache_root="$cache_root/go/$architecture"
+  mkdir -p "$go_cache_root/gocache"
+  output="$go_cache_root/agentd"
+  go_started_at=$SECONDS
+  log "构建 agentd：arch=${architecture} goarch=${go_arch} cache=${go_cache_root}"
   (
     cd "$project_root"
     CGO_ENABLED=0 GOOS=darwin GOARCH="$go_arch" GOTOOLCHAIN=local \
+      GOCACHE="$go_cache_root/gocache" \
       "$go_binary" build -trimpath \
       -ldflags "-s -w -X main.version=${agent_version}" \
       -o "$output" ./cmd/agentd
   )
+  log "agentd 构建完成：arch=${architecture} elapsed=$((SECONDS - go_started_at))s"
   outputs+=("$output")
 done
 
@@ -77,6 +107,7 @@ fi
 chmod 0755 "$agentd_output"
 cp "$launch_agent_source" "$launch_agent_output"
 /usr/bin/plutil -lint "$launch_agent_output" >/dev/null
+log "agentd 已内嵌：archs=${architectures[*]}"
 
 # --- Claude bridge -----------------------------------------------------------
 find_cargo() {
@@ -103,21 +134,38 @@ for architecture in "${architectures[@]}"; do
     arm64) rust_target=aarch64-apple-darwin ;;
     x86_64) rust_target=x86_64-apple-darwin ;;
   esac
+  # target-dir 按 profile/target 分开，Cargo 的增量产物可以跨 build phase 复用。
+  rust_target_dir="$cache_root/rust/$rust_profile/$rust_target"
+  mkdir -p "$rust_target_dir"
+  cargo_args=(
+    build
+    --locked
+    --manifest-path "$project_root/Cargo.toml"
+    --package alleycat-claude-bridge
+    --bin alleycat-claude-bridge
+    --target "$rust_target"
+    --target-dir "$rust_target_dir"
+  )
+  if [[ "$rust_profile" == "release" ]]; then
+    cargo_args+=(--release)
+  fi
+  bridge_binary="$rust_target_dir/$rust_target/$rust_profile/alleycat-claude-bridge"
+  rust_started_at=$SECONDS
+  log "构建 Claude bridge：arch=${architecture} target=${rust_target} profile=${rust_profile} target-dir=${rust_target_dir}"
   # Drop MACOSX_DEPLOYMENT_TARGET for this build. Xcode sets it for the Swift
   # target, and cargo applies it to host artifacts too — which breaks the
   # proc-macro crates rustc has to load at compile time (`can't find crate for
   # tokio_macros`). The bridge's own deployment floor comes from the target
   # triple, so nothing is lost by unsetting it here.
-  if ! env -u MACOSX_DEPLOYMENT_TARGET "$cargo_binary" build --release --locked \
-    --manifest-path "$project_root/Cargo.toml" \
-    --package alleycat-claude-bridge --bin alleycat-claude-bridge \
-    --target "$rust_target" \
-    --target-dir "$build_dir/rust"; then
+  if ! env -u MACOSX_DEPLOYMENT_TARGET "$cargo_binary" "${cargo_args[@]}"; then
     echo "Mimi Remote Mac 构建失败：无法为 $rust_target 构建 Claude bridge。" >&2
     echo "缺少目标时先安装：rustup target add $rust_target" >&2
     exit 1
   fi
-  bridge_outputs+=("$build_dir/rust/$rust_target/release/alleycat-claude-bridge")
+  [[ -x "$bridge_binary" ]] \
+    || { echo "Mimi Remote Mac 构建失败：Cargo 未产出 $bridge_binary。" >&2; exit 1; }
+  log "Claude bridge 构建完成：arch=${architecture} elapsed=$((SECONDS - rust_started_at))s"
+  bridge_outputs+=("$bridge_binary")
 done
 
 if [[ ${#bridge_outputs[@]} -eq 1 ]]; then
@@ -126,6 +174,7 @@ else
   /usr/bin/lipo -create "${bridge_outputs[@]}" -output "$bridge_output"
 fi
 chmod 0755 "$bridge_output"
+log "Claude bridge 已内嵌：archs=${architectures[*]} profile=${rust_profile}"
 
 if [[ "${CODE_SIGNING_ALLOWED:-NO}" == "YES" && -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]]; then
   /usr/bin/codesign --force --sign "$EXPANDED_CODE_SIGN_IDENTITY" \
@@ -138,6 +187,7 @@ fi
 
 "$agentd_output" version >/dev/null
 "$bridge_output" --version >/dev/null
+log "内嵌二进制 smoke check 通过"
 
 # This phase runs after Xcode has sealed the bundle, so the binaries it just
 # wrote are not covered by that seal. On a full build Xcode signs afterwards

--- a/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
@@ -43,13 +43,15 @@ extension AgentCommandClient {
             binary: URL,
             arguments: [String],
             allowFailure: Bool = false,
-            timeout: Duration = .seconds(15)
+            timeout: Duration = .seconds(15),
+            forceKillAfterTimeout: Bool = false
         ) async throws -> CommandResult {
             let result = try await executor.run(
                 executable: binary,
                 arguments: arguments,
                 timeout: timeout,
-                environment: environment
+                environment: environment,
+                forceKillAfterTimeout: forceKillAfterTimeout
             )
             if result.status != 0 && !allowFailure {
                 throw AgentClientError.commandFailed(
@@ -145,7 +147,10 @@ extension AgentCommandClient {
                 _ = try await execute(
                     binary: binary,
                     arguments: codexSharingRestartArguments(),
-                    timeout: .seconds(50)
+                    timeout: .seconds(50),
+                    // 迁移的 agentd 是短命 control CLI；超时后只回收它本身，
+                    // 不触碰共享 Codex daemon。其他通用命令保持普通 TERM 语义。
+                    forceKillAfterTimeout: true
                 )
             },
             setLANAccess: { enabled in

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -81,9 +81,12 @@ actor ProcessExecutor {
         async let stderrRead = Self.readBounded(stderrPipe.fileHandleForReading, limit: outputLimit)
 
         let timeoutState = LockedFlag()
-        let timeoutTask = Task.detached {
-            try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled else { return }
+        let processFinished = LockedFlag()
+        // 不能把 timeout 也放进 Swift cooperative executor：stdout、stderr 和
+        // waitUntilExit 都可能同步阻塞，在小规格 CI/用户机器上会占满可用线程，
+        // 让本应唤醒并回收进程的 timeout task 永远得不到调度。
+        let timeoutWorkItem = DispatchWorkItem {
+            guard !processFinished.value else { return }
             timeoutState.set()
             // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
             // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
@@ -91,12 +94,17 @@ actor ProcessExecutor {
             // Codex daemon；后端 marker/manual plist 仍保留，可安全重试。
             _ = Darwin.kill(processIdentifier, SIGTERM)
             guard forceKillAfterTimeout else { return }
-            try? await Task.sleep(for: .seconds(2))
-            // waitUntilExit 已返回时外层会 cancel；必须在 try? 吞掉
-            // CancellationError 后再次检查，避免误伤复用同一 PID 的新进程。
-            guard !Task.isCancelled else { return }
-            _ = Darwin.kill(processIdentifier, SIGKILL)
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) {
+                // waitUntilExit 已返回时会先标记 finished；二次检查避免误伤
+                // 已退出 control command 之后复用同一 PID 的新进程。
+                guard !processFinished.value else { return }
+                _ = Darwin.kill(processIdentifier, SIGKILL)
+            }
         }
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: Self.dispatchDeadline(after: timeout),
+            execute: timeoutWorkItem
+        )
 
         let status = await withTaskCancellationHandler {
             await Task.detached {
@@ -104,11 +112,10 @@ actor ProcessExecutor {
                 return process.terminationStatus
             }.value
         } onCancel: {
-            if process.isRunning {
-                process.terminate()
-            }
+            _ = Darwin.kill(processIdentifier, SIGTERM)
         }
-        timeoutTask.cancel()
+        processFinished.set()
+        timeoutWorkItem.cancel()
 
         let stdout = try await stdoutRead
         let stderr = try await stderrRead
@@ -127,6 +134,15 @@ actor ProcessExecutor {
     private struct BoundedRead {
         let data: Data
         let exceededLimit: Bool
+    }
+
+    private static func dispatchDeadline(after duration: Duration) -> DispatchTime {
+        let components = duration.components
+        let seconds = max(
+            0,
+            Double(components.seconds) + Double(components.attoseconds) / 1e18
+        )
+        return .now() + seconds
     }
 
     private static func readBounded(_ handle: FileHandle, limit: Int) async throws -> BoundedRead {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -80,6 +80,9 @@ actor ProcessExecutor {
         } catch {
             throw ProcessExecutorError.launchFailed(error.localizedDescription)
         }
+        // 启动成功后立即固定 PID。部分 hosted runner 在 terminate() 后会提前
+        // 清空 Process 的运行态，届时再读取 processIdentifier 可能已不是原 PID。
+        let processIdentifier = process.processIdentifier
 
         async let stdoutRead = Self.readBounded(stdoutPipe.fileHandleForReading, limit: outputLimit)
         async let stderrRead = Self.readBounded(stderrPipe.fileHandleForReading, limit: outputLimit)
@@ -93,11 +96,11 @@ actor ProcessExecutor {
             // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
             // “正在更新”。两秒后只强制回收这个短命 control CLI，不触碰共享
             // Codex daemon；后端 marker/manual plist 仍保留，可安全重试。
-            process.terminate()
+            _ = Darwin.kill(processIdentifier, SIGTERM)
             guard forceKillAfterTimeout else { return }
             try? await Task.sleep(for: .seconds(2))
             guard !processExited.value else { return }
-            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+            _ = Darwin.kill(processIdentifier, SIGKILL)
         }
 
         let status = await withTaskCancellationHandler {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -67,22 +67,11 @@ actor ProcessExecutor {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        // Foundation 在部分 hosted macOS runner 上会在 terminate() 返回后把
-        // isRunning 提前变为 false，即使目标进程忽略了 SIGTERM。用真实退出回调
-        // 记录内核已回收的事实，避免因此跳过两秒后的 SIGKILL。
-        let processExited = LockedFlag()
-        process.terminationHandler = { _ in
-            processExited.set()
-        }
-
         do {
             try process.run()
         } catch {
             throw ProcessExecutorError.launchFailed(error.localizedDescription)
         }
-        // 启动成功后立即固定 PID。部分 hosted runner 在 terminate() 后会提前
-        // 清空 Process 的运行态，届时再读取 processIdentifier 可能已不是原 PID。
-        let processIdentifier = process.processIdentifier
 
         async let stdoutRead = Self.readBounded(stdoutPipe.fileHandleForReading, limit: outputLimit)
         async let stderrRead = Self.readBounded(stderrPipe.fileHandleForReading, limit: outputLimit)
@@ -90,17 +79,17 @@ actor ProcessExecutor {
         let timeoutState = LockedFlag()
         let timeoutTask = Task.detached {
             try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled, !processExited.value else { return }
+            guard !Task.isCancelled, process.isRunning else { return }
             timeoutState.set()
             // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
             // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
             // “正在更新”。两秒后只强制回收这个短命 control CLI，不触碰共享
             // Codex daemon；后端 marker/manual plist 仍保留，可安全重试。
-            _ = Darwin.kill(processIdentifier, SIGTERM)
+            process.terminate()
             guard forceKillAfterTimeout else { return }
             try? await Task.sleep(for: .seconds(2))
-            guard !processExited.value else { return }
-            _ = Darwin.kill(processIdentifier, SIGKILL)
+            guard process.isRunning else { return }
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
         }
 
         let status = await withTaskCancellationHandler {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -67,6 +67,14 @@ actor ProcessExecutor {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        // Foundation 在部分 hosted macOS runner 上会在 terminate() 返回后把
+        // isRunning 提前变为 false，即使目标进程忽略了 SIGTERM。用真实退出回调
+        // 记录内核已回收的事实，避免因此跳过两秒后的 SIGKILL。
+        let processExited = LockedFlag()
+        process.terminationHandler = { _ in
+            processExited.set()
+        }
+
         do {
             try process.run()
         } catch {
@@ -79,7 +87,7 @@ actor ProcessExecutor {
         let timeoutState = LockedFlag()
         let timeoutTask = Task.detached {
             try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled, process.isRunning else { return }
+            guard !Task.isCancelled, !processExited.value else { return }
             timeoutState.set()
             // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
             // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
@@ -88,7 +96,7 @@ actor ProcessExecutor {
             process.terminate()
             guard forceKillAfterTimeout else { return }
             try? await Task.sleep(for: .seconds(2))
-            guard process.isRunning else { return }
+            guard !processExited.value else { return }
             _ = Darwin.kill(process.processIdentifier, SIGKILL)
         }
 

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -67,11 +67,22 @@ actor ProcessExecutor {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        // hosted runner 上 Process.isRunning 会在发送 terminate 后提前变为 false，
+        // 即使目标仍忽略 SIGTERM 运行。用真实退出回调记录子进程是否已被回收，
+        // 避免跳过 grace period 后的 SIGKILL。
+        let processExited = LockedFlag()
+        process.terminationHandler = { _ in
+            processExited.set()
+        }
+
         do {
             try process.run()
         } catch {
             throw ProcessExecutorError.launchFailed(error.localizedDescription)
         }
+        // Foundation 的运行态失效后 processIdentifier 也不再可靠，因此在启动
+        // 成功时固定本次短命 control command 的 PID。
+        let processIdentifier = process.processIdentifier
 
         async let stdoutRead = Self.readBounded(stdoutPipe.fileHandleForReading, limit: outputLimit)
         async let stderrRead = Self.readBounded(stderrPipe.fileHandleForReading, limit: outputLimit)
@@ -79,17 +90,17 @@ actor ProcessExecutor {
         let timeoutState = LockedFlag()
         let timeoutTask = Task.detached {
             try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled, process.isRunning else { return }
+            guard !Task.isCancelled, !processExited.value else { return }
             timeoutState.set()
             // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
             // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
             // “正在更新”。两秒后只强制回收这个短命 control CLI，不触碰共享
             // Codex daemon；后端 marker/manual plist 仍保留，可安全重试。
-            process.terminate()
+            _ = Darwin.kill(processIdentifier, SIGTERM)
             guard forceKillAfterTimeout else { return }
             try? await Task.sleep(for: .seconds(2))
-            guard process.isRunning else { return }
-            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+            guard !processExited.value else { return }
+            _ = Darwin.kill(processIdentifier, SIGKILL)
         }
 
         let status = await withTaskCancellationHandler {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -71,9 +71,6 @@ actor ProcessExecutor {
         // 即使目标仍忽略 SIGTERM 运行。用真实退出回调记录子进程是否已被回收，
         // 避免跳过 grace period 后的 SIGKILL。
         let processExited = LockedFlag()
-        process.terminationHandler = { _ in
-            processExited.set()
-        }
 
         do {
             try process.run()
@@ -83,6 +80,11 @@ actor ProcessExecutor {
         // Foundation 的运行态失效后 processIdentifier 也不再可靠，因此在启动
         // 成功时固定本次短命 control command 的 PID。
         let processIdentifier = process.processIdentifier
+        // 必须在 run() 成功后安装；部分 Foundation 版本会把尚未启动的 Process
+        // 当作已终止并提前触发 handler，导致超时任务被错误跳过。
+        process.terminationHandler = { _ in
+            processExited.set()
+        }
 
         async let stdoutRead = Self.readBounded(stdoutPipe.fileHandleForReading, limit: outputLimit)
         async let stderrRead = Self.readBounded(stderrPipe.fileHandleForReading, limit: outputLimit)
@@ -90,7 +92,7 @@ actor ProcessExecutor {
         let timeoutState = LockedFlag()
         let timeoutTask = Task.detached {
             try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled, !processExited.value else { return }
+            guard !Task.isCancelled, process.isRunning else { return }
             timeoutState.set()
             // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
             // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -107,10 +107,7 @@ actor ProcessExecutor {
         )
 
         let status = await withTaskCancellationHandler {
-            await Task.detached {
-                process.waitUntilExit()
-                return process.terminationStatus
-            }.value
+            await Self.waitUntilExit(process)
         } onCancel: {
             _ = Darwin.kill(processIdentifier, SIGTERM)
         }
@@ -145,25 +142,46 @@ actor ProcessExecutor {
         return .now() + seconds
     }
 
+    private static func waitUntilExit(_ process: Process) async -> Int32 {
+        await withCheckedContinuation { continuation in
+            // Process.waitUntilExit 是同步阻塞 API。不能用 Task.detached 包装，
+            // 否则会占住 Swift cooperative executor 的 worker。
+            Thread.detachNewThread {
+                process.waitUntilExit()
+                continuation.resume(returning: process.terminationStatus)
+            }
+        }
+    }
+
     private static func readBounded(_ handle: FileHandle, limit: Int) async throws -> BoundedRead {
-        try await Task.detached {
-            var collected = Data()
-            var exceeded = false
-            var total = 0
-            while true {
-                let chunk = try handle.read(upToCount: 64 * 1024) ?? Data()
-                if chunk.isEmpty { break }
-                total += chunk.count
-                if collected.count < limit {
-                    let remaining = limit - collected.count
-                    collected.append(chunk.prefix(remaining))
-                }
-                if total > limit {
-                    exceeded = true
+        try await withCheckedThrowingContinuation { continuation in
+            // FileHandle.read(upToCount:) 同样是同步阻塞 API；每次命令最多使用
+            // stdout/stderr 两条短命专用线程，避免挤占 timeout 所需的异步 worker。
+            Thread.detachNewThread {
+                do {
+                    var collected = Data()
+                    var exceeded = false
+                    var total = 0
+                    while true {
+                        let chunk = try handle.read(upToCount: 64 * 1024) ?? Data()
+                        if chunk.isEmpty { break }
+                        total += chunk.count
+                        if collected.count < limit {
+                            let remaining = limit - collected.count
+                            collected.append(chunk.prefix(remaining))
+                        }
+                        if total > limit {
+                            exceeded = true
+                        }
+                    }
+                    continuation.resume(
+                        returning: BoundedRead(data: collected, exceededLimit: exceeded)
+                    )
+                } catch {
+                    continuation.resume(throwing: error)
                 }
             }
-            return BoundedRead(data: collected, exceededLimit: exceeded)
-        }.value
+        }
     }
 }
 

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -1,4 +1,5 @@
 @preconcurrency import Foundation
+import Darwin
 
 struct CommandResult: Equatable, Sendable {
     let status: Int32
@@ -53,7 +54,8 @@ actor ProcessExecutor {
         arguments: [String],
         timeout: Duration = .seconds(15),
         outputLimit: Int = 1_048_576,
-        environment: [String: String]? = nil
+        environment: [String: String]? = nil,
+        forceKillAfterTimeout: Bool = false
     ) async throws -> CommandResult {
         let process = Process()
         process.executableURL = executable
@@ -79,7 +81,15 @@ actor ProcessExecutor {
             try? await Task.sleep(for: timeout)
             guard !Task.isCancelled, process.isRunning else { return }
             timeoutState.set()
+            // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
+            // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
+            // “正在更新”。两秒后只强制回收这个短命 control CLI，不触碰共享
+            // Codex daemon；后端 marker/manual plist 仍保留，可安全重试。
             process.terminate()
+            guard forceKillAfterTimeout else { return }
+            try? await Task.sleep(for: .seconds(2))
+            guard process.isRunning else { return }
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
         }
 
         let status = await withTaskCancellationHandler {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ProcessExecutor.swift
@@ -67,24 +67,15 @@ actor ProcessExecutor {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        // hosted runner 上 Process.isRunning 会在发送 terminate 后提前变为 false，
-        // 即使目标仍忽略 SIGTERM 运行。用真实退出回调记录子进程是否已被回收，
-        // 避免跳过 grace period 后的 SIGKILL。
-        let processExited = LockedFlag()
-
         do {
             try process.run()
         } catch {
             throw ProcessExecutorError.launchFailed(error.localizedDescription)
         }
-        // Foundation 的运行态失效后 processIdentifier 也不再可靠，因此在启动
-        // 成功时固定本次短命 control command 的 PID。
+        // hosted runner 上 Process.isRunning 可能在子进程仍存活时返回 false；
+        // 启动成功后固定 PID，并以 waitUntilExit 返回后取消 timeout task 作为
+        // 唯一退出门控，避免依赖 Foundation 的运行态缓存。
         let processIdentifier = process.processIdentifier
-        // 必须在 run() 成功后安装；部分 Foundation 版本会把尚未启动的 Process
-        // 当作已终止并提前触发 handler，导致超时任务被错误跳过。
-        process.terminationHandler = { _ in
-            processExited.set()
-        }
 
         async let stdoutRead = Self.readBounded(stdoutPipe.fileHandleForReading, limit: outputLimit)
         async let stderrRead = Self.readBounded(stderrPipe.fileHandleForReading, limit: outputLimit)
@@ -92,7 +83,7 @@ actor ProcessExecutor {
         let timeoutState = LockedFlag()
         let timeoutTask = Task.detached {
             try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled, process.isRunning else { return }
+            guard !Task.isCancelled else { return }
             timeoutState.set()
             // 先给 agentd 控制命令正常退出机会；如果它卡在不可取消的系统调用，
             // 仅发送 SIGTERM 会让 waitUntilExit 永久挂住，设置页也就一直显示
@@ -101,7 +92,9 @@ actor ProcessExecutor {
             _ = Darwin.kill(processIdentifier, SIGTERM)
             guard forceKillAfterTimeout else { return }
             try? await Task.sleep(for: .seconds(2))
-            guard !processExited.value else { return }
+            // waitUntilExit 已返回时外层会 cancel；必须在 try? 吞掉
+            // CancellationError 后再次检查，避免误伤复用同一 PID 的新进程。
+            guard !Task.isCancelled else { return }
             _ = Darwin.kill(processIdentifier, SIGKILL)
         }
 

--- a/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
@@ -114,4 +114,26 @@ final class AgentCommandClientTests: XCTestCase {
             "committed"
         )
     }
+
+    func testProcessTimeoutReapsControlCommandThatIgnoresTerminate() async {
+        let executor = ProcessExecutor()
+        let startedAt = ContinuousClock.now
+        do {
+            _ = try await executor.run(
+                executable: URL(filePath: "/bin/sh"),
+                arguments: ["-c", "trap '' TERM; while :; do sleep 1; done"],
+                timeout: .milliseconds(100),
+                forceKillAfterTimeout: true
+            )
+            XCTFail("忽略 SIGTERM 的 control command 必须超时")
+        } catch ProcessExecutorError.timedOut {
+            XCTAssertLessThan(
+                startedAt.duration(to: .now),
+                .seconds(4),
+                "timeout 后必须在 grace period 内回收 control command，不能让 UI 永久 busy"
+            )
+        } catch {
+            XCTFail("超时应保留 timedOut 语义，实际为 \(error)")
+        }
+    }
 }

--- a/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
@@ -121,7 +121,10 @@ final class AgentCommandClientTests: XCTestCase {
         do {
             _ = try await executor.run(
                 executable: URL(filePath: "/bin/sh"),
-                arguments: ["-c", "trap '' TERM; while :; do sleep 1; done"],
+                // 用 exec 保持同一个 PID 忽略 SIGTERM，避免循环派生的 sleep 子进程
+                // 在父 shell 被杀后继续持有 stdout/stderr pipe，让 CI 错把 pipe EOF
+                // 等待当成 ProcessExecutor 没有回收目标进程。
+                arguments: ["-c", "trap '' TERM; exec /bin/sleep 60"],
                 timeout: .milliseconds(100),
                 forceKillAfterTimeout: true
             )

--- a/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
+++ b/macos/MimiRemoteMac/Tests/AgentCommandClientTests.swift
@@ -121,10 +121,9 @@ final class AgentCommandClientTests: XCTestCase {
         do {
             _ = try await executor.run(
                 executable: URL(filePath: "/bin/sh"),
-                // 用 exec 保持同一个 PID 忽略 SIGTERM，避免循环派生的 sleep 子进程
-                // 在父 shell 被杀后继续持有 stdout/stderr pipe，让 CI 错把 pipe EOF
-                // 等待当成 ProcessExecutor 没有回收目标进程。
-                arguments: ["-c", "trap '' TERM; exec /bin/sleep 60"],
+                // 让 shell 本身忽略 SIGTERM，且不派生会继承 stdout/stderr pipe 的
+                // 子进程；否则测试测到的是后代等待 pipe EOF，而不是目标是否回收。
+                arguments: ["-c", "trap '' TERM; while :; do :; done"],
                 timeout: .milliseconds(100),
                 forceKillAfterTimeout: true
             )

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -25,7 +25,8 @@ for script_path in \
   scripts/check-pr-gate.sh \
   scripts/verify-change.sh \
   scripts/test-verify-change.sh \
-  scripts/test-macos-app.sh; do
+  scripts/test-macos-app.sh \
+  macos/MimiRemoteMac/Scripts/embed-agentd.sh; do
   bash -n -- "$script_path"
 done
 
@@ -190,17 +191,29 @@ unless macos_push_paths.include?("macos/MimiRemoteMac/**") &&
   abort("PR Gate 自检失败：Mac App CI 的 main push paths 与 PR scope 不一致。")
 end
 macos_job = macos_workflow.fetch("jobs").fetch("build-and-test")
-unless macos_job["runs-on"] == "macos-26" && macos_job["timeout-minutes"] == 35
-  abort("PR Gate 自检失败：Mac App CI 必须使用 macOS 26 runner 和 35 分钟超时。")
+unless macos_job["runs-on"] == "macos-26" && macos_job["timeout-minutes"] == 15
+  abort("PR Gate 自检失败：Mac App CI 必须使用 macOS 26 runner 和 15 分钟超时。")
 end
 unless macos_job.to_s.include?("bash ./scripts/test-macos-app.sh")
   abort("PR Gate 自检失败：Mac App CI 没有运行统一编译测试入口。")
 end
 macos_test_script = File.read("scripts/test-macos-app.sh")
-%w[xcodebuild CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test].each do |fragment|
+%w[xcodebuild -showBuildTimingSummary MACOS_EMBED_CACHE_DIR CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test].each do |fragment|
   unless macos_test_script.include?(fragment)
     abort("PR Gate 自检失败：Mac App 编译测试入口缺少 #{fragment}。")
   end
+end
+if macos_test_script.match?(/^\s*-quiet\s*$/)
+  abort("PR Gate 自检失败：Mac App 编译测试入口不得隐藏 Xcode 阶段日志。")
+end
+embed_script = File.read("macos/MimiRemoteMac/Scripts/embed-agentd.sh")
+%w[MACOS_EMBED_CACHE_DIR --target-dir --locked --release].each do |fragment|
+  unless embed_script.include?(fragment)
+    abort("PR Gate 自检失败：Mac App 内嵌构建脚本缺少 #{fragment}。")
+  end
+end
+unless macos_workflow.to_s.include?("MACOS_EMBED_CACHE_DIR")
+  abort("PR Gate 自检失败：Mac App CI 没有显式配置内嵌构建缓存目录。")
 end
 
 docs_path = ".github/workflows/docs-ci.yml"

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -190,8 +190,8 @@ unless macos_push_paths.include?("macos/MimiRemoteMac/**") &&
   abort("PR Gate 自检失败：Mac App CI 的 main push paths 与 PR scope 不一致。")
 end
 macos_job = macos_workflow.fetch("jobs").fetch("build-and-test")
-unless macos_job["runs-on"] == "macos-26" && macos_job["timeout-minutes"] == 20
-  abort("PR Gate 自检失败：Mac App CI 必须使用 macOS 26 runner 和 20 分钟超时。")
+unless macos_job["runs-on"] == "macos-26" && macos_job["timeout-minutes"] == 35
+  abort("PR Gate 自检失败：Mac App CI 必须使用 macOS 26 runner 和 35 分钟超时。")
 end
 unless macos_job.to_s.include?("bash ./scripts/test-macos-app.sh")
   abort("PR Gate 自检失败：Mac App CI 没有运行统一编译测试入口。")

--- a/scripts/test-macos-app.sh
+++ b/scripts/test-macos-app.sh
@@ -9,6 +9,13 @@ scheme="MimiRemoteMac"
 configuration="${MACOS_TEST_CONFIGURATION:-Debug}"
 architecture="${MACOS_TEST_ARCH:-$(uname -m)}"
 derived_data="${MACOS_DERIVED_DATA_PATH:-$ROOT_DIR/.build/MimiRemoteMacTests}"
+# 传给 Xcode build phase 的可复用缓存必须位于 DerivedData 或调用方明确指定的
+# 临时目录；默认值不会把 Rust/Go 的中间产物写进仓库。
+embed_cache="${MACOS_EMBED_CACHE_DIR:-$derived_data/MimiRemoteMacEmbedCache}"
+
+log() {
+  printf '[macos-test %s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
 
 case "$architecture" in
   arm64|x86_64) ;;
@@ -25,15 +32,18 @@ done
 
 # 必须通过真实 Scheme 运行测试，不只做 Swift 语法检查。这会同时
 # 编译 Mac App、内嵌 agentd / Claude bridge 和现有单测，但不读取发布签名凭据。
+log "开始真实 Scheme 测试：scheme=${scheme} configuration=${configuration} arch=${architecture}"
+log "DerivedData=${derived_data} embed-cache=${embed_cache}"
 xcodebuild \
-  -quiet \
   -project "$project_path" \
   -scheme "$scheme" \
   -configuration "$configuration" \
   -destination "platform=macOS,arch=$architecture" \
   -derivedDataPath "$derived_data" \
+  -showBuildTimingSummary \
   CODE_SIGNING_ALLOWED=NO \
   CODE_SIGNING_REQUIRED=NO \
+  MACOS_EMBED_CACHE_DIR="$embed_cache" \
   test
 
-echo "Mac App 编译与单测通过：scheme=${scheme} configuration=${configuration} arch=${architecture}"
+log "Mac App 编译与单测通过：scheme=${scheme} configuration=${configuration} arch=${architecture}"


### PR DESCRIPTION
## 目标

修复共享 Codex daemon 长时间运行时因过低 FD soft limit 导致 Browser、MCP、Skills、Shell 与网络能力一起失效的问题，并提供不打断请求的只读资源诊断。

关联 Linear：MIM-158。

## 方案

- 在稳定 LaunchAgent 中设置 `SoftResourceLimits/NumberOfFiles=8192`，不修改 hard limit。
- 从真实 Unix socket peer PID 读取 FD 数、直接子进程数、uptime 与 owner/lifecycle 一致性，不信任缓存 PID 或进程名。
- 通过 runtime status、HTTP API 与 Doctor 暴露资源状态；外部 owner 与 AttachOnly 不套用 Mimi 的目标上限。
- macOS 无法可靠读取另一进程的实时 `RLIMIT_NOFILE` 时，只展示“owner 目标 8192、当前进程未验证”，作为正常信息而不是永久 WARN。
- Mac 控制命令超时时先 TERM，宽限后只回收短命 control CLI，不向共享 daemon 发送 SIGKILL。
- 不实现基于不完整空闲证据的自动 recycle，不改变 thread writer 或 gateway 转发协议。

## 用户影响

- 新启动的 Mimi 稳定 owner 拥有更合理的 FD 预算。
- 用户可以看到真实 FD/子进程水位和 owner 状态，而不会被无法消除的未知 RLIMIT 警告干扰。
- 本 PR 不处理 Codex Browser 的签名父链；Browser runtime identity 在后续 MIM-159 stacked PR 中独立评审。

## 验证

- `go test ./... -count=1`
- `go vet ./...`
- `bash ./scripts/check-source-size.sh`
- `git diff --check`
- `MACOS_DERIVED_DATA_PATH=/private/tmp/mim158-split-deriveddata bash ./scripts/test-macos-app.sh`
  - Mac App 编译与单测通过，scheme `MimiRemoteMac`、Debug、arm64

## 风险与边界

- 8192 是 LaunchAgent 的启动目标，不冒充当前 listener 的实时有效 RLIMIT。
- 诊断只读；资源持续上涨仍需定位 Codex/MCP 上游回收责任。
- 当前生产仍使用官方 `codex app-server daemon start` 拓扑，因此本 PR 单独合并后不会恢复 Codex Desktop Browser backend。
