### PR TITLE
MIM-179 Fix Windows Claude session startup

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/pool/process.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/process.rs
@@ -184,6 +184,10 @@ pub struct ClaudeProcessHandle {
     /// can diff and skip no-op writes (avoids burning a request RTT per turn
     /// when nothing changes).
     runtime_state: Arc<Mutex<RuntimeState>>,
+    /// Serializes the read → control request → cache write transaction for
+    /// per-turn runtime overrides. The active-turn guard is registered later,
+    /// so concurrent turn/start calls can otherwise race in this window.
+    runtime_override_gate: Arc<Mutex<()>>,
     /// Background tasks. Held so they keep running for the handle's lifetime
     /// and abort cleanly on drop.
     _tasks: Arc<TaskSet>,
@@ -395,6 +399,7 @@ impl ClaudeProcessHandle {
             init_slot,
             pending_controls,
             runtime_state,
+            runtime_override_gate: Arc::new(Mutex::new(())),
             _tasks: tasks,
         })
     }
@@ -567,9 +572,10 @@ impl ClaudeProcessHandle {
     /// `Some(_)` means "ensure claude is running with this value" (dispatch
     /// only if it differs from the cached state).
     ///
-    /// On any setter failure the runtime cache is NOT updated, so a retry
-    /// will re-attempt rather than silently ignore the override. Errors are
-    /// returned as-is from `request_control`.
+    /// On setter failure the runtime cache is not updated. Explicit effort
+    /// rejection degrades only that turn; only a method-level unsupported
+    /// response disables future effort requests for this process. Transport,
+    /// timeout, and process-exit failures remain fatal.
     pub async fn apply_runtime_overrides(
         &self,
         model: Option<&str>,
@@ -577,6 +583,7 @@ impl ClaudeProcessHandle {
         permission_mode: Option<&str>,
         deadline: Duration,
     ) -> Result<(), ClaudeProcessError> {
+        let _runtime_override_guard = self.runtime_override_gate.lock().await;
         if let Some(want) = model {
             let need_dispatch = {
                 let guard = self.runtime_state.lock().await;
@@ -619,13 +626,17 @@ impl ClaudeProcessHandle {
                         guard.effort_level = Some(want.to_string());
                     }
                     Err(source @ ClaudeProcessError::ControlError { .. }) => {
+                        let globally_unsupported = effort_control_is_globally_unsupported(&source);
                         tracing::warn!(
                             error = %source,
                             effort_level = want,
-                            "claude runtime does not support effortLevel; continuing with its default"
+                            globally_unsupported,
+                            "claude runtime rejected effortLevel; continuing with its default"
                         );
-                        let mut guard = self.runtime_state.lock().await;
-                        guard.effort_level_unsupported = true;
+                        if globally_unsupported {
+                            let mut guard = self.runtime_state.lock().await;
+                            guard.effort_level_unsupported = true;
+                        }
                     }
                     Err(source) => {
                         return Err(ClaudeProcessError::RuntimeOverride {
@@ -706,6 +717,7 @@ fn apply_platform_security_args(args: &mut Vec<OsString>) {
         // tool while retaining stdio permission prompts for built-in tools.
         args.push("--disallowedTools".into());
         args.push("Bash".into());
+        args.push("PowerShell".into());
         return;
     }
     // Use a temporary override so the bridge never edits project or user
@@ -723,6 +735,62 @@ fn apply_platform_security_args(args: &mut Vec<OsString>) {
         .to_string()
         .into(),
     );
+}
+
+fn effort_control_is_globally_unsupported(error: &ClaudeProcessError) -> bool {
+    let ClaudeProcessError::ControlError { message, .. } = error else {
+        return false;
+    };
+    let normalized = message.to_ascii_lowercase();
+    let names_method =
+        normalized.contains("apply_flag_settings") || normalized.contains("apply flag settings");
+    names_method
+        && [
+            "unknown control request",
+            "unsupported control request",
+            "method not found",
+            "not implemented",
+        ]
+        .iter()
+        .any(|marker| normalized.contains(marker))
+}
+
+fn redact_url_userinfo(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    let mut copied_through = 0;
+    let mut search_from = 0;
+    while let Some(relative_scheme_end) = value[search_from..].find("://") {
+        let scheme_end = search_from + relative_scheme_end;
+        let scheme_start = value[..scheme_end]
+            .rfind(|character: char| {
+                !character.is_ascii_alphanumeric() && !matches!(character, '+' | '-' | '.')
+            })
+            .map_or(0, |index| index + 1);
+        let scheme = &value[scheme_start..scheme_end];
+        let authority_start = scheme_end + 3;
+        if scheme.is_empty() || !scheme.as_bytes()[0].is_ascii_alphabetic() {
+            search_from = authority_start;
+            continue;
+        }
+        if authority_start >= value.len() {
+            break;
+        }
+        let authority_end = value[authority_start..]
+            .find(|character: char| {
+                character.is_whitespace() || matches!(character, '/' | '?' | '#')
+            })
+            .map_or(value.len(), |offset| authority_start + offset);
+        let authority = &value[authority_start..authority_end];
+        if let Some(userinfo_end) = authority.rfind('@') {
+            result.push_str(&value[copied_through..authority_start]);
+            result.push_str("<redacted>@");
+            result.push_str(&authority[userinfo_end + 1..]);
+            copied_through = authority_end;
+        }
+        search_from = authority_end.max(authority_start + 1).min(value.len());
+    }
+    result.push_str(&value[copied_through..]);
+    result
 }
 
 impl alleycat_bridge_core::pool::PoolMember for ClaudeProcessHandle {
@@ -810,7 +878,8 @@ async fn reader_task(
                 let _ = events_tx.send(event);
             }
             Err(err) => {
-                tracing::warn!(?err, line = %trimmed, "claude reader task: failed to parse line");
+                let line = redact_url_userinfo(trimmed);
+                tracing::warn!(?err, line = %line, "claude reader task: failed to parse line");
             }
         }
     }
@@ -829,6 +898,7 @@ async fn stderr_task(stderr: ChildStderr, pid: Option<u32>) {
         // Claude prints diagnostic chatter to stderr; surface it through
         // tracing so debug builds get it without polluting the codex
         // JSON-RPC channel.
+        let line = redact_url_userinfo(&line);
         tracing::debug!(?pid, "claude stderr: {line}");
     }
 }
@@ -856,6 +926,7 @@ impl ClaudeProcessHandle {
             init_slot: Arc::new(InitSlot::default()),
             pending_controls: Arc::new(Mutex::new(HashMap::new())),
             runtime_state: Arc::new(Mutex::new(RuntimeState::default())),
+            runtime_override_gate: Arc::new(Mutex::new(())),
             _tasks: Arc::new(TaskSet {
                 writer: Mutex::new(None),
                 reader: Mutex::new(None),
@@ -889,13 +960,27 @@ mod tests {
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect();
         if cfg!(windows) {
-            assert_eq!(args, ["--disallowedTools", "Bash"]);
+            assert_eq!(args, ["--disallowedTools", "Bash", "PowerShell"]);
         } else {
             assert_eq!(args.first().map(String::as_str), Some("--settings"));
             assert!(
                 args.get(1)
                     .is_some_and(|settings| { settings.contains(r#""failIfUnavailable":true"#) })
             );
+        }
+    }
+
+    #[test]
+    fn child_diagnostics_redact_url_userinfo() {
+        let diagnostic = redact_url_userinfo(
+            "connect http://alice:hunter%402@proxy.example:8080 via socks5://bob:secret@proxy:1080",
+        );
+        assert_eq!(
+            diagnostic,
+            "connect http://<redacted>@proxy.example:8080 via socks5://<redacted>@proxy:1080"
+        );
+        for secret in ["alice", "hunter%402", "bob", "secret"] {
+            assert!(!diagnostic.contains(secret));
         }
     }
 
@@ -1216,6 +1301,124 @@ mod tests {
             .await
             .expect("unsupported effort remains a no-op");
         assert!(writer_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn value_specific_effort_rejection_does_not_disable_future_effort() {
+        let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<String>();
+        let (events_tx, _events_rx) = broadcast::channel(8);
+        let handle = Arc::new(ClaudeProcessHandle::__test_dangling(
+            writer_tx,
+            events_tx,
+            PathBuf::from("/tmp"),
+        ));
+        let pending = handle.pending_controls_handle();
+
+        let first_handle = Arc::clone(&handle);
+        let first = tokio::spawn(async move {
+            first_handle
+                .apply_runtime_overrides(None, Some("max"), None, Duration::from_secs(2))
+                .await
+        });
+        let first_line = writer_rx.recv().await.expect("first effort line");
+        let first_request: serde_json::Value = serde_json::from_str(&first_line).expect("json");
+        let first_id = first_request["request_id"].as_str().unwrap().to_string();
+        pending
+            .lock()
+            .await
+            .remove(&first_id)
+            .unwrap()
+            .send(ControlResponseBody::Error {
+                error: "effort max is not available for the current model".into(),
+            })
+            .unwrap();
+        first
+            .await
+            .expect("join")
+            .expect("value rejection falls back");
+
+        let second_handle = Arc::clone(&handle);
+        let second = tokio::spawn(async move {
+            second_handle
+                .apply_runtime_overrides(None, Some("medium"), None, Duration::from_secs(2))
+                .await
+        });
+        let second_line = writer_rx.recv().await.expect("second effort line");
+        let second_request: serde_json::Value = serde_json::from_str(&second_line).expect("json");
+        assert_eq!(
+            second_request["request"]["settings"]["effortLevel"],
+            "medium"
+        );
+        let second_id = second_request["request_id"].as_str().unwrap().to_string();
+        pending
+            .lock()
+            .await
+            .remove(&second_id)
+            .unwrap()
+            .send(ControlResponseBody::Success { response: None })
+            .unwrap();
+        second
+            .await
+            .expect("join")
+            .expect("supported effort retries");
+        assert_eq!(handle.runtime_snapshot().await.1.as_deref(), Some("medium"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_runtime_overrides_are_serialized() {
+        let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<String>();
+        let (events_tx, _events_rx) = broadcast::channel(8);
+        let handle = Arc::new(ClaudeProcessHandle::__test_dangling(
+            writer_tx,
+            events_tx,
+            PathBuf::from("/tmp"),
+        ));
+        let pending = handle.pending_controls_handle();
+
+        let first_handle = Arc::clone(&handle);
+        let first = tokio::spawn(async move {
+            first_handle
+                .apply_runtime_overrides(None, Some("medium"), None, Duration::from_secs(2))
+                .await
+        });
+        let first_line = writer_rx.recv().await.expect("first effort line");
+        let first_request: serde_json::Value = serde_json::from_str(&first_line).expect("json");
+
+        let second_handle = Arc::clone(&handle);
+        let second = tokio::spawn(async move {
+            second_handle
+                .apply_runtime_overrides(None, Some("high"), None, Duration::from_secs(2))
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            writer_rx.try_recv().is_err(),
+            "second override must wait until the first cache transaction completes"
+        );
+
+        let first_id = first_request["request_id"].as_str().unwrap().to_string();
+        pending
+            .lock()
+            .await
+            .remove(&first_id)
+            .unwrap()
+            .send(ControlResponseBody::Success { response: None })
+            .unwrap();
+        first.await.expect("first join").expect("first override");
+
+        let second_line = writer_rx.recv().await.expect("second effort line");
+        let second_request: serde_json::Value = serde_json::from_str(&second_line).expect("json");
+        assert_eq!(second_request["request"]["settings"]["effortLevel"], "high");
+        let second_id = second_request["request_id"].as_str().unwrap().to_string();
+        pending
+            .lock()
+            .await
+            .remove(&second_id)
+            .unwrap()
+            .send(ControlResponseBody::Success { response: None })
+            .unwrap();
+        second.await.expect("second join").expect("second override");
+        assert_eq!(handle.runtime_snapshot().await.1.as_deref(), Some("high"));
     }
 
     #[tokio::test]

--- a/bridges/claude/crates/claude-bridge/src/pool/process.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/process.rs
@@ -209,6 +209,7 @@ struct InitSlot {
 struct RuntimeState {
     model: Option<String>,
     effort_level: Option<String>,
+    effort_level_unsupported: bool,
     permission_mode: Option<String>,
 }
 
@@ -283,21 +284,7 @@ impl ClaudeProcessHandle {
         args.push("stream-json".into());
         args.push("--include-partial-messages".into());
         args.push("--verbose".into());
-        // 通过临时 JSON 覆盖启用 Claude 官方 Bash 沙箱；不改写项目或用户 settings。
-        // 沙箱不可用时直接失败，绝不回退到未隔离命令。
-        args.push("--settings".into());
-        args.push(
-            serde_json::json!({
-                "sandbox": {
-                    "enabled": true,
-                    "failIfUnavailable": true,
-                    "allowUnsandboxedCommands": false,
-                    "autoAllowBashIfSandboxed": false
-                }
-            })
-            .to_string()
-            .into(),
-        );
+        apply_platform_security_args(&mut args);
         if bypass_permissions {
             args.push("--dangerously-skip-permissions".into());
         } else {
@@ -376,6 +363,7 @@ impl ClaudeProcessHandle {
         let runtime_state = Arc::new(Mutex::new(RuntimeState {
             model: model.clone(),
             effort_level: None,
+            effort_level_unsupported: false,
             permission_mode: None,
         }));
 
@@ -614,23 +602,39 @@ impl ClaudeProcessHandle {
         if let Some(want) = effort_level {
             let need_dispatch = {
                 let guard = self.runtime_state.lock().await;
-                guard.effort_level.as_deref() != Some(want)
+                !guard.effort_level_unsupported && guard.effort_level.as_deref() != Some(want)
             };
             if need_dispatch {
-                self.request_control(
-                    ControlRequestBody::ApplyFlagSettings {
-                        settings: serde_json::json!({"effortLevel": want}),
-                    },
-                    deadline,
-                )
-                .await
-                .map_err(|source| ClaudeProcessError::RuntimeOverride {
-                    field: "effortLevel",
-                    value: want.to_string(),
-                    source: Box::new(source),
-                })?;
-                let mut guard = self.runtime_state.lock().await;
-                guard.effort_level = Some(want.to_string());
+                let result = self
+                    .request_control(
+                        ControlRequestBody::ApplyFlagSettings {
+                            settings: serde_json::json!({"effortLevel": want}),
+                        },
+                        deadline,
+                    )
+                    .await;
+                match result {
+                    Ok(_) => {
+                        let mut guard = self.runtime_state.lock().await;
+                        guard.effort_level = Some(want.to_string());
+                    }
+                    Err(source @ ClaudeProcessError::ControlError { .. }) => {
+                        tracing::warn!(
+                            error = %source,
+                            effort_level = want,
+                            "claude runtime does not support effortLevel; continuing with its default"
+                        );
+                        let mut guard = self.runtime_state.lock().await;
+                        guard.effort_level_unsupported = true;
+                    }
+                    Err(source) => {
+                        return Err(ClaudeProcessError::RuntimeOverride {
+                            field: "effortLevel",
+                            value: want.to_string(),
+                            source: Box::new(source),
+                        });
+                    }
+                }
             }
         }
         if let Some(want) = permission_mode {
@@ -693,6 +697,32 @@ impl ClaudeProcessHandle {
             handle.abort();
         }
     }
+}
+
+fn apply_platform_security_args(args: &mut Vec<OsString>) {
+    if cfg!(windows) {
+        // Claude Code does not support its Bash sandbox on native Windows.
+        // Do not silently run a shell outside the sandbox: disable the shell
+        // tool while retaining stdio permission prompts for built-in tools.
+        args.push("--disallowedTools".into());
+        args.push("Bash".into());
+        return;
+    }
+    // Use a temporary override so the bridge never edits project or user
+    // settings. If the platform sandbox is unavailable, fail closed.
+    args.push("--settings".into());
+    args.push(
+        serde_json::json!({
+            "sandbox": {
+                "enabled": true,
+                "failIfUnavailable": true,
+                "allowUnsandboxedCommands": false,
+                "autoAllowBashIfSandboxed": false
+            }
+        })
+        .to_string()
+        .into(),
+    );
 }
 
 impl alleycat_bridge_core::pool::PoolMember for ClaudeProcessHandle {
@@ -849,6 +879,25 @@ impl ClaudeProcessHandle {
 mod tests {
     use super::*;
     use crate::pool::claude_protocol::SystemInit;
+
+    #[test]
+    fn platform_security_never_runs_an_unsandboxed_windows_shell() {
+        let mut args = Vec::new();
+        apply_platform_security_args(&mut args);
+        let args: Vec<String> = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        if cfg!(windows) {
+            assert_eq!(args, ["--disallowedTools", "Bash"]);
+        } else {
+            assert_eq!(args.first().map(String::as_str), Some("--settings"));
+            assert!(
+                args.get(1)
+                    .is_some_and(|settings| { settings.contains(r#""failIfUnavailable":true"#) })
+            );
+        }
+    }
 
     #[tokio::test]
     async fn wait_for_init_returns_immediately_when_already_set() {
@@ -1108,6 +1157,64 @@ mod tests {
             .apply_runtime_overrides(None, Some("xhigh"), None, Duration::from_millis(50))
             .await
             .expect("duplicate is a no-op");
+        assert!(writer_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn unsupported_effort_falls_back_and_other_overrides_continue() {
+        let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<String>();
+        let (events_tx, _events_rx) = broadcast::channel(8);
+        let handle = Arc::new(ClaudeProcessHandle::__test_dangling(
+            writer_tx,
+            events_tx,
+            PathBuf::from("/tmp"),
+        ));
+        let pending = handle.pending_controls_handle();
+        let h2 = Arc::clone(&handle);
+        let task = tokio::spawn(async move {
+            h2.apply_runtime_overrides(
+                None,
+                Some("medium"),
+                Some("default"),
+                Duration::from_secs(2),
+            )
+            .await
+        });
+
+        let effort_line = writer_rx.recv().await.expect("effort writer line");
+        let effort: serde_json::Value = serde_json::from_str(&effort_line).expect("json");
+        let request_id = effort["request_id"].as_str().unwrap().to_string();
+        pending
+            .lock()
+            .await
+            .remove(&request_id)
+            .unwrap()
+            .send(ControlResponseBody::Error {
+                error: "unknown control request apply_flag_settings".into(),
+            })
+            .unwrap();
+
+        let permission_line = writer_rx.recv().await.expect("permission writer line");
+        let permission: serde_json::Value = serde_json::from_str(&permission_line).expect("json");
+        assert_eq!(permission["request"]["subtype"], "set_permission_mode");
+        let request_id = permission["request_id"].as_str().unwrap().to_string();
+        pending
+            .lock()
+            .await
+            .remove(&request_id)
+            .unwrap()
+            .send(ControlResponseBody::Success { response: None })
+            .unwrap();
+
+        task.await.expect("join").expect("fallback succeeds");
+        assert_eq!(
+            handle.runtime_snapshot().await,
+            (None, None, Some("default".into()))
+        );
+        handle
+            .apply_runtime_overrides(None, Some("xhigh"), None, Duration::from_millis(50))
+            .await
+            .expect("unsupported effort remains a no-op");
         assert!(writer_rx.try_recv().is_err());
     }
 

--- a/internal/claudeenv/environment.go
+++ b/internal/claudeenv/environment.go
@@ -1,0 +1,207 @@
+package claudeenv
+
+import (
+	"net/url"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+const bypassPermissionsKey = "CLAUDE_BRIDGE_BYPASS_PERMISSIONS"
+
+type environmentValue struct {
+	key   string
+	value string
+}
+
+var inheritedKeys = []string{
+	"HOME", "PATH", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "TERM",
+	"USERPROFILE", "HOMEDRIVE", "HOMEPATH", "APPDATA", "LOCALAPPDATA",
+	"TEMP", "TMP", "SYSTEMROOT", "COMSPEC", "PATHEXT", "PROGRAMDATA",
+	"NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR", "CLAUDE_CODE_CERT_STORE",
+}
+
+var proxyAliases = [][]string{
+	{"https_proxy", "HTTPS_PROXY"},
+	{"http_proxy", "HTTP_PROXY"},
+	{"all_proxy", "ALL_PROXY"},
+	{"no_proxy", "NO_PROXY"},
+}
+
+// Build returns the deterministic, restricted environment shared by setup
+// probes, the resident bridge, and the Claude child inherited from that bridge.
+// Configured values override inherited values. Proxy aliases follow Claude's
+// documented lowercase-before-uppercase preference on every platform.
+func Build(extra map[string]string) []string {
+	processEnvironment := parseEnvironment(os.Environ())
+	values := map[string]environmentValue{}
+	for _, key := range inheritedKeys {
+		if value, ok := lookupEnvironment(processEnvironment, key); ok && value != "" {
+			values[environmentKey(key)] = environmentValue{key: key, value: value}
+		}
+	}
+
+	extraKeys := make([]string, 0, len(extra))
+	for key := range extra {
+		extraKeys = append(extraKeys, key)
+	}
+	sort.Strings(extraKeys)
+	for _, key := range extraKeys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" || strings.Contains(trimmed, "=") || proxyGroup(trimmed) != nil {
+			continue
+		}
+		values[environmentKey(trimmed)] = environmentValue{key: trimmed, value: extra[key]}
+	}
+
+	for _, aliases := range proxyAliases {
+		entry, ok := preferredProxyValue(extra, processEnvironment, aliases)
+		if !ok {
+			continue
+		}
+		for _, alias := range aliases {
+			delete(values, environmentKey(alias))
+		}
+		values[environmentKey(entry.key)] = entry
+	}
+
+	values[environmentKey(bypassPermissionsKey)] = environmentValue{
+		key:   bypassPermissionsKey,
+		value: "false",
+	}
+
+	ordered := make([]environmentValue, 0, len(values))
+	for _, entry := range values {
+		ordered = append(ordered, entry)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		left := environmentKey(ordered[i].key)
+		right := environmentKey(ordered[j].key)
+		if left == right {
+			return ordered[i].key < ordered[j].key
+		}
+		return left < right
+	})
+
+	result := make([]string, 0, len(ordered))
+	for _, entry := range ordered {
+		result = append(result, entry.key+"="+entry.value)
+	}
+	return result
+}
+
+// HasSupportedProxy reports whether Claude has a non-empty HTTP(S) proxy.
+// ALL_PROXY is still forwarded for child tools, but it is not treated as proof
+// that Claude itself can connect; Claude Code does not support SOCKS proxies.
+func HasSupportedProxy(environment []string) bool {
+	for _, item := range environment {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		if !strings.EqualFold(key, "HTTP_PROXY") && !strings.EqualFold(key, "HTTPS_PROXY") {
+			continue
+		}
+		parsed, err := url.Parse(strings.TrimSpace(value))
+		if err != nil || parsed.Scheme == "" {
+			continue
+		}
+		if strings.EqualFold(parsed.Scheme, "http") || strings.EqualFold(parsed.Scheme, "https") {
+			return true
+		}
+	}
+	return false
+}
+
+// ProxyValues returns non-empty proxy values, longest first, for exact-value
+// redaction at log boundaries.
+func ProxyValues(environment []string) []string {
+	seen := map[string]struct{}{}
+	values := make([]string, 0, len(proxyAliases))
+	for _, item := range environment {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || strings.TrimSpace(value) == "" || proxyGroup(key) == nil {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+	return values
+}
+
+func parseEnvironment(environment []string) map[string]string {
+	values := make(map[string]string, len(environment))
+	for _, item := range environment {
+		if key, value, ok := strings.Cut(item, "="); ok {
+			values[key] = value
+		}
+	}
+	return values
+}
+
+func lookupEnvironment(environment map[string]string, key string) (string, bool) {
+	if value, ok := environment[key]; ok {
+		return value, true
+	}
+	if runtime.GOOS != "windows" {
+		return "", false
+	}
+	for candidate, value := range environment {
+		if strings.EqualFold(candidate, key) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func preferredProxyValue(
+	extra map[string]string,
+	processEnvironment map[string]string,
+	aliases []string,
+) (environmentValue, bool) {
+	if entry, ok := preferredMapValue(extra, aliases); ok {
+		return entry, true
+	}
+	return preferredMapValue(processEnvironment, aliases)
+}
+
+func preferredMapValue(values map[string]string, aliases []string) (environmentValue, bool) {
+	for _, alias := range aliases {
+		if value, ok := values[alias]; ok {
+			return environmentValue{key: alias, value: value}, true
+		}
+	}
+	otherKeys := make([]string, 0, 1)
+	for key := range values {
+		if strings.EqualFold(key, aliases[0]) {
+			otherKeys = append(otherKeys, key)
+		}
+	}
+	if len(otherKeys) == 0 {
+		return environmentValue{}, false
+	}
+	sort.Strings(otherKeys)
+	key := otherKeys[0]
+	return environmentValue{key: key, value: values[key]}, true
+}
+
+func proxyGroup(key string) []string {
+	for _, aliases := range proxyAliases {
+		if strings.EqualFold(key, aliases[0]) {
+			return aliases
+		}
+	}
+	return nil
+}
+
+func environmentKey(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
+}

--- a/internal/claudeenv/environment_test.go
+++ b/internal/claudeenv/environment_test.go
@@ -1,0 +1,105 @@
+package claudeenv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildUsesDeterministicProxyAliasPrecedence(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "https://inherited-upper.example:8443")
+	t.Setenv("https_proxy", "https://inherited-lower.example:8443")
+	environment := Build(map[string]string{
+		"HTTPS_PROXY": "https://configured-upper.example:8443",
+		"https_proxy": "https://configured-lower.example:8443",
+		"HTTP_PROXY":  "http://configured-upper.example:8080",
+		"http_proxy":  "http://configured-lower.example:8080",
+		"ALL_PROXY":   "socks5://configured-upper.example:1080",
+		"all_proxy":   "socks5://configured-lower.example:1080",
+		"NO_PROXY":    "upper.example",
+		"no_proxy":    "lower.example",
+	})
+
+	proxies := map[string][]string{}
+	for _, item := range environment {
+		key, value, ok := strings.Cut(item, "=")
+		if ok && proxyGroup(key) != nil {
+			proxies[strings.ToLower(key)] = append(proxies[strings.ToLower(key)], value)
+		}
+	}
+	want := map[string]string{
+		"https_proxy": "https://configured-lower.example:8443",
+		"http_proxy":  "http://configured-lower.example:8080",
+		"all_proxy":   "socks5://configured-lower.example:1080",
+		"no_proxy":    "lower.example",
+	}
+	if len(proxies) != len(want) {
+		t.Fatalf("lowercase configured proxy must win deterministically: %v", proxies)
+	}
+	for key, value := range want {
+		if got := proxies[key]; len(got) != 1 || got[0] != value {
+			t.Fatalf("%s precedence mismatch: got=%v want=%q", key, got, value)
+		}
+	}
+}
+
+func TestBuildAllowsConfiguredEmptyProxyToClearInheritedValue(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://inherited.example:8080")
+	environment := Build(map[string]string{"https_proxy": ""})
+	values := environmentMap(environment)
+	if value, ok := values["HTTPS_PROXY"]; !ok || value != "" {
+		t.Fatalf("configured empty lowercase proxy should deterministically clear inheritance: %v", values)
+	}
+	if HasSupportedProxy(environment) {
+		t.Fatal("cleared proxy must not be reported as configured")
+	}
+}
+
+func TestBuildIncludesWindowsProfileAndForcesPermissions(t *testing.T) {
+	t.Setenv("USERPROFILE", `C:\Users\mimi`)
+	environment := Build(map[string]string{
+		"CLAUDE_BRIDGE_BYPASS_PERMISSIONS": "true",
+	})
+	values := environmentMap(environment)
+	if values["USERPROFILE"] != `C:\Users\mimi` {
+		t.Fatalf("profile environment must reach probes and runtime: %v", values)
+	}
+	if values["CLAUDE_BRIDGE_BYPASS_PERMISSIONS"] != "false" {
+		t.Fatalf("permission bypass must be forced off: %v", values)
+	}
+}
+
+func TestHasSupportedProxyRejectsAllProxyAndSocks(t *testing.T) {
+	if HasSupportedProxy([]string{"ALL_PROXY=socks5://proxy.example:1080"}) {
+		t.Fatal("ALL_PROXY alone must not claim Claude HTTP proxy readiness")
+	}
+	if HasSupportedProxy([]string{"HTTPS_PROXY=socks5://proxy.example:1080"}) {
+		t.Fatal("SOCKS URL must not claim Claude HTTP proxy readiness")
+	}
+	if HasSupportedProxy([]string{"HTTPS_PROXY=proxy.example:8080"}) {
+		t.Fatal("proxy without an HTTP(S) URL scheme must not claim readiness")
+	}
+	if !HasSupportedProxy([]string{"HTTPS_PROXY=http://proxy.example:8080"}) {
+		t.Fatal("HTTP CONNECT proxy should be accepted")
+	}
+}
+
+func TestProxyValuesReturnsAliasesForRedaction(t *testing.T) {
+	values := ProxyValues([]string{
+		"HTTPS_PROXY=http://alice:hunter2@proxy.example:8080",
+		"NO_PROXY=localhost,internal.example",
+		"PATH=/bin",
+	})
+	if len(values) != 2 || values[0] != "http://alice:hunter2@proxy.example:8080" {
+		t.Fatalf("proxy values should be returned longest-first: %v", values)
+	}
+}
+
+func environmentMap(environment []string) map[string]string {
+	values := map[string]string{}
+	for _, item := range environment {
+		if key, value, ok := strings.Cut(item, "="); ok {
+			values[strings.ToUpper(key)] = value
+		}
+	}
+	return values
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,10 @@ import (
 	"github.com/gaixianggeng/mimi-remote/internal/claudebridge"
 )
 
-const AppName = "mimi-remote"
+const (
+	AppName                           = "mimi-remote"
+	DefaultClaudeMaxConcurrentBridges = 3
+)
 
 type Config struct {
 	Listen        string           `json:"listen"`
@@ -283,6 +286,14 @@ func loadRawWithoutProjectDiscovery(raw []byte) (Config, error) {
 			cfg.AppServer.Listen = ""
 		}
 	}
+	if cfg.Claude.MaxConcurrentBridges == 0 {
+		// Older setup versions serialized the disabled Claude section from a
+		// zero-value Config, then the tray could enable Claude while preserving
+		// that zero. Treat exactly zero as the legacy default so an upgrade can
+		// still start; negative values remain invalid, and an explicit env
+		// override is applied below and continues to fail validation.
+		cfg.Claude.MaxConcurrentBridges = DefaultClaudeMaxConcurrentBridges
+	}
 
 	cfg.Runtime.Type = normalizeRuntimeType(cfg.Runtime.Type)
 	cfg.AppServer.Transport = normalizeTransport(cfg.AppServer.Transport)
@@ -396,6 +407,17 @@ func DefaultAppServerWebSocketListen() string {
 	return defaultAppServerWebSocketListen
 }
 
+func DefaultClaudeConfig() ClaudeConfig {
+	return ClaudeConfig{
+		Enabled:              false,
+		BridgeBin:            "alleycat-claude-bridge",
+		MaxConcurrentBridges: DefaultClaudeMaxConcurrentBridges,
+		Env: map[string]string{
+			"TERM": "xterm-256color",
+		},
+	}
+}
+
 func defaults() Config {
 	return Config{
 		Listen: "127.0.0.1:8787",
@@ -418,14 +440,7 @@ func defaults() Config {
 				"TERM": "xterm-256color",
 			},
 		},
-		Claude: ClaudeConfig{
-			Enabled:              false,
-			BridgeBin:            "alleycat-claude-bridge",
-			MaxConcurrentBridges: 3,
-			Env: map[string]string{
-				"TERM": "xterm-256color",
-			},
-		},
+		Claude: DefaultClaudeConfig(),
 		Session: SessionConfig{
 			OutputBufferBytes: 128 * 1024,
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,6 +33,64 @@ func TestLoadWithEnvOverrides(t *testing.T) {
 	}
 	if !cfg.AppServer.AutoTitle {
 		t.Fatal("新安装默认应启用 Mac 端会话标题生成")
+	}
+}
+
+func TestLoadNormalizesLegacyZeroClaudeBridgeLimit(t *testing.T) {
+	clearAgentdEnv(t)
+	projectDir := t.TempDir()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults()
+	cfg.Auth.Token = "0123456789abcdef0123456789abcdef"
+	cfg.Claude.Enabled = true
+	cfg.Claude.BridgeBin = executable
+	cfg.Claude.MaxConcurrentBridges = 0
+	cfg.Projects = []ProjectConfig{{ID: "demo", Name: "demo", Path: projectDir}}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("legacy setup config should remain startable after Claude activation: %v", err)
+	}
+	if loaded.Claude.MaxConcurrentBridges != DefaultClaudeMaxConcurrentBridges {
+		t.Fatalf("legacy zero bridge limit was not normalized: got=%d want=%d", loaded.Claude.MaxConcurrentBridges, DefaultClaudeMaxConcurrentBridges)
+	}
+}
+
+func TestLoadRejectsExplicitZeroClaudeBridgeLimitFromEnvironment(t *testing.T) {
+	clearAgentdEnv(t)
+	projectDir := t.TempDir()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults()
+	cfg.Auth.Token = "0123456789abcdef0123456789abcdef"
+	cfg.Claude.Enabled = true
+	cfg.Claude.BridgeBin = executable
+	cfg.Projects = []ProjectConfig{{ID: "demo", Name: "demo", Path: projectDir}}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTD_CLAUDE_MAX_CONCURRENT_BRIDGES", "0")
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("an explicit zero bridge limit from the environment must remain invalid")
 	}
 }
 

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -404,6 +404,32 @@ func TestClaudeGatewayForcesBypassPermissionsOff(t *testing.T) {
 	}
 }
 
+func TestClaudeGatewayInheritsProxyEnvironmentAndAllowsConfigOverride(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:10808")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:10808")
+	t.Setenv("NO_PROXY", "localhost,127.0.0.1")
+	env := buildClaudeBridgeEnv(map[string]string{
+		"https_proxy": "http://127.0.0.1:18080",
+	})
+
+	values := map[string]string{}
+	for _, item := range env {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			canonical := strings.ToUpper(key)
+			if _, exists := values[canonical]; exists {
+				t.Fatalf("代理环境变量不应因大小写重复：%v", env)
+			}
+			values[canonical] = value
+		}
+	}
+	if values["HTTP_PROXY"] != "http://127.0.0.1:10808" ||
+		values["HTTPS_PROXY"] != "http://127.0.0.1:18080" ||
+		values["NO_PROXY"] != "localhost,127.0.0.1" {
+		t.Fatalf("Claude bridge 应继承代理并允许 claude.env 覆盖：%v", values)
+	}
+}
+
 func TestClaudeGatewayLimitReturnsJSONRPCErrorFrame(t *testing.T) {
 	bridge := writeTestBridge(t, `#!/bin/sh
 while IFS= read -r line; do sleep 10; done

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -406,6 +406,7 @@ func TestClaudeGatewayForcesBypassPermissionsOff(t *testing.T) {
 
 func TestClaudeGatewayInheritsProxyEnvironmentAndAllowsConfigOverride(t *testing.T) {
 	t.Setenv("HTTP_PROXY", "http://127.0.0.1:10808")
+	t.Setenv("http_proxy", "http://127.0.0.1:10808")
 	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:10808")
 	t.Setenv("NO_PROXY", "localhost,127.0.0.1")
 	env := buildClaudeBridgeEnv(map[string]string{
@@ -427,6 +428,22 @@ func TestClaudeGatewayInheritsProxyEnvironmentAndAllowsConfigOverride(t *testing
 		values["HTTPS_PROXY"] != "http://127.0.0.1:18080" ||
 		values["NO_PROXY"] != "localhost,127.0.0.1" {
 		t.Fatalf("Claude bridge 应继承代理并允许 claude.env 覆盖：%v", values)
+	}
+}
+
+func TestClaudeGatewayRedactsProxyCredentialsFromDiagnostics(t *testing.T) {
+	proxy := "http://alice:hunter%402@proxy.example:8080"
+	line := sanitizeClaudeBridgeDiagnostic(
+		"connect failed proxy="+proxy+" fallback=socks5://bob:secret@proxy.example:1080",
+		[]string{proxy},
+	)
+	for _, secret := range []string{"alice", "hunter%402", "bob", "secret"} {
+		if strings.Contains(line, secret) {
+			t.Fatalf("proxy credential %q leaked in diagnostic: %s", secret, line)
+		}
+	}
+	if !strings.Contains(line, "<redacted proxy>") || !strings.Contains(line, "socks5://<redacted>@") {
+		t.Fatalf("diagnostic should retain useful redacted structure: %s", line)
 	}
 }
 

--- a/internal/httpapi/claude_bridge_supervisor.go
+++ b/internal/httpapi/claude_bridge_supervisor.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"sync"
 	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/claudeenv"
 )
 
 // claudeBridgeStartTimeout bounds how long we wait for a freshly spawned bridge
@@ -164,7 +166,8 @@ func (s *claudeBridgeSupervisor) start(bin string, args []string, env map[string
 	}
 
 	cmd := exec.Command(bin, append(append([]string{}, args...), transportArgs...)...)
-	cmd.Env = buildClaudeBridgeEnv(env)
+	bridgeEnvironment := buildClaudeBridgeEnv(env)
+	cmd.Env = bridgeEnvironment
 	configureGatewayCommandProcessGroup(cmd)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -174,7 +177,7 @@ func (s *claudeBridgeSupervisor) start(bin string, args []string, env map[string
 		return fmt.Errorf("启动 Claude bridge 失败：%w", err)
 	}
 	s.startedAt = time.Now().UTC()
-	go captureClaudeBridgeStderr(stderr)
+	go captureClaudeBridgeStderr(stderr, claudeenv.ProxyValues(bridgeEnvironment))
 
 	done := make(chan struct{})
 	s.cmd = cmd

--- a/internal/httpapi/claude_gateway.go
+++ b/internal/httpapi/claude_gateway.go
@@ -10,9 +10,9 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/gaixianggeng/mimi-remote/internal/claudebridge"
+	"github.com/gaixianggeng/mimi-remote/internal/claudeenv"
 )
 
 const claudeBridgePolicyErrorCode = -32081
@@ -765,65 +766,13 @@ func pingClientGateway(ctx context.Context, client *websocket.Conn, clientWriteM
 }
 
 func buildClaudeBridgeEnv(extra map[string]string) []string {
-	keys := []string{
-		"HOME", "PATH", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "TERM",
-		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
-		"http_proxy", "https_proxy", "all_proxy", "no_proxy",
-	}
-	out := make([]string, 0, len(keys)+len(extra))
-	seen := map[string]struct{}{}
-	for _, key := range keys {
-		value := os.Getenv(key)
-		if value == "" {
-			continue
-		}
-		canonicalKey := strings.ToUpper(key)
-		if _, ok := seen[canonicalKey]; ok {
-			continue
-		}
-		out = append(out, key+"="+value)
-		seen[canonicalKey] = struct{}{}
-	}
-	for key, value := range extra {
-		key = strings.TrimSpace(key)
-		if key == "" || strings.Contains(key, "=") {
-			continue
-		}
-		canonicalKey := strings.ToUpper(key)
-		if _, ok := seen[canonicalKey]; ok {
-			for i, item := range out {
-				existingKey, _, _ := strings.Cut(item, "=")
-				if strings.EqualFold(existingKey, key) {
-					out[i] = key + "=" + value
-					break
-				}
-			}
-			continue
-		}
-		out = append(out, key+"="+value)
-		seen[canonicalKey] = struct{}{}
-	}
-	// 远程 Claude 通道永不允许绕过权限；即使本机配置误设为 true，也在进程边界强制覆盖。
-	const bypassKey = "CLAUDE_BRIDGE_BYPASS_PERMISSIONS"
-	foundBypass := false
-	for index, item := range out {
-		key, _, _ := strings.Cut(item, "=")
-		if strings.EqualFold(key, bypassKey) {
-			out[index] = bypassKey + "=false"
-			foundBypass = true
-			break
-		}
-	}
-	if !foundBypass {
-		out = append(out, bypassKey+"=false")
-	}
-	return out
+	return claudeenv.Build(extra)
 }
 
-func captureClaudeBridgeStderr(stderr io.Reader) {
+func captureClaudeBridgeStderr(stderr io.Reader, sensitiveValues []string) {
 	scanner := bufio.NewScanner(stderr)
 	for scanner.Scan() {
-		line := sanitizeGatewayDiagnostic(scanner.Text())
+		line := sanitizeClaudeBridgeDiagnostic(scanner.Text(), sensitiveValues)
 		if line == "" {
 			continue
 		}
@@ -832,6 +781,19 @@ func captureClaudeBridgeStderr(stderr io.Reader) {
 	if err := scanner.Err(); err != nil {
 		log.Printf("claude bridge stderr scanner error err=%v", err)
 	}
+}
+
+var diagnosticURLUserinfoPattern = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@`)
+
+func sanitizeClaudeBridgeDiagnostic(value string, sensitiveValues []string) string {
+	line := value
+	for _, sensitive := range sensitiveValues {
+		if sensitive != "" {
+			line = strings.ReplaceAll(line, sensitive, "<redacted proxy>")
+		}
+	}
+	line = diagnosticURLUserinfoPattern.ReplaceAllString(line, `${1}<redacted>@`)
+	return sanitizeGatewayDiagnostic(line)
 }
 
 func sanitizeGatewayDiagnostic(value string) string {

--- a/internal/httpapi/claude_gateway.go
+++ b/internal/httpapi/claude_gateway.go
@@ -765,7 +765,11 @@ func pingClientGateway(ctx context.Context, client *websocket.Conn, clientWriteM
 }
 
 func buildClaudeBridgeEnv(extra map[string]string) []string {
-	keys := []string{"HOME", "PATH", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "TERM"}
+	keys := []string{
+		"HOME", "PATH", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "TERM",
+		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+		"http_proxy", "https_proxy", "all_proxy", "no_proxy",
+	}
 	out := make([]string, 0, len(keys)+len(extra))
 	seen := map[string]struct{}{}
 	for _, key := range keys {
@@ -773,17 +777,23 @@ func buildClaudeBridgeEnv(extra map[string]string) []string {
 		if value == "" {
 			continue
 		}
+		canonicalKey := strings.ToUpper(key)
+		if _, ok := seen[canonicalKey]; ok {
+			continue
+		}
 		out = append(out, key+"="+value)
-		seen[key] = struct{}{}
+		seen[canonicalKey] = struct{}{}
 	}
 	for key, value := range extra {
 		key = strings.TrimSpace(key)
 		if key == "" || strings.Contains(key, "=") {
 			continue
 		}
-		if _, ok := seen[key]; ok {
+		canonicalKey := strings.ToUpper(key)
+		if _, ok := seen[canonicalKey]; ok {
 			for i, item := range out {
-				if strings.HasPrefix(item, key+"=") {
+				existingKey, _, _ := strings.Cut(item, "=")
+				if strings.EqualFold(existingKey, key) {
 					out[i] = key + "=" + value
 					break
 				}
@@ -791,12 +801,14 @@ func buildClaudeBridgeEnv(extra map[string]string) []string {
 			continue
 		}
 		out = append(out, key+"="+value)
+		seen[canonicalKey] = struct{}{}
 	}
 	// 远程 Claude 通道永不允许绕过权限；即使本机配置误设为 true，也在进程边界强制覆盖。
 	const bypassKey = "CLAUDE_BRIDGE_BYPASS_PERMISSIONS"
 	foundBypass := false
 	for index, item := range out {
-		if strings.HasPrefix(item, bypassKey+"=") {
+		key, _, _ := strings.Cut(item, "=")
+		if strings.EqualFold(key, bypassKey) {
 			out[index] = bypassKey + "=false"
 			foundBypass = true
 			break

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -34,15 +33,26 @@ type ClaudeConfigurationResult struct {
 	PreviousPreference ClaudeActivationPreference `json:"previous_preference"`
 	Changed            bool                       `json:"changed"`
 	RestartRequired    bool                       `json:"restart_required"`
+	ClaudeBin          string                     `json:"claude_bin,omitempty"`
+	ClaudeVersion      string                     `json:"claude_version,omitempty"`
+	LoggedIn           *bool                      `json:"logged_in,omitempty"`
+	ProxyConfigured    bool                       `json:"proxy_configured"`
+	SystemProxyEnabled bool                       `json:"system_proxy_enabled"`
+	ProxyMismatch      bool                       `json:"proxy_mismatch"`
 	Reason             string                     `json:"reason"`
 	Message            string                     `json:"message"`
 }
 
 type claudePreflightResult struct {
-	OK        bool
-	ClaudeBin string
-	Reason    string
-	Message   string
+	OK                 bool
+	ClaudeBin          string
+	ClaudeVersion      string
+	LoggedIn           *bool
+	ProxyConfigured    bool
+	SystemProxyEnabled bool
+	ProxyMismatch      bool
+	Reason             string
+	Message            string
 }
 
 func ParseClaudeActivationPreference(raw string) (ClaudeActivationPreference, error) {
@@ -139,6 +149,12 @@ func ConfigureClaude(
 			}
 		case ClaudeActivationAuto, ClaudeActivationEnabled:
 			preflight = preflightClaude(ctx, cfg)
+			result.ClaudeBin = preflight.ClaudeBin
+			result.ClaudeVersion = preflight.ClaudeVersion
+			result.LoggedIn = preflight.LoggedIn
+			result.ProxyConfigured = preflight.ProxyConfigured
+			result.SystemProxyEnabled = preflight.SystemProxyEnabled
+			result.ProxyMismatch = preflight.ProxyMismatch
 			if preflight.OK {
 				targetEnabled = true
 			} else if requested == ClaudeActivationEnabled {
@@ -192,6 +208,12 @@ func ConfigureClaude(
 	result.Preference = targetPreference
 	result.Changed = changed
 	result.RestartRequired = currentEnabled != targetEnabled || currentClaudeBin != targetClaudeBin
+	result.ClaudeBin = preflight.ClaudeBin
+	result.ClaudeVersion = preflight.ClaudeVersion
+	result.LoggedIn = preflight.LoggedIn
+	result.ProxyConfigured = preflight.ProxyConfigured
+	result.SystemProxyEnabled = preflight.SystemProxyEnabled
+	result.ProxyMismatch = preflight.ProxyMismatch
 	result.Reason = preflight.Reason
 	result.Message = preflight.Message
 	if targetEnabled && preflight.OK && preflight.Message == "" {
@@ -295,12 +317,20 @@ func encodeClaudeDocument(
 }
 
 func preflightClaude(ctx context.Context, cfg config.Config) claudePreflightResult {
+	commandEnvironment := claudeCommandEnvironment(cfg.Claude.Env)
+	proxyConfigured := claudeProxyConfigured(commandEnvironment)
+	systemProxyEnabled := claudeSystemProxyConfigured()
+	proxyMismatch := systemProxyEnabled && !proxyConfigured
+	baseResult := claudePreflightResult{
+		ProxyConfigured:    proxyConfigured,
+		SystemProxyEnabled: systemProxyEnabled,
+		ProxyMismatch:      proxyMismatch,
+	}
 	bridge, ok := claudebridge.ResolveBinary(cfg.Claude.BridgeBin)
 	if !ok {
-		return claudePreflightResult{
-			Reason:  "bridge_missing",
-			Message: "App 内没有可用的 Claude bridge，请重新安装 Mimi Remote Mac。",
-		}
+		baseResult.Reason = "bridge_missing"
+		baseResult.Message = "App 内没有可用的 Claude bridge，请重新安装 Mimi Remote。"
+		return baseResult
 	}
 	bridgeCtx, cancelBridge := context.WithTimeout(ctx, 2*time.Second)
 	bridgeCommand := exec.CommandContext(
@@ -308,66 +338,67 @@ func preflightClaude(ctx context.Context, cfg config.Config) claudePreflightResu
 		bridge,
 		append(append([]string{}, cfg.Claude.Args...), "--version")...,
 	)
-	bridgeCommand.Env = claudeCommandEnvironment(cfg.Claude.Env)
+	bridgeCommand.Env = commandEnvironment
 	bridgeVersionOutput, bridgeErr := bridgeCommand.Output()
 	cancelBridge()
 	bridgeVersion, parsed := claudebridge.ParseVersion(string(bridgeVersionOutput))
 	if bridgeErr != nil || !parsed {
-		return claudePreflightResult{
-			Reason:  "bridge_version_unknown",
-			Message: "无法确认 Claude bridge 版本，请重新安装 Mimi Remote Mac。",
-		}
+		baseResult.Reason = "bridge_version_unknown"
+		baseResult.Message = "无法确认 Claude bridge 版本，请重新安装 Mimi Remote。"
+		return baseResult
 	}
 	if !claudebridge.IsSupported(bridgeVersion) {
-		return claudePreflightResult{
-			Reason:  "bridge_unsupported",
-			Message: "Claude bridge 版本不兼容，请升级 Mimi Remote Mac。",
-		}
+		baseResult.Reason = "bridge_unsupported"
+		baseResult.Message = "Claude bridge 版本不兼容，请升级 Mimi Remote。"
+		return baseResult
 	}
 
 	configuredClaudeBin := strings.TrimSpace(cfg.Claude.Env[claudeBinaryEnvKey])
 	claudeBin, err := resolveClaudeBin(configuredClaudeBin)
 	if err != nil {
-		return claudePreflightResult{
-			Reason:  "claude_missing",
-			Message: "未检测到 Claude Code。安装并登录后，重新打开 Mimi Remote Mac 即可自动启用。",
-		}
+		baseResult.Reason = "claude_missing"
+		baseResult.Message = "未检测到 Claude Code。安装并登录后，重新打开 Mimi Remote 即可自动启用。"
+		return baseResult
 	}
+	baseResult.ClaudeBin = claudeBin
+	claudeVersion, err := probeClaudeVersion(ctx, claudeBin, commandEnvironment)
+	if err != nil {
+		baseResult.Reason = "claude_version_unknown"
+		baseResult.Message = "检测到 Claude Code，但无法确认版本。请重新安装或升级 Claude Code。"
+		return baseResult
+	}
+	baseResult.ClaudeVersion = claudeVersion
 	authCtx, cancelAuth := context.WithTimeout(ctx, 5*time.Second)
 	authCommand := exec.CommandContext(authCtx, claudeBin, "auth", "status")
-	authCommand.Env = claudeCommandEnvironment(cfg.Claude.Env)
-	authCommand.Stdout = io.Discard
+	authCommand.Env = commandEnvironment
 	authCommand.Stderr = io.Discard
-	authErr := authCommand.Run()
+	authOutput, authErr := authCommand.Output()
 	cancelAuth()
-	if authErr != nil {
-		return claudePreflightResult{
-			ClaudeBin: claudeBin,
-			Reason:    "claude_signed_out",
-			Message:   "已检测到 Claude Code，但尚未登录。请先在 Claude Code 中完成登录。",
-		}
+	loggedIn, parsedAuth := parseClaudeAuthStatus(authOutput)
+	if parsedAuth {
+		baseResult.LoggedIn = &loggedIn
 	}
-	return claudePreflightResult{
-		OK:        true,
-		ClaudeBin: claudeBin,
-		Reason:    "ready",
-		Message:   "已检测到 Claude Code 和兼容的 Claude bridge。",
+	if parsedAuth && !loggedIn {
+		baseResult.Reason = "claude_signed_out"
+		baseResult.Message = "已检测到 Claude Code，但尚未登录。请先在 Claude Code 中完成登录。"
+		return baseResult
 	}
+	if authErr != nil || !parsedAuth {
+		baseResult.Reason = "claude_auth_status_failed"
+		baseResult.Message = "已检测到 Claude Code，但无法确认登录状态。请在终端运行 claude auth status 查看具体原因。"
+		return baseResult
+	}
+	baseResult.OK = true
+	baseResult.Reason = "ready"
+	baseResult.Message = fmt.Sprintf("已检测到 Claude Code %s 和兼容的 Claude bridge。", claudeVersion)
+	if proxyMismatch {
+		baseResult.Message += " Windows 系统代理已启用，但 Claude 进程未配置 HTTP(S)_PROXY；如直连不可用，请重启 Mimi Remote 以继承用户代理环境。"
+	}
+	return baseResult
 }
 
 func resolveClaudeBin(configured string) (string, error) {
-	candidates := []string{strings.TrimSpace(configured), "claude"}
-	if home, err := os.UserHomeDir(); err == nil {
-		candidates = append(candidates,
-			filepath.Join(home, ".local", "bin", "claude"),
-			filepath.Join(home, ".npm-global", "bin", "claude"),
-		)
-		if runtime.GOOS == "windows" {
-			candidates = append(candidates,
-				filepath.Join(home, "AppData", "Roaming", "npm", "claude.cmd"),
-			)
-		}
-	}
+	candidates := claudeExecutableCandidates(configured)
 	seen := map[string]struct{}{}
 	for _, candidate := range candidates {
 		candidate = strings.TrimSpace(candidate)
@@ -390,24 +421,69 @@ func resolveClaudeBin(configured string) (string, error) {
 	return "", exec.ErrNotFound
 }
 
+func probeClaudeVersion(ctx context.Context, claudeBin string, environment []string) (string, error) {
+	versionCtx, cancelVersion := context.WithTimeout(ctx, 3*time.Second)
+	defer cancelVersion()
+	command := exec.CommandContext(versionCtx, claudeBin, "--version")
+	command.Env = environment
+	output, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	version, ok := claudebridge.ParseVersion(string(output))
+	if !ok {
+		return "", fmt.Errorf("无法解析 Claude Code 版本")
+	}
+	return version, nil
+}
+
+func parseClaudeAuthStatus(output []byte) (bool, bool) {
+	status := struct {
+		LoggedIn *bool `json:"loggedIn"`
+	}{}
+	if err := json.Unmarshal(output, &status); err != nil || status.LoggedIn == nil {
+		return false, false
+	}
+	return *status.LoggedIn, true
+}
+
+func claudeProxyConfigured(environment []string) bool {
+	for _, item := range environment {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		switch strings.ToUpper(strings.TrimSpace(key)) {
+		case "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY":
+			return true
+		}
+	}
+	return false
+}
+
 func claudeCommandEnvironment(extra map[string]string) []string {
 	environment := append([]string{}, os.Environ()...)
-	values := map[string]string{}
+	type environmentValue struct {
+		key   string
+		value string
+	}
+	values := map[string]environmentValue{}
 	for _, item := range environment {
 		if key, value, ok := strings.Cut(item, "="); ok {
-			values[key] = value
+			values[claudeEnvironmentKey(key)] = environmentValue{key: key, value: value}
 		}
 	}
 	for key, value := range extra {
 		key = strings.TrimSpace(key)
 		if key != "" && !strings.Contains(key, "=") {
-			values[key] = value
+			values[claudeEnvironmentKey(key)] = environmentValue{key: key, value: value}
 		}
 	}
-	values["CLAUDE_BRIDGE_BYPASS_PERMISSIONS"] = "false"
+	const bypassKey = "CLAUDE_BRIDGE_BYPASS_PERMISSIONS"
+	values[claudeEnvironmentKey(bypassKey)] = environmentValue{key: bypassKey, value: "false"}
 	environment = environment[:0]
-	for key, value := range values {
-		environment = append(environment, key+"="+value)
+	for _, entry := range values {
+		environment = append(environment, entry.key+"="+entry.value)
 	}
 	return environment
 }

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gaixianggeng/mimi-remote/internal/claudebridge"
+	"github.com/gaixianggeng/mimi-remote/internal/claudeenv"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 )
 
@@ -38,6 +40,8 @@ type ClaudeConfigurationResult struct {
 	LoggedIn           *bool                      `json:"logged_in,omitempty"`
 	ProxyConfigured    bool                       `json:"proxy_configured"`
 	SystemProxyEnabled bool                       `json:"system_proxy_enabled"`
+	SystemProxyKnown   bool                       `json:"system_proxy_known"`
+	SystemProxySource  string                     `json:"system_proxy_source,omitempty"`
 	ProxyMismatch      bool                       `json:"proxy_mismatch"`
 	Reason             string                     `json:"reason"`
 	Message            string                     `json:"message"`
@@ -50,9 +54,17 @@ type claudePreflightResult struct {
 	LoggedIn           *bool
 	ProxyConfigured    bool
 	SystemProxyEnabled bool
+	SystemProxyKnown   bool
+	SystemProxySource  string
 	ProxyMismatch      bool
 	Reason             string
 	Message            string
+}
+
+type claudeSystemProxyDetection struct {
+	Enabled bool
+	Known   bool
+	Source  string
 }
 
 func ParseClaudeActivationPreference(raw string) (ClaudeActivationPreference, error) {
@@ -154,6 +166,8 @@ func ConfigureClaude(
 			result.LoggedIn = preflight.LoggedIn
 			result.ProxyConfigured = preflight.ProxyConfigured
 			result.SystemProxyEnabled = preflight.SystemProxyEnabled
+			result.SystemProxyKnown = preflight.SystemProxyKnown
+			result.SystemProxySource = preflight.SystemProxySource
 			result.ProxyMismatch = preflight.ProxyMismatch
 			if preflight.OK {
 				targetEnabled = true
@@ -213,6 +227,8 @@ func ConfigureClaude(
 	result.LoggedIn = preflight.LoggedIn
 	result.ProxyConfigured = preflight.ProxyConfigured
 	result.SystemProxyEnabled = preflight.SystemProxyEnabled
+	result.SystemProxyKnown = preflight.SystemProxyKnown
+	result.SystemProxySource = preflight.SystemProxySource
 	result.ProxyMismatch = preflight.ProxyMismatch
 	result.Reason = preflight.Reason
 	result.Message = preflight.Message
@@ -318,12 +334,14 @@ func encodeClaudeDocument(
 
 func preflightClaude(ctx context.Context, cfg config.Config) claudePreflightResult {
 	commandEnvironment := claudeCommandEnvironment(cfg.Claude.Env)
-	proxyConfigured := claudeProxyConfigured(commandEnvironment)
-	systemProxyEnabled := claudeSystemProxyConfigured()
-	proxyMismatch := systemProxyEnabled && !proxyConfigured
+	proxyConfigured := claudeenv.HasSupportedProxy(commandEnvironment)
+	systemProxy := claudeSystemProxyStatus()
+	proxyMismatch := systemProxy.Known && systemProxy.Enabled && !proxyConfigured
 	baseResult := claudePreflightResult{
 		ProxyConfigured:    proxyConfigured,
-		SystemProxyEnabled: systemProxyEnabled,
+		SystemProxyEnabled: systemProxy.Enabled,
+		SystemProxyKnown:   systemProxy.Known,
+		SystemProxySource:  systemProxy.Source,
 		ProxyMismatch:      proxyMismatch,
 	}
 	bridge, ok := claudebridge.ResolveBinary(cfg.Claude.BridgeBin)
@@ -368,31 +386,23 @@ func preflightClaude(ctx context.Context, cfg config.Config) claudePreflightResu
 		return baseResult
 	}
 	baseResult.ClaudeVersion = claudeVersion
-	authCtx, cancelAuth := context.WithTimeout(ctx, 5*time.Second)
-	authCommand := exec.CommandContext(authCtx, claudeBin, "auth", "status")
-	authCommand.Env = commandEnvironment
-	authCommand.Stderr = io.Discard
-	authOutput, authErr := authCommand.Output()
-	cancelAuth()
-	loggedIn, parsedAuth := parseClaudeAuthStatus(authOutput)
-	if parsedAuth {
-		baseResult.LoggedIn = &loggedIn
-	}
-	if parsedAuth && !loggedIn {
-		baseResult.Reason = "claude_signed_out"
-		baseResult.Message = "已检测到 Claude Code，但尚未登录。请先在 Claude Code 中完成登录。"
-		return baseResult
-	}
-	if authErr != nil || !parsedAuth {
+	loggedIn, authErr := probeClaudeAuthStatus(ctx, claudeBin, commandEnvironment, 5*time.Second)
+	baseResult.LoggedIn = loggedIn
+	if authErr != nil {
 		baseResult.Reason = "claude_auth_status_failed"
 		baseResult.Message = "已检测到 Claude Code，但无法确认登录状态。请在终端运行 claude auth status 查看具体原因。"
+		return baseResult
+	}
+	if loggedIn == nil || !*loggedIn {
+		baseResult.Reason = "claude_signed_out"
+		baseResult.Message = "已检测到 Claude Code，但尚未登录。请先在 Claude Code 中完成登录。"
 		return baseResult
 	}
 	baseResult.OK = true
 	baseResult.Reason = "ready"
 	baseResult.Message = fmt.Sprintf("已检测到 Claude Code %s 和兼容的 Claude bridge。", claudeVersion)
 	if proxyMismatch {
-		baseResult.Message += " Windows 系统代理已启用，但 Claude 进程未配置 HTTP(S)_PROXY；如直连不可用，请重启 Mimi Remote 以继承用户代理环境。"
+		baseResult.Message += " Windows 用户代理已启用，但 Claude 进程未配置受支持的 HTTP(S) 代理；请设置 HTTPS_PROXY/HTTP_PROXY 或 claude.env 后完全重启 Mimi Remote。"
 	}
 	return baseResult
 }
@@ -447,43 +457,41 @@ func parseClaudeAuthStatus(output []byte) (bool, bool) {
 	return *status.LoggedIn, true
 }
 
-func claudeProxyConfigured(environment []string) bool {
-	for _, item := range environment {
-		key, value, ok := strings.Cut(item, "=")
-		if !ok || strings.TrimSpace(value) == "" {
-			continue
-		}
-		switch strings.ToUpper(strings.TrimSpace(key)) {
-		case "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY":
-			return true
-		}
+func probeClaudeAuthStatus(
+	ctx context.Context,
+	claudeBin string,
+	environment []string,
+	deadline time.Duration,
+) (*bool, error) {
+	authCtx, cancelAuth := context.WithTimeout(ctx, deadline)
+	authCommand := exec.CommandContext(authCtx, claudeBin, "auth", "status")
+	authCommand.Env = environment
+	authCommand.Stderr = io.Discard
+	authOutput, authErr := authCommand.Output()
+	authContextErr := authCtx.Err()
+	cancelAuth()
+
+	loggedIn, parsedAuth := parseClaudeAuthStatus(authOutput)
+	var result *bool
+	if parsedAuth {
+		result = &loggedIn
 	}
-	return false
+	if authErr != nil && authContextErr != nil {
+		return result, authContextErr
+	}
+	if !parsedAuth {
+		return nil, fmt.Errorf("Claude auth status 未返回有效 JSON")
+	}
+	if authErr == nil {
+		return result, nil
+	}
+	var exitError *exec.ExitError
+	if !loggedIn && errors.As(authErr, &exitError) && exitError.ExitCode() == 1 {
+		return result, nil
+	}
+	return result, authErr
 }
 
 func claudeCommandEnvironment(extra map[string]string) []string {
-	environment := append([]string{}, os.Environ()...)
-	type environmentValue struct {
-		key   string
-		value string
-	}
-	values := map[string]environmentValue{}
-	for _, item := range environment {
-		if key, value, ok := strings.Cut(item, "="); ok {
-			values[claudeEnvironmentKey(key)] = environmentValue{key: key, value: value}
-		}
-	}
-	for key, value := range extra {
-		key = strings.TrimSpace(key)
-		if key != "" && !strings.Contains(key, "=") {
-			values[claudeEnvironmentKey(key)] = environmentValue{key: key, value: value}
-		}
-	}
-	const bypassKey = "CLAUDE_BRIDGE_BYPASS_PERMISSIONS"
-	values[claudeEnvironmentKey(bypassKey)] = environmentValue{key: bypassKey, value: "false"}
-	environment = environment[:0]
-	for _, entry := range values {
-		environment = append(environment, entry.key+"="+entry.value)
-	}
-	return environment
+	return claudeenv.Build(extra)
 }

--- a/internal/setup/claude_candidates_unix.go
+++ b/internal/setup/claude_candidates_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func claudeExecutableCandidates(configured string) []string {
+	candidates := []string{strings.TrimSpace(configured), "claude"}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".local", "bin", "claude"),
+			filepath.Join(home, ".npm-global", "bin", "claude"),
+		)
+	}
+	return candidates
+}

--- a/internal/setup/claude_candidates_windows.go
+++ b/internal/setup/claude_candidates_windows.go
@@ -1,0 +1,65 @@
+package setup
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func claudeExecutableCandidates(configured string) []string {
+	rawCandidates := []string{strings.TrimSpace(configured)}
+	if resolved, err := exec.LookPath("claude"); err == nil {
+		rawCandidates = append(rawCandidates, resolved)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		rawCandidates = append(rawCandidates,
+			filepath.Join(home, ".local", "bin", "claude.exe"),
+			filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"),
+		)
+	}
+	if resolved, err := exec.LookPath("claude.exe"); err == nil {
+		rawCandidates = append(rawCandidates, resolved)
+	}
+
+	candidates := make([]string, 0, len(rawCandidates))
+	for _, candidate := range rawCandidates {
+		if native, ok := nativeClaudeExecutableCandidate(candidate); ok {
+			candidates = append(candidates, native)
+		}
+	}
+	return candidates
+}
+
+func nativeClaudeExecutableCandidate(candidate string) (string, bool) {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return "", false
+	}
+	resolved := candidate
+	if !filepath.IsAbs(resolved) {
+		path, err := exec.LookPath(resolved)
+		if err != nil {
+			return "", false
+		}
+		resolved = path
+	}
+	switch strings.ToLower(filepath.Ext(resolved)) {
+	case ".exe":
+		return filepath.Clean(resolved), true
+	case ".cmd", ".bat", ".ps1", "":
+		native := filepath.Join(
+			filepath.Dir(resolved),
+			"node_modules",
+			"@anthropic-ai",
+			"claude-code",
+			"bin",
+			"claude.exe",
+		)
+		info, err := os.Stat(native)
+		if err == nil && info.Mode().IsRegular() {
+			return filepath.Clean(native), true
+		}
+	}
+	return "", false
+}

--- a/internal/setup/claude_candidates_windows_test.go
+++ b/internal/setup/claude_candidates_windows_test.go
@@ -1,0 +1,86 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClaudeExecutableCandidatesIncludesOfficialNativeInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	want := filepath.Join(home, ".local", "bin", "claude.exe")
+	for _, candidate := range claudeExecutableCandidates("") {
+		if sameCleanPath(candidate, want) {
+			return
+		}
+	}
+	t.Fatalf("应检测官方 Windows 原生安装路径 %q", want)
+}
+
+func TestClaudeCommandEnvironmentOverridesWindowsKeysCaseInsensitively(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:10808")
+	environment := claudeCommandEnvironment(map[string]string{
+		"http_proxy": "http://127.0.0.1:18080",
+	})
+	found := 0
+	for _, item := range environment {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || !strings.EqualFold(key, "HTTP_PROXY") {
+			continue
+		}
+		found++
+		if value != "http://127.0.0.1:18080" {
+			t.Fatalf("claude.env 应覆盖继承的代理：%q", item)
+		}
+	}
+	if found != 1 {
+		t.Fatalf("Windows 环境不应包含大小写重复的代理键：%v", environment)
+	}
+}
+
+func TestNativeClaudeExecutableCandidateMigratesNPMShim(t *testing.T) {
+	npmRoot := filepath.Join(t.TempDir(), "npm")
+	shim := filepath.Join(npmRoot, "claude.cmd")
+	native := filepath.Join(
+		npmRoot,
+		"node_modules",
+		"@anthropic-ai",
+		"claude-code",
+		"bin",
+		"claude.exe",
+	)
+	if err := os.MkdirAll(filepath.Dir(native), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(native, []byte("native"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, ok := nativeClaudeExecutableCandidate(shim)
+	if !ok || !filepath.IsAbs(resolved) || !sameCleanPath(resolved, native) {
+		t.Fatalf("npm shim 应迁移到包内原生 claude.exe：resolved=%q ok=%t", resolved, ok)
+	}
+	candidates := claudeExecutableCandidates(shim)
+	if len(candidates) == 0 || !sameCleanPath(candidates[0], native) {
+		t.Fatalf("已配置 npm shim 时原生二进制应为首选：%v", candidates)
+	}
+}
+
+func TestNativeClaudeExecutableCandidateRejectsUnmappableScript(t *testing.T) {
+	shim := filepath.Join(t.TempDir(), "claude.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if resolved, ok := nativeClaudeExecutableCandidate(shim); ok {
+		t.Fatalf("没有包内原生二进制时不应持久化脚本 shim：%q", resolved)
+	}
+}
+
+func sameCleanPath(left string, right string) bool {
+	return filepath.Clean(left) == filepath.Clean(right)
+}

--- a/internal/setup/claude_proxy_unix.go
+++ b/internal/setup/claude_proxy_unix.go
@@ -2,10 +2,6 @@
 
 package setup
 
-func claudeSystemProxyConfigured() bool {
-	return false
-}
-
-func claudeEnvironmentKey(key string) string {
-	return key
+func claudeSystemProxyStatus() claudeSystemProxyDetection {
+	return claudeSystemProxyDetection{Known: true, Source: "not_applicable"}
 }

--- a/internal/setup/claude_proxy_unix.go
+++ b/internal/setup/claude_proxy_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package setup
+
+func claudeSystemProxyConfigured() bool {
+	return false
+}
+
+func claudeEnvironmentKey(key string) string {
+	return key
+}

--- a/internal/setup/claude_proxy_windows.go
+++ b/internal/setup/claude_proxy_windows.go
@@ -1,29 +1,111 @@
 package setup
 
 import (
+	"errors"
 	"strings"
+	"unsafe"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
-func claudeSystemProxyConfigured() bool {
+const (
+	winHTTPAccessTypeDefaultProxy   = 0
+	winHTTPAccessTypeNoProxy        = 1
+	winHTTPAccessTypeNamedProxy     = 3
+	winHTTPAccessTypeAutomaticProxy = 4
+)
+
+var (
+	winHTTPDLL                          = windows.NewLazySystemDLL("winhttp.dll")
+	winHTTPGetDefaultProxyConfiguration = winHTTPDLL.NewProc("WinHttpGetDefaultProxyConfiguration")
+	kernel32DLL                         = windows.NewLazySystemDLL("kernel32.dll")
+	globalFreeProc                      = kernel32DLL.NewProc("GlobalFree")
+)
+
+type winHTTPProxyInfo struct {
+	AccessType  uint32
+	Proxy       *uint16
+	ProxyBypass *uint16
+}
+
+func claudeSystemProxyStatus() claudeSystemProxyDetection {
 	key, err := registry.OpenKey(
 		registry.CURRENT_USER,
 		`Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
 		registry.QUERY_VALUE,
 	)
 	if err != nil {
-		return false
+		if errors.Is(err, registry.ErrNotExist) {
+			return claudeWinHTTPProxyStatus()
+		}
+		return claudeSystemProxyDetection{Source: "unknown"}
 	}
 	defer key.Close()
+
 	enabled, _, err := key.GetIntegerValue("ProxyEnable")
-	if err != nil || enabled == 0 {
-		return false
+	if err != nil && !errors.Is(err, registry.ErrNotExist) {
+		return claudeSystemProxyDetection{Source: "unknown"}
 	}
-	server, _, err := key.GetStringValue("ProxyServer")
-	return err == nil && strings.TrimSpace(server) != ""
+	if enabled != 0 {
+		server, _, serverErr := key.GetStringValue("ProxyServer")
+		if serverErr != nil || strings.TrimSpace(server) == "" {
+			return claudeSystemProxyDetection{Source: "unknown"}
+		}
+		return claudeSystemProxyDetection{Enabled: true, Known: true, Source: "wininet_manual"}
+	}
+
+	autoConfigURL, _, autoConfigErr := key.GetStringValue("AutoConfigURL")
+	if autoConfigErr != nil && !errors.Is(autoConfigErr, registry.ErrNotExist) {
+		return claudeSystemProxyDetection{Source: "unknown"}
+	}
+	if strings.TrimSpace(autoConfigURL) != "" {
+		return claudeSystemProxyDetection{Enabled: true, Known: true, Source: "wininet_pac"}
+	}
+
+	autoDetect, _, autoDetectErr := key.GetIntegerValue("AutoDetect")
+	if autoDetectErr != nil && !errors.Is(autoDetectErr, registry.ErrNotExist) {
+		return claudeSystemProxyDetection{Source: "unknown"}
+	}
+	if autoDetect != 0 {
+		return claudeSystemProxyDetection{Enabled: true, Known: true, Source: "wininet_auto_detect"}
+	}
+	return claudeWinHTTPProxyStatus()
 }
 
-func claudeEnvironmentKey(key string) string {
-	return strings.ToUpper(key)
+func claudeWinHTTPProxyStatus() claudeSystemProxyDetection {
+	if err := winHTTPGetDefaultProxyConfiguration.Find(); err != nil {
+		return claudeSystemProxyDetection{Source: "unknown"}
+	}
+	var info winHTTPProxyInfo
+	ok, _, callErr := winHTTPGetDefaultProxyConfiguration.Call(uintptr(unsafe.Pointer(&info)))
+	if ok == 0 {
+		if errors.Is(callErr, windows.ERROR_FILE_NOT_FOUND) {
+			return claudeSystemProxyDetection{Known: true, Source: "none"}
+		}
+		return claudeSystemProxyDetection{Source: "unknown"}
+	}
+	defer freeGlobalString(info.Proxy)
+	defer freeGlobalString(info.ProxyBypass)
+
+	switch info.AccessType {
+	case winHTTPAccessTypeNamedProxy:
+		if info.Proxy == nil || strings.TrimSpace(windows.UTF16PtrToString(info.Proxy)) == "" {
+			return claudeSystemProxyDetection{Source: "unknown"}
+		}
+		return claudeSystemProxyDetection{Enabled: true, Known: true, Source: "winhttp_manual"}
+	case winHTTPAccessTypeAutomaticProxy:
+		return claudeSystemProxyDetection{Enabled: true, Known: true, Source: "winhttp_auto"}
+	case winHTTPAccessTypeDefaultProxy, winHTTPAccessTypeNoProxy:
+		return claudeSystemProxyDetection{Known: true, Source: "none"}
+	default:
+		return claudeSystemProxyDetection{Source: "unknown"}
+	}
+}
+
+func freeGlobalString(value *uint16) {
+	if value == nil {
+		return
+	}
+	_, _, _ = globalFreeProc.Call(uintptr(unsafe.Pointer(value)))
 }

--- a/internal/setup/claude_proxy_windows.go
+++ b/internal/setup/claude_proxy_windows.go
@@ -1,0 +1,29 @@
+package setup
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func claudeSystemProxyConfigured() bool {
+	key, err := registry.OpenKey(
+		registry.CURRENT_USER,
+		`Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
+		registry.QUERY_VALUE,
+	)
+	if err != nil {
+		return false
+	}
+	defer key.Close()
+	enabled, _, err := key.GetIntegerValue("ProxyEnable")
+	if err != nil || enabled == 0 {
+		return false
+	}
+	server, _, err := key.GetStringValue("ProxyServer")
+	return err == nil && strings.TrimSpace(server) != ""
+}
+
+func claudeEnvironmentKey(key string) string {
+	return strings.ToUpper(key)
+}

--- a/internal/setup/claude_test.go
+++ b/internal/setup/claude_test.go
@@ -3,11 +3,13 @@ package setup
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/gaixianggeng/mimi-remote/internal/claudebridge"
 )
@@ -218,6 +220,69 @@ func TestParseClaudeAuthStatusRequiresExplicitLoggedInField(t *testing.T) {
 	}
 }
 
+func TestProbeClaudeAuthStatusDoesNotTurnTimeoutIntoSignedOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix 可执行脚本模拟 Claude CLI")
+	}
+	claude := filepath.Join(t.TempDir(), "claude")
+	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then printf '%s\\n' '{\"loggedIn\":false}'; exec sleep 10; fi\n")
+
+	loggedIn, err := probeClaudeAuthStatus(
+		context.Background(),
+		claude,
+		claudeCommandEnvironment(nil),
+		50*time.Millisecond,
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("输出 false 后超时必须保留 timeout 分类，got=%v", err)
+	}
+	if loggedIn == nil || *loggedIn {
+		t.Fatalf("诊断仍应保留进程输出的 loggedIn=false，got=%v", loggedIn)
+	}
+}
+
+func TestProbeClaudeAuthStatusRejectsUnexpectedExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix 可执行脚本模拟 Claude CLI")
+	}
+	claude := filepath.Join(t.TempDir(), "claude")
+	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then printf '%s\\n' '{\"loggedIn\":false}'; exit 2; fi\n")
+
+	loggedIn, err := probeClaudeAuthStatus(
+		context.Background(),
+		claude,
+		claudeCommandEnvironment(nil),
+		time.Second,
+	)
+	if err == nil {
+		t.Fatal("非约定退出码不得被误报为正常未登录")
+	}
+	if loggedIn == nil || *loggedIn {
+		t.Fatalf("诊断仍应保留进程输出的 loggedIn=false，got=%v", loggedIn)
+	}
+}
+
+func TestProbeClaudeAuthStatusDoesNotTurnSignalExitIntoSignedOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("本测试使用 Unix signal 模拟 Claude CLI 异常退出")
+	}
+	claude := filepath.Join(t.TempDir(), "claude")
+	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then printf '%s\\n' '{\"loggedIn\":false}'; kill -TERM $$; fi\n")
+
+	loggedIn, err := probeClaudeAuthStatus(
+		context.Background(),
+		claude,
+		claudeCommandEnvironment(nil),
+		time.Second,
+	)
+	if err == nil {
+		t.Fatal("signal 终止不得被误报为正常未登录")
+	}
+	if loggedIn == nil || *loggedIn {
+		t.Fatalf("诊断仍应保留进程输出的 loggedIn=false，got=%v", loggedIn)
+	}
+}
+
 func writeClaudeConfigurationFixture(t *testing.T, authExit int, enabled bool) string {
 	t.Helper()
 	root := t.TempDir()
@@ -229,7 +294,7 @@ func writeClaudeConfigurationFixture(t *testing.T, authExit int, enabled bool) s
 	if authExit != 0 {
 		loggedIn = "false"
 	}
-	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then printf '{\\\"loggedIn\\\":"+loggedIn+"}\\n'; exit "+strconv.Itoa(authExit)+"; fi\nprintf 'claude 2.1.220\\n'\n")
+	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then printf '%s\\n' '{\"loggedIn\":"+loggedIn+"}'; exit "+strconv.Itoa(authExit)+"; fi\nprintf 'claude 2.1.220\\n'\n")
 	configPath := filepath.Join(root, "config.json")
 	document := map[string]any{
 		"auth": map[string]any{"token": "0123456789abcdef0123456789abcdef"},

--- a/internal/setup/claude_test.go
+++ b/internal/setup/claude_test.go
@@ -205,6 +205,19 @@ func TestParseClaudeActivationPreferenceRejectsUnknownValue(t *testing.T) {
 	}
 }
 
+func TestParseClaudeAuthStatusRequiresExplicitLoggedInField(t *testing.T) {
+	loggedIn, ok := parseClaudeAuthStatus([]byte(`{"loggedIn":true,"authMethod":"claude.ai"}`))
+	if !ok || !loggedIn {
+		t.Fatal("有效 Claude auth status 应解析为已登录")
+	}
+	if _, ok := parseClaudeAuthStatus([]byte(`{"authMethod":"claude.ai"}`)); ok {
+		t.Fatal("缺少 loggedIn 时不得猜测登录状态")
+	}
+	if _, ok := parseClaudeAuthStatus([]byte(`not-json`)); ok {
+		t.Fatal("无效输出不得误报为已登出")
+	}
+}
+
 func writeClaudeConfigurationFixture(t *testing.T, authExit int, enabled bool) string {
 	t.Helper()
 	root := t.TempDir()
@@ -212,7 +225,11 @@ func writeClaudeConfigurationFixture(t *testing.T, authExit int, enabled bool) s
 	claude := filepath.Join(root, "claude")
 	// 测试夹具跟随 agentd 的最低兼容版本，避免能力门禁升级后测试仍伪装成旧 bridge。
 	writeExecutableFixture(t, bridge, "printf 'alleycat-claude-bridge "+claudebridge.MinimumVersion+"\\n'\n")
-	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then exit "+strconv.Itoa(authExit)+"; fi\nprintf 'claude 2.1.220\\n'\n")
+	loggedIn := "true"
+	if authExit != 0 {
+		loggedIn = "false"
+	}
+	writeExecutableFixture(t, claude, "if [ \"$1\" = \"auth\" ]; then printf '{\\\"loggedIn\\\":"+loggedIn+"}\\n'; exit "+strconv.Itoa(authExit)+"; fi\nprintf 'claude 2.1.220\\n'\n")
 	configPath := filepath.Join(root, "config.json")
 	document := map[string]any{
 		"auth": map[string]any{"token": "0123456789abcdef0123456789abcdef"},

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -167,6 +167,7 @@ func runWithFileOps(ctx context.Context, options Options, fileOps setupFileTrans
 				"TERM": "xterm-256color",
 			},
 		},
+		Claude: config.DefaultClaudeConfig(),
 		Session: config.SessionConfig{
 			OutputBufferBytes: 128 * 1024,
 		},

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -86,6 +86,20 @@ func TestRunCreatesConfigAndPairURL(t *testing.T) {
 	if len(cfg.ScanRoots) != 1 || cfg.ScanRoots[0] != scanRoot {
 		t.Fatalf("scan root 未写入配置：%+v", cfg.ScanRoots)
 	}
+	if cfg.Claude.MaxConcurrentBridges != config.DefaultClaudeMaxConcurrentBridges {
+		t.Fatalf("setup Claude 并发默认值异常：got=%d want=%d", cfg.Claude.MaxConcurrentBridges, config.DefaultClaudeMaxConcurrentBridges)
+	}
+	rawConfig, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored config.Config
+	if err := json.Unmarshal(rawConfig, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.Claude.MaxConcurrentBridges != config.DefaultClaudeMaxConcurrentBridges {
+		t.Fatalf("setup 必须把有效 Claude 并发值写入磁盘：got=%d want=%d", stored.Claude.MaxConcurrentBridges, config.DefaultClaudeMaxConcurrentBridges)
+	}
 }
 
 func TestPairingURLRefreshCreatesDistinctTicketsAndKeepsPriorValidUntilOwnExpiry(t *testing.T) {


### PR DESCRIPTION
## Summary

- resolve and persist a directly executable Windows Claude Code binary, including the official `.local` install and migration from the npm `claude.cmd` shim to the package-native `claude.exe`
- use one deterministic, restricted environment for setup probes and the resident bridge, including Windows profile/temp variables and documented lowercase proxy precedence for `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`
- report Claude CLI version, correctly classified auth state, process proxy readiness, and tri-state WinINET/PAC/WPAD/WinHTTP proxy diagnostics with actionable configuration guidance
- redact proxy credentials at both the Rust child diagnostic boundary and the Go agentd log boundary
- degrade only explicit effort-level rejections; preserve timeout, writer, and process-exit errors, cache only confirmed method-level incompatibility, and serialize concurrent runtime overrides
- keep native Windows secure by disabling both Bash and PowerShell because Claude's Bash sandbox is unavailable there; built-in tools remain behind stdio permission approvals
- write a valid default Claude bridge concurrency of 3 during setup and normalize legacy on-disk zero values so upgraded Windows services remain startable
- fix the Linux auth fixture so the PR Gate receives valid JSON

## Verification

- Windows real session: Claude Code 2.1.240, native npm binary, HTTP(S) proxy enabled, effort=medium; received `MIM179_OK` and `turn/completed`
- restored and restarted the installed v0.3.7 Windows service; `healthz`, process, service, and doctor checks pass with Claude enabled and `max_concurrent_bridges=3`
- `cargo +stable-x86_64-pc-windows-gnullvm test --workspace` — pass
- Go targeted config/setup/httpapi/claudeenv regression tests — pass
- `go test ./... -count=1` — only the two existing Windows tests that require symbolic-link privilege fail with `ERROR_PRIVILEGE_NOT_HELD`; all other packages/tests pass
- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass

## Security note

Native Windows Claude Code currently has no supported Bash sandbox. This change does not fall back to an unsandboxed shell: it explicitly disables Bash and PowerShell on Windows and keeps permission prompts enabled for other tools. WSL2 remains the path for fully sandboxed shell execution.

Linear: MIM-179