### PR TITLE
MIM-117 Fix workspace toolbar after rotation

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -295,6 +295,12 @@ struct UnifiedWorkbenchShell: View {
             presentation: .toolbar,
             manageConnections: { openConnectionSettings(layout: layout) }
         )
+        .simultaneousGesture(
+            TapGesture().onEnded {
+                // 设备入口移到 Shell 后仍需保持会话页原有的收键盘行为。
+                dismissSessionSearchKeyboard()
+            }
+        )
         .frame(width: 44, height: 44)
 
         if #available(iOS 26.0, *), !reduceTransparency {
@@ -302,6 +308,15 @@ struct UnifiedWorkbenchShell: View {
         } else {
             switcher.workbenchChromeCircle(tokens: tokens)
         }
+    }
+
+    private func dismissSessionSearchKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
     }
 
     private func splitLayout(

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -220,6 +220,12 @@ struct UnifiedWorkbenchShell: View {
         let bottomChromeClearance = WorkbenchPageLayout.compactBottomChromeClearance(
             bottomSafeAreaInset: bottomSafeAreaInset
         )
+        let showsTabletHostSwitcher = !layout.isPhone && (
+            navigationState.compactSelectedTab == .sessions
+                ? navigationState.compactSessionPath.isEmpty
+                : navigationState.compactSelectedTab == .workspaces
+                    && navigationState.compactWorkspacePath.isEmpty
+        )
 
         return TabView(selection: compactTabBinding(layout: layout)) {
             NavigationStack(path: compactPathBinding(for: .sessions, layout: layout)) {
@@ -262,6 +268,14 @@ struct UnifiedWorkbenchShell: View {
             }
             .tag(CompactWorkbenchTab.me)
         }
+        .overlay(alignment: .topLeading) {
+            if showsTabletHostSwitcher {
+                compactTabletHostSwitcher(layout: layout, tokens: tokens)
+                    .padding(.leading, 10)
+                    // 顶部 Chrome 的内容线比 TabView overlay 原点高 8pt。
+                    .offset(y: -8)
+            }
+        }
         // 原生 Tab 保留系统交互；材质按系统版本交给 Chrome 层，页面只负责保持背景连续。
         .compactTabBarChrome(tokens: tokens, reduceTransparency: reduceTransparency)
         .environment(\.workbenchBottomChromeClearance, bottomChromeClearance)
@@ -270,6 +284,24 @@ struct UnifiedWorkbenchShell: View {
             tokens: tokens,
             colorScheme: themeStore.resolvedColorScheme(for: colorScheme)
         )
+    }
+
+    @ViewBuilder
+    private func compactTabletHostSwitcher(
+        layout: WorkbenchLayout,
+        tokens: ThemeTokens
+    ) -> some View {
+        let switcher = HostSwitcherMenu(
+            presentation: .toolbar,
+            manageConnections: { openConnectionSettings(layout: layout) }
+        )
+        .frame(width: 44, height: 44)
+
+        if #available(iOS 26.0, *), !reduceTransparency {
+            switcher.glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            switcher.workbenchChromeCircle(tokens: tokens)
+        }
     }
 
     private func splitLayout(
@@ -1010,7 +1042,7 @@ struct UnifiedWorkbenchShell: View {
         layout: WorkbenchLayout,
         bottomContentMargin: CGFloat? = nil
     ) -> some View {
-        let manageConnections: (() -> Void)? = layout.usesCompactNavigation
+        let manageConnections: (() -> Void)? = layout.usesCompactNavigation && layout.isPhone
             ? { openConnectionSettings(layout: layout) }
             : nil
 
@@ -1038,7 +1070,7 @@ struct UnifiedWorkbenchShell: View {
 
     private func workspaces(layout: WorkbenchLayout) -> some View {
         let manageConnections: (() -> Void)?
-        if layout.usesCompactNavigation {
+        if layout.usesCompactNavigation && layout.isPhone {
             manageConnections = {
                 openConnectionSettings(layout: layout)
             }

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -202,7 +202,7 @@ struct WorkbenchNavigationState: Equatable {
             switch commit.reason {
             case .invalidation:
                 guard route.detailSessionID != nil else { return nil }
-                applyRoot(route.rootPage, usesCompactNavigation: usesCompactNavigation)
+                applyRoot(route.rootPage)
                 restoreMeIfNeeded(
                     preservesMe,
                     usesCompactNavigation: usesCompactNavigation
@@ -348,9 +348,9 @@ struct WorkbenchNavigationState: Equatable {
     ) -> WorkbenchNavigationEffect? {
         switch destination {
         case .sessions:
-            applyRoot(.sessions, usesCompactNavigation: usesCompactNavigation)
+            applyRoot(.sessions)
         case .workspaces:
-            applyRoot(.workspaces, usesCompactNavigation: usesCompactNavigation)
+            applyRoot(.workspaces)
         case .me:
             selection = .me
             if usesCompactNavigation {
@@ -375,22 +375,19 @@ struct WorkbenchNavigationState: Equatable {
         return effectForUserNavigation(to: destination, selectedSessionID: selectedSessionID)
     }
 
-    private mutating func applyRoot(
-        _ page: WorkbenchRootPage,
-        usesCompactNavigation: Bool
-    ) {
+    private mutating func applyRoot(_ page: WorkbenchRootPage) {
         pendingSessionSelectionID = nil
         switch page {
         case .sessions:
             route = .sessions
             selection = .sessions
-            guard usesCompactNavigation else { return }
+            // 宽屏期间也要同步隐藏的紧凑 Tab。否则旋转后首帧会先显示旧 Tab，
+            // 再由布局回调纠正，导致 iPad 顶栏第一次落到单独一行。
             compactSelectedTab = .sessions
             compactSessionPath = []
         case .workspaces:
             route = .workspaces
             selection = .workspaces
-            guard usesCompactNavigation else { return }
             compactSelectedTab = .workspaces
             compactWorkspacePath = []
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -2880,6 +2880,20 @@ extension ConversationDataFlowTests {
         }
     }
 
+    func testWorkbenchNavigationPreparesCompactWorkspaceBeforeLayoutTransition() {
+        var state = WorkbenchNavigationState(route: .sessions)
+
+        _ = state.reduce(
+            .open(.workspaces, source: nil),
+            usesCompactNavigation: false,
+            selectedSessionID: nil
+        )
+
+        XCTAssertEqual(state.route, .workspaces)
+        XCTAssertEqual(state.compactSelectedTab, .workspaces)
+        XCTAssertTrue(state.compactWorkspacePath.isEmpty)
+    }
+
     func testWorkbenchNavigationRestoresSessionIntoItsSourceStack() {
         var state = WorkbenchNavigationState()
         let route = WorkbenchRestorationRoute.session(


### PR DESCRIPTION
## 变更

- iPad 紧凑布局下，会话区与工作区共用 Shell 顶部的设备入口。
- 宽屏期间同步紧凑导航状态，避免横屏切到竖屏时首次渲染旧的工作区布局。
- 保留 iPhone 现有页面级设备入口和宽屏侧栏行为。

## 验证

- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/ConversationDataFlowTests/testWorkbenchNavigationPreparesCompactWorkspaceBeforeLayoutTransition`：1 项通过。
- `bash ./scripts/check-source-size.sh`：通过。
- `git diff --check origin/main...HEAD`：通过。
- 实体 iPad mini 横屏切到竖屏回归：会话区与工作区设备按钮首次渲染即与 Tab 同行，位置一致。

Linear：https://linear.app/code89757/issue/MIM-117/统一会话区与工作区左上角设备入口位置