### PR TITLE
MIM-174 MIM-175 加固 App Server 模式切换与断链 writer 交接

### DIFF
--- a/cmd/agentd/appserver_mode_start.go
+++ b/cmd/agentd/appserver_mode_start.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"maps"
+
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+// startManagedIndependentAppServerWebSocket 只为平台默认配置串行化最终
+// ownership 复核与 WS 启动；自定义 profile 不拥有全局 shared daemon owner。
+func startManagedIndependentAppServerWebSocket(
+	cfg config.Config,
+	configPath string,
+) (*appserver.ManagedWebSocketProcess, error) {
+	if !config.IsPlatformDefaultPath(configPath) {
+		return startManagedAppServerWebSocket(cfg)
+	}
+
+	expectedBin := cfg.Codex.Bin
+	expectedEnv := maps.Clone(cfg.Codex.Env)
+	var process *appserver.ManagedWebSocketProcess
+	ctx, cancel := context.WithTimeout(context.Background(), sharedDaemonReconcileTimeout)
+	defer cancel()
+	err := appserver.StartIndependentModeRuntime(
+		ctx,
+		func() error {
+			return config.ValidateSharedDaemonDisabledOwnership(configPath, expectedBin, expectedEnv)
+		},
+		func() error {
+			var startErr error
+			process, startErr = startManagedAppServerWebSocket(cfg)
+			return startErr
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return process, nil
+}

--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -1120,7 +1120,7 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 			return fmt.Errorf("app_server.listen 未配置，无法启用 app-server gateway")
 		}
 		if cfg.AppServer.Managed {
-			process, err := startManagedAppServerWebSocket(cfg)
+			process, err := startManagedIndependentAppServerWebSocket(cfg, configPath)
 			if err != nil {
 				return err
 			}

--- a/internal/appserver/local_daemon.go
+++ b/internal/appserver/local_daemon.go
@@ -750,6 +750,32 @@ func ReconcileRunningSharedDaemonForIndependentMode(
 	return reconcileRunningSharedDaemonForIndependentMode(ctx, options, validate)
 }
 
+// StartIndependentModeRuntime 把独立配置的最后复核与 runtime 启动放在
+// shared-daemon operation lock 的同一临界区。这样另一个 Mimi 进程不能在
+// “确认仍是 WS”与真正启动 WS backend 之间插入一次 shared 配置提交。
+func StartIndependentModeRuntime(
+	ctx context.Context,
+	validate func() error,
+	start func() error,
+) error {
+	if validate == nil {
+		return fmt.Errorf("独立模式 runtime 启动前的配置复核回调不能为空")
+	}
+	if start == nil {
+		return fmt.Errorf("独立模式 runtime 启动回调不能为空")
+	}
+	_, err := withSharedDaemonOperationLock(ctx, func() (LocalDaemonStatus, error) {
+		if err := validate(); err != nil {
+			return LocalDaemonStatus{}, fmt.Errorf("独立模式配置在 runtime 启动前已变化：%w", err)
+		}
+		if err := start(); err != nil {
+			return LocalDaemonStatus{}, err
+		}
+		return LocalDaemonStatus{}, nil
+	})
+	return err
+}
+
 func attachLocalDaemon(ctx context.Context, options LocalDaemonOptions) (LocalDaemonStatus, error) {
 	socketPath, err := LocalDaemonSocketPath(options.Env)
 	if err != nil {

--- a/internal/appserver/local_daemon_test.go
+++ b/internal/appserver/local_daemon_test.go
@@ -581,6 +581,21 @@ func TestValidateLocalDaemonProbeVersionRejectsMismatch(t *testing.T) {
 	}
 }
 
+func TestStartIndependentModeRuntimeRejectsChangedConfigBeforeStart(t *testing.T) {
+	startCalls := 0
+	err := StartIndependentModeRuntime(
+		context.Background(),
+		func() error { return errors.New("config switched to shared") },
+		func() error {
+			startCalls++
+			return nil
+		},
+	)
+	if err == nil || startCalls != 0 {
+		t.Fatalf("配置复核失败时不得启动独立 runtime：calls=%d err=%v", startCalls, err)
+	}
+}
+
 func startLocalDaemonTestServer(
 	t *testing.T,
 	codexHome string,

--- a/internal/appserver/shared_daemon_owner_darwin.go
+++ b/internal/appserver/shared_daemon_owner_darwin.go
@@ -1757,30 +1757,11 @@ func stopSharedDaemonWithExpectedIdentity(
 			return err
 		}
 	}
+	if err := requireCodexDesktopStopped(ctx, "执行官方 stop 前"); err != nil {
+		return err
+	}
 
-	bin := strings.TrimSpace(options.CodexBin)
-	if bin == "" {
-		bin = "codex"
-	}
-	cmd := exec.CommandContext(ctx, bin, "app-server", "daemon", "stop")
-	configureManagedCommand(cmd)
-	cmd.Env = buildManagedEnv(options.Env)
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		return nil
-	}
-	message := sanitizeDiagnostic(string(output))
-	lower := strings.ToLower(message)
-	if strings.Contains(lower, "not running") || strings.Contains(lower, "no running") {
-		return nil
-	}
-	if strings.Contains(lower, unmanagedSharedDaemonMessage) {
-		return fmt.Errorf("官方 lifecycle 报告 pid backend，但 stop 拒绝管理该进程，已停止迁移")
-	}
-	if message == "" {
-		return fmt.Errorf("停止旧 Codex local daemon 失败：%w", err)
-	}
-	return fmt.Errorf("停止旧 Codex local daemon 失败：%s", message)
+	return stopManagedSharedDaemonCommand(ctx, options)
 }
 
 func validateManagedSharedDaemonListenerIdentity(

--- a/internal/appserver/shared_daemon_owner_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_darwin_test.go
@@ -2169,6 +2169,51 @@ func TestSharedDaemonOperationLockSerializesCallers(t *testing.T) {
 	}
 }
 
+func TestStartIndependentModeRuntimeKeepsOperationLockThroughStart(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	startEntered := make(chan struct{})
+	releaseStart := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- StartIndependentModeRuntime(
+			context.Background(),
+			func() error { return nil },
+			func() error {
+				close(startEntered)
+				<-releaseStart
+				return nil
+			},
+		)
+	}()
+	<-startEntered
+
+	var competingEntered atomic.Bool
+	competingDone := make(chan error, 1)
+	go func() {
+		_, err := withSharedDaemonOperationLock(context.Background(), func() (LocalDaemonStatus, error) {
+			competingEntered.Store(true)
+			return LocalDaemonStatus{}, nil
+		})
+		competingDone <- err
+	}()
+	time.Sleep(150 * time.Millisecond)
+	if competingEntered.Load() {
+		t.Fatal("模式切换不能插入独立 runtime 的最终复核与启动")
+	}
+	close(releaseStart)
+	if err := <-startDone; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-competingDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runtime 启动结束后模式切换应取得 operation lock")
+	}
+}
+
 func TestInspectLaunchAgentStateDistinguishesLoadedFromRunning(t *testing.T) {
 	originalLaunchctl := sharedDaemonLaunchctl
 	t.Cleanup(func() { sharedDaemonLaunchctl = originalLaunchctl })

--- a/internal/appserver/shared_daemon_owner_process_darwin.go
+++ b/internal/appserver/shared_daemon_owner_process_darwin.go
@@ -105,47 +105,70 @@ func stopUnmanagedSharedDaemonWithExpectedIdentity(
 	expectedIdentity *sharedDaemonListenerProcess,
 	hooks unmanagedSharedDaemonHooks,
 ) error {
+	listener, err := validateUnmanagedSharedDaemonWithExpectedIdentity(
+		ctx,
+		socketPath,
+		expectedCodexPath,
+		expectedIdentity,
+		hooks,
+	)
+	if err != nil {
+		return err
+	}
+	if err := hooks.signalTERM(listener.PID); err != nil {
+		return fmt.Errorf("正常终止旧 Codex app-server 失败：%w", err)
+	}
+	return nil
+}
+
+// validateUnmanagedSharedDaemonWithExpectedIdentity 只完成最终 listener 取证，
+// 不执行停止动作。旧 pid backend 用它验证真实 socket peer 后仍调用官方 stop，
+// 普通 unmanaged 路径则由上层对返回的同一 PID 发送一次 TERM。
+func validateUnmanagedSharedDaemonWithExpectedIdentity(
+	ctx context.Context,
+	socketPath string,
+	expectedCodexPath string,
+	expectedIdentity *sharedDaemonListenerProcess,
+	hooks unmanagedSharedDaemonHooks,
+) (sharedDaemonListenerProcess, error) {
 	running, err := hooks.desktopRunning(ctx)
 	if err != nil {
-		return fmt.Errorf("确认 Codex Desktop 已退出失败：%w", err)
+		return sharedDaemonListenerProcess{}, fmt.Errorf("确认 Codex Desktop 已退出失败：%w", err)
 	}
 	if running {
-		return fmt.Errorf("Codex Desktop 仍在运行，拒绝接管非 daemon 管理的 app-server")
+		return sharedDaemonListenerProcess{}, fmt.Errorf("Codex Desktop 仍在运行，拒绝接管非 daemon 管理的 app-server")
 	}
 
 	listener, err := hooks.inspect(ctx, socketPath)
 	if err != nil {
-		return fmt.Errorf("识别非 daemon 管理的 Codex app-server 失败：%w", err)
+		return sharedDaemonListenerProcess{}, fmt.Errorf("识别非 daemon 管理的 Codex app-server 失败：%w", err)
 	}
 	if err := validateSharedDaemonListenerProcess(listener, hooks.currentUID(), expectedCodexPath); err != nil {
-		return err
+		return sharedDaemonListenerProcess{}, err
 	}
 	if expectedIdentity != nil && listener != *expectedIdentity {
-		return fmt.Errorf("Codex app-server owner 与已验证身份不一致，已停止迁移")
+		return sharedDaemonListenerProcess{}, fmt.Errorf("Codex app-server owner 与已验证身份不一致，已停止迁移")
 	}
 	// PID 可能在检查命令行期间退出并被复用。发送信号前再次从 socket
 	// 反查 owner；PID、UID、命令与可执行文件任一变化都停止迁移。
 	confirmed, err := hooks.inspect(ctx, socketPath)
 	if err != nil {
-		return fmt.Errorf("再次确认 Codex app-server owner 失败：%w", err)
+		return sharedDaemonListenerProcess{}, fmt.Errorf("再次确认 Codex app-server owner 失败：%w", err)
 	}
 	if confirmed != listener {
-		return fmt.Errorf("Codex app-server owner 在接管前发生变化，已停止迁移")
+		return sharedDaemonListenerProcess{}, fmt.Errorf("Codex app-server owner 在接管前发生变化，已停止迁移")
 	}
 	// 用户可能在首次检查后从 Dock 重新打开 Desktop。信号前必须
 	// 再按 bundle id 查一次；读取失败也 fail closed，不能凭旧快照
 	// 终止已经被新 Desktop 重新使用的 backend。
 	running, err = hooks.desktopRunning(ctx)
 	if err != nil {
-		return fmt.Errorf("信号前再次确认 Codex Desktop 已退出失败：%w", err)
+		return sharedDaemonListenerProcess{}, fmt.Errorf("信号前再次确认 Codex Desktop 已退出失败：%w", err)
 	}
 	if running {
-		return fmt.Errorf("Codex Desktop 在迁移前被重新打开，已停止接管")
+		return sharedDaemonListenerProcess{}, fmt.Errorf("Codex Desktop 在迁移前被重新打开，已停止接管")
 	}
-	if err := hooks.signalTERM(listener.PID); err != nil {
-		return fmt.Errorf("正常终止旧 Codex app-server 失败：%w", err)
-	}
-	return nil
+	return listener, nil
 }
 
 func validateSharedDaemonListenerProcess(

--- a/internal/appserver/shared_daemon_owner_process_darwin_test.go
+++ b/internal/appserver/shared_daemon_owner_process_darwin_test.go
@@ -130,6 +130,17 @@ exit 2
 			desktop:     func(context.Context) (bool, error) { return false, errors.New("query failed") },
 			wantMessage: "确认 Codex Desktop 已退出失败",
 		},
+		{
+			name: "desktop reopened before command",
+			desktop: func() func(context.Context) (bool, error) {
+				checks := 0
+				return func(context.Context) (bool, error) {
+					checks++
+					return checks == 2, nil
+				}
+			}(),
+			wantMessage: "重新打开",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/appserver/shared_daemon_reconcile_darwin.go
+++ b/internal/appserver/shared_daemon_reconcile_darwin.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // RemoveSharedDaemonOwner 只移除 Mimi 安装的未来启动入口和迁移标记，不停止当前
@@ -415,6 +416,16 @@ func stopSharedDaemonForConfirmedDisable(
 	if err != nil {
 		return err
 	}
+	if handled, stopErr := stopLegacyPIDBackendWithoutReportedPID(
+		ctx,
+		options,
+		owner,
+		lifecycle,
+		validateLegacyPIDBackendListener,
+		stopManagedSharedDaemonCommand,
+	); handled {
+		return stopErr
+	}
 	if lifecycle.Backend != nil {
 		if err := sharedDaemonValidateSignedRuntime(ctx, options, socketPath); err != nil {
 			return fmt.Errorf("共享 daemon listener 缺少签名 supervisor 父链：%w", err)
@@ -479,4 +490,79 @@ func stopSharedDaemonForConfirmedDisable(
 			currentUID:     os.Getuid,
 		},
 	)
+}
+
+type legacyPIDBackendValidateFunc func(
+	context.Context,
+	LocalDaemonOptions,
+	LocalDaemonLifecycleStatus,
+) error
+
+type legacyPIDBackendStopFunc func(context.Context, LocalDaemonOptions) error
+
+// 旧版 daemon version 会报告 backend=pid，但不返回 PID。此时不能进入依赖
+// lifecycle.PID 的普通路径；先严格验证真实 socket peer，再继续调用官方 stop。
+func stopLegacyPIDBackendWithoutReportedPID(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	owner SharedDaemonOwnerStatus,
+	lifecycle LocalDaemonLifecycleStatus,
+	validate legacyPIDBackendValidateFunc,
+	stop legacyPIDBackendStopFunc,
+) (bool, error) {
+	if lifecycle.Backend == nil || lifecycle.PID != nil ||
+		!strings.EqualFold(strings.TrimSpace(*lifecycle.Backend), "pid") {
+		return false, nil
+	}
+	if !sharedDaemonLoadedOwnerEvidence(owner) {
+		return true, fmt.Errorf("旧 pid backend 没有已确认的 Mimi stable owner，拒绝停止")
+	}
+	if validate == nil || stop == nil {
+		return true, fmt.Errorf("旧 pid backend 缺少安全取证或官方停止实现")
+	}
+	if err := validate(ctx, options, lifecycle); err != nil {
+		return true, err
+	}
+	return true, stop(ctx, options)
+}
+
+func validateLegacyPIDBackendListener(
+	ctx context.Context,
+	options LocalDaemonOptions,
+	lifecycle LocalDaemonLifecycleStatus,
+) error {
+	socketPath, err := LocalDaemonSocketPath(options.Env)
+	if err != nil {
+		return err
+	}
+	probeCtx, cancelProbe := context.WithTimeout(ctx, localDaemonProbeTimeout)
+	probe, err := ProbeLocalDaemonInfo(probeCtx, socketPath)
+	cancelProbe()
+	if err != nil {
+		return fmt.Errorf("无法确认旧 pid backend：%w", err)
+	}
+	if err := ValidateLocalDaemonLifecycle(lifecycle, socketPath); err != nil {
+		return err
+	}
+	if err := ValidateLocalDaemonProbeVersion(lifecycle, probe.Version); err != nil {
+		return err
+	}
+	if err := validatePrivateSharedDaemonSocket(socketPath, os.Getuid()); err != nil {
+		return err
+	}
+	if err := sharedDaemonValidateSignedRuntime(ctx, options, socketPath); err != nil {
+		return fmt.Errorf("旧 pid backend 缺少签名 supervisor 父链：%w", err)
+	}
+	_, err = validateUnmanagedSharedDaemonWithExpectedIdentity(
+		ctx,
+		socketPath,
+		lifecycle.ManagedCodexPath,
+		nil,
+		unmanagedSharedDaemonHooks{
+			desktopRunning: sharedDaemonDesktopRunning,
+			inspect:        inspectSharedDaemonListenerProcess,
+			currentUID:     os.Getuid,
+		},
+	)
+	return err
 }

--- a/internal/appserver/shared_daemon_reconcile_darwin_test.go
+++ b/internal/appserver/shared_daemon_reconcile_darwin_test.go
@@ -619,6 +619,55 @@ func TestIndependentModeReconcileWarnsWhenListenerOwnershipCannotBeConfirmed(t *
 	}
 }
 
+func TestStopLegacyPIDBackendWithoutReportedPIDUsesStrictFallback(t *testing.T) {
+	backend := "pid"
+	lifecycle := LocalDaemonLifecycleStatus{Backend: &backend}
+	owner := SharedDaemonOwnerStatus{
+		Installed: true,
+		Loaded:    true,
+		Secure:    true,
+		Label:     SharedDaemonLaunchAgentLabel,
+	}
+	stopCalls := 0
+	validateCalls := 0
+	handled, err := stopLegacyPIDBackendWithoutReportedPID(
+		context.Background(),
+		LocalDaemonOptions{},
+		owner,
+		lifecycle,
+		func(context.Context, LocalDaemonOptions, LocalDaemonLifecycleStatus) error {
+			validateCalls++
+			return nil
+		},
+		func(context.Context, LocalDaemonOptions) error {
+			stopCalls++
+			return nil
+		},
+	)
+	if err != nil || !handled || validateCalls != 1 || stopCalls != 1 {
+		t.Fatalf("旧 pid backend 应严格取证后调用官方 stop：handled=%t validate=%d stop=%d err=%v", handled, validateCalls, stopCalls, err)
+	}
+
+	owner.Loaded = false
+	handled, err = stopLegacyPIDBackendWithoutReportedPID(
+		context.Background(),
+		LocalDaemonOptions{},
+		owner,
+		lifecycle,
+		func(context.Context, LocalDaemonOptions, LocalDaemonLifecycleStatus) error {
+			validateCalls++
+			return nil
+		},
+		func(context.Context, LocalDaemonOptions) error {
+			stopCalls++
+			return nil
+		},
+	)
+	if !handled || err == nil || validateCalls != 1 || stopCalls != 1 {
+		t.Fatalf("缺少 stable owner 时必须 fail closed：handled=%t validate=%d stop=%d err=%v", handled, validateCalls, stopCalls, err)
+	}
+}
+
 func TestValidateManagedSharedDaemonListenerIdentity(t *testing.T) {
 	pid := uint32(4321)
 	lifecycle := LocalDaemonLifecycleStatus{PID: &pid}

--- a/internal/appserver/shared_daemon_stop_darwin.go
+++ b/internal/appserver/shared_daemon_stop_darwin.go
@@ -1,0 +1,36 @@
+//go:build darwin
+
+package appserver
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func stopManagedSharedDaemonCommand(ctx context.Context, options LocalDaemonOptions) error {
+	bin := strings.TrimSpace(options.CodexBin)
+	if bin == "" {
+		bin = "codex"
+	}
+	cmd := exec.CommandContext(ctx, bin, "app-server", "daemon", "stop")
+	configureManagedCommand(cmd)
+	cmd.Env = buildManagedEnv(options.Env)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	message := sanitizeDiagnostic(string(output))
+	lower := strings.ToLower(message)
+	if strings.Contains(lower, "not running") || strings.Contains(lower, "no running") {
+		return nil
+	}
+	if strings.Contains(lower, unmanagedSharedDaemonMessage) {
+		return fmt.Errorf("官方 lifecycle 报告 pid backend，但 stop 拒绝管理该进程，已停止迁移")
+	}
+	if message == "" {
+		return fmt.Errorf("停止旧 Codex local daemon 失败：%w", err)
+	}
+	return fmt.Errorf("停止旧 Codex local daemon 失败：%s", message)
+}

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -250,8 +250,15 @@ type appServerGatewayPolicy struct {
 	// archive 广播与 closed/notLoaded 在不同 upstream 连接上的到达次序没有保证。
 	// 记录已确认由 coordinator 发起的 archive，直到对应 unarchive 到达。
 	threadHandoffLifecycle map[string]time.Time
-	beforePendingRemember  func()
-	beforeManagedComplete  func()
+	// 已向 upstream 转发 resume/turn-start 的 thread 可能已让独立 app-server
+	// 取得 writer。连接异常结束时需要补排 handoff，不能只依赖终态通知。
+	threadWriterCandidates map[string]struct{}
+	// 请求收到明确错误时不能把其他 writer 当成 Mimi 持有；只有成功响应才
+	// 提升为 confirmed，断链时仍把无响应请求作为不确定候选处理。
+	pendingThreadWriters  map[string]appServerGatewayPendingThreadWriter
+	threadWriterForwardMu sync.Mutex
+	beforePendingRemember func()
+	beforeManagedComplete func()
 }
 
 type appServerGatewayPendingThreadRequest struct {
@@ -264,6 +271,11 @@ type appServerGatewayPendingThreadRequest struct {
 	threadID            string
 	managedWorktreePath string
 	createdAt           time.Time
+}
+
+type appServerGatewayPendingThreadWriter struct {
+	threadID  string
+	forwarded bool
 }
 
 type appServerGatewayPendingClientRequest struct {

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -149,6 +149,11 @@ func (p *appServerGatewayPolicy) validateClientFrameContext(ctx context.Context,
 		p.forgetPending(frame.ID)
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "app-server gateway 连接已关闭"}
 	}
+	if !p.rememberPendingThreadWriter(frame.ID, method, params) {
+		p.cancelPendingHistoryRequest(frame.ID)
+		p.forgetPending(frame.ID)
+		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "app-server gateway 连接已关闭"}
+	}
 	p.router.registerGatewayTurnStart(p.runtimeID, method, rewritten)
 	logGatewayForwardedClientTurnSummary(method, rewritten)
 	return rewritten, nil

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -168,6 +168,7 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 		return payload, true, nil
 	}
 	if gatewayFrameIsResponse(&frame) {
+		p.completePendingThreadWriter(&frame)
 		p.rememberAccountTokenUsageResponse(&frame, time.Now())
 		if pending, ok := p.consumePendingHistoryRequest(frame.ID); ok {
 			if len(frame.Error) == 0 && len(frame.Result) > 0 {
@@ -1029,9 +1030,11 @@ func (p *appServerGatewayPolicy) isClosed() bool {
 }
 
 func (p *appServerGatewayPolicy) close() {
+	p.threadWriterForwardMu.Lock()
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
+		p.threadWriterForwardMu.Unlock()
 		return
 	}
 	p.closed = true
@@ -1042,10 +1045,32 @@ func (p *appServerGatewayPolicy) close() {
 		}
 		delete(p.pendingThreads, key)
 	}
+	writerCandidates := make([]string, 0, len(p.threadWriterCandidates))
+	seenWriterCandidates := make(map[string]struct{}, len(p.threadWriterCandidates)+len(p.pendingThreadWriters))
+	for threadID := range p.threadWriterCandidates {
+		writerCandidates = append(writerCandidates, threadID)
+		seenWriterCandidates[threadID] = struct{}{}
+	}
+	for _, pending := range p.pendingThreadWriters {
+		if !pending.forwarded {
+			continue
+		}
+		threadID := pending.threadID
+		if _, exists := seenWriterCandidates[threadID]; exists {
+			continue
+		}
+		writerCandidates = append(writerCandidates, threadID)
+		seenWriterCandidates[threadID] = struct{}{}
+	}
+	p.threadWriterCandidates = nil
+	p.pendingThreadWriters = nil
+	handoffCapable := p.threadHandoffCapable
 	p.mu.Unlock()
+	p.threadWriterForwardMu.Unlock()
 	for _, path := range paths {
 		p.router.releaseManagedWorktreePendingUse(path)
 	}
+	p.scheduleThreadHandoffsAfterDisconnect(writerCandidates, handoffCapable)
 }
 
 func (p *appServerGatewayPolicy) threadsFromResult(raw json.RawMessage, pending appServerGatewayPendingThreadRequest) []appServerGatewayAllowedThread {
@@ -1293,6 +1318,9 @@ func (p *appServerGatewayPolicy) completePendingThreadResponse(key string, pendi
 		}
 		delete(p.pendingThreads, key)
 		for _, thread := range normalized {
+			if !gatewayThreadRejectsWrites(thread) {
+				p.rememberThreadWriterCandidateLocked(pending.method, thread.id)
+			}
 			p.allowedThreads[thread.id] = thread
 			p.router.allowGatewayThread(thread)
 		}
@@ -1317,6 +1345,9 @@ func (p *appServerGatewayPolicy) completePendingThreadResponse(key string, pendi
 	}
 	delete(p.pendingThreads, key)
 	for _, thread := range normalized {
+		if !gatewayThreadRejectsWrites(thread) {
+			p.rememberThreadWriterCandidateLocked(pending.method, thread.id)
+		}
 		p.allowedThreads[thread.id] = thread
 		p.router.allowGatewayThread(thread)
 	}

--- a/internal/httpapi/appserver_gateway_websocket.go
+++ b/internal/httpapi/appserver_gateway_websocket.go
@@ -18,14 +18,16 @@ func (r *Router) proxyAppServerGateway(ctx context.Context, client *websocket.Co
 	configureGatewayReadConn(client)
 	configureGatewayReadConn(upstream)
 	policy := &appServerGatewayPolicy{
-		router:                r,
-		runtimeID:             "codex",
-		pendingThreads:        map[string]appServerGatewayPendingThreadRequest{},
-		pendingClientRequests: map[string]appServerGatewayPendingClientRequest{},
-		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
-		pendingHistory:        map[string]appServerGatewayPendingHistoryRequest{},
-		historyBudgets:        map[string]appServerGatewayHistoryBudget{},
-		allowedThreads:        map[string]appServerGatewayAllowedThread{},
+		router:                 r,
+		runtimeID:              "codex",
+		pendingThreads:         map[string]appServerGatewayPendingThreadRequest{},
+		pendingClientRequests:  map[string]appServerGatewayPendingClientRequest{},
+		pendingServerRequests:  map[string]appServerGatewayPendingServerRequest{},
+		pendingHistory:         map[string]appServerGatewayPendingHistoryRequest{},
+		historyBudgets:         map[string]appServerGatewayHistoryBudget{},
+		allowedThreads:         map[string]appServerGatewayAllowedThread{},
+		threadWriterCandidates: map[string]struct{}{},
+		pendingThreadWriters:   map[string]appServerGatewayPendingThreadWriter{},
 	}
 	defer policy.releaseAllHistoryInflight()
 	defer policy.close()
@@ -104,7 +106,9 @@ func (r *Router) copyClientFramesToAppServer(ctx context.Context, client *websoc
 		}
 		requestID := monitor.beginRPCRequest(forwardPayload, len(forwardPayload))
 		writeStart := time.Now()
-		if err := writeWebSocketFrame(upstream, upstreamWriteMu, messageType, forwardPayload); err != nil {
+		if err := policy.forwardClientFrameToUpstream(forwardPayload, func() error {
+			return writeWebSocketFrame(upstream, upstreamWriteMu, messageType, forwardPayload)
+		}); err != nil {
 			monitor.cancelRPCRequest(requestID)
 			return gatewayCloseReason("upstream_write", err)
 		}

--- a/internal/httpapi/appserver_thread_handoff.go
+++ b/internal/httpapi/appserver_thread_handoff.go
@@ -31,7 +31,8 @@ const (
 	appServerThreadHandoffLifecycleGrace = 2 * time.Second
 	// completion 后留出一个很短的续问窗口。本地 FIFO 会在这段时间内发出
 	// turn/start 并取消 handoff；无后续输入时仍能在 10 秒验收窗口内释放 writer。
-	appServerTerminalHandoffGrace = 2 * time.Second
+	appServerTerminalHandoffGrace   = 2 * time.Second
+	appServerDisconnectHandoffGrace = 2 * time.Second
 )
 
 var errAppServerThreadHandoffExecuting = errors.New("thread handoff is executing")
@@ -388,7 +389,161 @@ func (p *appServerGatewayPolicy) scheduleThreadHandoffAfterTerminal(frame *appSe
 	if !ok || gatewayThreadRejectsWrites(thread) || p.router.threadHandoffs == nil {
 		return
 	}
+	p.forgetThreadWriterCandidate(threadID)
 	p.router.threadHandoffs.ScheduleAfter(threadID, appServerTerminalHandoffGrace)
+}
+
+func (p *appServerGatewayPolicy) rememberPendingThreadWriter(
+	id *json.RawMessage,
+	method string,
+	params map[string]any,
+) bool {
+	if method != "thread/resume" && method != "turn/start" {
+		return true
+	}
+	threadID, ok := gatewayStringParam(params, "threadId")
+	if !ok {
+		return true
+	}
+	thread, ok := p.allowedThread(threadID)
+	if !ok || gatewayThreadRejectsWrites(thread) {
+		return true
+	}
+	key := gatewayRequestIDKey(id)
+	if key == "" {
+		return true
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return false
+	}
+	if p.pendingThreadWriters == nil {
+		p.pendingThreadWriters = map[string]appServerGatewayPendingThreadWriter{}
+	}
+	p.pendingThreadWriters[key] = appServerGatewayPendingThreadWriter{threadID: threadID}
+	return true
+}
+
+func (p *appServerGatewayPolicy) forwardClientFrameToUpstream(
+	payload []byte,
+	write func() error,
+) error {
+	p.threadWriterForwardMu.Lock()
+	defer p.threadWriterForwardMu.Unlock()
+	if write == nil {
+		return fmt.Errorf("upstream writer 不能为空")
+	}
+	p.mu.Lock()
+	closed := p.closed
+	if closed {
+		delete(p.pendingThreadWriters, gatewayRequestIDFromPayload(payload))
+	}
+	p.mu.Unlock()
+	if closed {
+		return fmt.Errorf("app-server gateway 连接已关闭")
+	}
+	if err := write(); err != nil {
+		p.forgetPendingThreadWriter(payload)
+		return err
+	}
+	p.markPendingThreadWriterForwarded(payload)
+	return nil
+}
+
+func (p *appServerGatewayPolicy) markPendingThreadWriterForwarded(payload []byte) {
+	key := gatewayRequestIDFromPayload(payload)
+	if key == "" {
+		return
+	}
+	p.mu.Lock()
+	pending, ok := p.pendingThreadWriters[key]
+	if ok && !p.closed {
+		pending.forwarded = true
+		p.pendingThreadWriters[key] = pending
+	}
+	p.mu.Unlock()
+}
+
+func (p *appServerGatewayPolicy) forgetPendingThreadWriter(payload []byte) {
+	key := gatewayRequestIDFromPayload(payload)
+	if key == "" {
+		return
+	}
+	p.mu.Lock()
+	delete(p.pendingThreadWriters, key)
+	p.mu.Unlock()
+}
+
+func gatewayRequestIDFromPayload(payload []byte) string {
+	var frame appServerGatewayFrame
+	if json.Unmarshal(payload, &frame) != nil {
+		return ""
+	}
+	return gatewayRequestIDKey(frame.ID)
+}
+
+func (p *appServerGatewayPolicy) completePendingThreadWriter(frame *appServerGatewayFrame) {
+	if !gatewayFrameIsResponse(frame) {
+		return
+	}
+	key := gatewayRequestIDKey(frame.ID)
+	if key == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pending, ok := p.pendingThreadWriters[key]
+	if !ok {
+		return
+	}
+	delete(p.pendingThreadWriters, key)
+	if p.closed || len(frame.Error) > 0 {
+		return
+	}
+	p.rememberThreadWriterCandidateLocked("turn/start", pending.threadID)
+}
+
+func (p *appServerGatewayPolicy) forgetThreadWriterCandidate(threadID string) {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return
+	}
+	p.mu.Lock()
+	delete(p.threadWriterCandidates, threadID)
+	for key, pending := range p.pendingThreadWriters {
+		if pending.threadID == threadID {
+			delete(p.pendingThreadWriters, key)
+		}
+	}
+	p.mu.Unlock()
+}
+
+func (p *appServerGatewayPolicy) rememberThreadWriterCandidateLocked(method string, threadID string) {
+	if method != "thread/start" && method != "thread/resume" && method != "turn/start" {
+		return
+	}
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return
+	}
+	if p.threadWriterCandidates == nil {
+		p.threadWriterCandidates = map[string]struct{}{}
+	}
+	p.threadWriterCandidates[threadID] = struct{}{}
+}
+
+func (p *appServerGatewayPolicy) scheduleThreadHandoffsAfterDisconnect(
+	threadIDs []string,
+	handoffCapable bool,
+) {
+	if !handoffCapable || p == nil || p.router == nil || p.router.threadHandoffs == nil ||
+		normalizeAppServerRuntimeID(p.runtimeID) != "codex" || p.router.usesSharedCodexAppServer() {
+		return
+	}
+	for _, threadID := range threadIDs {
+		p.router.threadHandoffs.ScheduleAfter(threadID, appServerDisconnectHandoffGrace)
+	}
 }
 
 func (r *Router) usesSharedCodexAppServer() bool {

--- a/internal/httpapi/appserver_thread_handoff_test.go
+++ b/internal/httpapi/appserver_thread_handoff_test.go
@@ -75,6 +75,224 @@ func TestAppServerThreadHandoffDelayedCompletionIsCanceledByNewTurn(t *testing.T
 	waitForThreadHandoffEntryCount(t, coordinator, 0)
 }
 
+func TestGatewayDisconnectSchedulesAndReclaimsWriterCandidateHandoff(t *testing.T) {
+	coordinator := &appServerThreadHandoffCoordinator{
+		entries: map[string]*appServerThreadHandoffEntry{},
+		run: func(ctx context.Context, _ string, _ func() bool) (appServerThreadHandoffOutcome, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	}
+	t.Cleanup(coordinator.Close)
+	router := &Router{threadHandoffs: coordinator}
+	policy := &appServerGatewayPolicy{
+		router:               router,
+		runtimeID:            "codex",
+		threadHandoffCapable: true,
+		pendingThreads:       map[string]appServerGatewayPendingThreadRequest{},
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-disconnected": {id: "thread-disconnected"},
+		},
+		threadWriterCandidates: map[string]struct{}{},
+		pendingThreadWriters:   map[string]appServerGatewayPendingThreadWriter{},
+	}
+	requestID := json.RawMessage(`"disconnect-resume"`)
+	if !policy.rememberPendingThreadWriter(
+		&requestID,
+		"thread/resume",
+		map[string]any{"threadId": "thread-disconnected"},
+	) {
+		t.Fatal("活动连接应记录已转发的 resume")
+	}
+	if err := policy.forwardClientFrameToUpstream(
+		[]byte(`{"id":"disconnect-resume"}`),
+		func() error { return nil },
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	policy.close()
+	waitForThreadHandoffEntryCount(t, coordinator, 1)
+	if err := router.reclaimCodexThreadHandoff(context.Background(), "thread-disconnected"); err != nil {
+		t.Fatalf("快速重连应取消尚未执行的断链 handoff：%v", err)
+	}
+	waitForThreadHandoffEntryCount(t, coordinator, 0)
+}
+
+func TestGatewayDisconnectHandoffRespectsRuntimeCapabilityAndTransport(t *testing.T) {
+	tests := []struct {
+		name       string
+		runtimeID  string
+		transport  string
+		capable    bool
+		candidates map[string]struct{}
+	}{
+		{name: "missing capability", runtimeID: "codex", capable: false, candidates: map[string]struct{}{"thread-a": {}}},
+		{name: "shared daemon", runtimeID: "codex", transport: "unix", capable: true, candidates: map[string]struct{}{"thread-b": {}}},
+		{name: "claude runtime", runtimeID: "claude", capable: true, candidates: map[string]struct{}{"thread-c": {}}},
+		{name: "read only", runtimeID: "codex", capable: true, candidates: map[string]struct{}{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			coordinator := &appServerThreadHandoffCoordinator{
+				entries: map[string]*appServerThreadHandoffEntry{},
+				run: func(context.Context, string, func() bool) (appServerThreadHandoffOutcome, error) {
+					return appServerThreadHandoffAlreadyReleased, nil
+				},
+			}
+			t.Cleanup(coordinator.Close)
+			policy := &appServerGatewayPolicy{
+				router: &Router{
+					cfg:            config.Config{AppServer: config.AppServerConfig{Transport: test.transport}},
+					threadHandoffs: coordinator,
+				},
+				runtimeID:              test.runtimeID,
+				threadHandoffCapable:   test.capable,
+				pendingThreads:         map[string]appServerGatewayPendingThreadRequest{},
+				threadWriterCandidates: test.candidates,
+			}
+			policy.close()
+			waitForThreadHandoffEntryCount(t, coordinator, 0)
+		})
+	}
+}
+
+func TestGatewayTracksOnlyWriterCreatingThreadMethods(t *testing.T) {
+	policy := &appServerGatewayPolicy{
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-turn":     {id: "thread-turn"},
+			"thread-readonly": {id: "thread-readonly", readOnly: true},
+		},
+		threadWriterCandidates: map[string]struct{}{},
+	}
+	readID := json.RawMessage(`"read"`)
+	if !policy.rememberPendingThreadWriter(&readID, "thread/read", map[string]any{"threadId": "thread-read"}) {
+		t.Fatal("普通只读请求不应被拒绝")
+	}
+	if len(policy.threadWriterCandidates) != 0 {
+		t.Fatalf("纯 thread/read 不得成为 writer 候选：%v", policy.threadWriterCandidates)
+	}
+	resumeID := json.RawMessage(`"resume-readonly"`)
+	if !policy.rememberPendingThreadWriter(&resumeID, "thread/resume", map[string]any{"threadId": "thread-readonly"}) {
+		t.Fatal("只读 resume 不应被 close barrier 拒绝")
+	}
+	if len(policy.pendingThreadWriters) != 0 {
+		t.Fatalf("只读 thread/resume 不得成为 writer 候选：%v", policy.pendingThreadWriters)
+	}
+	turnID := json.RawMessage(`"turn"`)
+	if !policy.rememberPendingThreadWriter(&turnID, "turn/start", map[string]any{"threadId": "thread-turn"}) {
+		t.Fatal("活动连接应记录已转发的 turn/start")
+	}
+	pending := policy.pendingThreadWriters[gatewayRequestIDKey(&turnID)]
+	if len(policy.threadWriterCandidates) != 0 || pending.threadID != "thread-turn" || pending.forwarded {
+		t.Fatalf("未收到响应的 turn/start 只能进入 pending：confirmed=%v pending=%v", policy.threadWriterCandidates, policy.pendingThreadWriters)
+	}
+	policy.completePendingThreadWriter(&appServerGatewayFrame{ID: &turnID, Result: json.RawMessage(`{}`)})
+	policy.rememberThreadWriterCandidateLocked("thread/start", "thread-new")
+	if len(policy.threadWriterCandidates) != 2 {
+		t.Fatalf("resume/start 路径应记录 writer 候选：%v", policy.threadWriterCandidates)
+	}
+}
+
+func TestGatewayRejectedWriterRequestDoesNotBecomeConfirmedCandidate(t *testing.T) {
+	policy := &appServerGatewayPolicy{
+		allowedThreads:         map[string]appServerGatewayAllowedThread{"desktop-owned": {id: "desktop-owned"}},
+		threadWriterCandidates: map[string]struct{}{},
+		pendingThreadWriters:   map[string]appServerGatewayPendingThreadWriter{},
+	}
+	requestID := json.RawMessage(`"resume-rejected"`)
+	if !policy.rememberPendingThreadWriter(
+		&requestID,
+		"thread/resume",
+		map[string]any{"threadId": "desktop-owned"},
+	) {
+		t.Fatal("活动连接应记录待确认的 resume")
+	}
+	policy.completePendingThreadWriter(&appServerGatewayFrame{
+		ID:    &requestID,
+		Error: json.RawMessage(`{"code":-32600,"message":"already has an active writer"}`),
+	})
+	if len(policy.pendingThreadWriters) != 0 || len(policy.threadWriterCandidates) != 0 {
+		t.Fatalf("明确拒绝的 resume 不得触发断链 handoff：confirmed=%v pending=%v", policy.threadWriterCandidates, policy.pendingThreadWriters)
+	}
+}
+
+func TestGatewayUpstreamWriteFailureDoesNotScheduleDisconnectHandoff(t *testing.T) {
+	coordinator := &appServerThreadHandoffCoordinator{
+		entries: map[string]*appServerThreadHandoffEntry{},
+		run: func(context.Context, string, func() bool) (appServerThreadHandoffOutcome, error) {
+			return appServerThreadHandoffAlreadyReleased, nil
+		},
+	}
+	t.Cleanup(coordinator.Close)
+	policy := &appServerGatewayPolicy{
+		router:               &Router{threadHandoffs: coordinator},
+		runtimeID:            "codex",
+		threadHandoffCapable: true,
+		pendingThreads:       map[string]appServerGatewayPendingThreadRequest{},
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-write-failed": {id: "thread-write-failed"},
+		},
+		pendingThreadWriters: map[string]appServerGatewayPendingThreadWriter{},
+	}
+	requestID := json.RawMessage(`"write-failed"`)
+	if !policy.rememberPendingThreadWriter(
+		&requestID,
+		"turn/start",
+		map[string]any{"threadId": "thread-write-failed"},
+	) {
+		t.Fatal("活动连接应暂存待写入的 turn/start")
+	}
+	err := policy.forwardClientFrameToUpstream(
+		[]byte(`{"id":"write-failed"}`),
+		func() error { return errors.New("upstream closed") },
+	)
+	if err == nil {
+		t.Fatal("upstream 写入失败应返回错误")
+	}
+	policy.close()
+	waitForThreadHandoffEntryCount(t, coordinator, 0)
+}
+
+func TestGatewayResumeResponseDoesNotScheduleReadOnlyRelatedThreadHandoff(t *testing.T) {
+	coordinator := &appServerThreadHandoffCoordinator{
+		entries: map[string]*appServerThreadHandoffEntry{},
+		run: func(ctx context.Context, _ string, _ func() bool) (appServerThreadHandoffOutcome, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	}
+	t.Cleanup(coordinator.Close)
+	router := &Router{
+		gatewayThreads: map[string]appServerGatewayAllowedThread{},
+		threadHandoffs: coordinator,
+	}
+	createdAt := time.Now()
+	pending := appServerGatewayPendingThreadRequest{method: "thread/resume", createdAt: createdAt}
+	policy := &appServerGatewayPolicy{
+		router:                 router,
+		runtimeID:              "codex",
+		threadHandoffCapable:   true,
+		pendingThreads:         map[string]appServerGatewayPendingThreadRequest{"resume": pending},
+		allowedThreads:         map[string]appServerGatewayAllowedThread{},
+		threadWriterCandidates: map[string]struct{}{},
+	}
+	policy.completePendingThreadResponse("resume", pending, []appServerGatewayAllowedThread{
+		{id: "thread-parent", scopeID: "scope", runtimeID: "codex"},
+		{id: "thread-child", scopeID: "scope", runtimeID: "codex", readOnly: true},
+	})
+	policy.close()
+
+	waitForThreadHandoffEntryCount(t, coordinator, 1)
+	coordinator.mu.Lock()
+	_, parentScheduled := coordinator.entries["thread-parent"]
+	_, childScheduled := coordinator.entries["thread-child"]
+	coordinator.mu.Unlock()
+	if !parentScheduled || childScheduled {
+		t.Fatalf("断链只应交接可写父线程：parent=%t child=%t", parentScheduled, childScheduled)
+	}
+}
+
 func TestAppServerTurnCompletedNotificationSchedulesTerminalHandoff(t *testing.T) {
 	coordinator := &appServerThreadHandoffCoordinator{
 		entries: map[string]*appServerThreadHandoffEntry{},
@@ -85,16 +303,23 @@ func TestAppServerTurnCompletedNotificationSchedulesTerminalHandoff(t *testing.T
 	}
 	t.Cleanup(coordinator.Close)
 	policy := &appServerGatewayPolicy{
-		router:               &Router{threadHandoffs: coordinator},
-		runtimeID:            "codex",
-		threadHandoffCapable: true,
-		allowedThreads:       map[string]appServerGatewayAllowedThread{"thread-terminal": {id: "thread-terminal"}},
+		router:                 &Router{threadHandoffs: coordinator},
+		runtimeID:              "codex",
+		threadHandoffCapable:   true,
+		allowedThreads:         map[string]appServerGatewayAllowedThread{"thread-terminal": {id: "thread-terminal"}},
+		threadWriterCandidates: map[string]struct{}{"thread-terminal": {}},
+		pendingThreadWriters: map[string]appServerGatewayPendingThreadWriter{
+			"pending-terminal": {threadID: "thread-terminal", forwarded: true},
+		},
 	}
 	payload := []byte(`{"method":"turn/completed","params":{"threadId":"thread-terminal","turnId":"turn-1"}}`)
 
 	forwarded, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, payload)
 	if policyErr != nil || !forward || string(forwarded) != string(payload) {
 		t.Fatalf("turn/completed 应原样透传并调度 handoff，forward=%t err=%+v payload=%s", forward, policyErr, forwarded)
+	}
+	if len(policy.threadWriterCandidates) != 0 || len(policy.pendingThreadWriters) != 0 {
+		t.Fatalf("terminal 已接管调度后必须清理 close-handoff 候选：confirmed=%v pending=%v", policy.threadWriterCandidates, policy.pendingThreadWriters)
 	}
 	coordinator.mu.Lock()
 	entry := coordinator.entries["thread-terminal"]


### PR DESCRIPTION
## 目标

同时修复 MIM-174 与 MIM-175，避免 App Server 共享/独立模式切换后出现双 backend，并在移动端断链后可靠释放独立 app-server 持有的 thread writer。

## 修改

- 旧 `backend=pid && PID=nil` 兼容路径先完成 stable owner、socket、UID、managed executable/argv、启动身份、签名父链和 Desktop 双重复核，再调用官方 `codex app-server daemon stop`。
- 独立 WS runtime 的最终磁盘配置复核与 managed 进程启动放入同一 operation lock 临界区。
- 官方 daemon stop 前增加最后一次 Desktop 状态检查。
- gateway 追踪已成功写入 upstream 的 `thread/resume` 与 `turn/start`；成功响应和 ACK 丢失窗口在连接关闭后安排延迟 handoff。
- 明确 rejected、upstream write failure、只读子线程、shared Unix backend 和缺失 capability 的旧客户端不触发断链 handoff。
- `turn/completed` 接管调度后清理 close 候选，避免重复 archive/unarchive。

## 验证

- `go test ./...`
- `go test -race ./internal/appserver ./cmd/agentd`
- `go test -race ./internal/httpapi`
- `bash ./scripts/check-source-size.sh`
- `git diff --check origin/main...HEAD`

以上均通过。

## 剩余运行态验证

尚未在真实 Codex Desktop 与实际网络断链环境中执行模式切换验收；本 PR 保持 Draft，等待运行态验证与 CI。

## Linear

- MIM-174
- MIM-175
