### PR TITLE
MIM-141 修复公开仓库安全工具安装超时

### DIFF
--- a/.github/workflows/public-repo-safety.yml
+++ b/.github/workflows/public-repo-safety.yml
@@ -77,13 +77,60 @@ jobs:
           cache: true
 
       - name: Install repository safety tools
+        shell: bash
         run: |
           if command -v rg >/dev/null 2>&1; then
             rg --version
-          else
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y ripgrep
+            exit 0
           fi
+
+          if [[ "${RUNNER_ARCH:-}" != "X64" ]]; then
+            echo "不支持的 runner 架构：${RUNNER_ARCH:-<未设置>}，仅支持 X64。" >&2
+            exit 1
+          fi
+
+          : "${RUNNER_TEMP:?RUNNER_TEMP 未设置。}"
+          : "${GITHUB_PATH:?GITHUB_PATH 未设置。}"
+
+          ripgrep_asset="ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"
+          ripgrep_url="https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"
+          ripgrep_sha256="33e15bcf1624b25cdd2a55813a47a2f95dbe126268203e76aa6a585d1e7b149c"
+          ripgrep_root="ripgrep-15.2.0-x86_64-unknown-linux-musl"
+          ripgrep_dir="$(mktemp -d "${RUNNER_TEMP}/ripgrep.XXXXXX")"
+          archive_path="${ripgrep_dir}/${ripgrep_asset}"
+          extract_dir="${ripgrep_dir}/extract"
+          rg_path="${extract_dir}/${ripgrep_root}/rg"
+          mkdir -p "$extract_dir"
+
+          # 固定官方归档并校验摘要，避免包管理器更新超时或引入未锁定来源。
+          curl \
+            --proto '=https' \
+            --tlsv1.2 \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-max-time 60 \
+            --connect-timeout 10 \
+            --max-time 120 \
+            --output "$archive_path" \
+            "$ripgrep_url"
+
+          if ! printf '%s  %s\n' "$ripgrep_sha256" "$archive_path" | sha256sum --check --status -; then
+            echo "ripgrep 下载文件 SHA-256 校验失败。" >&2
+            exit 1
+          fi
+
+          tar --extract --gzip --file "$archive_path" --directory "$extract_dir"
+          if [[ ! -x "$rg_path" ]]; then
+            echo "ripgrep 归档中缺少可执行文件：$rg_path" >&2
+            exit 1
+          fi
+
+          printf '%s\n' "$(dirname "$rg_path")" >> "$GITHUB_PATH"
+          "$rg_path" --version
 
       - name: Check public repository safety
         shell: bash

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -260,6 +260,9 @@ unless safety_inputs.is_a?(Hash) &&
   abort("PR Gate 自检失败：公开仓库安全门的 reusable inputs 必须默认 fail closed 到完整历史。")
 end
 safety_job = safety_workflow.fetch("jobs").fetch("verify")
+unless safety_job["runs-on"] == "ubuntu-latest" && safety_job["timeout-minutes"] == 5
+  abort("PR Gate 自检失败：公开仓库安全门必须使用 Ubuntu runner 和 5 分钟超时。")
+end
 safety_steps = safety_job.fetch("steps")
 safety_checkout = safety_steps.find { |step| step["name"] == "Checkout" }
 unless safety_checkout&.dig("with", "fetch-depth") == 0
@@ -278,8 +281,78 @@ unless safety_go && safety_go["if"] == "steps.safety.outputs.third_party == 'tru
   abort("PR Gate 自检失败：Setup Go 必须只在第三方许可检查需要时运行。")
 end
 safety_install = safety_steps.find { |step| step["name"] == "Install repository safety tools" }
-unless safety_install.to_s.include?("command -v rg")
+unless safety_install && safety_install["run"].is_a?(String) && safety_install["run"].include?("command -v rg")
   abort("PR Gate 自检失败：公开仓库安全工具安装必须优先复用 runner 已有 ripgrep。")
+end
+safety_install_run = safety_install.fetch("run")
+safety_install_lines = safety_install_run.lines.map do |line|
+  line.strip.sub(/ \\\z/, "")
+end
+required_install_lines = [
+  'if command -v rg >/dev/null 2>&1; then',
+  'rg --version',
+  'if [[ "${RUNNER_ARCH:-}" != "X64" ]]; then',
+  'ripgrep_asset="ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"',
+  'ripgrep_url="https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"',
+  'ripgrep_sha256="33e15bcf1624b25cdd2a55813a47a2f95dbe126268203e76aa6a585d1e7b149c"',
+  'ripgrep_root="ripgrep-15.2.0-x86_64-unknown-linux-musl"',
+  'tar --extract --gzip --file "$archive_path" --directory "$extract_dir"',
+  %q{printf '%s\n' "$(dirname "$rg_path")" >> "$GITHUB_PATH"},
+  '"$rg_path" --version',
+]
+required_install_lines.each do |required_line|
+  unless safety_install_lines.include?(required_line)
+    abort("PR Gate 自检失败：公开仓库安全工具安装缺少有效命令 #{required_line}。")
+  end
+end
+
+curl_index = safety_install_lines.index("curl")
+curl_url_index = safety_install_lines.index('"$ripgrep_url"')
+checksum_line = %q{if ! printf '%s  %s\n' "$ripgrep_sha256" "$archive_path" | sha256sum --check --status -; then}
+checksum_index = safety_install_lines.index(checksum_line)
+tar_index = safety_install_lines.index('tar --extract --gzip --file "$archive_path" --directory "$extract_dir"')
+github_path_index = safety_install_lines.index(%q{printf '%s\n' "$(dirname "$rg_path")" >> "$GITHUB_PATH"})
+rg_version_index = safety_install_lines.rindex('"$rg_path" --version')
+ordered_indexes = [curl_index, curl_url_index, checksum_index, tar_index, github_path_index, rg_version_index]
+unless ordered_indexes.none?(&:nil?) && ordered_indexes.each_cons(2).all? { |left, right| left < right }
+  abort("PR Gate 自检失败：公开仓库安全工具必须依次下载、校验、解压、导出 PATH 并执行已校验的 rg。")
+end
+
+required_curl_lines = [
+  "--proto '=https'",
+  "--tlsv1.2",
+  "--fail",
+  "--silent",
+  "--show-error",
+  "--location",
+  "--retry 3",
+  "--retry-delay 2",
+  "--retry-max-time 60",
+  "--connect-timeout 10",
+  "--max-time 120",
+  '--output "$archive_path"',
+]
+curl_lines = safety_install_lines[(curl_index + 1)...curl_url_index]
+required_curl_lines.each do |required_line|
+  unless curl_lines.include?(required_line)
+    abort("PR Gate 自检失败：ripgrep 下载命令缺少 #{required_line}。")
+  end
+end
+
+safety_run_scripts = safety_steps.each_with_object([]) do |step, scripts|
+  scripts << step["run"] if step["run"].is_a?(String)
+end.join("\n")
+if safety_run_scripts.match?(/\bapt(?:-get)?\b/)
+  abort("PR Gate 自检失败：公开仓库安全门不得依赖 apt/apt-get。")
+end
+step_actions = safety_steps.each_with_object([]) do |step, actions|
+  actions << step["uses"] if step["uses"].is_a?(String)
+end
+third_party_actions = step_actions.reject do |action|
+  action.start_with?("actions/", "./")
+end
+unless third_party_actions.empty?
+  abort("PR Gate 自检失败：公开仓库安全门不得新增第三方 Action：#{third_party_actions.join(', ')}。")
 end
 safety_check = safety_steps.find { |step| step["name"] == "Check public repository safety" }
 unless safety_check && safety_check.to_s.include?("--pull-request") &&


### PR DESCRIPTION
## 变更

- runner 已有 `rg` 时继续直接复用。
- runner 缺少 `rg` 时，从官方 Release 下载固定的 ripgrep 15.2.0 x86_64 musl 归档。
- 下载使用有限重试、连接超时和总时长限制，并在解压和执行前校验固定 SHA-256。
- PR Gate 自测新增安装来源、参数、执行顺序、无 apt 和无第三方 Action 的回归约束。

## 原因

Public Repository Safety 在缺少 `rg` 时执行 `apt-get update/install`。Ubuntu archive 请求卡住后，5 分钟 job 被取消，最终导致 PR Gate 失败。

## 影响

不改变 secret、Git 历史、品牌身份或第三方许可检查范围。只替换缺少 `rg` 时的安装路径，并保留 `timeout-minutes: 5`。

## 验证

- `bash -n scripts/check-pr-gate.sh`
- YAML `safe_load`
- `bash ./scripts/check-pr-gate.sh`
- `bash ./scripts/check-public-repo-safety.sh --pull-request --base 567f47e6dc22b7595fd4ab6d8cf64a504bb04854 --head ccd6ba4632708bcbe85ab4ba0422ac5638ff1bd0`
- `git diff --check`
- 实际下载官方归档，SHA-256 为 `33e15bcf1624b25cdd2a55813a47a2f95dbe126268203e76aa6a585d1e7b149c`，归档内 `rg` 路径符合预期。
- 独立安全复审结论：`ship`。

Linear: MIM-141
