### PR TITLE
MIM-176 修复共享模式本地工具宿主缺失

### DIFF
--- a/macos/MimiRemoteMac/Sources/App/CodexDaemonSupervisor.swift
+++ b/macos/MimiRemoteMac/Sources/App/CodexDaemonSupervisor.swift
@@ -32,6 +32,7 @@ enum CodexDaemonSupervisorInvocation {
 enum CodexDaemonSupervisorError: Error, Equatable {
     case notInsideDesktopBundle(String)
     case bundleMismatch
+    case helperMissing(String)
     case signatureRejected(String)
     case stagingFailed(String)
     case spawnFailed(String)
@@ -40,6 +41,7 @@ enum CodexDaemonSupervisorError: Error, Equatable {
         switch self {
         case .notInsideDesktopBundle(let name): "\(name) 不在 Codex Desktop App bundle 内"
         case .bundleMismatch: "node 与 codex 不属于同一个 Codex Desktop App bundle"
+        case .helperMissing(let path): "Codex Desktop bundle 缺少可用的 codex-code-mode-host：\(path)"
         case .signatureRejected(let name): "\(name) 不是受支持的 OpenAI 签名程序"
         case .stagingFailed(let detail): "准备一次性共享 daemon 程序失败：\(detail)"
         case .spawnFailed(let detail): "拉起共享 daemon 失败：\(detail)"
@@ -56,6 +58,7 @@ struct CodexDaemonSupervisorStaging {
     let directory: URL
     let node: String
     let codex: String
+    let codeModeHost: String
 
     func remove() {
         _ = chmod(directory.path, S_IRWXU)
@@ -68,6 +71,8 @@ enum CodexDaemonSupervisor {
     static let openAITeamIdentifier = "2DC432GLL2"
     static let nodeSigningIdentifier = "node"
     static let codexSigningIdentifier = "codex"
+    static let codeModeHostSigningIdentifier = "codex-code-mode-host"
+    private static let codeModeHostFilename = "codex-code-mode-host"
     static let stagedCodexEnvironmentKey = "MIMI_REMOTE_PINNED_CODEX_PATH"
     private static let strippedEnvironmentKeys: Set<String> = [
         "CODEX_APP_SERVER_USE_LOCAL_DAEMON",
@@ -136,7 +141,7 @@ enum CodexDaemonSupervisor {
     /// 原始 Desktop App 位于当前用户可写的 /Applications 时，单纯“验签路径后再执行”
     /// 仍有替换窗口。先用 APFS clone 取得独立 inode，再对真正将执行的副本验签；随后
     /// 把目录降为只读。macOS 会在运行中可执行文件被删除时终止进程，因此一次性目录
-    /// 必须保留到 node/codex 都退出，再由 supervisor 统一清理。
+    /// 必须保留到 node、codex 及其 helper 都退出，再由 supervisor 统一清理。
     ///
     /// 这层防护覆盖 App 更新和普通路径替换，不把同 UID 主动篡改临时副本作为安全边界；
     /// 后一种威胁需要 root-owned staging/特权 helper，超出当前无提权 LaunchAgent 的范围。
@@ -145,6 +150,9 @@ enum CodexDaemonSupervisor {
         clone: (String, String) throws -> Void = cloneExecutable,
         verifySignature: (String, String) -> Bool = verifyOpenAISignature
     ) throws -> CodexDaemonSupervisorStaging {
+        // helper 不是 supervisor 的外部参数。它只能由已经验收的 node/codex
+        // bundle 推导，避免调用方把另一份可执行文件带进 TCC 责任进程链。
+        let codeModeHost = try codeModeHostPath(for: command)
         let directory = FileManager.default.temporaryDirectory
             .appending(path: UUID().uuidString, directoryHint: .isDirectory)
         do {
@@ -155,25 +163,63 @@ enum CodexDaemonSupervisor {
             )
             let stagedNode = directory.appending(path: "node").path
             let stagedCodex = directory.appending(path: "codex").path
+            let stagedCodeModeHost = directory.appending(path: codeModeHostFilename).path
             try clone(command.node, stagedNode)
             try clone(command.codex, stagedCodex)
+            try clone(codeModeHost, stagedCodeModeHost)
             guard verifySignature(stagedNode, nodeSigningIdentifier) else {
                 throw CodexDaemonSupervisorError.signatureRejected("一次性 node supervisor")
             }
             guard verifySignature(stagedCodex, codexSigningIdentifier) else {
                 throw CodexDaemonSupervisorError.signatureRejected("一次性 Codex app-server")
             }
+            guard verifySignature(stagedCodeModeHost, codeModeHostSigningIdentifier) else {
+                throw CodexDaemonSupervisorError.signatureRejected("一次性 codex-code-mode-host")
+            }
             guard chmod(stagedNode, S_IRUSR | S_IXUSR) == 0,
                   chmod(stagedCodex, S_IRUSR | S_IXUSR) == 0,
+                  chmod(stagedCodeModeHost, S_IRUSR | S_IXUSR) == 0,
                   chmod(directory.path, S_IRUSR | S_IXUSR) == 0 else {
                 throw CodexDaemonSupervisorError.stagingFailed(String(cString: strerror(errno)))
             }
-            return .init(directory: directory, node: stagedNode, codex: stagedCodex)
+            return .init(
+                directory: directory,
+                node: stagedNode,
+                codex: stagedCodex,
+                codeModeHost: stagedCodeModeHost
+            )
         } catch {
             _ = chmod(directory.path, S_IRWXU)
             try? FileManager.default.removeItem(at: directory)
             throw error
         }
+    }
+
+    /// 从已验签的 node/codex 对中推导同一 bundle 的 code-mode helper。
+    /// 这里不接受独立 helper 参数，且拒绝 bundle 外的路径或符号链接，避免 TOCTOU
+    /// 防护只覆盖主程序而把 helper 留成可替换的旁路。
+    private static func codeModeHostPath(
+        for command: CodexDaemonSupervisorInvocation.Command
+    ) throws -> String {
+        let node = URL(fileURLWithPath: command.node).resolvingSymlinksInPath().path
+        guard let bundle = desktopBundle(forNode: node) else {
+            throw CodexDaemonSupervisorError.notInsideDesktopBundle("node supervisor")
+        }
+        let resources = URL(fileURLWithPath: bundle).appendingPathComponent("Contents/Resources")
+        let expectedCodex = resources.appendingPathComponent("codex").path
+        let codex = URL(fileURLWithPath: command.codex).resolvingSymlinksInPath().path
+        guard codex == expectedCodex else {
+            throw CodexDaemonSupervisorError.bundleMismatch
+        }
+
+        let helper = resources.appendingPathComponent(codeModeHostFilename).path
+        let helperURL = URL(fileURLWithPath: helper)
+        guard helperURL.resolvingSymlinksInPath().path == helper,
+              let attributes = try? FileManager.default.attributesOfItem(atPath: helper),
+              attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw CodexDaemonSupervisorError.helperMissing(helper)
+        }
+        return helper
     }
 
     static func cloneExecutable(source: String, destination: String) throws {

--- a/macos/MimiRemoteMac/Tests/CodexDaemonSupervisorTests.swift
+++ b/macos/MimiRemoteMac/Tests/CodexDaemonSupervisorTests.swift
@@ -12,6 +12,34 @@ final class CodexDaemonSupervisorTests: XCTestCase {
         CodexDaemonSupervisorInvocation.Command(node: node, codex: codex)
     }
 
+    private struct StagingFixture {
+        let root: URL
+        let command: CodexDaemonSupervisorInvocation.Command
+        let helper: URL
+    }
+
+    private func makeStagingFixture(includeHelper: Bool = true) throws -> StagingFixture {
+        let root = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let resources = root.appending(path: "ChatGPT.app/Contents/Resources")
+        let nodeDirectory = resources.appending(path: "cua_node/bin")
+        try FileManager.default.createDirectory(at: nodeDirectory, withIntermediateDirectories: true)
+
+        let sourceNode = nodeDirectory.appending(path: "node")
+        let sourceCodex = resources.appending(path: "codex")
+        let sourceHelper = resources.appending(path: "codex-code-mode-host")
+        try Data("node".utf8).write(to: sourceNode)
+        try Data("codex".utf8).write(to: sourceCodex)
+        if includeHelper {
+            try Data("code-mode-host".utf8).write(to: sourceHelper)
+        }
+
+        return StagingFixture(
+            root: root,
+            command: .init(node: sourceNode.path, codex: sourceCodex.path),
+            helper: sourceHelper
+        )
+    }
+
     func testParseAcceptsOnlyTheExactSupervisorShape() {
         let flag = CodexDaemonSupervisorInvocation.flag
         XCTAssertEqual(
@@ -115,19 +143,116 @@ final class CodexDaemonSupervisorTests: XCTestCase {
         XCTAssertEqual(environment, ["PATH": "/usr/bin:/bin", "CODEX_HOME": "/tmp/codex-home"])
     }
 
-    func testStageExecutablesVerifiesTheIndependentCopiesAndMakesDirectoryReadOnly() throws {
-        let root = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
-        let sourceNode = root.appending(path: "source-node")
-        let sourceCodex = root.appending(path: "source-codex")
-        try Data("node".utf8).write(to: sourceNode)
-        try Data("codex".utf8).write(to: sourceCodex)
-        defer { try? FileManager.default.removeItem(at: root) }
+    func testStageExecutablesRejectsMissingCodeModeHostBeforeCloning() throws {
+        let fixture = try makeStagingFixture(includeHelper: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        var cloneCalled = false
+        XCTAssertThrowsError(
+            try CodexDaemonSupervisor.stageExecutables(
+                fixture.command,
+                clone: { _, _ in cloneCalled = true },
+                verifySignature: { _, _ in true }
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? CodexDaemonSupervisorError,
+                .helperMissing(fixture.helper.path)
+            )
+        }
+        XCTAssertFalse(cloneCalled)
+    }
+
+    func testStageExecutablesRejectsSymbolicLinkCodeModeHostBeforeCloning() throws {
+        let fixture = try makeStagingFixture(includeHelper: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let realHelper = fixture.helper.deletingLastPathComponent().appending(path: "real-code-mode-host")
+        try Data("code-mode-host".utf8).write(to: realHelper)
+        try FileManager.default.createSymbolicLink(at: fixture.helper, withDestinationURL: realHelper)
+
+        var cloneCalled = false
+        XCTAssertThrowsError(
+            try CodexDaemonSupervisor.stageExecutables(
+                fixture.command,
+                clone: { _, _ in cloneCalled = true },
+                verifySignature: { _, _ in true }
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? CodexDaemonSupervisorError,
+                .helperMissing(fixture.helper.path)
+            )
+        }
+        XCTAssertFalse(cloneCalled)
+    }
+
+    func testStageExecutablesRejectsUnsignedCodeModeHostAndCleansUp() throws {
+        let fixture = try makeStagingFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        var stagedDirectory: URL?
+        var thrownError: Error?
+        XCTAssertThrowsError(
+            try CodexDaemonSupervisor.stageExecutables(
+                fixture.command,
+                clone: { source, destination in
+                    stagedDirectory = URL(fileURLWithPath: destination).deletingLastPathComponent()
+                    try FileManager.default.copyItem(atPath: source, toPath: destination)
+                },
+                verifySignature: { _, identifier in
+                    identifier != CodexDaemonSupervisor.codeModeHostSigningIdentifier
+                }
+            )
+        ) { thrownError = $0 }
+        XCTAssertEqual(
+            thrownError as? CodexDaemonSupervisorError,
+            .signatureRejected("一次性 codex-code-mode-host")
+        )
+        XCTAssertNotNil(stagedDirectory)
+        if let stagedDirectory {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: stagedDirectory.path))
+        }
+    }
+
+    func testStageExecutablesCloneFailureCleansUpPartialDirectory() throws {
+        let fixture = try makeStagingFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        var stagedDirectory: URL?
+        var thrownError: Error?
+        XCTAssertThrowsError(
+            try CodexDaemonSupervisor.stageExecutables(
+                fixture.command,
+                clone: { source, destination in
+                    stagedDirectory = URL(fileURLWithPath: destination).deletingLastPathComponent()
+                    if source == fixture.helper.path {
+                        throw CodexDaemonSupervisorError.stagingFailed("simulated clone failure")
+                    }
+                    try FileManager.default.copyItem(atPath: source, toPath: destination)
+                },
+                verifySignature: { _, _ in true }
+            )
+        ) { thrownError = $0 }
+        XCTAssertEqual(
+            thrownError as? CodexDaemonSupervisorError,
+            .stagingFailed("simulated clone failure")
+        )
+        XCTAssertNotNil(stagedDirectory)
+        if let stagedDirectory {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: stagedDirectory.path))
+        }
+    }
+
+    func testStageExecutablesVerifiesThreeIndependentCopiesAndMakesDirectoryReadOnly() throws {
+        let fixture = try makeStagingFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
 
         var verified: [String] = []
+        var clonedSources: [String] = []
         let staging = try CodexDaemonSupervisor.stageExecutables(
-            .init(node: sourceNode.path, codex: sourceCodex.path),
+            fixture.command,
             clone: { source, destination in
+                clonedSources.append(source)
                 try FileManager.default.copyItem(atPath: source, toPath: destination)
             },
             verifySignature: { path, identifier in
@@ -139,9 +264,46 @@ final class CodexDaemonSupervisorTests: XCTestCase {
 
         XCTAssertEqual(try Data(contentsOf: URL(fileURLWithPath: staging.node)), Data("node".utf8))
         XCTAssertEqual(try Data(contentsOf: URL(fileURLWithPath: staging.codex)), Data("codex".utf8))
-        XCTAssertEqual(verified.count, 2)
+        XCTAssertEqual(
+            try Data(contentsOf: URL(fileURLWithPath: staging.codeModeHost)),
+            Data("code-mode-host".utf8)
+        )
+        XCTAssertEqual(
+            staging.codeModeHost,
+            staging.directory.appending(path: "codex-code-mode-host").path
+        )
+        XCTAssertEqual(clonedSources, [fixture.command.node, fixture.command.codex, fixture.helper.path])
+        XCTAssertEqual(
+            verified.map { $0.components(separatedBy: ":").first! },
+            [
+                CodexDaemonSupervisor.nodeSigningIdentifier,
+                CodexDaemonSupervisor.codexSigningIdentifier,
+                CodexDaemonSupervisor.codeModeHostSigningIdentifier,
+            ]
+        )
+        for path in [staging.node, staging.codex, staging.codeModeHost] {
+            let attributes = try FileManager.default.attributesOfItem(atPath: path)
+            XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o500)
+        }
         let attributes = try FileManager.default.attributesOfItem(atPath: staging.directory.path)
         XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o500)
+    }
+
+    func testStageExecutablesCleanupRemovesTheReadOnlyDirectory() throws {
+        let fixture = try makeStagingFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let staging = try CodexDaemonSupervisor.stageExecutables(
+            fixture.command,
+            clone: { source, destination in
+                try FileManager.default.copyItem(atPath: source, toPath: destination)
+            },
+            verifySignature: { _, _ in true }
+        )
+        let directory = staging.directory
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+        staging.remove()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
     }
 
     func testWaitStatusMappingMatchesSupervisorContract() {


### PR DESCRIPTION
## 问题

共享实验模式启用后，Browser 和本地命令都会报错：

    failed to spawn code-mode host .../T/<uuid>/codex-code-mode-host: No such file or directory

MIM-170 的 supervisor 只把 node 与 codex clone 到一次性 staging 目录。Codex 会从自身同目录寻找 codex-code-mode-host，但该 helper 没有被复制。

Linear：https://linear.app/code89757/issue/MIM-176/共享实验模式缺少-codex-本地工具宿主browser-与命令无法启动

## 修复

- 从已验证的同一 Codex Desktop bundle 固定推导 codex-code-mode-host，不增加外部参数面。
- 把 helper 与 node、codex 一起 clone 到 staging 目录，并保留固定相邻文件名。
- 对 staged helper 验证 OpenAI Team 与 codex-code-mode-host identifier。
- 拒绝缺失、非普通文件或符号链接 helper。
- 三个可执行文件与目录统一设为 0500，沿用失败和退出清理语义。

## 自动验证

- Mac App 完整构建与 146 个测试通过。
- `bash ./scripts/check-source-size.sh` 通过。
- `git diff --check` 通过。
- GitHub PR Gate 全部通过。

## 真实运行态验收

- 安装 development build 后启用共享模式，staged 目录包含 `node`、`codex` 和 `codex-code-mode-host`，三者签名及 0500 权限验证通过。
- 共享模式下实际执行 Git、GitHub、Linear 和 Codex 内置 Browser 均成功；Browser 刷新百度并读取到标题与搜索框。
- 关闭共享后恢复独立 WS，Git、Linear 和 Browser 均继续可用。
- 再次启用共享后重复完整检查仍通过，未复现 ENOENT 或权限问题。
