### PR TITLE
MIM-108 优先加载「我的」页 Token 活动缓存

### DIFF
--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -419,7 +419,6 @@ struct SettingsView: View {
                 return
             }
             let preflightSucceeded = await appStore.preflightConnection()
-            _ = await appStore.testConnectionOnFirstSettingsAppearanceIfNeeded()
             let hasConnectedStatus: Bool
             if case .connected = appStore.connectionStatus {
                 hasConnectedStatus = true
@@ -429,14 +428,11 @@ struct SettingsView: View {
             guard (preflightSucceeded || hasConnectedStatus), appStore.isConfigured else {
                 return
             }
-            // 用 channel/model 元数据判断 Claude 是否真正接入；设置页独立打开时也要刷新，
-            // 不能依赖用户先进入 Conversation 才出现 Claude 用量卡。
-            await sessionStore.refreshAppServerModelOptions()
-            await sessionStore.refreshCodexUsage()
-            if sessionStore.hasClaudeRuntimeChannel {
-                await sessionStore.refreshClaudeUsage()
-            }
-            await sessionStore.refreshAccountTokenUsage()
+            // 完整连接测速可能持续数秒。账号概览与它并行刷新，Token 活动才能及时命中
+            // agentd 的最近快照，不再长时间停留在“刷新后显示”的 idle 状态。
+            async let connectionTest: Bool = appStore.testConnectionOnFirstSettingsAppearanceIfNeeded()
+            async let accountOverview: Void = sessionStore.refreshSettingsAccountOverview()
+            _ = await (connectionTest, accountOverview)
             let hasNotLoadedInitialData = sessionStore.projects.isEmpty
                 && sessionStore.statusMessage == nil
             guard sessionStore.errorMessage != nil || hasNotLoadedInitialData else {

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -3,6 +3,19 @@ import os
 import UserNotifications
 
 extension SessionStore {
+    func refreshSettingsAccountOverview() async {
+        // Token 活动在 agentd 已有 12 小时快照，必须先发请求才能立即命中。
+        // 模型目录和额度查询可能较慢，不能把低频活动快照排在它们之后。
+        async let tokenActivity: Void = refreshAccountTokenUsage()
+
+        await refreshAppServerModelOptions()
+        await refreshCodexUsage()
+        if hasClaudeRuntimeChannel {
+            await refreshClaudeUsage()
+        }
+        await tokenActivity
+    }
+
     func refreshAccountTokenUsage(forceRefresh: Bool = false) async {
         let hostScope = appStore.activeHostScope
         guard accountTokenUsageRefreshHostScope != hostScope else {

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -17,19 +17,6 @@ extension SessionStore {
         await refreshUsage(runtimeProvider: runtimeProvider)
     }
 
-    func refreshSettingsAccountOverview() async {
-        // Token 活动在 agentd 已有 12 小时快照，必须先发请求才能立即命中。
-        // 模型目录和额度查询可能较慢，不能把低频活动快照排在它们之后。
-        async let tokenActivity: Void = refreshAccountTokenUsage()
-
-        await refreshAppServerModelOptions()
-        await refreshCodexUsage()
-        if hasClaudeRuntimeChannel {
-            await refreshClaudeUsage()
-        }
-        await tokenActivity
-    }
-
     func isRefreshingUsage(runtimeProvider: String) -> Bool {
         refreshingUsageRuntimeProviders.contains(Self.normalizedRuntimeProvider(runtimeProvider))
     }

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -17,6 +17,19 @@ extension SessionStore {
         await refreshUsage(runtimeProvider: runtimeProvider)
     }
 
+    func refreshSettingsAccountOverview() async {
+        // Token 活动在 agentd 已有 12 小时快照，必须先发请求才能立即命中。
+        // 模型目录和额度查询可能较慢，不能把低频活动快照排在它们之后。
+        async let tokenActivity: Void = refreshAccountTokenUsage()
+
+        await refreshAppServerModelOptions()
+        await refreshCodexUsage()
+        if hasClaudeRuntimeChannel {
+            await refreshClaudeUsage()
+        }
+        await tokenActivity
+    }
+
     func isRefreshingUsage(runtimeProvider: String) -> Bool {
         refreshingUsageRuntimeProviders.contains(Self.normalizedRuntimeProvider(runtimeProvider))
     }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -1727,6 +1727,44 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.accountRateLimitsByRuntime["claude"]?.primaryUsedPercent, 30)
     }
 
+    func testSettingsAccountOverviewDoesNotWaitForSlowClaudeUsageBeforeTokenActivity() async {
+        let gate = UsageRefreshGate()
+        let tokenActivityStarted = expectation(description: "Token activity request started")
+        let buckets = [AccountTokenUsageDailyBucket(startDate: "2026-08-18", tokens: 42)]
+        let client = MockSessionStoreClient(
+            projects: [],
+            sessions: [],
+            runtimeChannelAvailability: ["claude": true],
+            rateLimitHandler: { provider in
+                await gate.response(for: provider)
+            },
+            accountTokenUsageHandler: {
+                tokenActivityStarted.fulfill()
+                return AccountTokenUsageSnapshot(
+                    summary: AccountTokenUsageSummary(lifetimeTokens: 42),
+                    dailyUsageBuckets: buckets
+                )
+            }
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        let refresh = Task { await store.refreshSettingsAccountOverview() }
+        await gate.waitForRequest(provider: "claude")
+        await fulfillment(of: [tokenActivityStarted], timeout: 1)
+
+        XCTAssertTrue(store.isRefreshingUsage(runtimeProvider: "claude"))
+        XCTAssertEqual(store.accountTokenActivity.displayBuckets, buckets)
+
+        await gate.finishClaude()
+        await refresh.value
+        XCTAssertFalse(store.isRefreshingUsage(runtimeProvider: "claude"))
+    }
+
     func testClaudeAuthenticationWarmupFailureStaysSilent() async {
         let project = makeProject(id: "proj_claude_warm_silent")
         let session = makeSession(


### PR DESCRIPTION
## 改动

- 设置页同时启动完整连接测试和账号概览刷新。
- 账号概览先启动 Token 活动请求，再等待模型目录与 Codex / Claude 额度查询。
- 补充回归测试，验证慢 Claude 额度请求不会阻塞 Token 活动数据落地。

## 根因

agentd 的 12 小时 Token 活动缓存正常，但 iOS 设置页此前把 `account/usage/read` 排在完整连接测试、模型目录和额度查询之后。页面会长时间停留在“刷新后显示 Token 活动”，此时缓存请求实际上还没有发出。

## 影响

进入「我的」页后，Token 活动可以尽早命中 agentd 的最近快照，不再等待其他较慢的设置页请求完成。手动强制刷新、同主机请求合并和旧主机响应丢弃语义保持不变。

## 验证

- agentd 缓存定向测试：2 项通过。
- iOS Token 活动相关回归：6 项通过，0 failures。
- `git diff --check`：通过。
- iPhone 17 Pro USB 真机：Debug 构建、签名、安装和启动成功。
- 新上下文 Sol 复审：`ship`，无阻断发现。

## 关联

- Linear: [MIM-108](https://linear.app/code89757/issue/MIM-108/让我的页-token-用量优先显示缓存并低频刷新)

待用户完成真实账号下的首屏出现时间与再次进入缓存命中体验确认。
