### PR TITLE
MIM-10 Fix shared daemon iOS turn ownership

### DIFF
--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -585,13 +585,21 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 				terminalTurnID = entry.turnID
 			}
 			t.removeGatewayOwnedTurnClaim(entry.metaThreadID, terminalTurnID)
+			// evidence 先到时 entry.turnID 仍为空，不能让其他 Turn 的迟到 terminal
+			// 清除已经绑定 Turn 的新版 pending。旧格式没有 pending Turn ID，继续
+			// fail-closed；无 ID terminal 也按不确定边界清理。
+			terminalMatchesPendingTurn := turnID == "" ||
+				entry.gatewayTurnPendingTurnID == "" ||
+				turnID == entry.gatewayTurnPendingTurnID
 			// 旧 turn 的迟到 terminal 不能终止已经开始的新 turn。
 			if turnID == "" || entry.turnID == "" || turnID == entry.turnID {
 				entry.active = false
 				entry.turnID = ""
 				entry.turnStartedAt = time.Time{}
 				entry.gatewayOwned = false
-				clearGatewayTurnPending(entry)
+				if terminalMatchesPendingTurn {
+					clearGatewayTurnPending(entry)
+				}
 			}
 		}
 	}

--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -20,7 +20,7 @@ import (
 const (
 	externalActivityCandidateLimit = 500
 	maxExternalActivityLineBytes   = 1 << 20
-	// Gateway 登记只需要覆盖 turn/start 到 rollout 写入 user_message 的短窗口。
+	// Gateway 登记只需要覆盖 turn/start 到 rollout 写入用户消息证据的短窗口。
 	// 有界 TTL 可以避免断线或 upstream 写失败后留下永久“本机发起”证据。
 	gatewayTurnRegistrationTTL   = 2 * time.Minute
 	gatewayTurnRegistrationLimit = 512
@@ -73,12 +73,13 @@ type externalRolloutCacheEntry struct {
 	threadSource string
 	active       bool
 	turnID       string
-	// gatewayTurnPending 表示在 task_started 之前到达的 user_message 已与 gateway 登记匹配；
+	// gatewayTurnPending 表示在 task_started 之前到达的用户消息证据已与 gateway 登记匹配；
 	// gatewayOwned 绑定当前 active turn。真实 rollout 可能先写 task_started，也可能先写
-	// user_message，因此两个方向都要支持；新的 task_started 仍必须重新取证。
+	// 用户消息证据，因此两个方向都要支持；新的 task_started 仍必须重新取证。
 	gatewayTurnPending             bool
 	gatewayTurnPendingAt           time.Time
 	gatewayTurnPendingRegisteredAt time.Time
+	gatewayTurnPendingTurnID       string
 	gatewayOwned                   bool
 	turnStartedAt                  time.Time
 }
@@ -102,6 +103,10 @@ type externalRolloutRecord struct {
 		Type         string `json:"type"`
 		TurnID       string `json:"turn_id"`
 		ClientID     string `json:"client_id"`
+		Item         struct {
+			Type     string `json:"type"`
+			ClientID string `json:"client_id"`
+		} `json:"item"`
 	} `json:"payload"`
 }
 
@@ -178,7 +183,7 @@ func (t *ExternalActivityTracker) Diagnostics() ExternalActivityDiagnostics {
 
 // RegisterGatewayTurnStart 登记一个已经通过 agentd gateway 校验的 Codex turn/start。
 // 登记本身不会改变外部活动判断；只有同线程 rollout 随后写出时间相符且 client_id
-// 完全一致的 user_message，才能把紧随其后的 task_started 认定为 iPad 发起。
+// 完全一致的用户消息证据，才能把紧随其后的 task_started 认定为 iPad 发起。
 func (t *ExternalActivityTracker) RegisterGatewayTurnStart(threadID string, clientUserMessageID string) {
 	threadID = strings.TrimSpace(threadID)
 	clientUserMessageID = strings.TrimSpace(clientUserMessageID)
@@ -532,28 +537,15 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 		turnID := strings.TrimSpace(record.Payload.TurnID)
 		switch strings.TrimSpace(record.Payload.Type) {
 		case "user_message":
-			// rollout 的落盘顺序并不固定：当前版本通常先写 task_started，再写
-			// user_message；旧版本或边界窗口也可能相反。精确证据到达时，已有 active
-			// turn 就直接归属本机，否则留给紧随其后的 task_started 消费。
-			evidence, matched := t.consumeGatewayTurnRegistration(
-				entry.metaThreadID,
-				record.Payload.ClientID,
-				record.Timestamp,
-			)
-			clearGatewayTurnPending(entry)
-			if matched &&
-				entry.active &&
-				gatewayTurnEvidenceMatchesTaskStart(evidence, entry.turnStartedAt) {
-				entry.gatewayOwned = true
-				t.setGatewayOwnedTurnClaim(
-					entry.metaThreadID,
-					entry.turnID,
-					evidence.eventAt,
+			t.applyGatewayUserMessageEvidence(entry, record.Payload.ClientID, "", record.Timestamp)
+		case "item_completed":
+			if record.Payload.Item.Type == "UserMessage" && turnID != "" {
+				t.applyGatewayUserMessageEvidence(
+					entry,
+					record.Payload.Item.ClientID,
+					turnID,
+					record.Timestamp,
 				)
-			} else if matched && !entry.active {
-				entry.gatewayTurnPending = true
-				entry.gatewayTurnPendingAt = evidence.eventAt
-				entry.gatewayTurnPendingRegisteredAt = evidence.registeredAt
 			}
 		case "task_started":
 			turnStartedAt, _ := parseExternalRolloutTimestamp(record.Timestamp)
@@ -561,6 +553,7 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 			entry.turnID = turnID
 			entry.turnStartedAt = turnStartedAt
 			pendingOwned := entry.gatewayTurnPending &&
+				(entry.gatewayTurnPendingTurnID == "" || entry.gatewayTurnPendingTurnID == turnID) &&
 				gatewayTurnEvidenceMatchesTaskStart(
 					gatewayTurnEvidence{
 						registeredAt: entry.gatewayTurnPendingRegisteredAt,
@@ -604,10 +597,44 @@ func (t *ExternalActivityTracker) applyExternalRolloutLine(entry *externalRollou
 	}
 }
 
+func (t *ExternalActivityTracker) applyGatewayUserMessageEvidence(
+	entry *externalRolloutCacheEntry,
+	clientUserMessageID string,
+	evidenceTurnID string,
+	rawTimestamp string,
+) {
+	// rollout 的落盘顺序并不固定：当前版本通常先写 task_started，再写用户消息证据；
+	// 旧版本或边界窗口也可能相反。当前格式携带 turn_id，必须与 active 或紧随其后的
+	// task_started 精确一致，避免迟到的旧 iOS 消息误认领新的 Desktop turn。
+	evidence, matched := t.consumeGatewayTurnRegistration(
+		entry.metaThreadID,
+		clientUserMessageID,
+		rawTimestamp,
+	)
+	clearGatewayTurnPending(entry)
+	if matched &&
+		entry.active &&
+		(evidenceTurnID == "" || evidenceTurnID == entry.turnID) &&
+		gatewayTurnEvidenceMatchesTaskStart(evidence, entry.turnStartedAt) {
+		entry.gatewayOwned = true
+		t.setGatewayOwnedTurnClaim(
+			entry.metaThreadID,
+			entry.turnID,
+			evidence.eventAt,
+		)
+	} else if matched && !entry.active {
+		entry.gatewayTurnPending = true
+		entry.gatewayTurnPendingAt = evidence.eventAt
+		entry.gatewayTurnPendingRegisteredAt = evidence.registeredAt
+		entry.gatewayTurnPendingTurnID = evidenceTurnID
+	}
+}
+
 func clearGatewayTurnPending(entry *externalRolloutCacheEntry) {
 	entry.gatewayTurnPending = false
 	entry.gatewayTurnPendingAt = time.Time{}
 	entry.gatewayTurnPendingRegisteredAt = time.Time{}
+	entry.gatewayTurnPendingTurnID = ""
 }
 
 func expireGatewayTurnPending(entry *externalRolloutCacheEntry, now time.Time) bool {

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -356,6 +356,245 @@ func TestExternalActivityAlsoSupportsUserMessageBeforeTaskStarted(t *testing.T) 
 	}
 }
 
+func TestExternalActivitySupportsCurrentItemCompletedUserMessageFormat(t *testing.T) {
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		lines func(time.Time) []string
+	}{
+		{
+			name: "task_started before item_completed",
+			lines: func(now time.Time) []string {
+				return []string{
+					externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-ipad"),
+					externalItemCompletedUserMessageLine(
+						now.Add(time.Second),
+						"thread-ipad",
+						"turn-ipad",
+						"client-ipad",
+					),
+				}
+			},
+		},
+		{
+			name: "item_completed before task_started",
+			lines: func(now time.Time) []string {
+				return []string{
+					externalItemCompletedUserMessageLine(
+						now.Add(100*time.Millisecond),
+						"thread-ipad",
+						"turn-ipad",
+						"client-ipad",
+					),
+					externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-ipad"),
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newExternalActivityTrackerFixture(t)
+			fixture.tracker.now = func() time.Time { return now }
+			fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
+			path := fixture.writeRollout("thread-ipad", "Codex Desktop", fixture.projectDir, tc.lines(now)...)
+			if err := os.Chtimes(path, now, now); err != nil {
+				t.Fatal(err)
+			}
+			fixture.rows = []externalActivityTestRow{{
+				ID: "thread-ipad", CWD: fixture.projectDir, Source: "vscode",
+				ThreadSource: "user", RolloutPath: path,
+			}}
+
+			if got := fixture.snapshot(t); len(got) != 0 {
+				t.Fatalf("当前 item_completed/UserMessage 格式不应被识别为 Desktop external：%+v", got)
+			}
+			entry := fixture.tracker.files[path]
+			if !entry.active || !entry.gatewayOwned || entry.turnID != "turn-ipad" {
+				t.Fatalf("当前格式应复用 gateway 归属和 task_started 顺序逻辑：%+v", entry)
+			}
+		})
+	}
+}
+
+func TestExternalActivityIgnoresNonUserMessageItemCompleted(t *testing.T) {
+	itemTypes := []string{"AgentMessage", "user_message", " UserMessage "}
+	for _, itemType := range itemTypes {
+		t.Run(itemType, func(t *testing.T) {
+			fixture := newExternalActivityTrackerFixture(t)
+			now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+			fixture.tracker.now = func() time.Time { return now }
+			fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+			path := fixture.writeRollout(
+				"thread-1",
+				"Codex Desktop",
+				fixture.projectDir,
+				externalItemCompletedLine(
+					now.Add(100*time.Millisecond),
+					"thread-1",
+					"turn-desktop",
+					itemType,
+					"client-ipad",
+				),
+				externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-desktop"),
+			)
+			if err := os.Chtimes(path, now, now); err != nil {
+				t.Fatal(err)
+			}
+			fixture.rows = []externalActivityTestRow{{
+				ID: "thread-1", CWD: fixture.projectDir, Source: "vscode",
+				ThreadSource: "user", RolloutPath: path,
+			}}
+
+			got := fixture.snapshot(t)
+			if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+				t.Fatalf("非精确 UserMessage item 不得隐藏 Desktop turn：%+v", got)
+			}
+			entry := fixture.tracker.files[path]
+			if entry.gatewayOwned || entry.gatewayTurnPending {
+				t.Fatalf("非 UserMessage item 不得产生 gateway ownership：%+v", entry)
+			}
+		})
+	}
+}
+
+func TestExternalActivityCurrentUserMessageRequiresExactClientID(t *testing.T) {
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		eventClient string
+	}{
+		{name: "wrong client id", eventClient: "client-desktop"},
+		{name: "missing client id", eventClient: ""},
+		{name: "whitespace client id", eventClient: "   "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newExternalActivityTrackerFixture(t)
+			fixture.tracker.now = func() time.Time { return now }
+			fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+			path := fixture.writeRollout(
+				"thread-1",
+				"Codex Desktop",
+				fixture.projectDir,
+				externalItemCompletedUserMessageLine(
+					now.Add(100*time.Millisecond),
+					"thread-1",
+					"turn-desktop",
+					tc.eventClient,
+				),
+				externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-desktop"),
+			)
+			if err := os.Chtimes(path, now, now); err != nil {
+				t.Fatal(err)
+			}
+			fixture.rows = []externalActivityTestRow{{
+				ID: "thread-1", CWD: fixture.projectDir, Source: "vscode",
+				ThreadSource: "user", RolloutPath: path,
+			}}
+
+			got := fixture.snapshot(t)
+			if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+				t.Fatalf("空或错误 client_id 必须 fail-closed 保留 Desktop external：%+v", got)
+			}
+			entry := fixture.tracker.files[path]
+			if entry.gatewayOwned || entry.gatewayTurnPending {
+				t.Fatalf("空或错误 client_id 不得产生 gateway ownership：%+v", entry)
+			}
+		})
+	}
+}
+
+func TestExternalActivityCurrentUserMessageRequiresExactTurnID(t *testing.T) {
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		lines []string
+	}{
+		{
+			name: "pending evidence cannot claim different started turn",
+			lines: []string{
+				externalItemCompletedUserMessageLine(
+					now.Add(100*time.Millisecond),
+					"thread-1",
+					"turn-ipad",
+					"client-ipad",
+				),
+				externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-desktop"),
+			},
+		},
+		{
+			name: "late evidence cannot claim superseding desktop turn",
+			lines: []string{
+				externalEventLineAt(now.Add(100*time.Millisecond), "task_started", "turn-ipad"),
+				externalEventLineAt(now.Add(200*time.Millisecond), "task_complete", "turn-ipad"),
+				externalEventLineAt(now.Add(300*time.Millisecond), "task_started", "turn-desktop"),
+				externalItemCompletedUserMessageLine(
+					now.Add(500*time.Millisecond),
+					"thread-1",
+					"turn-ipad",
+					"client-ipad",
+				),
+			},
+		},
+		{
+			name: "terminal clears pending evidence before desktop turn",
+			lines: []string{
+				externalItemCompletedUserMessageLine(
+					now.Add(100*time.Millisecond),
+					"thread-1",
+					"turn-ipad",
+					"client-ipad",
+				),
+				externalEventLineAt(now.Add(200*time.Millisecond), "task_complete", "turn-ipad"),
+				externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-desktop"),
+			},
+		},
+		{
+			name: "missing turn id fails closed",
+			lines: []string{
+				externalItemCompletedUserMessageLine(
+					now.Add(100*time.Millisecond),
+					"thread-1",
+					"",
+					"client-ipad",
+				),
+				externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-desktop"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newExternalActivityTrackerFixture(t)
+			fixture.tracker.now = func() time.Time { return now }
+			fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+			path := fixture.writeRollout(
+				"thread-1",
+				"Codex Desktop",
+				fixture.projectDir,
+				tc.lines...,
+			)
+			if err := os.Chtimes(path, now, now); err != nil {
+				t.Fatal(err)
+			}
+			fixture.rows = []externalActivityTestRow{{
+				ID: "thread-1", CWD: fixture.projectDir, Source: "vscode",
+				ThreadSource: "user", RolloutPath: path,
+			}}
+
+			got := fixture.snapshot(t)
+			if len(got) != 1 || got[0].TurnID != "turn-desktop" {
+				t.Fatalf("不匹配或缺失 turn_id 必须 fail-closed 保留 Desktop external：%+v", got)
+			}
+			entry := fixture.tracker.files[path]
+			if !entry.active || entry.turnID != "turn-desktop" ||
+				entry.gatewayOwned || entry.gatewayTurnPending {
+				t.Fatalf("Desktop turn 不得吸收其他 turn 的 ownership 证据：%+v", entry)
+			}
+		})
+	}
+}
+
 func TestExternalActivityExpiredPendingEvidenceCannotHideLaterDesktopTurn(t *testing.T) {
 	fixture := newExternalActivityTrackerFixture(t)
 	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
@@ -986,6 +1225,39 @@ func externalUserMessageLine(timestamp time.Time, clientID string) string {
 	payload := map[string]any{"type": "user_message"}
 	if strings.TrimSpace(clientID) != "" {
 		payload["client_id"] = clientID
+	}
+	record := map[string]any{
+		"timestamp": timestamp.UTC().Format(time.RFC3339Nano),
+		"type":      "event_msg",
+		"payload":   payload,
+	}
+	data, _ := json.Marshal(record)
+	return string(data)
+}
+
+func externalItemCompletedUserMessageLine(
+	timestamp time.Time,
+	threadID string,
+	turnID string,
+	clientID string,
+) string {
+	return externalItemCompletedLine(timestamp, threadID, turnID, "UserMessage", clientID)
+}
+
+func externalItemCompletedLine(timestamp time.Time, threadID, turnID, itemType, clientID string) string {
+	item := map[string]any{"type": itemType}
+	if clientID != "" {
+		item["client_id"] = clientID
+	}
+	payload := map[string]any{
+		"type": "item_completed",
+		"item": item,
+	}
+	if threadID != "" {
+		payload["thread_id"] = threadID
+	}
+	if turnID != "" {
+		payload["turn_id"] = turnID
 	}
 	record := map[string]any{
 		"timestamp": timestamp.UTC().Format(time.RFC3339Nano),

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -550,6 +550,19 @@ func TestExternalActivityCurrentUserMessageRequiresExactTurnID(t *testing.T) {
 			},
 		},
 		{
+			name: "idless terminal clears pending evidence before desktop turn",
+			lines: []string{
+				externalItemCompletedUserMessageLine(
+					now.Add(100*time.Millisecond),
+					"thread-1",
+					"turn-ipad",
+					"client-ipad",
+				),
+				externalEventLineAt(now.Add(200*time.Millisecond), "task_complete", ""),
+				externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-desktop"),
+			},
+		},
+		{
 			name: "missing turn id fails closed",
 			lines: []string{
 				externalItemCompletedUserMessageLine(
@@ -592,6 +605,41 @@ func TestExternalActivityCurrentUserMessageRequiresExactTurnID(t *testing.T) {
 				t.Fatalf("Desktop turn 不得吸收其他 turn 的 ownership 证据：%+v", entry)
 			}
 		})
+	}
+}
+
+func TestExternalActivityCurrentPendingSurvivesUnrelatedTerminal(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-1", "client-ipad")
+	path := fixture.writeRollout(
+		"thread-1",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalItemCompletedUserMessageLine(
+			now.Add(100*time.Millisecond),
+			"thread-1",
+			"turn-ipad",
+			"client-ipad",
+		),
+		externalEventLineAt(now.Add(200*time.Millisecond), "task_complete", "turn-older"),
+		externalEventLineAt(now.Add(500*time.Millisecond), "task_started", "turn-ipad"),
+	)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-1", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("其他 Turn 的迟到 terminal 不应清除当前 pending ownership：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if !entry.active || entry.turnID != "turn-ipad" || !entry.gatewayOwned || entry.gatewayTurnPending {
+		t.Fatalf("pending ownership 应由匹配的 task_started 消费：%+v", entry)
 	}
 }
 


### PR DESCRIPTION
## 目标

修复共享 daemon 模式下，iOS 发起的 Turn 被误判为 Codex Desktop 占用，导致引导消息和审批响应被拒绝的问题。

## 实现

- 解析新版 rollout `item_completed` / `UserMessage` 的嵌套 `client_id`
- 用 `turn_id` 精确绑定 iOS ownership，拒绝过期或错配事件认领新 Turn
- 保留旧 `user_message` rollout 兼容路径
- 保持 Desktop ownership 不可确认时的 fail-closed 保护
- 补充事件乱序、错配 Turn、缺失字段和终态清理回归测试

## 验证

- `go test ./internal/codexhistory -count=1`
- `go test ./internal/httpapi -run 'TestAppServerGateway(RegistersOnlyValidatedCodexTurnStarts|RejectsWritesWhileCodexDesktopTurnIsActive|SharedModeFailsClosedWhenDesktopActivityIsUnavailable|RejectsReverseResponseWhileCodexDesktopTurnIsActive|AllowsOwnedReverseResponseAfterClaimTTLReclassification|OwnedReverseResponseStillRejectsDifferentDesktopTurn)$' -count=1`
- `gofmt -d internal/codexhistory/external_activity.go internal/codexhistory/external_activity_test.go`
- `git diff --check`
- `bash ./scripts/check-source-size.sh`

## 未验证

尚未在部署后的真实共享 daemon 环境复现移动端引导发送和审批响应。

Linear: https://linear.app/code89757/issue/MIM-10