### PR TITLE
MIM-165 生成可读的 Nightly TestFlight 更新内容

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/check-packaging.sh"
       - "scripts/check-app-store-metadata.sh"
       - "scripts/check-nightly-release.sh"
+      - "scripts/generate-nightly-what-to-test.rb"
       - ".github/workflows/docs-ci.yml"
   workflow_dispatch:
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -30,6 +30,7 @@ on:
       - "scripts/restart-agentd-dev-handoff-macos.sh"
       - "scripts/verify-release.sh"
       - "scripts/check-nightly-release.sh"
+      - "scripts/generate-nightly-what-to-test.rb"
       - "scripts/check-pr-gate.sh"
       - "scripts/ci-pr-scope.sh"
       - ".github/workflows/go-ci.yml"

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -42,6 +42,7 @@ on:
       - ".github/workflows/ios-ci.yml"
       - ".github/workflows/nightly.yml"
       - "scripts/check-nightly-release.sh"
+      - "scripts/generate-nightly-what-to-test.rb"
       - "scripts/check-pr-gate.sh"
       - "scripts/ci-pr-scope.sh"
       - "config/release/ios-asc-cli.env"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -159,20 +159,93 @@ jobs:
             skip_reason="force_publish=true，忽略同一 commit 的成功记录。"
           fi
 
-          commit_title="$(git log -1 --format=%s "$source_sha" \
-            | tr '\r\n' ' ' \
-            | tr -cd '[:print:]' \
-            | sed -E 's/[[:space:]]+/ /g; s/^ +//; s/ +$//' \
-            | cut -c1-120)"
-          [[ -n "$commit_title" ]] || commit_title="main commit"
-          what_to_test="Nightly $(TZ=Asia/Shanghai date +%F) ${source_sha:0:7}: ${commit_title}"
+          baseline_sha=""
+          nightly_date="$(TZ=Asia/Shanghai date +%F)"
+          if [[ "$should_publish" == "true" ]]; then
+            # 只从成功的 Nightly run 中选基线，并逐个用 Git 祖先关系校验；API
+            # 返回的 run/head SHA 不直接信任，找不到可达基线时交给生成器安全兜底。
+            baseline_page=1
+            while [[ -z "$baseline_sha" ]]; do
+              baseline_runs_file="$RUNNER_TEMP/nightly-successful-runs-${baseline_page}.json"
+              curl --fail --silent --show-error \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer $GH_TOKEN" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/nightly.yml/runs?per_page=100&page=${baseline_page}" \
+                > "$baseline_runs_file"
+              baseline_candidates="$RUNNER_TEMP/nightly-baseline-candidates-${baseline_page}.txt"
+              SOURCE_SHA="$source_sha" CURRENT_RUN_ID="$GITHUB_RUN_ID" \
+                ruby -rjson -e '
+                  data = JSON.parse(File.read(ARGV.fetch(0)))
+                  source_sha = ENV.fetch("SOURCE_SHA")
+                  current_run_id = ENV.fetch("CURRENT_RUN_ID")
+                  runs = data.fetch("workflow_runs", []).select do |run|
+                    run["conclusion"] == "success" &&
+                      run["id"].to_s != current_run_id &&
+                      run["head_sha"].to_s.match?(/\A[0-9a-f]{40}\z/) &&
+                      run["head_sha"] != source_sha &&
+                      run["head_branch"] == "main" &&
+                      %w[schedule workflow_dispatch].include?(run["event"])
+                  end
+                  runs.sort_by { |run| [run["created_at"].to_s, run["id"].to_i] }.reverse_each do |run|
+                    puts run.fetch("head_sha")
+                  end
+                ' "$baseline_runs_file" > "$baseline_candidates"
+
+              while IFS= read -r candidate_sha; do
+                [[ "$candidate_sha" =~ ^[0-9a-f]{40}$ ]] || continue
+                if git cat-file -e "${candidate_sha}^{commit}" 2>/dev/null &&
+                  git merge-base --is-ancestor "$candidate_sha" "$source_sha" 2>/dev/null; then
+                  baseline_sha="$candidate_sha"
+                  break
+                fi
+              done < "$baseline_candidates"
+
+              baseline_count="$(ruby -rjson -e 'puts JSON.parse(File.read(ARGV.fetch(0))).fetch("workflow_runs", []).length' "$baseline_runs_file")"
+              [[ "$baseline_count" -lt 100 ]] && break
+              baseline_page=$((baseline_page + 1))
+            done
+
+            generator_args=(
+              scripts/generate-nightly-what-to-test.rb
+              --date "$nightly_date"
+              --head-sha "$source_sha"
+            )
+            [[ -z "$baseline_sha" ]] || generator_args+=(--base-sha "$baseline_sha")
+            what_to_test="$(ruby "${generator_args[@]}")"
+          else
+            # 去重成功分支不能再访问 Actions API；该占位只用于 plan 输出，
+            # publish 已因 should_publish=false 跳过，避免改变既有 skip 语义。
+            what_to_test="Nightly ${nightly_date} ${source_sha:0:7}: 已有成功 Nightly，跳过本次发布。"
+          fi
           echo "$skip_reason"
+          echo "Nightly What to Test 基线：${baseline_sha:-无可达上一成功 SHA}"
+
+          # GITHUB_OUTPUT 的 delimiter 必须是随机且不出现在 payload 独立行中；
+          # 即使提交标题包含 Actions 命令样式文本，也不能提前闭合多行 output。
+          new_delimiter() {
+            local random_hex
+            random_hex="$(od -An -N16 -tx1 /dev/urandom | tr -d '[:space:]')"
+            [[ "$random_hex" =~ ^[0-9a-f]{32}$ ]] || {
+              echo "无法生成安全的 Nightly output delimiter。" >&2
+              exit 1
+            }
+            printf 'MIMI_NIGHTLY_WHAT_TO_TEST_%s' "$random_hex"
+          }
+          delimiter="$(new_delimiter)"
+          while printf '%s\n' "$what_to_test" | grep -Fqx -- "$delimiter"; do
+            delimiter="$(new_delimiter)"
+          done
+          if printf '%s\n' "$what_to_test" | grep -Fqx -- "$delimiter"; then
+            echo "Nightly What to Test delimiter 出现在 payload 独立行。" >&2
+            exit 1
+          fi
           {
             echo "source_sha=$source_sha"
             echo "should_publish=$should_publish"
-            # commit title 已在上方去除换行，因此使用单行 output，避免固定
-            # heredoc delimiter 被恶意或意外的提交标题提前闭合。
-            echo "what_to_test=$what_to_test"
+            echo "what_to_test<<$delimiter"
+            printf '%s\n' "$what_to_test"
+            echo "$delimiter"
           } >> "$GITHUB_OUTPUT"
 
   release-secrets-preflight:

--- a/docs/nightly-release.md
+++ b/docs/nightly-release.md
@@ -14,7 +14,7 @@
 
 ## 实现
 
-Nightly 的 What to Test 只包含北京时间日期、短 SHA 和清洗后的 commit title。App 的 marketing version 与 host 的 `v*` 版本线独立；build number 继续由 App Store Connect 预检分配。Windows 签名和真实 Runtime 不属于 Nightly 的阻塞链路。
+Nightly 的 What to Test 根据上一成功 Nightly 与当前 source SHA 之间的可达变更范围生成：包含北京时间日期、短 SHA 范围和去重后的非 merge commit 标题，只保留真正进入 iOS App 或 Widget 产物的更新，并过滤 Mac/agentd、Web、纯 CI、文档、测试与发布控制噪音。首次 Nightly、找不到祖先基线或没有 TestFlight 产物变更时会给出明确的完整验证/无新增功能兜底，内容最多 4000 个 Unicode 字符。App 的 marketing version 与 host 的 `v*` 版本线独立；build number 继续由 App Store Connect 预检分配。Windows 签名和真实 Runtime 不属于 Nightly 的阻塞链路。
 
 ## 风险与优化
 

--- a/scripts/check-nightly-release.sh
+++ b/scripts/check-nightly-release.sh
@@ -13,7 +13,8 @@ run_check() {
   ruby - "$CHECK_ROOT/.github/workflows/nightly.yml" \
     "$CHECK_ROOT/.github/workflows/ios-ci.yml" \
     "$CHECK_ROOT/.github/workflows/release.yml" \
-    "$CHECK_ROOT/scripts/distribute_internal_build.rb" <<'RUBY'
+    "$CHECK_ROOT/scripts/distribute_internal_build.rb" \
+    "$CHECK_ROOT/scripts/generate-nightly-what-to-test.rb" <<'RUBY'
 require "yaml"
 
 def fail_check(message)
@@ -60,10 +61,12 @@ def assert_pinned_actions(path, workflow)
   end
 end
 
-nightly_path, ios_path, release_path, distributor_path = ARGV
+nightly_path, ios_path, release_path, distributor_path, generator_path = ARGV
 nightly = load_yaml(nightly_path)
 ios = load_yaml(ios_path)
 release = load_yaml(release_path)
+fail_check("Nightly What to Test 生成器不存在") unless File.file?(generator_path)
+generator = File.read(generator_path)
 [nightly, ios, release].zip([nightly_path, ios_path, release_path]).each do |workflow, path|
   assert_pinned_actions(path, workflow)
 end
@@ -118,6 +121,23 @@ dedup_run = steps(plan).fetch(dedup_index).fetch("run")
   '%w[schedule workflow_dispatch].include?(value["event"])',
   'value["uploaded"] == true'
 ].each { |needle| fail_check("Nightly evidence 绑定缺少 #{needle}") unless dedup_run.include?(needle) }
+[
+  'run["conclusion"] == "success"', 'run["head_branch"] == "main"',
+  'run["head_sha"] != source_sha', 'per_page=100&page=${baseline_page}',
+  'if [[ "$should_publish" == "true" ]]; then',
+  'git cat-file -e "${candidate_sha}^{commit}"',
+  'git merge-base --is-ancestor "$candidate_sha" "$source_sha"',
+  'scripts/generate-nightly-what-to-test.rb', 'GITHUB_OUTPUT',
+  'what_to_test<<$delimiter', 'od -An -N16 -tx1 /dev/urandom',
+  'grep -Fqx -- "$delimiter"'
+].each { |needle| fail_check("Nightly What to Test 安全边界缺少 #{needle}") unless dedup_run.include?(needle) }
+[
+  'MAX_LENGTH = 4000', '--no-merges', 'diff-tree', 'changed_paths', 'base_sha != head_sha',
+  'noise_path?', 'testflight_payload_path?', 'ios/MimiRemote/WidgetExtension/',
+  'Info-Catalyst.plist', 'MimiRemotePhysicalUITests.xcscheme',
+  'FALLBACK_NO_BASELINE', 'FALLBACK_NO_USER_CHANGES',
+  'normalized_title', '其余 #{remaining} 项更新未展开'
+].each { |needle| fail_check("Nightly What to Test 生成器缺少 #{needle}") unless generator.include?(needle) }
 fail_check("Nightly plan 必须输出 source_sha/what_to_test/should_publish") unless
   %w[source_sha what_to_test should_publish].all? { |key| plan.dig("outputs", key).to_s.include?("steps.plan.outputs") }
 
@@ -299,7 +319,9 @@ self_test() {
   cp "$ROOT_DIR/.github/workflows/ios-ci.yml" "$test_root/.github/workflows/"
   cp "$ROOT_DIR/.github/workflows/release.yml" "$test_root/.github/workflows/"
   cp "$ROOT_DIR/scripts/distribute_internal_build.rb" "$test_root/scripts/"
+  cp "$ROOT_DIR/scripts/generate-nightly-what-to-test.rb" "$test_root/scripts/"
   MIMI_NIGHTLY_RELEASE_ROOT="$test_root" "$0" --check >/dev/null
+  ruby "$test_root/scripts/generate-nightly-what-to-test.rb" --self-test >/dev/null
 
   expect_failure() {
     if MIMI_NIGHTLY_RELEASE_ROOT="$test_root" "$0" --check >/dev/null 2>&1; then
@@ -328,6 +350,7 @@ self_test() {
     expect_failure
   }
   mutate_nightly 'artifact["name"] == "nightly-testflight-#{sha}"' 'artifact["name"]'
+  mutate_nightly 'if [[ "$should_publish" == "true" ]]; then' 'if true; then'
   mutate_nightly 'artifact["expired"] == false' 'artifact["expired"] != true'
   mutate_nightly 'workflow_run["id"].to_s == run_id' 'workflow_run["id"]'
   mutate_nightly 'workflow_run["head_sha"] == sha' 'workflow_run["head_sha"]'

--- a/scripts/ci-pr-scope.sh
+++ b/scripts/ci-pr-scope.sh
@@ -136,7 +136,7 @@ else
       *.go|go.mod|go.sum|.goreleaser.yml|SKILL.md|packaging/*|packaging/**/*|contracts/mimi-protocol/*|contracts/mimi-protocol/**/*)
         go_scope=true
         ;;
-      scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-nightly-release.sh|scripts/check-packaging.sh|scripts/check-source-size.sh|scripts/check-mimi-protocol-contract.sh|scripts/check-macos-*|scripts/check-release-*|scripts/build-macos-installer.sh|scripts/build-windows-installer.ps1|scripts/check-windows-installer.ps1|scripts/test-windows-install.ps1|scripts/install-linux.sh|scripts/test-install-linux.sh|scripts/package-skill.sh|scripts/sign-agentd-dev-macos.sh|scripts/restart-agentd-dev-macos.sh|scripts/restart-agentd-dev-handoff-macos.sh|scripts/verify-release.sh)
+      scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-nightly-release.sh|scripts/generate-nightly-what-to-test.rb|scripts/check-packaging.sh|scripts/check-source-size.sh|scripts/check-mimi-protocol-contract.sh|scripts/check-macos-*|scripts/check-release-*|scripts/build-macos-installer.sh|scripts/build-windows-installer.ps1|scripts/check-windows-installer.ps1|scripts/test-windows-install.ps1|scripts/install-linux.sh|scripts/test-install-linux.sh|scripts/package-skill.sh|scripts/sign-agentd-dev-macos.sh|scripts/restart-agentd-dev-macos.sh|scripts/restart-agentd-dev-handoff-macos.sh|scripts/verify-release.sh)
         go_scope=true
         ;;
     esac
@@ -145,7 +145,7 @@ else
       ios/MimiRemote/*|ios/MimiRemote/**/*|.xcodebuildmcp/*|.xcodebuildmcp/**/*|contracts/mimi-protocol/*|contracts/mimi-protocol/**/*|internal/protocolcontract/*|internal/protocolcontract/**/*)
         ios_scope=true
         ;;
-      scripts/ios-dev.sh|scripts/ios-device-lease.sh|scripts/test-ios-device-management.sh|scripts/testdata/ios-device-management/*|scripts/testdata/ios-device-management/**/*|scripts/ios_testflight_ci.sh|scripts/ios_testflight_local.sh|scripts/ios_asc_*|scripts/test-ios-asc-cli.sh|scripts/distribute_internal_build.rb|scripts/git-testflight-push|scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-nightly-release.sh|scripts/test-ios-localization-smoke.sh|scripts/check-ios-*|scripts/check-app-store-metadata.sh|scripts/check-source-size.sh|scripts/deploy-ipad.sh|config/release/ios-asc-cli.env|config/release/ios-testflight.local.env)
+      scripts/ios-dev.sh|scripts/ios-device-lease.sh|scripts/test-ios-device-management.sh|scripts/testdata/ios-device-management/*|scripts/testdata/ios-device-management/**/*|scripts/ios_testflight_ci.sh|scripts/ios_testflight_local.sh|scripts/ios_asc_*|scripts/test-ios-asc-cli.sh|scripts/distribute_internal_build.rb|scripts/generate-nightly-what-to-test.rb|scripts/git-testflight-push|scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-nightly-release.sh|scripts/test-ios-localization-smoke.sh|scripts/check-ios-*|scripts/check-app-store-metadata.sh|scripts/check-source-size.sh|scripts/deploy-ipad.sh|config/release/ios-asc-cli.env|config/release/ios-testflight.local.env)
         ios_scope=true
         ;;
     esac
@@ -163,7 +163,7 @@ else
     esac
 
     case "$changed_path" in
-      scripts/check-packaging.sh|scripts/check-app-store-metadata.sh|scripts/check-nightly-release.sh)
+      scripts/check-packaging.sh|scripts/check-app-store-metadata.sh|scripts/check-nightly-release.sh|scripts/generate-nightly-what-to-test.rb)
         docs_scope=true
         ;;
     esac

--- a/scripts/generate-nightly-what-to-test.rb
+++ b/scripts/generate-nightly-what-to-test.rb
@@ -1,0 +1,336 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# 生成 Nightly TestFlight 的 What to Test。此脚本只读取 checkout 中的 Git
+# 历史，不读取 Secret，也不把提交者、路径或环境变量写入发布说明。
+
+require "date"
+require "fileutils"
+require "open3"
+require "optparse"
+require "rbconfig"
+require "tmpdir"
+
+MAX_LENGTH = 4000
+MAX_TITLE_LENGTH = 180
+FALLBACK_NO_BASELINE = "建议完整验证当前构建（首次 Nightly 或找不到上一成功 Nightly 基线）。"
+FALLBACK_NO_USER_CHANGES = "仅内部维护/文档/测试调整，无新增用户功能。"
+
+class GitCommandError < StandardError; end
+
+def git_output(repo, *arguments)
+  stdout, stderr, status = Open3.capture3("git", *arguments, chdir: repo)
+  return stdout if status.success?
+
+  detail = stderr.to_s.strip
+  detail = "退出码 #{status.exitstatus}" if detail.empty?
+  raise GitCommandError, "git #{arguments.join(" ")} 失败：#{detail}"
+end
+
+def valid_sha?(value)
+  value.is_a?(String) && value.match?(/\A[0-9a-f]{40}\z/i)
+end
+
+def commit_exists?(repo, sha)
+  return false unless valid_sha?(sha)
+
+  _stdout, _stderr, status = Open3.capture3("git", "cat-file", "-e", "#{sha}^{commit}", chdir: repo)
+  status.success?
+end
+
+def ancestor?(repo, base_sha, head_sha)
+  return false unless commit_exists?(repo, base_sha) && commit_exists?(repo, head_sha)
+
+  _stdout, _stderr, status = Open3.capture3("git", "merge-base", "--is-ancestor", base_sha, head_sha, chdir: repo)
+  status.success?
+end
+
+def short_sha(sha)
+  valid_sha?(sha) ? sha[0, 7] : sha.to_s.gsub(/[^0-9a-f]/i, "")[0, 7].to_s
+end
+
+def normalized_title(value)
+  # 提交 subject 理论上只有一行，但仍清洗控制字符和换行，避免把恶意标题
+  # 变成额外的 What to Test 行或 GitHub Actions output 控制内容。
+  cleaned = value.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+  cleaned = cleaned.gsub(/[[:space:]\p{Cc}]+/u, " ").strip
+  return "" if cleaned.empty?
+
+  return cleaned if cleaned.length <= MAX_TITLE_LENGTH
+
+  "#{cleaned[0, MAX_TITLE_LENGTH - 1]}…"
+end
+
+def documentation_path?(path)
+  basename = File.basename(path)
+  path.start_with?("docs/", "artifacts/") ||
+    basename.match?(/\.(?:md|markdown|rst|txt)\z/i) ||
+    basename.match?(/\A(?:README|CHANGELOG|CONTRIBUTING|SECURITY|LICENSE)(?:\.|\z)/i)
+end
+
+def test_path?(path)
+  parts = path.split("/")
+  basename = parts.last.to_s
+  parts.any? { |part| part.match?(/\A(?:test|tests|testdata|spec|specs|fixtures?)\z/i) } ||
+    parts.any? { |part| part.match?(%r{\A(?:[^/]+)(?:Tests|UITests)\z}) } ||
+    basename.match?(/(?:\A|[._-])(?:test|tests|spec)(?:[._-]|\z)/i) ||
+    basename.match?(/_test\.[^.]+\z/i)
+end
+
+def release_control_path?(path)
+  path.start_with?("config/release/", "scripts/release/") ||
+    path.match?(%r{\Ascripts/(?:check|test|verify|ci|generate|build|sign|deploy|package|install)-}) ||
+    path.match?(%r{\Ascripts/(?:ios_asc|ios_testflight|distribute_internal|git-testflight)}) ||
+    path.match?(%r{\Ascripts/[^/]*(?:release|testflight)[^/]*\z}i) ||
+    path == ".goreleaser.yml"
+end
+
+def ci_control_path?(path)
+  path.start_with?(".github/", ".circleci/", ".buildkite/") ||
+    %w[Jenkinsfile Makefile].include?(path)
+end
+
+def noise_path?(path)
+  documentation_path?(path) || test_path?(path) || release_control_path?(path) || ci_control_path?(path)
+end
+
+def testflight_payload_path?(path)
+  # Nightly 只上传 iOS App 与 Widget；Mac、agentd、Web 等源码即使是用户可感知
+  # 功能，也不属于这个 TestFlight 构建，不能写进本包的测试说明。
+  return true if path.start_with?("ios/MimiRemote/Sources/") && !path.include?("/.claude/")
+  return true if path.start_with?("ios/MimiRemote/WidgetExtension/")
+  return true if path.start_with?("ios/MimiRemote/Resources/Assets.xcassets/") &&
+    !path.start_with?("ios/MimiRemote/Resources/Assets.xcassets/AppIconMac.appiconset/")
+  return true if %w[
+    ios/MimiRemote/Resources/Info.plist
+    ios/MimiRemote/Resources/Localizable.xcstrings
+    ios/MimiRemote/Resources/MimiRemote.entitlements
+    ios/MimiRemote/Resources/PrivacyInfo.xcprivacy
+    ios/MimiRemote/Resources/en.lproj/InfoPlist.strings
+    ios/MimiRemote/Resources/zh-Hans.lproj/InfoPlist.strings
+    ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+    ios/MimiRemote/MimiRemote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+    ios/MimiRemote/project.yml
+  ].include?(path)
+
+  false
+end
+
+def changed_paths(repo, commit_sha)
+  git_output(
+    repo,
+    "diff-tree",
+    "--root",
+    "--no-commit-id",
+    "--name-only",
+    "-r",
+    "-z",
+    "--no-renames",
+    commit_sha
+  ).split("\0").reject(&:empty?)
+end
+
+def commit_subject(repo, commit_sha)
+  git_output(repo, "log", "-1", "--format=%s", commit_sha).lines.first.to_s
+end
+
+def range_commits(repo, base_sha, head_sha)
+  git_output(repo, "log", "--no-merges", "--reverse", "--format=%H", "#{base_sha}..#{head_sha}")
+    .lines
+    .map(&:strip)
+    .reject(&:empty?)
+end
+
+def user_change_titles(repo, base_sha, head_sha)
+  seen = {}
+  range_commits(repo, base_sha, head_sha).each_with_object([]) do |commit_sha, titles|
+    paths = changed_paths(repo, commit_sha)
+    # 只有真正进入 TestFlight payload 的生产文件才能生成条目。混合提交
+    # 保留原 subject，无法归属到 iOS/Widget 产物时不猜测用户功能。
+    relevant_paths = paths.reject { |path| noise_path?(path) }
+    next unless relevant_paths.any? { |path| testflight_payload_path?(path) }
+
+    title = normalized_title(commit_subject(repo, commit_sha))
+    next if title.empty? || seen[title]
+
+    seen[title] = true
+    titles << title
+  end
+end
+
+def render_summary(date, base_sha, head_sha, titles)
+  date_line = "Nightly 日期：#{date}"
+  if valid_sha?(base_sha) && base_sha != head_sha && ancestor?(Dir.pwd, base_sha, head_sha)
+    header = [date_line, "SHA 范围：#{short_sha(base_sha)}..#{short_sha(head_sha)}", "本次更新："]
+  else
+    header = [date_line, "当前 SHA：#{short_sha(head_sha)}", "本次更新："]
+    titles = [FALLBACK_NO_BASELINE]
+  end
+
+  if titles.empty?
+    titles = [FALLBACK_NO_USER_CHANGES]
+  end
+
+  render = lambda do |selected|
+    (header + selected.map { |title| "- #{title}" }).join("\n")
+  end
+  result = render.call(titles)
+  return result if result.length <= MAX_LENGTH
+
+  # 先稳定地按 Git log 顺序保留条目，再追加明确的省略数量；若 marker 本身
+  # 仍超限，逐项回退，保证任何 Unicode 字符串都不会超过 4000 个字符。
+  selected = []
+  titles.each do |title|
+    candidate = render.call(selected + [title])
+    break if candidate.length > MAX_LENGTH
+
+    selected << title
+  end
+
+  remaining = titles.length - selected.length
+  marker = "其余 #{remaining} 项更新未展开（内容已截断）。"
+  while render.call(selected + [marker]).length > MAX_LENGTH && selected.any?
+    selected.pop
+    remaining += 1
+    marker = "其余 #{remaining} 项更新未展开（内容已截断）。"
+  end
+
+  final = render.call(selected + [marker])
+  # header 远小于上限；该保护只防止未来修改 header 时破坏长度契约。
+  final[0, MAX_LENGTH]
+end
+
+def generate_summary(repo, date, base_sha, head_sha)
+  unless valid_sha?(head_sha) && commit_exists?(repo, head_sha)
+    raise ArgumentError, "head SHA 必须是存在的 40 位 commit SHA。"
+  end
+
+  usable_base = valid_sha?(base_sha) && base_sha != head_sha && ancestor?(repo, base_sha, head_sha) ? base_sha : nil
+  titles = usable_base ? user_change_titles(repo, usable_base, head_sha) : []
+  # render_summary 通过 Dir.pwd 判断祖先关系；调用方固定传入 checkout 根目录，
+  # 这里使用同一目录生成最终内容，避免误把不可达基线当成可信 range。
+  previous_dir = Dir.pwd
+  Dir.chdir(repo) do
+    return render_summary(date, usable_base, head_sha, titles)
+  end
+ensure
+  Dir.chdir(previous_dir) if previous_dir && Dir.pwd != previous_dir
+end
+
+def run_self_test
+  included_payload_paths = %w[
+    ios/MimiRemote/Sources/RootView.swift
+    ios/MimiRemote/WidgetExtension/Info.plist
+    ios/MimiRemote/Resources/Info.plist
+    ios/MimiRemote/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+    ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+    ios/MimiRemote/MimiRemote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+    ios/MimiRemote/project.yml
+  ]
+  excluded_payload_paths = %w[
+    ios/MimiRemote/Resources/Info-Catalyst.plist
+    ios/MimiRemote/Resources/MimiRemote-Catalyst.entitlements
+    ios/MimiRemote/Resources/LocalizationTechnicalStringAllowlist.json
+    ios/MimiRemote/Resources/Assets.xcassets/AppIconMac.appiconset/Contents.json
+    ios/MimiRemote/MimiRemote.xcodeproj/xcshareddata/xcschemes/MimiRemotePhysicalUITests.xcscheme
+    ios/MimiRemote/Sources/Features/.claude/settings.json
+    macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
+  ]
+  raise "self-test: iOS/Widget payload 路径被漏掉" unless included_payload_paths.all? { |path| testflight_payload_path?(path) }
+  raise "self-test: 非 TestFlight payload 路径被误收" if excluded_payload_paths.any? { |path| testflight_payload_path?(path) }
+
+  Dir.mktmpdir("mimi-nightly-what-to-test-self-test") do |repo|
+    git = lambda do |*args|
+      git_output(repo, *args)
+    end
+    git.call("init", "-q")
+    git.call("config", "user.name", "Mimi Nightly Self Test")
+    git.call("config", "user.email", "nightly-self-test@example.invalid")
+
+    write_commit = lambda do |path, content, title|
+      absolute = File.join(repo, path)
+      FileUtils.mkdir_p(File.dirname(absolute))
+      File.write(absolute, content)
+      git.call("add", "--", path)
+      git.call("commit", "-q", "-m", title)
+      git.call("rev-parse", "HEAD").strip
+    end
+
+    write_commit.call("ios/MimiRemote/Sources/base.swift", "struct Base {}\n", "baseline")
+    baseline = git.call("rev-parse", "HEAD").strip
+    first = write_commit.call("ios/MimiRemote/Sources/feature.swift", "struct Feature {}\n", "Add feature")
+    duplicate = write_commit.call("ios/MimiRemote/Sources/feature.swift", "struct Feature { let v = 2 }\n", "Add feature")
+    write_commit.call("docs/notes.md", "docs\n", "Document feature")
+    write_commit.call("Tests/FeatureTests.swift", "tests\n", "Test feature")
+    write_commit.call(".github/workflows/example.yml", "name: CI\n", "Tune CI")
+    write_commit.call("scripts/check-nightly-release.sh", "#!/usr/bin/env bash\n", "Harden release check")
+    write_commit.call("internal/httpapi/daemon.go", "package httpapi\n", "Backend only change")
+    write_commit.call("ios/MimiRemote/WidgetExtension/another.swift", "struct Another {}\n", "Second feature")
+    main_branch = git.call("branch", "--show-current").strip
+    git.call("checkout", "-q", "-b", "nightly-self-test-feature")
+    write_commit.call("ios/MimiRemote/Sources/branch.swift", "struct BranchFeature {}\n", "Branch feature")
+    git.call("checkout", "-q", main_branch)
+    git.call("merge", "--no-ff", "-q", "-m", "Merge synthetic branch", "nightly-self-test-feature")
+    latest = git.call("rev-parse", "HEAD").strip
+
+    summary = generate_summary(repo, "2026-08-18", baseline, latest)
+    raise "self-test: 多提交标题缺失" unless summary.include?("- Add feature") && summary.include?("- Second feature") && summary.include?("- Branch feature")
+    raise "self-test: 重复标题未去重" unless summary.scan("- Add feature").length == 1
+    raise "self-test: 噪音提交未过滤" if summary.include?("Document feature") || summary.include?("Tune CI") || summary.include?("Harden release check") || summary.include?("Backend only change")
+    raise "self-test: merge commit 未过滤" if summary.include?("Merge synthetic branch")
+    raise "self-test: summary 应包含范围" unless summary.include?("SHA 范围：#{short_sha(baseline)}..#{short_sha(latest)}")
+    raise "self-test: 未覆盖中间提交" unless first != duplicate
+
+    noise_head = write_commit.call("docs/only.md", "docs\n", "Only docs")
+    noise_summary = generate_summary(repo, "2026-08-18", latest, noise_head)
+    raise "self-test: 纯噪音兜底缺失" unless noise_summary.include?(FALLBACK_NO_USER_CHANGES)
+
+    first_summary = generate_summary(repo, "2026-08-18", nil, latest)
+    raise "self-test: 首次 Nightly 兜底缺失" unless first_summary.include?(FALLBACK_NO_BASELINE) && first_summary.include?(short_sha(latest))
+    invalid_base_summary = generate_summary(repo, "2026-08-18", "0" * 40, latest)
+    raise "self-test: 无效基线未安全兜底" unless invalid_base_summary.include?(FALLBACK_NO_BASELINE)
+
+    malicious = normalized_title("unsafe\n::set-output name=token::leak\r\nnext")
+    raise "self-test: 恶意/换行 subject 未清洗" if malicious.include?("\n") || malicious.include?("\r")
+    raise "self-test: 恶意 subject 未保持单行" unless malicious.lines.length == 1
+
+    long_base = git.call("rev-parse", "HEAD").strip
+    40.times do |index|
+      write_commit.call("ios/MimiRemote/Sources/long-#{index}.swift", "struct Long#{index} {}\n", "Long feature #{index} #{'x' * 220}")
+    end
+    long_head = git.call("rev-parse", "HEAD").strip
+    long_summary = generate_summary(repo, "2026-08-18", long_base, long_head)
+    raise "self-test: 超长内容超过 4000 字符" unless long_summary.length <= MAX_LENGTH
+    raise "self-test: 超长内容未说明省略项" unless long_summary.include?("内容已截断") && long_summary.match?(/其余 \d+ 项更新未展开/)
+    raise "self-test: 输出含独立控制行" if long_summary.lines.any? { |line| line.chomp == "::set-output" }
+
+    puts "Nightly What to Test 生成器自测通过：首次/无效基线、纯噪音、多提交、去重、长度上限与恶意标题场景均符合预期。"
+  end
+end
+
+options = { date: Date.today.iso8601, base_sha: nil, head_sha: nil, self_test: false }
+OptionParser.new do |parser|
+  parser.banner = "用法：ruby scripts/generate-nightly-what-to-test.rb --head-sha SHA [--base-sha SHA] [--date YYYY-MM-DD]"
+  parser.on("--head-sha SHA", "当前 Nightly immutable commit SHA") { |value| options[:head_sha] = value }
+  parser.on("--base-sha SHA", "上一成功 Nightly 的可达基线 SHA") { |value| options[:base_sha] = value }
+  parser.on("--date DATE", "Nightly 日期（YYYY-MM-DD）") { |value| options[:date] = value }
+  parser.on("--self-test", "运行无网络生成器自测") { options[:self_test] = true }
+end.parse!
+
+if options[:self_test]
+  run_self_test
+  exit 0
+end
+
+abort "必须提供 --head-sha。" unless options[:head_sha]
+begin
+  Date.iso8601(options[:date])
+rescue Date::Error
+  abort "--date 必须是 YYYY-MM-DD。"
+end
+
+begin
+  puts generate_summary(Dir.pwd, options[:date], options[:base_sha], options[:head_sha])
+rescue ArgumentError, GitCommandError => error
+  abort "Nightly What to Test 生成失败：#{error.message}"
+end

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -169,6 +169,11 @@ release_checker_output="$(assert_plan release_checker scripts/check-nightly-rele
 assert_contains "$release_checker_output" "check-nightly-release.sh --check"
 assert_contains "$release_checker_output" "check-nightly-release.sh --self-test"
 
+release_generator_output="$(assert_plan release_generator scripts/generate-nightly-what-to-test.rb)"
+assert_contains "$release_generator_output" "ruby -c -- scripts/generate-nightly-what-to-test.rb"
+assert_contains "$release_generator_output" "check-nightly-release.sh --check"
+assert_contains "$release_generator_output" "check-nightly-release.sh --self-test"
+
 release_config_output="$(assert_plan release_config config/release/ios-asc-cli.env)"
 assert_contains "$release_config_output" "check-nightly-release.sh --check"
 

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -341,7 +341,7 @@ for path in "${changed_paths[@]:-}"; do
       ;;
   esac
   case "$path" in
-    .github/workflows/release.yml|.github/workflows/nightly.yml|scripts/check-nightly-release.sh|scripts/check-release-source.sh|scripts/verify-release.sh|scripts/ios_testflight_*|config/release/*|docs/nightly-release.md)
+    .github/workflows/release.yml|.github/workflows/nightly.yml|scripts/check-nightly-release.sh|scripts/generate-nightly-what-to-test.rb|scripts/check-release-source.sh|scripts/verify-release.sh|scripts/ios_testflight_*|config/release/*|docs/nightly-release.md)
       has_release_control=true
       ;;
   esac


### PR DESCRIPTION
## 变更内容

- 从最近一个成功且可达的 Nightly SHA 生成本次 TestFlight 更新范围。
- 汇总 iOS App / Widget 的非 merge 提交标题，过滤 Mac、agentd、Web、CI、文档、测试及发布控制噪音。
- 增加首次 Nightly、无相关变更、超长内容和恶意标题的安全兜底。
- 使用随机且经过冲突检查的 delimiter 写入多行 GitHub Actions output。
- 补齐 Nightly checker、验证映射、CI path 和发布文档。

## 原因

每日 TestFlight 包当前只有 “Nightly” 或单个 commit 标题，无法说明相对上一成功构建实际需要验证的内容。

## 验证

- `bash ./scripts/verify-change.sh --base origin/main`：9/9 通过
- `ruby scripts/generate-nightly-what-to-test.rb --self-test`：通过
- `bash ./scripts/check-nightly-release.sh --self-test`：通过
- 独立只读 Sol 复审：`ship`

关联 Linear：MIM-165
