### PR TITLE
MIM-11 Restore host platform icon

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/HostSwitcherMenu.swift
@@ -36,8 +36,7 @@ struct HostSwitcherMenu: View {
                 hostStatusStore.refreshIfNeeded(appStore: appStore, sessionStore: sessionStore)
             })
             .task(id: platformRefreshTrigger) {
-                guard appStore.connectionProfiles.count > 1,
-                      appStore.connectionProfiles.contains(where: { $0.hostPlatform == .unknown }) else {
+                guard Self.needsPlatformRefresh(appStore.connectionProfiles) else {
                     return
                 }
                 hostStatusStore.refreshIfNeeded(appStore: appStore, sessionStore: sessionStore)
@@ -153,8 +152,8 @@ struct HostSwitcherMenu: View {
                 connectionText: isSwitching ? L10n.text("ui.connecting") : currentConnectionText
             )))
         case .toolbar:
-            // 顶栏只表达当前主机可切换；多设备时用服务端真实平台增强辨识度，
-            // 单设备和未知平台继续使用通用电脑，避免根据名称或地址猜测系统。
+            // 顶栏始终使用服务端真实平台增强辨识度；只有未知平台继续使用通用电脑，
+            // 避免根据名称或地址猜测系统。
             ZStack(alignment: .bottomTrailing) {
                 // 圆形按钮的触控范围保持不变，只放大品牌图形的光学占比。
                 HostPlatformGlyph(kind: currentHostIconKind, size: 22)
@@ -183,10 +182,15 @@ struct HostSwitcherMenu: View {
     }
 
     private var currentHostIconKind: HostPlatformIconKind {
-        guard appStore.connectionProfiles.count > 1 else {
-            return .genericComputer
-        }
-        return appStore.activeConnectionProfile?.hostPlatform.iconKind ?? .genericComputer
+        Self.iconKind(for: appStore.activeConnectionProfile)
+    }
+
+    static func iconKind(for profile: ConnectionProfile?) -> HostPlatformIconKind {
+        profile?.hostPlatform.iconKind ?? .genericComputer
+    }
+
+    static func needsPlatformRefresh(_ profiles: [ConnectionProfile]) -> Bool {
+        profiles.contains(where: { $0.hostPlatform == .unknown })
     }
 
     private var platformRefreshTrigger: String {
@@ -215,8 +219,7 @@ struct HostSwitcherMenu: View {
         connectionText: String
     ) -> String {
         var components = [profileName]
-        if appStore.connectionProfiles.count > 1,
-           let platformName = appStore.activeConnectionProfile?.hostPlatform.displayName {
+        if let platformName = appStore.activeConnectionProfile?.hostPlatform.displayName {
             components.append(platformName)
         }
         components.append(connectionText)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/HostStatusStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/HostStatusStoreTests.swift
@@ -8,6 +8,35 @@ final class HostStatusStoreTests: XCTestCase {
         super.tearDown()
     }
 
+    func testSingleProfileUsesKnownPlatformIconAndRefreshesUnknownPlatform() {
+        let knownProfile = ConnectionProfile(
+            id: "known",
+            displayName: "Mac",
+            endpoint: "http://127.0.0.1:8787",
+            lastSuccessfulAt: nil,
+            hostPlatform: .apple
+        )
+        let windowsProfile = ConnectionProfile(
+            id: "windows",
+            displayName: "Windows PC",
+            endpoint: "http://127.0.0.1:8787",
+            lastSuccessfulAt: nil,
+            hostPlatform: .windows
+        )
+        let unknownProfile = ConnectionProfile(
+            id: "unknown",
+            displayName: "Computer",
+            endpoint: "http://127.0.0.1:8787",
+            lastSuccessfulAt: nil
+        )
+
+        XCTAssertEqual(HostSwitcherMenu.iconKind(for: knownProfile), .apple)
+        XCTAssertEqual(HostSwitcherMenu.iconKind(for: windowsProfile), .windows11)
+        XCTAssertFalse(HostSwitcherMenu.needsPlatformRefresh([knownProfile]))
+        XCTAssertEqual(HostSwitcherMenu.iconKind(for: unknownProfile), .genericComputer)
+        XCTAssertTrue(HostSwitcherMenu.needsPlatformRefresh([unknownProfile]))
+    }
+
     func testProbeRequestsOnlyInactiveProfileAndReusesSuccessTTL() async throws {
         let fixture = try makeFixture(
             inactiveExpectedInstallationID: "installation-b",


### PR DESCRIPTION
## 变更

- 单设备场景也直接使用服务端返回的平台类型展示 Apple 或 Windows 图标。
- 平台未知时继续使用通用电脑图标，并触发状态刷新补全平台信息。
- 增加单设备已知、未知和 Windows 平台的回归覆盖。

## 验证

- `bash ./scripts/check-source-size.sh`：通过。
- `git diff --check origin/main...HEAD`：通过。
- 同一 MIM-11 改动此前已部署到实体 iPad mini，Apple 平台图标显示正确。
- 本次实体 iPad mini 当前处于已配对但离线状态，重新连接后的覆盖安装验证待补写。

Linear：MIM-11