### PR TITLE
MIM-167 support Xcode 27 DeviceHub

### DIFF
--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -421,6 +421,64 @@ simulator_is_booted() {
   '
 }
 
+simulator_ui_warning() {
+  echo "警告：$1。Simulator 界面不是必需步骤，将继续构建、安装并启动。" >&2
+}
+
+current_developer_dir() {
+  if [[ -n "${DEVELOPER_DIR:-}" ]]; then
+    printf '%s\n' "$DEVELOPER_DIR"
+    return 0
+  fi
+
+  if ! command -v xcode-select >/dev/null 2>&1; then
+    return 1
+  fi
+  xcode-select -p
+}
+
+open_simulator_ui() {
+  local developer_dir
+  if ! developer_dir="$(current_developer_dir 2>/dev/null)" || [[ -z "$developer_dir" ]]; then
+    simulator_ui_warning "无法解析当前 Developer 目录"
+    return 0
+  fi
+
+  if [[ ! -d "$developer_dir" ]]; then
+    simulator_ui_warning "Developer 目录不存在：$developer_dir"
+    return 0
+  fi
+
+  local resolved_developer_dir
+  if ! resolved_developer_dir="$(cd "$developer_dir" 2>/dev/null && pwd -P)"; then
+    simulator_ui_warning "无法解析 Developer 目录：$developer_dir"
+    return 0
+  fi
+  local xcode_contents_dir
+  if ! xcode_contents_dir="$(cd "$resolved_developer_dir/.." 2>/dev/null && pwd -P)"; then
+    simulator_ui_warning "无法解析 Xcode 包目录：$developer_dir"
+    return 0
+  fi
+
+  local ui_app=""
+  if [[ -d "$resolved_developer_dir/Applications/Simulator.app" ]]; then
+    ui_app="$resolved_developer_dir/Applications/Simulator.app"
+  elif [[ -d "$xcode_contents_dir/Applications/DeviceHub.app" ]]; then
+    ui_app="$xcode_contents_dir/Applications/DeviceHub.app"
+  else
+    simulator_ui_warning "找不到 Simulator 或 DeviceHub 界面应用"
+    return 0
+  fi
+
+  if ! command -v "$OPEN_BIN" >/dev/null 2>&1 && [[ ! -x "$OPEN_BIN" ]]; then
+    simulator_ui_warning "找不到或无法执行 open 命令：$OPEN_BIN"
+    return 0
+  fi
+  if ! "$OPEN_BIN" "$ui_app"; then
+    simulator_ui_warning "打开界面应用失败：$ui_app"
+  fi
+}
+
 run_xcodebuild() {
   local action="$1"
   shift
@@ -546,11 +604,10 @@ case "$command_name" in
       exit 0
     fi
 
-    require_command "$OPEN_BIN"
     if ! simulator_is_booted "$SELECTED_ID"; then
       "$XCRUN_BIN" simctl boot "$SELECTED_ID"
     fi
-    "$OPEN_BIN" -a Simulator
+    open_simulator_ui
     "$XCRUN_BIN" simctl bootstatus "$SELECTED_ID" -b
     run_xcodebuild build "$@"
 

--- a/scripts/test-ios-device-management.sh
+++ b/scripts/test-ios-device-management.sh
@@ -13,6 +13,7 @@ export IOS_TEST_SIMULATORS_JSON="$FIXTURE_DIR/simulators.json"
 export IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/physical-devices.json"
 export IOS_TEST_XCODEBUILD_LOG="$TEMP_DIR/xcodebuild.log"
 unset IOS_TEST_DESTINATION IOS_SIMULATOR_ID IOS_SIMULATOR_NAME IOS_DEVICE_ID IOS_DEVICE_NAME IOS_TARGET_MODE
+unset DEVELOPER_DIR IOS_OPEN_BIN IOS_TEST_OPEN_LOG IOS_TEST_OPEN_FAIL
 
 fail() {
   echo "iOS 设备管理测试失败：$1" >&2
@@ -38,6 +39,46 @@ assert_not_contains() {
   local needle="$2"
   local label="$3"
   [[ "$haystack" != *"$needle"* ]] || fail "${label}：不应包含 '$needle'"
+}
+
+run_simulator_ui_case() {
+  local case_name="$1"
+  local developer_dir="$2"
+  local open_failure="${3:-0}"
+  local open_log="$TEMP_DIR/${case_name}-open.log"
+  local xcodebuild_log="$TEMP_DIR/${case_name}-xcodebuild.log"
+  local xcrun_log="$TEMP_DIR/${case_name}-xcrun.log"
+  local output_log="$TEMP_DIR/${case_name}-run.log"
+  : > "$open_log"
+  : > "$xcodebuild_log"
+  : > "$xcrun_log"
+
+  set +e
+  DEVELOPER_DIR="$developer_dir" \
+  IOS_OPEN_BIN="$FIXTURE_DIR/fake-open.sh" \
+  IOS_TEST_OPEN_LOG="$open_log" \
+  IOS_TEST_OPEN_FAIL="$open_failure" \
+  IOS_TEST_XCODEBUILD_LOG="$xcodebuild_log" \
+  IOS_TEST_XCRUN_LOG="$xcrun_log" \
+  IOS_TEST_CREATE_APP=1 \
+  IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/no-physical-devices.json" \
+  IOS_TARGET_MODE=simulator \
+  IOS_SIMULATOR_ID="M5-27-UDID" \
+  IOS_DERIVED_DATA_PATH="$TEMP_DIR/${case_name}-derived" \
+  bash "$ROOT_DIR/scripts/ios-dev.sh" run >"$output_log" 2>&1
+  local status=$?
+  set -e
+
+  assert_equal "0" "$status" "Simulator run（${case_name}）必须在界面辅助步骤失败时继续"
+  assert_contains "$(cat "$xcodebuild_log")" "build" \
+    "Simulator run（${case_name}）必须继续执行构建"
+  assert_contains "$(cat "$xcrun_log")" "simctl install M5-27-UDID" \
+    "Simulator run（${case_name}）必须继续安装 App"
+  assert_contains "$(cat "$xcrun_log")" \
+    "simctl launch --terminate-running-process M5-27-UDID com.gaixianggeng.mimi" \
+    "Simulator run（${case_name}）必须继续启动 App"
+  SIMULATOR_UI_OPEN_LOG="$open_log"
+  SIMULATOR_UI_OUTPUT_LOG="$output_log"
 }
 
 write_lease_metadata() {
@@ -382,5 +423,39 @@ simulator_target="$(
 )"
 assert_contains "$simulator_target" "dev-simulator-derived/IPHONE-27-UDID" \
   "不同 Simulator 必须使用独立 DerivedData"
+
+legacy_xcode_contents="$TEMP_DIR/xcode-legacy/Contents"
+legacy_developer_dir="$legacy_xcode_contents/Developer"
+mkdir -p "$legacy_developer_dir/Applications/Simulator.app" \
+  "$legacy_xcode_contents/Applications/DeviceHub.app"
+run_simulator_ui_case "legacy-simulator" "$legacy_developer_dir"
+legacy_simulator_app="$(cd "$legacy_developer_dir/Applications/Simulator.app" && pwd -P)"
+assert_equal "$legacy_simulator_app" \
+  "$(cat "$SIMULATOR_UI_OPEN_LOG")" \
+  "存在 legacy Simulator.app 时必须直接打开该路径并优先于 DeviceHub.app"
+
+devicehub_xcode_contents="$TEMP_DIR/xcode-devicehub/Contents"
+devicehub_developer_dir="$devicehub_xcode_contents/Developer"
+mkdir -p "$devicehub_developer_dir" "$devicehub_xcode_contents/Applications/DeviceHub.app"
+run_simulator_ui_case "devicehub" "$devicehub_developer_dir"
+devicehub_app="$(cd "$devicehub_xcode_contents/Applications/DeviceHub.app" && pwd -P)"
+assert_equal "$devicehub_app" \
+  "$(cat "$SIMULATOR_UI_OPEN_LOG")" \
+  "缺少 legacy Simulator.app 时必须直接打开同一 Xcode 包的 DeviceHub.app"
+
+empty_developer_dir="$TEMP_DIR/xcode-empty/Contents/Developer"
+mkdir -p "$empty_developer_dir"
+run_simulator_ui_case "missing-ui" "$empty_developer_dir"
+assert_contains "$(cat "$SIMULATOR_UI_OUTPUT_LOG")" "找不到 Simulator 或 DeviceHub 界面应用" \
+  "找不到界面应用时必须输出中文告警"
+assert_equal "" "$(cat "$SIMULATOR_UI_OPEN_LOG")" \
+  "找不到界面应用时不得调用 open"
+
+failed_open_xcode_contents="$TEMP_DIR/xcode-open-failure/Contents"
+failed_open_developer_dir="$failed_open_xcode_contents/Developer"
+mkdir -p "$failed_open_developer_dir" "$failed_open_xcode_contents/Applications/DeviceHub.app"
+run_simulator_ui_case "open-failure" "$failed_open_developer_dir" 1
+assert_contains "$(cat "$SIMULATOR_UI_OUTPUT_LOG")" "打开界面应用失败" \
+  "open 返回非零时必须输出中文告警"
 
 printf 'iOS 统一入口、目标选择、固定测试设备、租约和外部 xcodebuild 检查通过。\n'

--- a/scripts/testdata/ios-device-management/fake-open.sh
+++ b/scripts/testdata/ios-device-management/fake-open.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${IOS_TEST_OPEN_LOG:-}" ]]; then
+  printf '%s\n' "$*" >> "$IOS_TEST_OPEN_LOG"
+fi
+if [[ "${IOS_TEST_OPEN_FAIL:-0}" == "1" ]]; then
+  echo "fake-open 模拟失败" >&2
+  exit 23
+fi

--- a/scripts/testdata/ios-device-management/fake-xcrun.sh
+++ b/scripts/testdata/ios-device-management/fake-xcrun.sh
@@ -5,6 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SIMULATORS_JSON="${IOS_TEST_SIMULATORS_JSON:-$ROOT_DIR/scripts/testdata/ios-device-management/simulators.json}"
 PHYSICAL_JSON="${IOS_TEST_PHYSICAL_JSON:-$ROOT_DIR/scripts/testdata/ios-device-management/physical-devices.json}"
 
+if [[ -n "${IOS_TEST_XCRUN_LOG:-}" ]]; then
+  printf '%s\n' "$*" >> "$IOS_TEST_XCRUN_LOG"
+fi
+
 case "$*" in
   "simctl list devices available -j")
     /bin/cat "$SIMULATORS_JSON"


### PR DESCRIPTION
## 变更

- 根据当前 Developer 目录优先打开 `Simulator.app`，Xcode 27 下改为打开同一 Xcode 包中的 `DeviceHub.app`。
- 将模拟器界面打开视为非关键步骤；路径缺失或 `open` 失败时输出告警并继续构建、安装和启动。
- 增加 fake-run 回归测试，覆盖 legacy Simulator、DeviceHub、界面缺失和 `open` 失败。

## 原因

Xcode 27 不再提供 `Developer/Applications/Simulator.app`。原脚本硬编码 `open -a Simulator`，并在 `set -e` 下于真正构建前退出。

## 验证

- `bash -n scripts/ios-dev.sh scripts/test-ios-device-management.sh scripts/testdata/ios-device-management/fake-open.sh scripts/testdata/ios-device-management/fake-xcrun.sh`
- `bash scripts/test-ios-device-management.sh`
- `git diff --check`
- Xcode 27.0 beta 5 下执行 `IOS_TARGET_MODE=simulator bash ./scripts/ios-dev.sh run`：`BUILD SUCCEEDED`，App 成功安装并启动。

Linear：[MIM-167](https://linear.app/code89757/issue/MIM-167/xcode-27-%E4%B8%8B-ios-devsh-run-%E5%9C%A8%E6%9E%84%E5%BB%BA%E5%89%8D%E4%B8%AD%E6%96%ADsimulator-%E7%9B%AE%E6%A0%87%E6%97%A0%E6%B3%95%E8%BF%90%E8%A1%8C)
