### PR TITLE
MIM-161 暴露 Codex Desktop 实验功能入口并完善冲突引导

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -4944,6 +4944,23 @@
         }
       }
     },
+    "ui.codex_active_writer_conflict_requires_shared_service": {
+      "comment": "Shown when another Codex app-server owns the session writer. Explain the recovery path without exposing the raw JSON-RPC error.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This session is held by another Codex app-server. Close it in Codex Desktop, or enable sharing in Experimental Features on the Mac and fully restart Codex Desktop, then try again."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此会话正被另一个 Codex app-server 占用。请先在 Codex Desktop 中关闭它；如需跨端继续，请在 Mac 的“实验功能”中开启共享并完全重启 Codex Desktop，然后重试。"
+          }
+        }
+      }
+    },
     "ui.codex_currently_returns_value": {
       "comment": "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations": {

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -38744,6 +38744,276 @@
         }
       }
     },
+    "ui.experimental_features": {
+      "comment": "Title for the settings destination that explains opt-in experimental capabilities.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimental Features"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实验功能"
+          }
+        }
+      }
+    },
+    "ui.enable_on_mac": {
+      "comment": "Settings row value explaining that the experiment must be enabled on the paired Mac.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable on Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 上开启"
+          }
+        }
+      }
+    },
+    "ui.share_codex_desktop_sessions_experimental": {
+      "comment": "Title of the experimental Codex Desktop shared-session capability.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share Codex Desktop sessions (experimental)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共享 Codex Desktop 会话（实验）"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_summary": {
+      "comment": "Summary of what the Codex Desktop shared-session experiment does.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let Mimi Remote and Codex Desktop use the same local session service, so you can continue an idle session across devices."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让 Mimi Remote 与 Codex Desktop 共用同一个本地会话服务，以便在不同设备间继续空闲会话。"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_warning": {
+      "comment": "Risk and concurrency note for the Codex Desktop shared-session experiment.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This feature changes the Codex Desktop launch environment and may change with future Codex versions. A running task remains read-only on the other device."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此功能会修改 Codex Desktop 的启动环境，并可能随 Codex 版本变化。正在运行的任务在另一端仍为只读。"
+          }
+        }
+      }
+    },
+    "ui.how_to_enable_on_mac": {
+      "comment": "Section heading for instructions that must be completed on the Mac.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How to enable on Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如何在 Mac 上开启"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_step_open_mimi_menu": {
+      "comment": "First step for enabling the Codex Desktop shared-session experiment.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click the Mimi icon in the Mac menu bar."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 菜单栏中点按 Mimi 图标。"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_step_choose_experiments": {
+      "comment": "Second step for enabling the Codex Desktop shared-session experiment.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Experimental Features…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择“实验功能…”。"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_step_enable_sharing": {
+      "comment": "Third step for enabling the Codex Desktop shared-session experiment.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn on Share Codex Desktop sessions (experimental)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开启“共享 Codex Desktop 会话（实验）”。"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_step_restart_desktop": {
+      "comment": "Fourth step for enabling the Codex Desktop shared-session experiment.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save any running tasks, then quit Codex Desktop completely and reopen it."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存正在运行的任务，然后完全退出并重新打开 Codex Desktop。"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_step_verify_session": {
+      "comment": "Fifth step for verifying the Codex Desktop shared-session experiment.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When the status says Environment configured, continue the same idle session once to verify sharing."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认状态显示“环境已配置”，再用同一条空闲会话完成一次跨端续写验证。"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_mac_only_note": {
+      "comment": "Explains why the iOS guide does not provide a remote toggle for the Mac experiment.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This setting can only be changed on the Mac running Mimi Remote Mac. This iPhone or iPad cannot restart Codex Desktop for you."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此设置只能在运行 Mimi Remote Mac 的电脑上修改；iPhone 或 iPad 无法代替 Mac 重启 Codex Desktop。"
+          }
+        }
+      }
+    },
+    "ui.codex_experiment_service_note": {
+      "comment": "Explains how stopping the Mac service affects mobile shared sessions.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep the Mimi Remote Mac service running. Choosing Quit and Stop Service… disconnects mobile devices; reopen the Mac app or sign in to the Mac again to restart it."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请保持 Mimi Remote Mac 服务运行。选择“退出并停止服务…”会断开移动设备；重新打开 Mac App 或再次登录 Mac 后会重启服务。"
+          }
+        }
+      }
+    },
+    "ui.before_you_use_it": {
+      "comment": "Section heading for important notes before using an experimental feature.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Before you use it"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用须知"
+          }
+        }
+      }
+    },
+    "ui.step_value_value": {
+      "comment": "VoiceOver label for a numbered setup step. The first value is the step number and the second is its instruction.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step %1$@: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %1$@ 步：%2$@"
+          }
+        }
+      }
+    },
     "·": {
       "comment": "A separator between two elements.",
       "isCommentAutoGenerated": true,

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -4950,13 +4950,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This session is held by another Codex app-server. Close it in Codex Desktop, or enable sharing in Experimental Features on the Mac and fully restart Codex Desktop, then try again."
+            "value": "This session is held by another Codex app-server. Close it in Codex Desktop, or enable sharing in Experimental Features on the Mac, choose Apply Settings and Fully Restart Codex Desktop, and confirm before trying again."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此会话正被另一个 Codex app-server 占用。请先在 Codex Desktop 中关闭它；如需跨端继续，请在 Mac 的“实验功能”中开启共享并完全重启 Codex Desktop，然后重试。"
+            "value": "此会话正被另一个 Codex app-server 占用。请先在 Codex Desktop 中关闭它；如需跨端继续，请在 Mac 的“实验功能”中开启共享，点击“应用设置并完全重启 Codex Desktop”并确认，然后重试。"
           }
         }
       }
@@ -38907,19 +38907,19 @@
       }
     },
     "ui.codex_experiment_step_restart_desktop": {
-      "comment": "Fourth step for enabling the Codex Desktop shared-session experiment.",
+      "comment": "Fourth step for enabling the Codex Desktop shared-session experiment. The Mac in-app action is required to commit the daemon migration; manually reopening Codex Desktop is insufficient.",
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Save any running tasks, then quit Codex Desktop completely and reopen it."
+            "value": "Save any running tasks. In the Mac experiment window, choose Apply Settings and Fully Restart Codex Desktop, then confirm."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存正在运行的任务，然后完全退出并重新打开 Codex Desktop。"
+            "value": "保存正在运行的任务，然后在 Mac 的实验功能窗口中点击“应用设置并完全重启 Codex Desktop”，并确认应用。"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
@@ -1381,6 +1381,108 @@ private extension DefaultModelRuntime {
     }
 }
 
+/// iOS 只能说明和引导，不能伪装成能够修改 Mac launchd 环境的远程开关。
+/// 真正的启用入口继续由 Mimi Remote Mac 持有，确保配置、Desktop 重启与失败回滚在同一台电脑完成。
+enum CodexDesktopExperimentGuide {
+    static let stepKeys = [
+        "ui.codex_experiment_step_open_mimi_menu",
+        "ui.codex_experiment_step_choose_experiments",
+        "ui.codex_experiment_step_enable_sharing",
+        "ui.codex_experiment_step_restart_desktop",
+        "ui.codex_experiment_step_verify_session",
+    ]
+}
+
+struct ExperimentalFeaturesSettingsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var themeStore: ThemeStore
+
+    var body: some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label {
+                        Text(L10n.text("ui.share_codex_desktop_sessions_experimental"))
+                            .font(themeStore.uiFont(.headline, weight: .semibold))
+                            .foregroundStyle(tokens.primaryText)
+                    } icon: {
+                        Image(systemName: "desktopcomputer")
+                            .foregroundStyle(tokens.accent)
+                    }
+
+                    Text(L10n.text("ui.codex_experiment_summary"))
+                        .font(themeStore.uiFont(.subheadline))
+                        .foregroundStyle(tokens.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.vertical, 8)
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier("settings.experimentalFeatures.codexSharing")
+            } footer: {
+                Text(L10n.text("ui.codex_experiment_warning"))
+            }
+
+            Section {
+                ForEach(Array(CodexDesktopExperimentGuide.stepKeys.enumerated()), id: \.offset) { index, key in
+                    HStack(alignment: .top, spacing: 12) {
+                        Text(String(index + 1))
+                            .font(themeStore.uiFont(.footnote, weight: .semibold))
+                            .foregroundStyle(tokens.accent)
+                            .frame(width: 28, height: 28)
+                            .background(tokens.accent.opacity(0.12), in: Circle())
+                            .accessibilityHidden(true)
+
+                        Text(L10n.text(key))
+                            .font(themeStore.uiFont(.body))
+                            .foregroundStyle(tokens.primaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+                    }
+                    .padding(.vertical, 6)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(
+                        L10n.format(
+                            "ui.step_value_value",
+                            index + 1,
+                            L10n.text(key)
+                        )
+                    )
+                    .accessibilityIdentifier("settings.experimentalFeatures.step.\(index + 1)")
+                }
+            } header: {
+                Text(L10n.text("ui.how_to_enable_on_mac"))
+                    .textCase(nil)
+            } footer: {
+                Text(L10n.text("ui.codex_experiment_mac_only_note"))
+            }
+
+            Section {
+                Label {
+                    Text(L10n.text("ui.codex_experiment_service_note"))
+                        .font(themeStore.uiFont(.subheadline))
+                        .foregroundStyle(tokens.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                } icon: {
+                    Image(systemName: "info.circle")
+                        .foregroundStyle(tokens.accent)
+                }
+                .padding(.vertical, 6)
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier("settings.experimentalFeatures.serviceNote")
+            } header: {
+                Text(L10n.text("ui.before_you_use_it"))
+                    .textCase(nil)
+            }
+        }
+        .themedSettingsForm(tokens: tokens)
+        .navigationTitle(L10n.text("ui.experimental_features"))
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("settings.experimentalFeatures.detail")
+    }
+}
+
 extension View {
     func themedSettingsForm(tokens: ThemeTokens) -> some View {
         scrollContentBackground(.hidden)

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -352,6 +352,18 @@ struct SettingsView: View {
 
             Section {
                 NavigationLink {
+                    ExperimentalFeaturesSettingsView()
+                } label: {
+                    SettingsValueLabel(
+                        title: L10n.text("ui.experimental_features"),
+                        value: L10n.text("ui.enable_on_mac"),
+                        systemImage: "flask"
+                    )
+                }
+                .settingsStandardListRow()
+                .accessibilityIdentifier("settings.experimentalFeatures")
+
+                NavigationLink {
                     DiagnosticsAndSupportSettingsView(
                         showsHistoryDiagnostics: developerModeEnabled
                     )

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -411,7 +411,12 @@ extension SessionStore {
                 return
             }
             let policyRejected = Self.isDeterministicGatewayPolicyFailure(message)
-            let canReconnect = shouldAutoReconnectWebSocket(sessionID: sessionID) && !policyRejected
+            let activeWriterConflict = Self.isCodexActiveWriterConflict(message)
+            // 另一套 app-server 已持有 writer 时，同参数重连只会重复失败。停止重连并给出
+            // Mac 侧共享入口，避免把结构性冲突伪装成短暂网络波动。
+            let canReconnect = shouldAutoReconnectWebSocket(sessionID: sessionID)
+                && !policyRejected
+                && !activeWriterConflict
             if connectedSessionID == sessionID {
                 connectedSessionID = nil
                 connectedHostScope = nil
@@ -430,7 +435,11 @@ extension SessionStore {
                 scheduleWebSocketReconnect(sessionID: sessionID, reason: message)
             } else {
                 setWebSocketStatus(.failed(message))
-                setErrorMessage(policyRejected ? L10n.format("ui.the_connection_was_rejected_by_server_policy_and", message) : message)
+                if activeWriterConflict {
+                    setErrorMessage(L10n.text("ui.codex_active_writer_conflict_requires_shared_service"))
+                } else {
+                    setErrorMessage(policyRejected ? L10n.format("ui.the_connection_was_rejected_by_server_policy_and", message) : message)
+                }
             }
         case .terminated(let reason):
             if reason == .credentialsInvalid,
@@ -478,6 +487,18 @@ extension SessionStore {
         case .connecting:
             setWebSocketStatus(.connecting)
         }
+    }
+
+    /// 只识别 app-server 已知的单 writer 拒绝；其他 -32600（例如 no rollout found、
+    /// 参数不兼容）仍沿原有错误与恢复路径处理，不能被这个 UX 映射吞掉。
+    nonisolated static func isCodexActiveWriterConflict(_ message: String) -> Bool {
+        guard message.contains("-32600") else {
+            return false
+        }
+        let lowerMessage = message.lowercased()
+        return lowerMessage.contains("already has an active writer")
+            || lowerMessage.contains("external_thread_active")
+            || (lowerMessage.contains("thread is active") && lowerMessage.contains("codex desktop"))
     }
 
     @discardableResult

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -567,6 +567,24 @@ final class CodexAppServerProtocolTests: XCTestCase {
         ))
     }
 
+    func testActiveWriterConflictOnlyMatchesKnownSingleWriterRejections() {
+        XCTAssertTrue(SessionStore.isCodexActiveWriterConflict(
+            "app-server 错误 -32600：already has an active writer"
+        ))
+        XCTAssertTrue(SessionStore.isCodexActiveWriterConflict(
+            "app-server error -32600: thread is active in Codex Desktop"
+        ))
+        XCTAssertFalse(SessionStore.isCodexActiveWriterConflict(
+            "app-server 错误 -32600：no rollout found for thread id thr_empty"
+        ))
+        XCTAssertFalse(SessionStore.isCodexActiveWriterConflict(
+            "app-server 错误 -32600：Invalid request: collaborationMode.mode"
+        ))
+        XCTAssertFalse(SessionStore.isCodexActiveWriterConflict(
+            "app-server 错误 -32080：already has an active writer"
+        ))
+    }
+
     func testSanitizedForRuntimePolicyDowngradesClaudeFullAccess() {
         var options = CodexAppServerTurnOptions.default
         options.runtimeProvider = "claude"

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -265,6 +265,53 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(appStore.requiresRePairing)
     }
 
+    func testActiveWriterConflictStopsReconnectAndShowsSharedSetupGuidance() async throws {
+        let project = makeProject(id: "proj_active_writer_conflict")
+        let running = makeSession(
+            id: "sess_active_writer_conflict",
+            projectID: project.id,
+            title: "Desktop 会话",
+            status: "running",
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            },
+            webSocketReconnectDelayNanoseconds: { _ in 0 }
+        )
+
+        store.selectedProjectID = project.id
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(running)
+        await store.selectSession(running)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        let rawFailure = "app-server 错误 -32600：already has an active writer"
+        socket.emitStatus(.failed(rawFailure))
+        try await waitForWebSocketStatus(.failed(rawFailure), store: store)
+        try await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(sockets.count, 1, "单 writer 冲突不能进入无意义的自动重连")
+        XCTAssertEqual(
+            store.errorMessage,
+            L10n.text("ui.codex_active_writer_conflict_requires_shared_service")
+        )
+        XCTAssertFalse(store.errorMessage?.contains("-32600") == true)
+    }
+
     func testLateOlderNetworkPathUpdateCannotOverwriteSatisfiedState() async throws {
         let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
@@ -108,14 +108,14 @@ final class LocalizationTests: XCTestCase {
             "Click the Mimi icon in the Mac menu bar.",
             "Choose Experimental Features…",
             "Turn on Share Codex Desktop sessions (experimental).",
-            "Save any running tasks, then quit Codex Desktop completely and reopen it.",
+            "Save any running tasks. In the Mac experiment window, choose Apply Settings and Fully Restart Codex Desktop, then confirm.",
             "When the status says Environment configured, continue the same idle session once to verify sharing.",
         ]
         let expectedChinese = [
             "在 Mac 菜单栏中点按 Mimi 图标。",
             "选择“实验功能…”。",
             "开启“共享 Codex Desktop 会话（实验）”。",
-            "保存正在运行的任务，然后完全退出并重新打开 Codex Desktop。",
+            "保存正在运行的任务，然后在 Mac 的实验功能窗口中点击“应用设置并完全重启 Codex Desktop”，并确认应用。",
             "确认状态显示“环境已配置”，再用同一条空闲会话完成一次跨端续写验证。",
         ]
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
@@ -89,6 +89,9 @@ final class LocalizationTests: XCTestCase {
             ("ui.token_activity", "Token Activity", "Token 活动"),
             ("ui.my_preferences", "My Preferences", "我的偏好设置"),
             ("ui.more", "More", "更多"),
+            ("ui.experimental_features", "Experimental Features", "实验功能"),
+            ("ui.enable_on_mac", "Enable on Mac", "在 Mac 上开启"),
+            ("ui.how_to_enable_on_mac", "How to enable on Mac", "如何在 Mac 上开启"),
             ("ui.personalization", "Appearance & Personalization", "外观与个性化"),
             ("ui.advanced_and_development", "Advanced & Development", "高级与开发"),
             ("ui.about_and_legal", "About & Legal", "关于与法律")
@@ -98,6 +101,37 @@ final class LocalizationTests: XCTestCase {
             XCTAssertEqual(L10n.text(key, language: .english), english)
             XCTAssertEqual(L10n.text(key, language: .simplifiedChinese), simplifiedChinese)
         }
+    }
+
+    func testCodexDesktopExperimentGuideHasCompleteLocalizedSteps() {
+        let expectedEnglish = [
+            "Click the Mimi icon in the Mac menu bar.",
+            "Choose Experimental Features…",
+            "Turn on Share Codex Desktop sessions (experimental).",
+            "Save any running tasks, then quit Codex Desktop completely and reopen it.",
+            "When the status says Environment configured, continue the same idle session once to verify sharing.",
+        ]
+        let expectedChinese = [
+            "在 Mac 菜单栏中点按 Mimi 图标。",
+            "选择“实验功能…”。",
+            "开启“共享 Codex Desktop 会话（实验）”。",
+            "保存正在运行的任务，然后完全退出并重新打开 Codex Desktop。",
+            "确认状态显示“环境已配置”，再用同一条空闲会话完成一次跨端续写验证。",
+        ]
+
+        XCTAssertEqual(CodexDesktopExperimentGuide.stepKeys.count, 5)
+        XCTAssertEqual(
+            CodexDesktopExperimentGuide.stepKeys.map {
+                L10n.text($0, language: .english)
+            },
+            expectedEnglish
+        )
+        XCTAssertEqual(
+            CodexDesktopExperimentGuide.stepKeys.map {
+                L10n.text($0, language: .simplifiedChinese)
+            },
+            expectedChinese
+        )
     }
 
     func testSessionRowStatefulActionLabelsAreLocalized() {

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -485,6 +485,7 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         let defaultPermissions = app.descendant(identifier: "settings.defaultPermissions")
         let diagnostics = app.descendant(identifier: "settings.diagnostics")
         let advanced = app.descendant(identifier: "settings.advancedDevelopment")
+        let experimentalFeatures = app.descendant(identifier: "settings.experimentalFeatures")
         let aboutLegal = app.descendant(identifier: "settings.aboutLegal")
 
         XCTAssertTrue(tokenUsage.waitForExistence(timeout: 8), "我的页面应展示统一 Token 模块")
@@ -527,7 +528,7 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         XCTAssertTrue(scrollUntilHittable(aboutLegal), "我的页面应能滚动到“更多”分区")
         // “Mac 与设备”已在页面顶部验证；滚到底部后它可能被 List 懒加载卸载，
         // 这里只检查当前可见的“更多”入口，避免把视口状态误判为功能缺失。
-        let bottomRows = [diagnostics, advanced, aboutLegal]
+        let bottomRows = [experimentalFeatures, diagnostics, advanced, aboutLegal]
         for row in bottomRows {
             XCTAssertTrue(row.waitForExistence(timeout: 4), "“更多”分区入口应存在")
             XCTAssertEqual(
@@ -542,6 +543,34 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         bottomScreenshot.name = "me-preferences-and-more"
         bottomScreenshot.lifetime = .keepAlways
         add(bottomScreenshot)
+    }
+
+    func testExperimentalFeaturesGuideExplainsMacSetup() throws {
+        try enterWorkbenchIfNeeded()
+        try openSettings()
+
+        let experimentalFeatures = app.descendant(identifier: "settings.experimentalFeatures")
+        XCTAssertTrue(
+            scrollUntilHittable(experimentalFeatures, maximumSwipes: 8),
+            "我的页面应能滚动到实验功能入口"
+        )
+        XCTAssertEqual(
+            experimentalFeatures.frame.height,
+            52,
+            accuracy: 1,
+            "实验功能入口应保持设置页标准行高"
+        )
+        experimentalFeatures.tap()
+        XCTAssertTrue(
+            app.descendant(identifier: "settings.experimentalFeatures.detail")
+                .waitForExistence(timeout: 5),
+            "实验功能入口应进入 Mac 端开启引导"
+        )
+        let finalStep = app.descendant(identifier: "settings.experimentalFeatures.step.5")
+        XCTAssertTrue(
+            scrollUntilHittable(finalStep, maximumSwipes: 4),
+            "实验功能引导应完整展示重启和跨端验证步骤"
+        )
     }
 
     func testComposerPlanGoalAndModelMenusSurviveRotationWithoutCrash() throws {

--- a/macos/MimiRemoteMac/MimiRemoteMac.xcodeproj/project.pbxproj
+++ b/macos/MimiRemoteMac/MimiRemoteMac.xcodeproj/project.pbxproj
@@ -13,7 +13,9 @@
 		1A8CB50439D0E08A8514EA5B /* BrandColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252E87DED48E48439FF3A75F /* BrandColors.swift */; };
 		2D3D7AD1F48F6D665E50089E /* AgentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B97C2451CBB1E2B78D009C /* AgentModelsTests.swift */; };
 		2D88E2B17C680EC02E71EAB5 /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F22A0DD397F37B0B0E8849 /* HostStoreTests.swift */; };
+		2F6C3092D9D2A6993F9C62B0 /* ExperimentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97938E4BFF530423DDA33CDC /* ExperimentsView.swift */; };
 		3753BB1F5923C410265B44D3 /* ServiceManagementClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0431AEFF2D4E005613D17105 /* ServiceManagementClient.swift */; };
+		3ABA9673CC0175469AE1E8D3 /* ExperimentPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56099ADC68FDE1F3D89FEACF /* ExperimentPresentation.swift */; };
 		427C6CE3D4E0488047ABA134 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1A62A4B02D2D4B3685ED5AD /* Assets.xcassets */; };
 		43BD61177935A8FEB6E85133 /* ProcessEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7280BD1DDAD2AA31F8F8C8AC /* ProcessEnvironment.swift */; };
 		58C74CEDC10E4370604F7FA6 /* HomebrewServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7026C81DC36F9303474CE6 /* HomebrewServiceClient.swift */; };
@@ -24,6 +26,7 @@
 		7DA4ACD2AA9E502238AC5228 /* AgentLogClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34FFFDD49F996F5FB064A2 /* AgentLogClient.swift */; };
 		9190117090B67A3342D6120D /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE4D38858D995BC12D0856A /* QRCodeView.swift */; };
 		9381140D2855654A9E07746E /* StatusComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4847134E49077F02AF8BBE /* StatusComponents.swift */; };
+		A1A08305F933F264072454B6 /* ExperimentPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14513EDAFE3A09C6F7A08CC1 /* ExperimentPresentationTests.swift */; };
 		AD199C3299AE46CEBBFBD8F4 /* MenuRuntimePresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */; };
 		B0007C75D28B779DE9DE6270 /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE170A943EDB5164E2CD95 /* PairingView.swift */; };
 		B4E72BE5C26B15E8255D9F2B /* HealthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF645CF76E8BD94261F54A9 /* HealthClient.swift */; };
@@ -54,6 +57,7 @@
 		067C5878128418FC7FEBE76A /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		08DE170A943EDB5164E2CD95 /* PairingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingView.swift; sourceTree = "<group>"; };
 		0B8B42F16AE872A2164A2C14 /* MacSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSettingsView.swift; sourceTree = "<group>"; };
+		14513EDAFE3A09C6F7A08CC1 /* ExperimentPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPresentationTests.swift; sourceTree = "<group>"; };
 		252E87DED48E48439FF3A75F /* BrandColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandColors.swift; sourceTree = "<group>"; };
 		38BFD44EAEE64300C32946C4 /* AgentCommandClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCommandClient.swift; sourceTree = "<group>"; };
 		414A74A2A5A2877C1A9CB604 /* MenuBarContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContentView.swift; sourceTree = "<group>"; };
@@ -61,6 +65,7 @@
 		47FFCBD7F69A1A4EAA2D1871 /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		4970FED3A0AD33401F1DFE86 /* ProcessExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExecutor.swift; sourceTree = "<group>"; };
 		4A4847134E49077F02AF8BBE /* StatusComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusComponents.swift; sourceTree = "<group>"; };
+		56099ADC68FDE1F3D89FEACF /* ExperimentPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPresentation.swift; sourceTree = "<group>"; };
 		63E0418360C87C9E75E7C24A /* MimiRemoteMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MimiRemoteMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A7026C81DC36F9303474CE6 /* HomebrewServiceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewServiceClient.swift; sourceTree = "<group>"; };
 		6FF645CF76E8BD94261F54A9 /* HealthClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthClient.swift; sourceTree = "<group>"; };
@@ -68,6 +73,7 @@
 		8BE4D38858D995BC12D0856A /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
 		8DA7DA1200E8FF88D5E0DDF2 /* DiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsView.swift; sourceTree = "<group>"; };
 		95CEFC2080963A6433B43217 /* MenuBarWindowPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarWindowPlacementTests.swift; sourceTree = "<group>"; };
+		97938E4BFF530423DDA33CDC /* ExperimentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentsView.swift; sourceTree = "<group>"; };
 		A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRuntimePresentationTests.swift; sourceTree = "<group>"; };
 		A1A62A4B02D2D4B3685ED5AD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AC5CFE21A0402846201F7BF2 /* CodexDesktopIntegrationClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexDesktopIntegrationClient.swift; sourceTree = "<group>"; };
@@ -143,6 +149,7 @@
 			children = (
 				8C5E3D3FF91A672DE791876B /* Dashboard */,
 				C911B774DE54774E89F61F28 /* Diagnostics */,
+				839BAEAF0E1DAF285F44A1CB /* Experiments */,
 				6A3D806EC959CB76486AA2EA /* MenuBar */,
 				95A7A7AE02B2D68F286356EA /* Onboarding */,
 				4582ED716415B96BA7CE71B0 /* Pairing */,
@@ -157,6 +164,7 @@
 				DFA410B972FDE86680731233 /* AgentCommandClientTests.swift */,
 				F9B97C2451CBB1E2B78D009C /* AgentModelsTests.swift */,
 				D5DFB2FC63FF54C2F40513F6 /* CodexDesktopIntegrationClientTests.swift */,
+				14513EDAFE3A09C6F7A08CC1 /* ExperimentPresentationTests.swift */,
 				01F22A0DD397F37B0B0E8849 /* HostStoreTests.swift */,
 				95CEFC2080963A6433B43217 /* MenuBarWindowPlacementTests.swift */,
 				A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */,
@@ -171,6 +179,15 @@
 				B78765A951C28D21B18CCFAF /* MenuRuntimePresentation.swift */,
 			);
 			path = MenuBar;
+			sourceTree = "<group>";
+		};
+		839BAEAF0E1DAF285F44A1CB /* Experiments */ = {
+			isa = PBXGroup;
+			children = (
+				56099ADC68FDE1F3D89FEACF /* ExperimentPresentation.swift */,
+				97938E4BFF530423DDA33CDC /* ExperimentsView.swift */,
+			);
+			path = Experiments;
 			sourceTree = "<group>";
 		};
 		8C5E3D3FF91A672DE791876B /* Dashboard */ = {
@@ -367,6 +384,8 @@
 				BD1147B84D71960BBBB74E49 /* CodexDesktopIntegrationClient.swift in Sources */,
 				78843D42483895178C480F25 /* DashboardView.swift in Sources */,
 				0CA331176F893C656E0CCDA1 /* DiagnosticsView.swift in Sources */,
+				3ABA9673CC0175469AE1E8D3 /* ExperimentPresentation.swift in Sources */,
+				2F6C3092D9D2A6993F9C62B0 /* ExperimentsView.swift in Sources */,
 				B4E72BE5C26B15E8255D9F2B /* HealthClient.swift in Sources */,
 				58C74CEDC10E4370604F7FA6 /* HomebrewServiceClient.swift in Sources */,
 				642F9E49711F073D72016DF1 /* HostStore.swift in Sources */,
@@ -391,6 +410,7 @@
 				F0B1F99A2045339CB960772E /* AgentCommandClientTests.swift in Sources */,
 				2D3D7AD1F48F6D665E50089E /* AgentModelsTests.swift in Sources */,
 				D465B71BBE211F263557A9B6 /* CodexDesktopIntegrationClientTests.swift in Sources */,
+				A1A08305F933F264072454B6 /* ExperimentPresentationTests.swift in Sources */,
 				2D88E2B17C680EC02E71EAB5 /* HostStoreTests.swift in Sources */,
 				11399EBAD3569F1EA7DC3A55 /* MenuBarWindowPlacementTests.swift in Sources */,
 				AD199C3299AE46CEBBFBD8F4 /* MenuRuntimePresentationTests.swift in Sources */,

--- a/macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
+++ b/macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
@@ -46,6 +46,11 @@ struct MimiRemoteMacApp: App {
         }
         .defaultSize(width: 720, height: 620)
 
+        Window("实验功能", id: ExperimentMenuRouting.windowID) {
+            ExperimentsView(store: store)
+        }
+        .defaultSize(width: 500, height: 680)
+
         Settings {
             MacSettingsView(store: store)
         }
@@ -69,4 +74,5 @@ enum AppWindow: String {
     case dashboard
     case pairing
     case diagnostics
+    case experiments
 }

--- a/macos/MimiRemoteMac/Sources/Features/Experiments/ExperimentPresentation.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Experiments/ExperimentPresentation.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+enum ExperimentMenuRouting {
+    static let menuTitle = "实验功能…"
+    static let windowID = "experiments"
+}
+
+/// 实验功能窗口与菜单入口共用的展示规则。
+///
+/// 这里仅描述已有 HostStore 状态，不保存或推导第二份配置；这样菜单、设置导航
+/// 和实验功能窗口始终从同一个事实源渲染，也能在不依赖 SwiftUI 的情况下测试文案。
+enum ExperimentPresentation {
+    static func codexStatusTitle(for state: CodexDesktopStatusState) -> String {
+        switch state {
+        case .disabled:
+            "已关闭"
+        case .notInstalled:
+            "未安装"
+        case .backendNotShared:
+            "后端未确认共享"
+        case .pendingRestart:
+            "需要重启"
+        case .ready:
+            "环境已配置"
+        case .failed:
+            "配置失败"
+        case .externalConflict:
+            "外部配置冲突"
+        }
+    }
+
+    static func codexStatusDetail(
+        for state: CodexDesktopStatusState,
+        error: String? = nil
+    ) -> String {
+        let detail: String
+        switch state {
+        case .disabled:
+            detail = "共享已关闭。Mimi Remote 仍使用独立服务；如果两端同时打开同一会话，可能发生写入冲突。"
+        case .notInstalled:
+            detail = "未检测到 Codex Desktop。请先安装后再启用共享。"
+        case .backendNotShared:
+            detail = "共享尚未生效。请先修复配置并确认 agentd 的共享服务；同一会话可能无法在两端打开。"
+        case .pendingRestart:
+            detail = "保存任务后应用设置并完全重启 Codex Desktop。"
+        case .ready:
+            detail = "环境已配置，待用同一空闲会话跨端验证；正在运行的任务仍只读。"
+        case .failed:
+            detail = "共享尚未生效，配置失败。请先修复配置后再重试；同一会话可能无法在两端打开。"
+        case .externalConflict:
+            detail = "共享尚未生效，检测到外部配置冲突。请先修复配置；同一会话可能无法在两端打开。"
+        }
+
+        guard state == .pendingRestart || state == .failed || state == .externalConflict,
+              let diagnostic = sanitizedDiagnostic(error)
+        else {
+            return detail
+        }
+        return detail + " 详情：" + diagnostic
+    }
+
+    static func codexToggleDescription(isEnabled: Bool) -> String {
+        if isEnabled {
+            return "已开启：Mimi Remote 与 Codex Desktop 将尝试共享同一空闲会话；正在运行的任务仍只读。"
+        }
+        return "已关闭：Mimi Remote 仍使用独立服务；如果两端同时打开同一会话，可能发生写入冲突。"
+    }
+
+    /// 菜单入口只显示少量可行动的摘要；详细状态始终在实验功能窗口内查看。
+    static func menuStatusText(
+        owner: ServiceOwner,
+        codexState: CodexDesktopStatusState
+    ) -> String? {
+        guard owner == .macApp else { return "不可管理" }
+        switch codexState {
+        case .pendingRestart:
+            return "需要重启"
+        case .ready:
+            return "已启用"
+        case .disabled, .notInstalled, .backendNotShared, .failed, .externalConflict:
+            return nil
+        }
+    }
+
+    static func menuAccessibilityLabel(
+        owner: ServiceOwner,
+        codexState: CodexDesktopStatusState
+    ) -> String {
+        let title = "实验功能"
+        guard let status = menuStatusText(owner: owner, codexState: codexState) else {
+            return title
+        }
+        return "\(title)，\(status)"
+    }
+
+    private static func sanitizedDiagnostic(_ error: String?) -> String? {
+        guard let error else { return nil }
+        var value = error.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        // 保留失败原因对诊断的价值，但把协议码和英文 writer 术语转成平静的
+        // 用户文案，避免把底层 JSON-RPC 错误直接当作界面提示。
+        value = value.replacingOccurrences(of: "-32600", with: "会话写入冲突")
+        value = value.replacingOccurrences(
+            of: "already has an active writer",
+            with: "同一会话正在被其他端占用",
+            options: [.caseInsensitive]
+        )
+        value = value.replacingOccurrences(
+            of: "active writer",
+            with: "同一会话占用",
+            options: [.caseInsensitive]
+        )
+        return value
+    }
+}

--- a/macos/MimiRemoteMac/Sources/Features/Experiments/ExperimentsView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Experiments/ExperimentsView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// Claude 与 Codex Desktop 的唯一控制面板。
+///
+/// 菜单栏和通用设置只负责导航到这里；开关仍由 HostStore 执行，避免在多个界面
+/// 复制绑定或把菜单首层的点击误解为直接修改配置。
+struct ExperimentsView: View {
+    let store: HostStore
+    @State private var confirmsCodexRestart = false
+
+    var body: some View {
+        Form {
+            Section("Claude") {
+                Toggle("启用 Claude 实验通道", isOn: Binding(
+                    get: { store.claudeEnabled },
+                    set: { enabled in
+                        Task { await store.setClaudeEnabled(enabled) }
+                    }
+                ))
+                .disabled(!store.canChangeClaude)
+
+                LabeledContent("运行状态") {
+                    HStack(spacing: 6) {
+                        if store.isUpdatingClaude {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(store.isUpdatingClaude ? "正在更新" : store.claudeStatusTitle)
+                    }
+                }
+
+                Text(store.claudeStatusDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text("需要本机安装并登录 Claude Code。启用或关闭时会安全地重新加载 agentd；Codex 主通道不受影响。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Codex Desktop") {
+                Toggle("共享 Codex Desktop 会话（实验）", isOn: Binding(
+                    get: { store.codexDesktopEnabled },
+                    set: { enabled in
+                        Task { await store.setCodexDesktopEnabled(enabled) }
+                    }
+                ))
+                .disabled(!store.canChangeCodexDesktop)
+
+                Text(ExperimentPresentation.codexToggleDescription(isEnabled: store.codexDesktopEnabled))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                LabeledContent("运行状态") {
+                    HStack(spacing: 6) {
+                        if store.isCodexDesktopBusy {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(store.isCodexDesktopBusy ? "正在更新" : store.codexDesktopStatusTitle)
+                    }
+                }
+
+                Text(store.codexDesktopStatusDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if store.canRestartCodexDesktop {
+                    Button("应用设置并完全重启 Codex Desktop") {
+                        confirmsCodexRestart = true
+                    }
+                    .disabled(store.isCodexDesktopBusy)
+                }
+            }
+
+            Section("边界") {
+                Text("正在运行的 Desktop turn 仍只读，不会因为打开或保存实验设置而放宽保护。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .scenePadding()
+        .frame(width: 500, height: 680)
+        .alert("应用 Codex 共享设置？", isPresented: $confirmsCodexRestart) {
+            Button("取消", role: .cancel) {}
+            Button("确认应用") {
+                Task { await store.restartCodexDesktop() }
+            }
+        } message: {
+            Text("请先保存任务。应用时会正常退出 Codex Desktop，再迁移共享 daemon 并验证结果；如果 Desktop 已退出，只迁移 daemon，不会擅自打开 App。该操作会短暂中断当前连接到 daemon 的手机、SSH 或 CLI。")
+        }
+    }
+}
+
+#if DEBUG
+    #Preview("实验功能") {
+        ExperimentsView(store: .preview(.ready))
+    }
+#endif

--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -97,6 +97,21 @@ struct MenuBarContentView: View {
                     .padding(.leading, MenuBarLayout.textColumnLeading)
 
                 MenuActionRow(
+                    title: ExperimentMenuRouting.menuTitle,
+                    systemImage: "flask",
+                    trailingText: store.experimentMenuStatusText,
+                    accessibilityLabel: store.experimentMenuAccessibilityLabel
+                ) {
+                    // 菜单首层只导航，不直接切换实验开关：配置执行需要保留
+                    // HostStore 的单 writer、确认和重启语义，避免误触改变服务状态。
+                    presentWindow(.experiments)
+                }
+
+                Divider()
+                    .opacity(MenuBarLayout.actionDividerOpacity)
+                    .padding(.leading, MenuBarLayout.textColumnLeading)
+
+                MenuActionRow(
                     title: "设置",
                     systemImage: "gearshape"
                 ) {
@@ -933,6 +948,8 @@ private struct MenuActionRow: View {
     var role: ButtonRole?
     var showsDisclosure = true
     var isWorking = false
+    var trailingText: String?
+    var accessibilityLabel: String?
     let action: () -> Void
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovered = false
@@ -948,6 +965,11 @@ private struct MenuActionRow: View {
                     .font(.callout.weight(.medium))
                     .foregroundStyle(labelColor)
                 Spacer(minLength: 0)
+                if let trailingText {
+                    Text(trailingText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
                 if isWorking {
                     ProgressView()
                         .controlSize(.small)
@@ -973,6 +995,7 @@ private struct MenuActionRow: View {
         .buttonStyle(MenuPressButtonStyle())
         .disabled(!isEnabled)
         .opacity(isEnabled ? 1 : 0.45)
+        .accessibilityLabel(accessibilityLabel ?? title)
         .onHover { hovering in
             withAnimation(reduceMotion ? nil : .easeOut(duration: 0.12)) {
                 isHovered = hovering

--- a/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct MacSettingsView: View {
     let store: HostStore
+    @Environment(\.openWindow) private var openWindow
     @State private var confirmsRestore = false
-    @State private var confirmsCodexRestart = false
 
     var body: some View {
         Form {
@@ -33,63 +33,12 @@ struct MacSettingsView: View {
                 }
             }
 
-            Section("Claude") {
-                Toggle("启用 Claude 实验通道", isOn: Binding(
-                    get: { store.claudeEnabled },
-                    set: { enabled in
-                        Task { await store.setClaudeEnabled(enabled) }
-                    }
-                ))
-                .disabled(!store.canChangeClaude)
-
-                LabeledContent("运行状态") {
-                    HStack(spacing: 6) {
-                        if store.isUpdatingClaude {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-                        Text(store.isUpdatingClaude ? "正在更新" : store.claudeStatusTitle)
-                    }
+            Section("实验功能") {
+                Button(ExperimentMenuRouting.menuTitle) {
+                    // 通用设置保留唯一导航入口；开关和重启确认只在实验功能窗口维护。
+                    openWindow(id: ExperimentMenuRouting.windowID)
                 }
-
-                Text(store.claudeStatusDetail)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Text("需要本机安装并登录 Claude Code。启用或关闭时会安全地重新加载 agentd；Codex 主通道不受影响。")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Section("Codex Desktop") {
-                Toggle("共享本地 app-server 会话", isOn: Binding(
-                    get: { store.codexDesktopEnabled },
-                    set: { enabled in
-                        Task { await store.setCodexDesktopEnabled(enabled) }
-                    }
-                ))
-                .disabled(!store.canChangeCodexDesktop)
-
-                LabeledContent("运行状态") {
-                    HStack(spacing: 6) {
-                        if store.isCodexDesktopBusy {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-                        Text(store.isCodexDesktopBusy ? "正在更新" : store.codexDesktopStatusTitle)
-                    }
-                }
-
-                Text(store.codexDesktopStatusDetail)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Button("应用待处理设置") {
-                    confirmsCodexRestart = true
-                }
-                .disabled(!store.canRestartCodexDesktop)
-
-                Text("Mimi Remote 与 Codex Desktop 共享同一会话服务。仅 Desktop 没有进行中的任务时手机可继续；正在运行的任务仍只读。当前进程需要完全重启后才会应用设置。")
+                Text("Claude 与 Codex Desktop 的实验开关、状态和重启操作集中在同一窗口。")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -110,14 +59,6 @@ struct MacSettingsView: View {
             }
         } message: {
             Text("切换期间移动设备会短暂断开；Homebrew 启动失败时会自动恢复 App 服务。")
-        }
-        .alert("应用 Codex 共享设置？", isPresented: $confirmsCodexRestart) {
-            Button("取消", role: .cancel) {}
-            Button("确认应用") {
-                Task { await store.restartCodexDesktop() }
-            }
-        } message: {
-            Text("如果 Codex Desktop 正在运行，会先请求它正常退出，迁移共享 daemon 并验证成功后再重新打开；如果 Desktop 已退出，只迁移 daemon，不会擅自打开 App。该操作会短暂中断当前连接到 daemon 的手机、SSH 或 CLI，请先保存进行中的工作。")
         }
     }
 

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -64,40 +64,30 @@ final class HostStore {
     }
 
     var codexDesktopStatusTitle: String {
-        switch codexDesktopStatus.state {
-        case .disabled: "已关闭"
-        case .notInstalled: "未安装"
-        case .backendNotShared: "后端未确认共享"
-        case .pendingRestart: "需要重启"
-        case .ready: "已配置"
-        case .failed: "配置失败"
-        case .externalConflict: "外部配置冲突"
-        }
+        ExperimentPresentation.codexStatusTitle(for: codexDesktopStatus.state)
     }
 
     var codexDesktopStatusDetail: String {
-        if let codexDesktopError {
-            return codexDesktopError
-        }
-        switch codexDesktopStatus.state {
-        case .disabled:
-            return "Codex Desktop 共享开关已关闭；Mimi Remote 不会在新进程中注入该环境变量。"
-        case .notInstalled:
-            return "未检测到 bundle id 为 com.openai.codex 的 Codex Desktop。"
-        case .backendNotShared:
-            return "agentd 尚未确认 Unix socket 共享；确认后才会显示已就绪，不会提前声称已共享。"
-        case .pendingRestart:
-            if codexDaemonMigrationRequired, !codexDesktopStatus.appRunning {
-                return "共享 daemon 等待你确认迁移。应用时不会打开 Codex Desktop，但会短暂中断当前连接到该 daemon 的手机、SSH 或 CLI。"
-            }
-            return "Codex Desktop 当前正在运行，需正常退出后应用设置。迁移会短暂中断当前连接到共享 daemon 的客户端。"
-        case .ready:
-            return "agentd 已连接共享会话服务，Codex Desktop 已按共享环境配置。请用同一空闲会话完成一次跨端续写验证；正在运行的任务仍只读。"
-        case .failed:
-            return "无法配置 Codex Desktop 共享环境，请检查错误后重试。"
-        case .externalConflict:
-            return "环境变量已被其他程序修改；Mimi Remote 不会覆盖外部值。"
-        }
+        // 具体错误仍保留在 Store 供诊断和重试使用；展示层仅在待处理/失败边界附上
+        // 脱敏后的诊断摘要，避免把底层协议错误（例如裸 -32600）直接暴露给用户。
+        ExperimentPresentation.codexStatusDetail(
+            for: codexDesktopStatus.state,
+            error: codexDesktopError
+        )
+    }
+
+    var experimentMenuStatusText: String? {
+        ExperimentPresentation.menuStatusText(
+            owner: owner,
+            codexState: codexDesktopStatus.state
+        )
+    }
+
+    var experimentMenuAccessibilityLabel: String {
+        ExperimentPresentation.menuAccessibilityLabel(
+            owner: owner,
+            codexState: codexDesktopStatus.state
+        )
     }
 
     var claudeStatusTitle: String {

--- a/macos/MimiRemoteMac/Tests/ExperimentPresentationTests.swift
+++ b/macos/MimiRemoteMac/Tests/ExperimentPresentationTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import MimiRemoteMac
+
+final class ExperimentPresentationTests: XCTestCase {
+    func testMenuAndSettingsShareTheExperimentWindowRoute() {
+        XCTAssertEqual(ExperimentMenuRouting.menuTitle, "实验功能…")
+        XCTAssertEqual(ExperimentMenuRouting.windowID, AppWindow.experiments.rawValue)
+    }
+
+    func testCodexStatusTitlesDescribeReadyEnvironmentAsConfigured() {
+        XCTAssertEqual(
+            ExperimentPresentation.codexStatusTitle(for: .ready),
+            "环境已配置"
+        )
+    }
+
+    func testCodexStatusDetailsKeepEachBoundaryActionable() {
+        let disabled = ExperimentPresentation.codexStatusDetail(for: .disabled)
+        XCTAssertTrue(disabled.contains("独立服务"))
+        XCTAssertTrue(disabled.contains("写入冲突"))
+
+        let pending = ExperimentPresentation.codexStatusDetail(for: .pendingRestart)
+        XCTAssertEqual(pending, "保存任务后应用设置并完全重启 Codex Desktop。")
+
+        let ready = ExperimentPresentation.codexStatusDetail(for: .ready)
+        XCTAssertTrue(ready.contains("待用同一空闲会话跨端验证"))
+        XCTAssertFalse(ready.contains("端到端已验证"))
+
+        for state in [
+            CodexDesktopStatusState.backendNotShared,
+            .failed,
+            .externalConflict,
+        ] {
+            let detail = ExperimentPresentation.codexStatusDetail(for: state)
+            XCTAssertTrue(detail.contains("共享尚未生效"))
+            XCTAssertTrue(detail.contains("先修复配置"))
+            XCTAssertTrue(detail.contains("同一会话可能无法在两端打开"))
+            XCTAssertFalse(detail.contains("-32600"))
+        }
+
+        let failedWithProtocolError = ExperimentPresentation.codexStatusDetail(
+            for: .failed,
+            error: "app-server 错误 -32600：already has an active writer"
+        )
+        XCTAssertTrue(failedWithProtocolError.contains("会话写入冲突"))
+        XCTAssertTrue(failedWithProtocolError.contains("同一会话正在被其他端占用"))
+        XCTAssertFalse(failedWithProtocolError.contains("-32600"))
+        XCTAssertFalse(failedWithProtocolError.localizedCaseInsensitiveContains("active writer"))
+    }
+
+    func testMenuStatusUsesHostOwnerAndCodexStateWithoutDuplicatingControls() {
+        XCTAssertEqual(
+            ExperimentPresentation.menuStatusText(owner: .macApp, codexState: .pendingRestart),
+            "需要重启"
+        )
+        XCTAssertEqual(
+            ExperimentPresentation.menuStatusText(owner: .macApp, codexState: .ready),
+            "已启用"
+        )
+        XCTAssertNil(
+            ExperimentPresentation.menuStatusText(owner: .macApp, codexState: .disabled)
+        )
+        XCTAssertEqual(
+            ExperimentPresentation.menuStatusText(owner: .homebrew, codexState: .ready),
+            "不可管理"
+        )
+        XCTAssertEqual(
+            ExperimentPresentation.menuAccessibilityLabel(owner: .macApp, codexState: .pendingRestart),
+            "实验功能，需要重启"
+        )
+    }
+
+    func testCodexToggleDescriptionExplainsPositiveEnabledBehavior() {
+        let enabled = ExperimentPresentation.codexToggleDescription(isEnabled: true)
+        XCTAssertTrue(enabled.contains("将尝试共享同一空闲会话"))
+        XCTAssertTrue(enabled.contains("正在运行的任务仍只读"))
+    }
+}

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -1191,7 +1191,7 @@ final class HostStoreTests: XCTestCase {
 
         XCTAssertEqual(writes.values, ["set-true-/tmp/codex"])
         XCTAssertTrue(store.codexDesktopEnabled)
-        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertEqual(store.codexDesktopStatusTitle, "环境已配置")
     }
 
     func testBootstrapWaitsForSharedRuntimeBeforeRestoringLoginEnvironment() async {
@@ -1252,7 +1252,7 @@ final class HostStoreTests: XCTestCase {
         ])
         XCTAssertNil(store.codexDesktopError)
         XCTAssertTrue(store.codexDesktopEnabled)
-        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertEqual(store.codexDesktopStatusTitle, "环境已配置")
     }
 
     func testBootstrapDoesNotRestoreEnvironmentForExplicitNonSharedRuntime() async {
@@ -1438,7 +1438,7 @@ final class HostStoreTests: XCTestCase {
 
         XCTAssertEqual(events.values, ["daemon-restart", "desktop-restart"])
         XCTAssertNil(store.codexDesktopError)
-        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertEqual(store.codexDesktopStatusTitle, "环境已配置")
         XCTAssertFalse(store.canRestartCodexDesktop)
     }
 
@@ -1482,7 +1482,7 @@ final class HostStoreTests: XCTestCase {
 
         XCTAssertEqual(events.values, ["daemon-restart"])
         XCTAssertNil(store.codexDesktopError)
-        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertEqual(store.codexDesktopStatusTitle, "环境已配置")
         XCTAssertFalse(store.canRestartCodexDesktop)
     }
 
@@ -1578,7 +1578,7 @@ final class HostStoreTests: XCTestCase {
         gate.resume()
         await staleRefresh.value
 
-        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertEqual(store.codexDesktopStatusTitle, "环境已配置")
         XCTAssertFalse(store.canRestartCodexDesktop)
     }
 
@@ -1640,7 +1640,7 @@ final class HostStoreTests: XCTestCase {
         await restart.value
 
         XCTAssertNil(store.codexDesktopError)
-        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertEqual(store.codexDesktopStatusTitle, "环境已配置")
         XCTAssertFalse(store.canRestartCodexDesktop)
     }
 
@@ -1701,7 +1701,7 @@ final class HostStoreTests: XCTestCase {
 
         XCTAssertEqual(events.values, ["desktop-true", "daemon-restart"])
         XCTAssertFalse(events.values.contains("desktop-restart"))
-        XCTAssertEqual(store.codexDesktopStatusTitle, "已配置")
+        XCTAssertEqual(store.codexDesktopStatusTitle, "环境已配置")
         XCTAssertNil(store.codexDesktopError)
     }
 


### PR DESCRIPTION
## 改动

- 在 Mac 菜单栏第一层增加“实验功能…”入口，统一承接 Codex Desktop 共享设置。
- 将共享能力明确标记为实验功能，并按未开启、待重启、配置异常、环境已配置等状态给出对应说明。
- 对非共享链路上的 `active writer` 冲突提供可操作的恢复引导，保留单写者保护。
- 在 iPhone / iPad 的“我的 → 更多”增加“实验功能”入口，说明需要在 Mac 端开启并完全重启 Codex Desktop。
- 补齐中英文文案、VoiceOver 语义和相关回归测试。

## 原因与影响

原入口只位于 Mac 设置深处，且“已配置”容易被理解为已经完成跨端验证；共享未生效时，用户也难以理解同一会话出现 writer 冲突的原因。本改动提高入口可发现性，并让状态、限制和恢复步骤与真实运行方式一致。

共享仍默认关闭，不会自动重启 Codex Desktop，也不会绕过正在运行任务的只读保护。

## 验证

- Mac 实验功能展示与状态映射相关测试通过。
- iOS 本地化测试通过（23/23）。
- iOS 主 App 与 UI 测试产物构建通过，实验功能入口专项 UI 测试通过。
- 已在实体 iPad mini 与实体 iPhone 上完成 Debug 构建、安装、启动和人工验收。

Linear: MIM-161
