### PR TITLE
MIM-184 修复 Apple 语音启动卡住

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		989F7144D36711010C69FAD9 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 6C892E2BB83F2EE5FDD6EDA4 /* Localizable.xcstrings */; };
 		9928E62AE42C8C038223B3EC /* testComposerStatusTrayExtremelyNarrowCompactWidth.1.png in Resources */ = {isa = PBXBuildFile; fileRef = CEE63E1F88F94DC3D0C543CF /* testComposerStatusTrayExtremelyNarrowCompactWidth.1.png */; };
 		9B897FC15CC75C70A0DC5444 /* TokenUsageCardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620EE3CCFD6A92164C8F272F /* TokenUsageCardSnapshotTests.swift */; platformFilters = (ios, ); };
+		A18400000000000000000001 /* AppleVoiceStartupWatchdogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A18400000000000000000002 /* AppleVoiceStartupWatchdogTests.swift */; };
 		9BB164C3CFDE5A1120D2A096 /* ProfileRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302CD30CD51E926987FAD6C3 /* ProfileRootView.swift */; };
 		9CDA4F02261EE4460043EC2B /* testRichMarkdownConversationRendering.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 2ACC589478ECDD4A4FB9BEB0 /* testRichMarkdownConversationRendering.1.png */; };
 		9DB7FDC4C6AB0FBB1DE2DC8D /* testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5F6590638B16083675339655 /* testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png */; };
@@ -485,6 +486,7 @@
 		83CFAE116262795C7501365E /* CarStatusSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshotTests.swift; sourceTree = "<group>"; };
 		85879EDF3D64609C3C6BA873 /* WorkspaceGitSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGitSummaryTests.swift; sourceTree = "<group>"; };
 		86B6C2FC1CE749D7A8268F85 /* ConversationComposerHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationComposerHistoryTests.swift; sourceTree = "<group>"; };
+		A18400000000000000000002 /* AppleVoiceStartupWatchdogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleVoiceStartupWatchdogTests.swift; sourceTree = "<group>"; };
 		88A2FAA4C2526405C2DDB750 /* LogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStore.swift; sourceTree = "<group>"; };
 		8AA53A2531C62C2974077C88 /* LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
 		8AE76E723980EA82E7BBD4A8 /* testSkillInvocationCardLightAppearance.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSkillInvocationCardLightAppearance.1.png; sourceTree = "<group>"; };
@@ -743,6 +745,7 @@
 			children = (
 				1FC88F25CEBA6C13050A2B4F /* AgentAPIClientRequestTests.swift */,
 				554F31B0074B97074AE97B31 /* AppExternalLinksTests.swift */,
+				A18400000000000000000002 /* AppleVoiceStartupWatchdogTests.swift */,
 				54AAB784C642D2B0234E48BA /* CameraAttachmentTests.swift */,
 				83CFAE116262795C7501365E /* CarStatusSnapshotTests.swift */,
 				FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */,
@@ -1483,6 +1486,7 @@
 			files = (
 				84F5B773E0438B85B671B2F3 /* AgentAPIClientRequestTests.swift in Sources */,
 				FA451031EB72AE10C3552C3F /* AppExternalLinksTests.swift in Sources */,
+				A18400000000000000000001 /* AppleVoiceStartupWatchdogTests.swift in Sources */,
 				03E7996441667D59DF2F9E3A /* CameraAttachmentTests.swift in Sources */,
 				101A9079E24B09BCAB8B54FF /* CarStatusSnapshotTests.swift in Sources */,
 				523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */,

--- a/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
@@ -219,6 +219,7 @@ final class AppleSpeechTranscriptionSession {
 
     func start(
         locale: Locale,
+        onStartupMonitoringReady: @escaping @MainActor () -> Void,
         onTranscript: @escaping @MainActor (String) -> Void,
         onLevel: @escaping @MainActor (CGFloat) -> Void,
         onFailure: @escaping @MainActor (Error) -> Void
@@ -248,6 +249,7 @@ final class AppleSpeechTranscriptionSession {
             try await installationRequest.downloadAndInstall()
         }
         try Task.checkCancellation()
+        onStartupMonitoringReady()
 
         guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: modules) else {
             throw AppleSpeechTranscriptionError.audioFormatUnavailable

--- a/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
@@ -122,6 +122,7 @@ enum AppleSpeechTranscriptionError: LocalizedError {
     case noTranscriptionResult
     case audioSessionInterrupted
     case mediaServicesReset
+    case startupTimedOut
 
     var errorDescription: String? {
         switch self {
@@ -133,7 +134,7 @@ enum AppleSpeechTranscriptionError: LocalizedError {
             return L10n.text("ui.apple_voice_input_audio_conversion_failed")
         case .recordingFailed:
             return L10n.text("ui.apple_voice_input_could_not_start_recording")
-        case .resultStreamEnded, .noTranscriptionResult, .mediaServicesReset:
+        case .resultStreamEnded, .noTranscriptionResult, .mediaServicesReset, .startupTimedOut:
             return L10n.text("ui.apple_voice_input_stopped_please_try_again")
         case .audioSessionInterrupted:
             return L10n.text("ui.apple_voice_input_was_interrupted_please_try_again")
@@ -158,6 +159,8 @@ enum AppleSpeechTranscriptionError: LocalizedError {
             return "audio_session_interrupted"
         case .mediaServicesReset:
             return "media_services_reset"
+        case .startupTimedOut:
+            return "startup_timeout"
         }
     }
 }
@@ -172,7 +175,7 @@ final class AppleSpeechTranscriptionSession {
         category: "AppleSpeech"
     )
 
-    private let sessionID = UUID()
+    private let sessionID: UUID
     private var analyzer: SpeechAnalyzer?
     private var audioEngine: AVAudioEngine?
     private let audioSessionCoordinator: VoiceAudioSessionCoordinator
@@ -188,8 +191,30 @@ final class AppleSpeechTranscriptionSession {
     private var acceptsTranscriptionResults = false
     private var isFinishing = false
 
-    init(audioSessionCoordinator: VoiceAudioSessionCoordinator = .shared) {
+    init(
+        sessionID: UUID = UUID(),
+        audioSessionCoordinator: VoiceAudioSessionCoordinator = .shared
+    ) {
+        self.sessionID = sessionID
         self.audioSessionCoordinator = audioSessionCoordinator
+    }
+
+    func logStartRequested(locale: Locale) {
+        Self.logger.info(
+            "start_requested id=\(self.sessionID.uuidString, privacy: .public) locale=\(locale.identifier, privacy: .public)"
+        )
+    }
+
+    func logPermissionDone(granted: Bool) {
+        Self.logger.info(
+            "permission_done id=\(self.sessionID.uuidString, privacy: .public) granted=\(granted, privacy: .public)"
+        )
+    }
+
+    func logStartupTimeout() {
+        Self.logger.error(
+            "startup_timeout id=\(self.sessionID.uuidString, privacy: .public)"
+        )
     }
 
     func start(
@@ -334,7 +359,11 @@ final class AppleSpeechTranscriptionSession {
         onLevel: @escaping @MainActor (CGFloat) -> Void,
         onFailure: @escaping @MainActor (Error) -> Void
     ) async throws {
+        try Task.checkCancellation()
         let activation = try await audioSessionCoordinator.activate()
+        Self.logger.info(
+            "audio_session_activated id=\(self.sessionID.uuidString, privacy: .public)"
+        )
         do {
             // start() 等待系统会话期间可能已被取消；先检查，再触碰 MainActor 上的 engine。
             try Task.checkCancellation()
@@ -379,6 +408,9 @@ final class AppleSpeechTranscriptionSession {
                 inputNode.removeTap(onBus: 0)
                 throw AppleSpeechTranscriptionError.recordingFailed
             }
+            Self.logger.info(
+                "audio_engine_started id=\(self.sessionID.uuidString, privacy: .public)"
+            )
             audioEngine = engine
             audioSessionActivation = activation
             Self.logger.info(

--- a/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
@@ -362,7 +362,9 @@ final class AppleSpeechTranscriptionSession {
         onFailure: @escaping @MainActor (Error) -> Void
     ) async throws {
         try Task.checkCancellation()
-        let activation = try await audioSessionCoordinator.activate()
+        let activation = try await audioSessionCoordinator.activate(onRecovery: { [weak self] succeeded in
+            self?.recoverAudioCapture(succeeded: succeeded, onFailure: onFailure)
+        })
         Self.logger.info(
             "audio_session_activated id=\(self.sessionID.uuidString, privacy: .public)"
         )
@@ -421,6 +423,41 @@ final class AppleSpeechTranscriptionSession {
         } catch {
             await audioSessionCoordinator.deactivate(activation)
             throw error
+        }
+    }
+
+    private func recoverAudioCapture(
+        succeeded: Bool,
+        onFailure: @escaping @MainActor (Error) -> Void
+    ) {
+        guard !isFinishing,
+              audioSessionActivation != nil,
+              let audioEngine else {
+            return
+        }
+        guard succeeded else {
+            reportFailure(
+                AppleSpeechTranscriptionError.recordingFailed,
+                stage: "audio_session_recovery",
+                onFailure: onFailure
+            )
+            return
+        }
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+            Self.logger.info(
+                "audio_capture_recovered id=\(self.sessionID.uuidString, privacy: .public)"
+            )
+        } catch {
+            reportFailure(
+                AppleSpeechTranscriptionError.recordingFailed,
+                stage: "audio_session_recovery",
+                onFailure: onFailure
+            )
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/AppleSpeechTranscription.swift
@@ -180,6 +180,7 @@ final class AppleSpeechTranscriptionSession {
     private var audioEngine: AVAudioEngine?
     private let audioSessionCoordinator: VoiceAudioSessionCoordinator
     private var audioSessionActivation: VoiceAudioSessionCoordinator.Activation?
+    private var audioSessionRecoveryGate = VoiceAudioCaptureRecoveryGate()
     private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
     private var resultsTask: Task<Void, Never>?
     private var audioSessionObserverTokens: [NSObjectProtocol] = []
@@ -232,6 +233,7 @@ final class AppleSpeechTranscriptionSession {
         didReceiveFirstAudioBuffer = false
         didReceiveFirstResult = false
         acceptsTranscriptionResults = true
+        audioSessionRecoveryGate.reset()
         healthMonitor.reset()
         Self.logger.info(
             "session_start id=\(self.sessionID.uuidString, privacy: .public) locale=\(locale.identifier, privacy: .public)"
@@ -371,6 +373,9 @@ final class AppleSpeechTranscriptionSession {
         do {
             // start() 等待系统会话期间可能已被取消；先检查，再触碰 MainActor 上的 engine。
             try Task.checkCancellation()
+            if audioSessionRecoveryGate.consumePendingResult() == false {
+                throw AppleSpeechTranscriptionError.recordingFailed
+            }
 
             let engine = AVAudioEngine()
             let inputNode = engine.inputNode
@@ -430,12 +435,17 @@ final class AppleSpeechTranscriptionSession {
         succeeded: Bool,
         onFailure: @escaping @MainActor (Error) -> Void
     ) {
-        guard !isFinishing,
-              audioSessionActivation != nil,
-              let audioEngine else {
+        guard !isFinishing else {
             return
         }
-        guard succeeded else {
+        guard let recoveryResult = audioSessionRecoveryGate.receive(
+            succeeded,
+            isCaptureReady: audioSessionActivation != nil && audioEngine != nil
+        ) else {
+            return
+        }
+        guard let audioEngine else { return }
+        guard recoveryResult else {
             reportFailure(
                 AppleSpeechTranscriptionError.recordingFailed,
                 stage: "audio_session_recovery",
@@ -621,6 +631,7 @@ final class AppleSpeechTranscriptionSession {
         healthWatchdogTask = nil
         stopObservingAudioSession()
         healthMonitor.reset()
+        audioSessionRecoveryGate.reset()
         acceptsTranscriptionResults = false
         analyzer = nil
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -792,9 +792,17 @@ final class VoiceInputController: NSObject, ObservableObject {
                     await session.cancel()
                     return
                 }
-                armAppleStartupWatchdog(requestID: requestID)
                 try await session.start(
                     locale: locale,
+                    onStartupMonitoringReady: { [weak self] in
+                        guard let self,
+                              activeProvider == .apple,
+                              startRequestID == requestID,
+                              isPreparing else {
+                            return
+                        }
+                        armAppleStartupWatchdog(requestID: requestID)
+                    },
                     onTranscript: { [weak self] transcript in
                         guard self?.activeProvider == .apple,
                               self?.startRequestID == requestID else {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -792,6 +792,7 @@ final class VoiceInputController: NSObject, ObservableObject {
                     await session.cancel()
                     return
                 }
+                armAppleStartupWatchdog(requestID: requestID)
                 try await session.start(
                     locale: locale,
                     onTranscript: { [weak self] transcript in
@@ -852,20 +853,6 @@ final class VoiceInputController: NSObject, ObservableObject {
                 completeAppleInteraction(notifyFinish: true)
             }
         }
-        appleStartupWatchdogTask = AppleVoiceStartupWatchdog().arm { [weak self] in
-            guard let self,
-                  self.activeProvider == .apple,
-                  self.startRequestID == requestID,
-                  self.isPreparing else {
-                return
-            }
-            (self.appleSession as? AppleSpeechTranscriptionSession)?.logStartupTimeout()
-            self.errorMessage = self.userFacingAppleSpeechError(
-                AppleSpeechTranscriptionError.startupTimedOut
-            )
-            self.startRequestID = nil
-            self.cancelAppleTranscription(notifyFinish: true)
-        }
     }
 
     func stop() {
@@ -913,7 +900,6 @@ final class VoiceInputController: NSObject, ObservableObject {
             return
         }
         cancelAppleStartupWatchdog()
-        startRequestID = nil
         isPreparing = false
         isRecording = false
         levelMeter.reset()
@@ -983,6 +969,24 @@ final class VoiceInputController: NSObject, ObservableObject {
     private func cancelAppleStartupWatchdog() {
         appleStartupWatchdogTask?.cancel()
         appleStartupWatchdogTask = nil
+    }
+
+    @available(iOS 26.0, *)
+    private func armAppleStartupWatchdog(requestID: UUID) {
+        cancelAppleStartupWatchdog()
+        appleStartupWatchdogTask = AppleVoiceStartupWatchdog().arm { [weak self] in
+            guard let self,
+                  self.activeProvider == .apple,
+                  self.startRequestID == requestID,
+                  self.isPreparing else {
+                return
+            }
+            (self.appleSession as? AppleSpeechTranscriptionSession)?.logStartupTimeout()
+            self.errorMessage = self.userFacingAppleSpeechError(
+                AppleSpeechTranscriptionError.startupTimedOut
+            )
+            self.cancelAppleTranscription(notifyFinish: true)
+        }
     }
 
     private func userFacingAppleSpeechError(_ error: Error) -> String {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -594,6 +594,18 @@ final class SystemVoiceAudioSessionBackend: VoiceAudioSessionBackend, @unchecked
     }
 }
 
+private final class VoiceAudioSessionOperationSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: UInt64 = 0
+
+    func next() -> UInt64 {
+        lock.withLock {
+            value &+= 1
+            return value
+        }
+    }
+}
+
 actor VoiceAudioSessionCoordinator {
     typealias RecoveryHandler = @MainActor @Sendable (_ succeeded: Bool) -> Void
 
@@ -604,11 +616,13 @@ actor VoiceAudioSessionCoordinator {
     static let shared = VoiceAudioSessionCoordinator()
 
     private let backend: any VoiceAudioSessionBackend
+    private let operationSequence = VoiceAudioSessionOperationSequence()
     private var currentActivationID: UUID?
     private var currentActivationRecoveryHandler: RecoveryHandler?
     private var activationRequestIDs: Set<UUID> = []
     private var latestActivationRequestID: UUID?
-    private var failedActivationRefreshRequestIDs: Set<UUID> = []
+    private var latestSuccessfulActivationSequences: [UUID: UInt64] = [:]
+    private var failedActivationRefreshSequences: [UUID: UInt64] = [:]
     private var hasAbandonedActivation = false
 
     init(backend: any VoiceAudioSessionBackend = SystemVoiceAudioSessionBackend()) {
@@ -631,16 +645,31 @@ actor VoiceAudioSessionCoordinator {
 
         var didActivateBackend = false
         do {
-            repeat {
-                try await performActivationAttempt(requestID: requestID)
+            while true {
+                let activationSequence = try await performActivationAttempt(requestID: requestID)
                 didActivateBackend = true
+                recordSuccessfulActivation(activationSequence, for: requestID)
                 try Task.checkCancellation()
                 // 旧停用可能在本次 setActive 成功后才落地。补激活若已明确失败，
                 // 发布租约前再激活一次，不能让调用方在失活会话上启动采集器。
-            } while failedActivationRefreshRequestIDs.remove(requestID) != nil
+                guard let deactivationSequence = failedActivationRefreshSequences.removeValue(
+                    forKey: requestID
+                ) else {
+                    break
+                }
+                let latestActivationSequence = latestSuccessfulActivationSequences[
+                    requestID,
+                    default: activationSequence
+                ]
+                if latestActivationSequence > deactivationSequence {
+                    // 本次 setActive 晚于旧停用落地，会话已经恢复，不需要重复激活。
+                    break
+                }
+            }
         } catch {
             activationRequestIDs.remove(requestID)
-            failedActivationRefreshRequestIDs.remove(requestID)
+            failedActivationRefreshSequences.removeValue(forKey: requestID)
+            latestSuccessfulActivationSequences.removeValue(forKey: requestID)
             if didActivateBackend {
                 markAbandonedActivation()
             }
@@ -650,20 +679,26 @@ actor VoiceAudioSessionCoordinator {
 
         activationRequestIDs.remove(requestID)
         guard latestActivationRequestID == requestID else {
+            latestSuccessfulActivationSequences.removeValue(forKey: requestID)
             markAbandonedActivation()
             deactivateAbandonedActivationIfIdle()
             throw CancellationError()
         }
 
         let activation = Activation(id: requestID)
+        if let previousActivationID = currentActivationID,
+           previousActivationID != activation.id {
+            latestSuccessfulActivationSequences.removeValue(forKey: previousActivationID)
+        }
         currentActivationID = activation.id
         currentActivationRecoveryHandler = onRecovery
         hasAbandonedActivation = false
         return activation
     }
 
-    private func performActivationAttempt(requestID: UUID) async throws {
+    private func performActivationAttempt(requestID: UUID) async throws -> UInt64 {
         let backend = self.backend
+        let operationSequence = self.operationSequence
         // setActive(true) 是同步阻塞调用。每次尝试使用独立执行任务，确保一次挂起不会占住
         // coordinator actor；后续重试仍能登记自己的请求并独立尝试激活。
         let activationTask = Task.detached(priority: .userInitiated) {
@@ -671,8 +706,9 @@ actor VoiceAudioSessionCoordinator {
             try backend.prepareForRecording()
             try Task.checkCancellation()
             try backend.activateForRecording()
+            return operationSequence.next()
         }
-        try await withTaskCancellationHandler {
+        return try await withTaskCancellationHandler {
             try await activationTask.value
         } onCancel: {
             activationTask.cancel()
@@ -685,8 +721,16 @@ actor VoiceAudioSessionCoordinator {
     private func cancelActivationRequest(_ requestID: UUID) {
         // 同步系统调用可能不响应 Task 取消；先移除逻辑请求，避免它阻止有效重试结束时停用。
         activationRequestIDs.remove(requestID)
-        failedActivationRefreshRequestIDs.remove(requestID)
+        failedActivationRefreshSequences.removeValue(forKey: requestID)
+        latestSuccessfulActivationSequences.removeValue(forKey: requestID)
         deactivateAbandonedActivationIfIdle()
+    }
+
+    private func recordSuccessfulActivation(_ sequence: UInt64, for requestID: UUID) {
+        latestSuccessfulActivationSequences[requestID] = max(
+            latestSuccessfulActivationSequences[requestID] ?? 0,
+            sequence
+        )
     }
 
     private func markAbandonedActivation() {
@@ -711,15 +755,16 @@ actor VoiceAudioSessionCoordinator {
 
     private func scheduleDeactivation() {
         let backend = self.backend
+        let operationSequence = self.operationSequence
         Task.detached(priority: .userInitiated) {
             // iOS 18–25 在新 I/O 已经启动时可能先停用会话，再以 isBusy 返回失败。
             // 无论返回值如何，都按“可能已经停用”处理；有新租约时补激活是幂等且更安全的结果。
             try? backend.deactivateRecording()
-            await self.deactivationDidComplete()
+            await self.deactivationDidComplete(sequence: operationSequence.next())
         }
     }
 
-    private func deactivationDidComplete() {
+    private func deactivationDidComplete(sequence: UInt64) {
         hasAbandonedActivation = false
         guard currentActivationID != nil || !activationRequestIDs.isEmpty else {
             return
@@ -728,11 +773,18 @@ actor VoiceAudioSessionCoordinator {
         let recoveryActivationID = currentActivationID ?? latestActivationRequestID.flatMap { requestID in
             activationRequestIDs.contains(requestID) ? requestID : nil
         }
-        scheduleActivationRefresh(recoveryActivationID: recoveryActivationID)
+        scheduleActivationRefresh(
+            recoveryActivationID: recoveryActivationID,
+            deactivationSequence: sequence
+        )
     }
 
-    private func scheduleActivationRefresh(recoveryActivationID: UUID?) {
+    private func scheduleActivationRefresh(
+        recoveryActivationID: UUID?,
+        deactivationSequence: UInt64
+    ) {
         let backend = self.backend
+        let operationSequence = self.operationSequence
         Task.detached(priority: .userInitiated) {
             do {
                 try backend.prepareForRecording()
@@ -740,12 +792,16 @@ actor VoiceAudioSessionCoordinator {
             } catch {
                 await self.activationRefreshDidFinish(
                     recoveryActivationID: recoveryActivationID,
+                    deactivationSequence: deactivationSequence,
+                    activationSequence: nil,
                     succeeded: false
                 )
                 return
             }
             await self.activationRefreshDidFinish(
                 recoveryActivationID: recoveryActivationID,
+                deactivationSequence: deactivationSequence,
+                activationSequence: operationSequence.next(),
                 succeeded: true
             )
         }
@@ -753,10 +809,21 @@ actor VoiceAudioSessionCoordinator {
 
     private func activationRefreshDidFinish(
         recoveryActivationID: UUID?,
+        deactivationSequence: UInt64,
+        activationSequence: UInt64?,
         succeeded: Bool
     ) {
         if let recoveryActivationID,
+           let latestActivationSequence = latestSuccessfulActivationSequences[recoveryActivationID],
+           latestActivationSequence > deactivationSequence {
+            // 同一请求已有一次发生在旧停用之后的成功激活；迟到补激活结果不能结束健康录音。
+            return
+        }
+        if let recoveryActivationID,
            currentActivationID == recoveryActivationID {
+            if let activationSequence {
+                recordSuccessfulActivation(activationSequence, for: recoveryActivationID)
+            }
             if let recoveryHandler = currentActivationRecoveryHandler {
                 // setActive(false) 已经可能中断当前采集；补激活后通知租约持有者重启采集器。
                 Task { @MainActor in
@@ -768,10 +835,16 @@ actor VoiceAudioSessionCoordinator {
         if let recoveryActivationID,
            currentActivationID == nil,
            activationRequestIDs.contains(recoveryActivationID) {
+            if let activationSequence {
+                recordSuccessfulActivation(activationSequence, for: recoveryActivationID)
+            }
             // 请求的后端 setActive 已经可能成功，但 actor 还未发布租约。记录补激活失败，
             // 让该请求在取得租约前重新确认会话为 active。
             if !succeeded {
-                failedActivationRefreshRequestIDs.insert(recoveryActivationID)
+                failedActivationRefreshSequences[recoveryActivationID] = max(
+                    failedActivationRefreshSequences[recoveryActivationID] ?? 0,
+                    deactivationSequence
+                )
             }
             return
         }
@@ -794,6 +867,7 @@ actor VoiceAudioSessionCoordinator {
         }
         currentActivationID = nil
         currentActivationRecoveryHandler = nil
+        latestSuccessfulActivationSequences.removeValue(forKey: activation.id)
         // 新请求已进入 setActive 时，旧租约只能移交当前激活状态，不能执行全局停用。
         // 新请求成功后会接管租约；失败或取消后再由 abandoned cleanup 配对停用。
         guard activationRequestIDs.isEmpty else {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -26,6 +26,28 @@ struct AppleVoiceStartupWatchdog {
     }
 }
 
+struct VoiceAudioCaptureRecoveryGate {
+    private var pendingResult: Bool?
+
+    mutating func receive(_ succeeded: Bool, isCaptureReady: Bool) -> Bool? {
+        guard isCaptureReady else {
+            // 租约可能先于采集器发布；保留最新结果，不能在启动窗口静默丢失恢复失败。
+            pendingResult = succeeded
+            return nil
+        }
+        return succeeded
+    }
+
+    mutating func consumePendingResult() -> Bool? {
+        defer { pendingResult = nil }
+        return pendingResult
+    }
+
+    mutating func reset() {
+        pendingResult = nil
+    }
+}
+
 enum VoiceMicButtonState: Equatable {
     case idle
     case preparing
@@ -914,6 +936,7 @@ final class VoiceInputController: NSObject, ObservableObject {
     private var appleFinishHandler: (() -> Void)?
     private let audioSessionCoordinator: VoiceAudioSessionCoordinator
     private var audioSessionActivation: VoiceAudioSessionCoordinator.Activation?
+    private var audioSessionRecoveryGate = VoiceAudioCaptureRecoveryGate()
     private var audioSessionCleanupTask: Task<Void, Never>?
     private var codexStartupTask: Task<Void, Never>?
 
@@ -932,6 +955,7 @@ final class VoiceInputController: NSObject, ObservableObject {
         finishHandler = onFinish
         pressStartedAt = Date()
         recordingStartedAt = nil
+        audioSessionRecoveryGate.reset()
         errorMessage = nil
         noticeMessage = nil
 
@@ -1289,6 +1313,9 @@ final class VoiceInputController: NSObject, ObservableObject {
             guard startRequestID == requestID else {
                 throw CancellationError()
             }
+            if audioSessionRecoveryGate.consumePendingResult() == false {
+                throw VoiceInputError.recordingFailed
+            }
 
             let url = FileManager.default.temporaryDirectory
                 .appendingPathComponent("voice-\(UUID().uuidString)")
@@ -1322,12 +1349,17 @@ final class VoiceInputController: NSObject, ObservableObject {
 
     private func recoverCodexAudioCapture(requestID: UUID, succeeded: Bool) {
         guard activeProvider == .codex,
-              startRequestID == requestID,
-              isRecording,
-              let recorder else {
+              startRequestID == requestID else {
             return
         }
-        guard succeeded else {
+        guard let recoveryResult = audioSessionRecoveryGate.receive(
+            succeeded,
+            isCaptureReady: isRecording && recorder != nil
+        ) else {
+            return
+        }
+        guard let recorder else { return }
+        guard recoveryResult else {
             errorMessage = VoiceInputError.recordingFailed.localizedDescription
             finish(fileURL: nil)
             return
@@ -1422,6 +1454,7 @@ final class VoiceInputController: NSObject, ObservableObject {
         startRequestID = nil
         pressStartedAt = nil
         recordingStartedAt = nil
+        audioSessionRecoveryGate.reset()
         isPreparing = false
         isRecording = false
         activeProvider = nil

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -2,6 +2,30 @@ import AVFoundation
 import SwiftUI
 import UIKit
 
+struct AppleVoiceStartupWatchdog {
+    static let defaultTimeout: Duration = .seconds(15)
+
+    let timeout: Duration
+
+    init(timeout: Duration = Self.defaultTimeout) {
+        self.timeout = timeout
+    }
+
+    func arm(onTimeout: @escaping @MainActor @Sendable () -> Void) -> Task<Void, Never> {
+        Task { @MainActor in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else {
+                return
+            }
+            onTimeout()
+        }
+    }
+}
+
 enum VoiceMicButtonState: Equatable {
     case idle
     case preparing
@@ -562,7 +586,7 @@ final class SystemVoiceAudioSessionBackend: VoiceAudioSessionBackend, @unchecked
     }
 
     func activateForRecording() throws {
-        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        try audioSession.setActive(true)
     }
 
     func deactivateRecording() throws {
@@ -589,8 +613,22 @@ actor VoiceAudioSessionCoordinator {
     }
 
     func activate() throws -> Activation {
+        try Task.checkCancellation()
         try backend.prepareForRecording()
+        try Task.checkCancellation()
+
+        let hadExistingActivation = currentActivationID != nil
         try backend.activateForRecording()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            // setActive 已经成功但调用方在返回前取消时，必须撤销这次独占激活。
+            // 已有租约表示音频会话原本就在使用中，此时不能误停仍有效的新会话。
+            if !hadExistingActivation {
+                try? backend.deactivateRecording()
+            }
+            throw error
+        }
         let activation = Activation(id: UUID())
         currentActivationID = activation.id
         return activation
@@ -629,6 +667,7 @@ final class VoiceInputController: NSObject, ObservableObject {
     // 只在 iOS 26+ 方法内部还原成 AppleSpeechTranscriptionSession。
     private var appleSession: AnyObject?
     private var appleLifecycleTask: Task<Void, Never>?
+    private var appleStartupWatchdogTask: Task<Void, Never>?
     private var appleFinishHandler: (() -> Void)?
     private let audioSessionCoordinator: VoiceAudioSessionCoordinator
     private var audioSessionActivation: VoiceAudioSessionCoordinator.Activation?
@@ -729,17 +768,21 @@ final class VoiceInputController: NSObject, ObservableObject {
 
         isPreparing = true
         MimiHaptics.prepare(.commit)
-        let session = AppleSpeechTranscriptionSession(audioSessionCoordinator: audioSessionCoordinator)
+        let session = AppleSpeechTranscriptionSession(
+            sessionID: requestID,
+            audioSessionCoordinator: audioSessionCoordinator
+        )
         appleSession = session
-        let pendingAudioSessionCleanup = audioSessionCleanupTask
+        session.logStartRequested(locale: locale)
         appleLifecycleTask = Task { [weak self, weak session] in
             guard let self, let session else { return }
             do {
-                // cancel() 会立即恢复 UI；真正开始下一轮前仍需等旧音频会话清理完毕。
-                await pendingAudioSessionCleanup?.value
                 guard startRequestID == requestID else { return }
-                guard await requestRecordPermission() else {
+                let granted = await requestRecordPermission()
+                session.logPermissionDone(granted: granted)
+                guard granted else {
                     guard startRequestID == requestID else { return }
+                    cancelAppleStartupWatchdog()
                     errorMessage = L10n.text("ui.microphone_permission_is_not_enabled_please_allow_it")
                     await session.cancel()
                     completeAppleInteraction(notifyFinish: true)
@@ -775,6 +818,7 @@ final class VoiceInputController: NSObject, ObservableObject {
                         // 结果流可能在 session.start() 返回前就失败；先让本次请求失效，
                         // 防止外层启动任务随后又把已经失败的会话标成录音中。
                         startRequestID = nil
+                        cancelAppleStartupWatchdog()
                         errorMessage = userFacingAppleSpeechError(error)
                         isPreparing = false
                         isRecording = false
@@ -789,6 +833,7 @@ final class VoiceInputController: NSObject, ObservableObject {
                     await session.cancel()
                     return
                 }
+                cancelAppleStartupWatchdog()
                 appleLifecycleTask = nil
                 isPreparing = false
                 isRecording = true
@@ -806,6 +851,20 @@ final class VoiceInputController: NSObject, ObservableObject {
                 errorMessage = userFacingAppleSpeechError(error)
                 completeAppleInteraction(notifyFinish: true)
             }
+        }
+        appleStartupWatchdogTask = AppleVoiceStartupWatchdog().arm { [weak self] in
+            guard let self,
+                  self.activeProvider == .apple,
+                  self.startRequestID == requestID,
+                  self.isPreparing else {
+                return
+            }
+            (self.appleSession as? AppleSpeechTranscriptionSession)?.logStartupTimeout()
+            self.errorMessage = self.userFacingAppleSpeechError(
+                AppleSpeechTranscriptionError.startupTimedOut
+            )
+            self.startRequestID = nil
+            self.cancelAppleTranscription(notifyFinish: true)
         }
     }
 
@@ -853,6 +912,8 @@ final class VoiceInputController: NSObject, ObservableObject {
             completeAppleInteraction(notifyFinish: true)
             return
         }
+        cancelAppleStartupWatchdog()
+        startRequestID = nil
         isPreparing = false
         isRecording = false
         levelMeter.reset()
@@ -875,13 +936,12 @@ final class VoiceInputController: NSObject, ObservableObject {
     private func cancelAppleTranscription(notifyFinish: Bool) {
         let session = appleSession as? AppleSpeechTranscriptionSession
         let lifecycleTask = appleLifecycleTask
+        startRequestID = nil
+        cancelAppleStartupWatchdog()
         lifecycleTask?.cancel()
-        let previousCleanup = audioSessionCleanupTask
-        audioSessionCleanupTask = Task {
-            // 等被取消的 start/finish 任务真正退出后再补一次幂等清理；
-            // 下一次 start 会等待这条任务链，避免旧 Apple 会话与新录音交叉。
-            await previousCleanup?.value
-            await lifecycleTask?.value
+        // 系统权限或 Speech await 可能不响应取消；旧任务只异步收尾，不能成为下一轮启动的闸门。
+        // 会话的 activation lease 会让迟到的旧 deactivate 失效，避免关闭新会话。
+        Task {
             await session?.cancel()
         }
         completeAppleInteraction(notifyFinish: notifyFinish)
@@ -890,6 +950,7 @@ final class VoiceInputController: NSObject, ObservableObject {
     @available(iOS 26.0, *)
     private func completeAppleInteraction(notifyFinish: Bool) {
         let handler = appleFinishHandler
+        cancelAppleStartupWatchdog()
         appleFinishHandler = nil
         appleSession = nil
         appleLifecycleTask = nil
@@ -905,6 +966,7 @@ final class VoiceInputController: NSObject, ObservableObject {
 
     private func completeUnavailableAppleInteraction(notifyFinish: Bool) {
         let handler = appleFinishHandler
+        cancelAppleStartupWatchdog()
         appleFinishHandler = nil
         appleLifecycleTask?.cancel()
         appleLifecycleTask = nil
@@ -916,6 +978,11 @@ final class VoiceInputController: NSObject, ObservableObject {
         if notifyFinish {
             handler?()
         }
+    }
+
+    private func cancelAppleStartupWatchdog() {
+        appleStartupWatchdogTask?.cancel()
+        appleStartupWatchdogTask = nil
     }
 
     private func userFacingAppleSpeechError(_ error: Error) -> String {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -702,11 +702,9 @@ actor VoiceAudioSessionCoordinator {
     private func scheduleDeactivation() {
         let backend = self.backend
         Task.detached(priority: .userInitiated) {
-            do {
-                try backend.deactivateRecording()
-            } catch {
-                return
-            }
+            // iOS 18–25 在新 I/O 已经启动时可能先停用会话，再以 isBusy 返回失败。
+            // 无论返回值如何，都按“可能已经停用”处理；有新租约时补激活是幂等且更安全的结果。
+            try? backend.deactivateRecording()
             await self.deactivationDidComplete()
         }
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -717,31 +717,45 @@ actor VoiceAudioSessionCoordinator {
             return
         }
         // 停用开始后可能已经有新租约或新请求；迟到停用必须补一次激活，保证最终状态为 active。
-        scheduleActivationRefresh()
+        scheduleActivationRefresh(recoveryActivationID: currentActivationID)
     }
 
-    private func scheduleActivationRefresh() {
+    private func scheduleActivationRefresh(recoveryActivationID: UUID?) {
         let backend = self.backend
         Task.detached(priority: .userInitiated) {
             do {
                 try backend.prepareForRecording()
                 try backend.activateForRecording()
             } catch {
-                await self.activationRefreshDidFinish(succeeded: false)
+                await self.activationRefreshDidFinish(
+                    recoveryActivationID: recoveryActivationID,
+                    succeeded: false
+                )
                 return
             }
-            await self.activationRefreshDidFinish(succeeded: true)
+            await self.activationRefreshDidFinish(
+                recoveryActivationID: recoveryActivationID,
+                succeeded: true
+            )
         }
     }
 
-    private func activationRefreshDidFinish(succeeded: Bool) {
-        guard currentActivationID == nil else {
+    private func activationRefreshDidFinish(
+        recoveryActivationID: UUID?,
+        succeeded: Bool
+    ) {
+        if let recoveryActivationID,
+           currentActivationID == recoveryActivationID {
             if let recoveryHandler = currentActivationRecoveryHandler {
                 // setActive(false) 已经可能中断当前采集；补激活后通知租约持有者重启采集器。
                 Task { @MainActor in
                     recoveryHandler(succeeded)
                 }
             }
+            return
+        }
+        // 补激活属于旧租约时，不能把迟到的失败结果转发给已经接管的新录音。
+        guard currentActivationID == nil else {
             return
         }
         guard succeeded else {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -564,10 +564,10 @@ enum AdvancedTurnOptionsError: LocalizedError {
     }
 }
 
-/// 将系统音频会话调用隔离在非 MainActor 的串行执行域中。
+/// 将系统音频会话调用隔离在非 MainActor 的协调域中。
 ///
 /// AVAudioSession 的 category/active 切换可能阻塞；UI 与录音器生命周期仍由 MainActor 管理，
-/// 这里只负责不可并发的系统会话状态，避免阻塞界面或发生旧清理关闭新录音的竞态。
+/// 这里只负责系统会话租约，避免阻塞界面或发生旧清理关闭新录音的竞态。
 protocol VoiceAudioSessionBackend: Sendable {
     func prepareForRecording() throws
     func activateForRecording() throws
@@ -603,6 +603,9 @@ actor VoiceAudioSessionCoordinator {
 
     private let backend: any VoiceAudioSessionBackend
     private var currentActivationID: UUID?
+    private var activationRequestIDs: Set<UUID> = []
+    private var latestActivationRequestID: UUID?
+    private var hasAbandonedActivation = false
 
     init(backend: any VoiceAudioSessionBackend = SystemVoiceAudioSessionBackend()) {
         self.backend = backend
@@ -612,26 +615,71 @@ actor VoiceAudioSessionCoordinator {
         try backend.prepareForRecording()
     }
 
-    func activate() throws -> Activation {
+    func activate() async throws -> Activation {
         try Task.checkCancellation()
-        try backend.prepareForRecording()
-        try Task.checkCancellation()
+        let requestID = UUID()
+        activationRequestIDs.insert(requestID)
+        latestActivationRequestID = requestID
 
-        let hadExistingActivation = currentActivationID != nil
-        try backend.activateForRecording()
+        let backend = self.backend
+        // setActive(true) 是同步阻塞调用。每次请求使用独立执行任务，确保一次挂起不会占住
+        // coordinator actor；后续重试仍能登记自己的请求并独立尝试激活。
+        let activationTask = Task.detached(priority: .userInitiated) {
+            try Task.checkCancellation()
+            try backend.prepareForRecording()
+            try Task.checkCancellation()
+            try backend.activateForRecording()
+        }
+        do {
+            try await withTaskCancellationHandler {
+                try await activationTask.value
+            } onCancel: {
+                activationTask.cancel()
+            }
+        } catch {
+            activationRequestIDs.remove(requestID)
+            deactivateAbandonedActivationIfIdle()
+            throw error
+        }
+
+        activationRequestIDs.remove(requestID)
         do {
             try Task.checkCancellation()
         } catch {
-            // setActive 已经成功但调用方在返回前取消时，必须撤销这次独占激活。
-            // 已有租约表示音频会话原本就在使用中，此时不能误停仍有效的新会话。
-            if !hadExistingActivation {
-                try? backend.deactivateRecording()
-            }
+            markAbandonedActivation()
+            deactivateAbandonedActivationIfIdle()
             throw error
         }
-        let activation = Activation(id: UUID())
+        guard latestActivationRequestID == requestID else {
+            markAbandonedActivation()
+            deactivateAbandonedActivationIfIdle()
+            throw CancellationError()
+        }
+
+        let activation = Activation(id: requestID)
         currentActivationID = activation.id
+        hasAbandonedActivation = false
         return activation
+    }
+
+    private func markAbandonedActivation() {
+        // AVAudioSession 是进程级共享状态；已有租约时，迟到成功已经由该租约共同拥有。
+        if currentActivationID == nil {
+            hasAbandonedActivation = true
+        }
+    }
+
+    private func deactivateAbandonedActivationIfIdle() {
+        // 有更新请求或有效租约时不能停用全局 AVAudioSession，否则迟到旧请求会关闭新录音。
+        guard
+            hasAbandonedActivation,
+            activationRequestIDs.isEmpty,
+            currentActivationID == nil
+        else {
+            return
+        }
+        hasAbandonedActivation = false
+        try? backend.deactivateRecording()
     }
 
     func deactivate(_ activation: Activation) {
@@ -640,6 +688,7 @@ actor VoiceAudioSessionCoordinator {
             return
         }
         currentActivationID = nil
+        hasAbandonedActivation = false
         try? backend.deactivateRecording()
     }
 }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -611,8 +611,12 @@ actor VoiceAudioSessionCoordinator {
         self.backend = backend
     }
 
-    func prewarm() throws {
-        try backend.prepareForRecording()
+    func prewarm() async throws {
+        let backend = self.backend
+        // 预热也会调用同步的 AVAudioSession API；它不能占住负责重试租约的 actor。
+        try await Task.detached(priority: .utility) {
+            try backend.prepareForRecording()
+        }.value
     }
 
     func activate() async throws -> Activation {
@@ -688,7 +692,50 @@ actor VoiceAudioSessionCoordinator {
             return
         }
         hasAbandonedActivation = false
-        try? backend.deactivateRecording()
+        scheduleDeactivation()
+    }
+
+    private func scheduleDeactivation() {
+        let backend = self.backend
+        Task.detached(priority: .userInitiated) {
+            do {
+                try backend.deactivateRecording()
+            } catch {
+                return
+            }
+            await self.deactivationDidComplete()
+        }
+    }
+
+    private func deactivationDidComplete() {
+        hasAbandonedActivation = false
+        guard currentActivationID != nil || !activationRequestIDs.isEmpty else {
+            return
+        }
+        // 停用开始后可能已经有新租约或新请求；迟到停用必须补一次激活，保证最终状态为 active。
+        scheduleActivationRefresh()
+    }
+
+    private func scheduleActivationRefresh() {
+        let backend = self.backend
+        Task.detached(priority: .userInitiated) {
+            do {
+                try backend.prepareForRecording()
+                try backend.activateForRecording()
+            } catch {
+                return
+            }
+            await self.activationRefreshDidComplete()
+        }
+    }
+
+    private func activationRefreshDidComplete() {
+        guard currentActivationID == nil else {
+            return
+        }
+        // 补激活完成时请求可能已取消；保留遗留标记，让最后一个请求退出时配对停用。
+        hasAbandonedActivation = true
+        deactivateAbandonedActivationIfIdle()
     }
 
     func deactivate(_ activation: Activation) {
@@ -704,7 +751,7 @@ actor VoiceAudioSessionCoordinator {
             return
         }
         hasAbandonedActivation = false
-        try? backend.deactivateRecording()
+        scheduleDeactivation()
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -608,6 +608,7 @@ actor VoiceAudioSessionCoordinator {
     private var currentActivationRecoveryHandler: RecoveryHandler?
     private var activationRequestIDs: Set<UUID> = []
     private var latestActivationRequestID: UUID?
+    private var failedActivationRefreshRequestIDs: Set<UUID> = []
     private var hasAbandonedActivation = false
 
     init(backend: any VoiceAudioSessionBackend = SystemVoiceAudioSessionBackend()) {
@@ -628,38 +629,26 @@ actor VoiceAudioSessionCoordinator {
         activationRequestIDs.insert(requestID)
         latestActivationRequestID = requestID
 
-        let backend = self.backend
-        // setActive(true) 是同步阻塞调用。每次请求使用独立执行任务，确保一次挂起不会占住
-        // coordinator actor；后续重试仍能登记自己的请求并独立尝试激活。
-        let activationTask = Task.detached(priority: .userInitiated) {
-            try Task.checkCancellation()
-            try backend.prepareForRecording()
-            try Task.checkCancellation()
-            try backend.activateForRecording()
-        }
+        var didActivateBackend = false
         do {
-            try await withTaskCancellationHandler {
-                try await activationTask.value
-            } onCancel: {
-                activationTask.cancel()
-                Task {
-                    await self.cancelActivationRequest(requestID)
-                }
-            }
+            repeat {
+                try await performActivationAttempt(requestID: requestID)
+                didActivateBackend = true
+                try Task.checkCancellation()
+                // 旧停用可能在本次 setActive 成功后才落地。补激活若已明确失败，
+                // 发布租约前再激活一次，不能让调用方在失活会话上启动采集器。
+            } while failedActivationRefreshRequestIDs.remove(requestID) != nil
         } catch {
             activationRequestIDs.remove(requestID)
+            failedActivationRefreshRequestIDs.remove(requestID)
+            if didActivateBackend {
+                markAbandonedActivation()
+            }
             deactivateAbandonedActivationIfIdle()
             throw error
         }
 
         activationRequestIDs.remove(requestID)
-        do {
-            try Task.checkCancellation()
-        } catch {
-            markAbandonedActivation()
-            deactivateAbandonedActivationIfIdle()
-            throw error
-        }
         guard latestActivationRequestID == requestID else {
             markAbandonedActivation()
             deactivateAbandonedActivationIfIdle()
@@ -673,9 +662,30 @@ actor VoiceAudioSessionCoordinator {
         return activation
     }
 
+    private func performActivationAttempt(requestID: UUID) async throws {
+        let backend = self.backend
+        // setActive(true) 是同步阻塞调用。每次尝试使用独立执行任务，确保一次挂起不会占住
+        // coordinator actor；后续重试仍能登记自己的请求并独立尝试激活。
+        let activationTask = Task.detached(priority: .userInitiated) {
+            try Task.checkCancellation()
+            try backend.prepareForRecording()
+            try Task.checkCancellation()
+            try backend.activateForRecording()
+        }
+        try await withTaskCancellationHandler {
+            try await activationTask.value
+        } onCancel: {
+            activationTask.cancel()
+            Task {
+                await self.cancelActivationRequest(requestID)
+            }
+        }
+    }
+
     private func cancelActivationRequest(_ requestID: UUID) {
         // 同步系统调用可能不响应 Task 取消；先移除逻辑请求，避免它阻止有效重试结束时停用。
         activationRequestIDs.remove(requestID)
+        failedActivationRefreshRequestIDs.remove(requestID)
         deactivateAbandonedActivationIfIdle()
     }
 
@@ -715,7 +725,10 @@ actor VoiceAudioSessionCoordinator {
             return
         }
         // 停用开始后可能已经有新租约或新请求；迟到停用必须补一次激活，保证最终状态为 active。
-        scheduleActivationRefresh(recoveryActivationID: currentActivationID)
+        let recoveryActivationID = currentActivationID ?? latestActivationRequestID.flatMap { requestID in
+            activationRequestIDs.contains(requestID) ? requestID : nil
+        }
+        scheduleActivationRefresh(recoveryActivationID: recoveryActivationID)
     }
 
     private func scheduleActivationRefresh(recoveryActivationID: UUID?) {
@@ -749,6 +762,16 @@ actor VoiceAudioSessionCoordinator {
                 Task { @MainActor in
                     recoveryHandler(succeeded)
                 }
+            }
+            return
+        }
+        if let recoveryActivationID,
+           currentActivationID == nil,
+           activationRequestIDs.contains(recoveryActivationID) {
+            // 请求的后端 setActive 已经可能成功，但 actor 还未发布租约。记录补激活失败，
+            // 让该请求在取得租约前重新确认会话为 active。
+            if !succeeded {
+                failedActivationRefreshRequestIDs.insert(recoveryActivationID)
             }
             return
         }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -635,6 +635,9 @@ actor VoiceAudioSessionCoordinator {
                 try await activationTask.value
             } onCancel: {
                 activationTask.cancel()
+                Task {
+                    await self.cancelActivationRequest(requestID)
+                }
             }
         } catch {
             activationRequestIDs.remove(requestID)
@@ -660,6 +663,12 @@ actor VoiceAudioSessionCoordinator {
         currentActivationID = activation.id
         hasAbandonedActivation = false
         return activation
+    }
+
+    private func cancelActivationRequest(_ requestID: UUID) {
+        // 同步系统调用可能不响应 Task 取消；先移除逻辑请求，避免它阻止有效重试结束时停用。
+        activationRequestIDs.remove(requestID)
+        deactivateAbandonedActivationIfIdle()
     }
 
     private func markAbandonedActivation() {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -595,6 +595,8 @@ final class SystemVoiceAudioSessionBackend: VoiceAudioSessionBackend, @unchecked
 }
 
 actor VoiceAudioSessionCoordinator {
+    typealias RecoveryHandler = @MainActor @Sendable (_ succeeded: Bool) -> Void
+
     struct Activation: Sendable, Equatable {
         fileprivate let id: UUID
     }
@@ -603,6 +605,7 @@ actor VoiceAudioSessionCoordinator {
 
     private let backend: any VoiceAudioSessionBackend
     private var currentActivationID: UUID?
+    private var currentActivationRecoveryHandler: RecoveryHandler?
     private var activationRequestIDs: Set<UUID> = []
     private var latestActivationRequestID: UUID?
     private var hasAbandonedActivation = false
@@ -619,7 +622,7 @@ actor VoiceAudioSessionCoordinator {
         }.value
     }
 
-    func activate() async throws -> Activation {
+    func activate(onRecovery: RecoveryHandler? = nil) async throws -> Activation {
         try Task.checkCancellation()
         let requestID = UUID()
         activationRequestIDs.insert(requestID)
@@ -665,6 +668,7 @@ actor VoiceAudioSessionCoordinator {
 
         let activation = Activation(id: requestID)
         currentActivationID = activation.id
+        currentActivationRecoveryHandler = onRecovery
         hasAbandonedActivation = false
         return activation
     }
@@ -723,14 +727,24 @@ actor VoiceAudioSessionCoordinator {
                 try backend.prepareForRecording()
                 try backend.activateForRecording()
             } catch {
+                await self.activationRefreshDidFinish(succeeded: false)
                 return
             }
-            await self.activationRefreshDidComplete()
+            await self.activationRefreshDidFinish(succeeded: true)
         }
     }
 
-    private func activationRefreshDidComplete() {
+    private func activationRefreshDidFinish(succeeded: Bool) {
         guard currentActivationID == nil else {
+            if let recoveryHandler = currentActivationRecoveryHandler {
+                // setActive(false) 已经可能中断当前采集；补激活后通知租约持有者重启采集器。
+                Task { @MainActor in
+                    recoveryHandler(succeeded)
+                }
+            }
+            return
+        }
+        guard succeeded else {
             return
         }
         // 补激活完成时请求可能已取消；保留遗留标记，让最后一个请求退出时配对停用。
@@ -744,6 +758,7 @@ actor VoiceAudioSessionCoordinator {
             return
         }
         currentActivationID = nil
+        currentActivationRecoveryHandler = nil
         // 新请求已进入 setActive 时，旧租约只能移交当前激活状态，不能执行全局停用。
         // 新请求成功后会接管租约；失败或取消后再由 abandoned cleanup 配对停用。
         guard activationRequestIDs.isEmpty else {
@@ -783,6 +798,7 @@ final class VoiceInputController: NSObject, ObservableObject {
     private let audioSessionCoordinator: VoiceAudioSessionCoordinator
     private var audioSessionActivation: VoiceAudioSessionCoordinator.Activation?
     private var audioSessionCleanupTask: Task<Void, Never>?
+    private var codexStartupTask: Task<Void, Never>?
 
     init(audioSessionCoordinator: VoiceAudioSessionCoordinator = .shared) {
         self.audioSessionCoordinator = audioSessionCoordinator
@@ -831,7 +847,7 @@ final class VoiceInputController: NSObject, ObservableObject {
         MimiHaptics.prepare(.commit)
 
         let pendingAudioSessionCleanup = audioSessionCleanupTask
-        Task {
+        codexStartupTask = Task {
             // 新一轮录音必须等待上一轮清理落地，避免 category/active 状态交叉。
             await pendingAudioSessionCleanup?.value
             guard startRequestID == requestID else {
@@ -851,6 +867,7 @@ final class VoiceInputController: NSObject, ObservableObject {
             }
             do {
                 try await startRecording(requestID: requestID)
+                codexStartupTask = nil
             } catch {
                 guard startRequestID == requestID else {
                     return
@@ -1147,7 +1164,9 @@ final class VoiceInputController: NSObject, ObservableObject {
     }
 
     private func startRecording(requestID: UUID) async throws {
-        let activation = try await audioSessionCoordinator.activate()
+        let activation = try await audioSessionCoordinator.activate(onRecovery: { [weak self] succeeded in
+            self?.recoverCodexAudioCapture(requestID: requestID, succeeded: succeeded)
+        })
         do {
             try Task.checkCancellation()
             guard startRequestID == requestID else {
@@ -1182,6 +1201,26 @@ final class VoiceInputController: NSObject, ObservableObject {
             await audioSessionCoordinator.deactivate(activation)
             throw error
         }
+    }
+
+    private func recoverCodexAudioCapture(requestID: UUID, succeeded: Bool) {
+        guard activeProvider == .codex,
+              startRequestID == requestID,
+              isRecording,
+              let recorder else {
+            return
+        }
+        guard succeeded else {
+            errorMessage = VoiceInputError.recordingFailed.localizedDescription
+            finish(fileURL: nil)
+            return
+        }
+        guard recorder.record() else {
+            errorMessage = VoiceInputError.recordingFailed.localizedDescription
+            finish(fileURL: nil)
+            return
+        }
+        startMetering()
     }
 
     private func startMetering() {
@@ -1257,6 +1296,9 @@ final class VoiceInputController: NSObject, ObservableObject {
         )
         recorder?.stop()
         recorder = nil
+        // 启动可能仍阻塞在系统音频会话；先取消任务，让 coordinator 立即淘汰旧请求。
+        codexStartupTask?.cancel()
+        codexStartupTask = nil
         meteringTask?.cancel()
         meteringTask = nil
         recordingURL = nil

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -688,6 +688,12 @@ actor VoiceAudioSessionCoordinator {
             return
         }
         currentActivationID = nil
+        // 新请求已进入 setActive 时，旧租约只能移交当前激活状态，不能执行全局停用。
+        // 新请求成功后会接管租约；失败或取消后再由 abandoned cleanup 配对停用。
+        guard activationRequestIDs.isEmpty else {
+            hasAbandonedActivation = true
+            return
+        }
         hasAbandonedActivation = false
         try? backend.deactivateRecording()
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerVoiceSupport.swift
@@ -669,8 +669,10 @@ actor VoiceAudioSessionCoordinator {
         } catch {
             activationRequestIDs.remove(requestID)
             failedActivationRefreshSequences.removeValue(forKey: requestID)
-            latestSuccessfulActivationSequences.removeValue(forKey: requestID)
-            if didActivateBackend {
+            let hadSuccessfulActivation = latestSuccessfulActivationSequences.removeValue(
+                forKey: requestID
+            ) != nil
+            if didActivateBackend || hadSuccessfulActivation {
                 markAbandonedActivation()
             }
             deactivateAbandonedActivationIfIdle()
@@ -722,7 +724,13 @@ actor VoiceAudioSessionCoordinator {
         // 同步系统调用可能不响应 Task 取消；先移除逻辑请求，避免它阻止有效重试结束时停用。
         activationRequestIDs.remove(requestID)
         failedActivationRefreshSequences.removeValue(forKey: requestID)
-        latestSuccessfulActivationSequences.removeValue(forKey: requestID)
+        let hadSuccessfulActivation = latestSuccessfulActivationSequences.removeValue(
+            forKey: requestID
+        ) != nil
+        if hadSuccessfulActivation {
+            // 待发布请求可能已经通过补激活占用了全局会话；取消时必须配对停用。
+            markAbandonedActivation()
+        }
         deactivateAbandonedActivationIfIdle()
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -149,20 +149,28 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         XCTAssertNil(retryError)
         XCTAssertEqual(backend.operations, [.prepare, .activate, .prepare, .activate])
 
+        await retryRequest.value
+        let activation = try XCTUnwrap(retryActivation)
+        await coordinator.deactivate(activation)
+        let deactivationDeadline = ContinuousClock.now + .milliseconds(250)
+        while backend.operations.last != .deactivate, ContinuousClock.now < deactivationDeadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertEqual(
+            backend.operations,
+            [.prepare, .activate, .prepare, .activate, .deactivate]
+        )
+
         backend.releaseActivation()
         do {
             _ = try await oldRequest.value
             XCTFail("Cancelled request must not retain audio activation")
         } catch is CancellationError {
-            // 迟到旧请求不能覆盖或关闭已经成功的重试。
+            // 迟到旧请求只清理自己的遗留激活。
         }
-        await retryRequest.value
-
-        let activation = try XCTUnwrap(retryActivation)
-        await coordinator.deactivate(activation)
         XCTAssertEqual(
             backend.operations,
-            [.prepare, .activate, .prepare, .activate, .deactivate]
+            [.prepare, .activate, .prepare, .activate, .deactivate, .deactivate]
         )
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -344,6 +344,45 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         try await waitForOperation(.deactivate, count: 2, in: backend)
     }
 
+    func testCancellingPendingRequestDeactivatesSuccessfulRefresh() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(
+            blockedActivationCall: 2,
+            blockedDeactivationCall: 1
+        )
+        defer {
+            backend.releaseActivation()
+            backend.releaseDeactivation()
+        }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let oldActivation = try await coordinator.activate()
+
+        await coordinator.deactivate(oldActivation)
+        try await waitForDeactivationStart(in: backend)
+
+        let retryRequest = Task {
+            try await coordinator.activate()
+        }
+        try await waitForActivationStart(in: backend)
+
+        // 主激活继续阻塞，旧停用落地后的补激活先成功并占用全局音频会话。
+        backend.releaseDeactivation()
+        try await waitForOperation(.activate, count: 3, in: backend)
+        try await Task.sleep(for: .milliseconds(40))
+
+        retryRequest.cancel()
+        // 不释放主激活也必须先清理补激活，不能让 .record/.duckOthers 一直保持 active。
+        try await waitForOperation(.deactivate, count: 2, in: backend)
+
+        backend.releaseActivation()
+        do {
+            _ = try await retryRequest.value
+            XCTFail("Cancelled request must not retain audio activation")
+        } catch is CancellationError {
+            // 迟到的主激活成功后还会执行自己的补偿停用。
+        }
+        try await waitForOperation(.deactivate, count: 3, in: backend)
+    }
+
     func testStaleRefreshFailureDoesNotStopNewerActivation() async throws {
         let backend = StartupWatchdogAudioSessionBackend(
             blockedActivationCall: 3,
@@ -496,6 +535,17 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         blockedPreparationCall = nil
         self.blockedActivationCall = blockedActivationCall
         self.failingActivationCall = failingActivationCall
+        self.blockedDeactivationCall = blockedDeactivationCall
+        failingDeactivationCall = nil
+    }
+
+    init(
+        blockedActivationCall: Int,
+        blockedDeactivationCall: Int
+    ) {
+        blockedPreparationCall = nil
+        self.blockedActivationCall = blockedActivationCall
+        failingActivationCall = nil
         self.blockedDeactivationCall = blockedDeactivationCall
         failingDeactivationCall = nil
     }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -247,11 +247,15 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         }
 
         let retryCompleted = expectation(description: "retry completed during deactivation")
+        let captureRecovered = expectation(description: "capture recovered after late deactivation")
         var retryActivation: VoiceAudioSessionCoordinator.Activation?
         var retryError: Error?
         let retryRequest = Task {
             do {
-                retryActivation = try await coordinator.activate()
+                retryActivation = try await coordinator.activate(onRecovery: { succeeded in
+                    XCTAssertTrue(succeeded)
+                    captureRecovered.fulfill()
+                })
             } catch {
                 retryError = error
             }
@@ -268,6 +272,7 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         backend.releaseDeactivation()
         await retryRequest.value
         try await waitForOperation(.activate, count: 3, in: backend)
+        await fulfillment(of: [captureRecovered], timeout: 0.25)
 
         let activation = try XCTUnwrap(retryActivation)
         await coordinator.deactivate(activation)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -73,7 +73,33 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         XCTAssertEqual(backend.operations, [.prepare, .activate])
 
         await coordinator.deactivate(retryActivation)
-        XCTAssertEqual(backend.operations, [.prepare, .activate, .deactivate])
+        try await waitForOperations([.prepare, .activate, .deactivate], in: backend)
+    }
+
+    func testActivationDoesNotWaitForBlockedPrewarm() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(blockedPreparationCall: 1)
+        defer { backend.releasePreparation() }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let prewarmRequest = Task {
+            try await coordinator.prewarm()
+        }
+
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while !backend.hasStartedPreparation, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        guard backend.hasStartedPreparation else {
+            XCTFail("Audio prewarm did not start")
+            return
+        }
+
+        let activation = try await coordinator.activate()
+        XCTAssertEqual(backend.operations, [.prepare, .prepare, .activate])
+
+        backend.releasePreparation()
+        try await prewarmRequest.value
+        await coordinator.deactivate(activation)
+        try await waitForOperations([.prepare, .prepare, .activate, .deactivate], in: backend)
     }
 
     func testCancellationDuringActivationIsCleanedUpBeforeRetry() async throws {
@@ -102,15 +128,15 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         } catch is CancellationError {
             // setActive 返回后检测到取消，并立即配对停用。
         }
-        XCTAssertEqual(backend.operations, [.prepare, .activate, .deactivate])
+        try await waitForOperations([.prepare, .activate, .deactivate], in: backend)
 
         let retryActivation = try await coordinator.activate()
         XCTAssertEqual(backend.operations, [.prepare, .activate, .deactivate, .prepare, .activate])
 
         await coordinator.deactivate(retryActivation)
-        XCTAssertEqual(
-            backend.operations,
-            [.prepare, .activate, .deactivate, .prepare, .activate, .deactivate]
+        try await waitForOperations(
+            [.prepare, .activate, .deactivate, .prepare, .activate, .deactivate],
+            in: backend
         )
     }
 
@@ -168,9 +194,9 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         } catch is CancellationError {
             // 迟到旧请求只清理自己的遗留激活。
         }
-        XCTAssertEqual(
-            backend.operations,
-            [.prepare, .activate, .prepare, .activate, .deactivate, .deactivate]
+        try await waitForOperations(
+            [.prepare, .activate, .prepare, .activate, .deactivate, .deactivate],
+            in: backend
         )
     }
 
@@ -198,10 +224,78 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         backend.releaseActivation()
         let retryActivation = try await retryRequest.value
         await coordinator.deactivate(retryActivation)
+        try await waitForOperations(
+            [.prepare, .activate, .prepare, .activate, .deactivate],
+            in: backend
+        )
+    }
+
+    func testRetryDoesNotWaitForBlockedDeactivation() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(blockedDeactivationCall: 1)
+        defer { backend.releaseDeactivation() }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let oldActivation = try await coordinator.activate()
+
+        await coordinator.deactivate(oldActivation)
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while !backend.hasStartedDeactivation, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        guard backend.hasStartedDeactivation else {
+            XCTFail("Audio deactivation did not start")
+            return
+        }
+
+        let retryCompleted = expectation(description: "retry completed during deactivation")
+        var retryActivation: VoiceAudioSessionCoordinator.Activation?
+        var retryError: Error?
+        let retryRequest = Task {
+            do {
+                retryActivation = try await coordinator.activate()
+            } catch {
+                retryError = error
+            }
+            retryCompleted.fulfill()
+        }
+
+        await fulfillment(of: [retryCompleted], timeout: 0.25)
+        XCTAssertNil(retryError)
         XCTAssertEqual(
             backend.operations,
-            [.prepare, .activate, .prepare, .activate, .deactivate]
+            [.prepare, .activate, .deactivate, .prepare, .activate]
         )
+
+        backend.releaseDeactivation()
+        await retryRequest.value
+        try await waitForOperation(.activate, count: 3, in: backend)
+
+        let activation = try XCTUnwrap(retryActivation)
+        await coordinator.deactivate(activation)
+        try await waitForOperation(.deactivate, count: 2, in: backend)
+    }
+
+    private func waitForOperations(
+        _ expected: [StartupWatchdogAudioSessionBackend.Operation],
+        in backend: StartupWatchdogAudioSessionBackend
+    ) async throws {
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while backend.operations != expected, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertEqual(backend.operations, expected)
+    }
+
+    private func waitForOperation(
+        _ operation: StartupWatchdogAudioSessionBackend.Operation,
+        count: Int,
+        in backend: StartupWatchdogAudioSessionBackend
+    ) async throws {
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while backend.operations.filter({ $0 == operation }).count < count,
+              ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertGreaterThanOrEqual(backend.operations.filter { $0 == operation }.count, count)
     }
 }
 
@@ -214,18 +308,44 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
 
     private let lock = NSLock()
     private var storedOperations: [Operation] = []
+    private let blockedPreparationCall: Int?
     private let blockedActivationCall: Int?
+    private let blockedDeactivationCall: Int?
+    private let preparationCondition = NSCondition()
+    private var preparationStarted = false
+    private var preparationReleased = false
+    private var preparationCallCount = 0
     private let activationCondition = NSCondition()
     private var activationStarted = false
     private var activationReleased = false
     private var activationCallCount = 0
+    private let deactivationCondition = NSCondition()
+    private var deactivationStarted = false
+    private var deactivationReleased = false
+    private var deactivationCallCount = 0
 
     init(blocksActivation: Bool = false) {
+        blockedPreparationCall = nil
         blockedActivationCall = blocksActivation ? 1 : nil
+        blockedDeactivationCall = nil
     }
 
     init(blockedActivationCall: Int) {
+        blockedPreparationCall = nil
         self.blockedActivationCall = blockedActivationCall
+        blockedDeactivationCall = nil
+    }
+
+    init(blockedDeactivationCall: Int) {
+        blockedPreparationCall = nil
+        blockedActivationCall = nil
+        self.blockedDeactivationCall = blockedDeactivationCall
+    }
+
+    init(blockedPreparationCall: Int) {
+        self.blockedPreparationCall = blockedPreparationCall
+        blockedActivationCall = nil
+        blockedDeactivationCall = nil
     }
 
     var operations: [Operation] {
@@ -238,8 +358,31 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         return activationStarted
     }
 
+    var hasStartedPreparation: Bool {
+        preparationCondition.lock()
+        defer { preparationCondition.unlock() }
+        return preparationStarted
+    }
+
+    var hasStartedDeactivation: Bool {
+        deactivationCondition.lock()
+        defer { deactivationCondition.unlock() }
+        return deactivationStarted
+    }
+
     func prepareForRecording() throws {
         record(.prepare)
+        guard let blockedPreparationCall else { return }
+        preparationCondition.lock()
+        preparationCallCount += 1
+        if preparationCallCount == blockedPreparationCall {
+            preparationStarted = true
+            preparationCondition.broadcast()
+            while !preparationReleased {
+                preparationCondition.wait()
+            }
+        }
+        preparationCondition.unlock()
     }
 
     func activateForRecording() throws {
@@ -259,6 +402,17 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
 
     func deactivateRecording() throws {
         record(.deactivate)
+        guard let blockedDeactivationCall else { return }
+        deactivationCondition.lock()
+        deactivationCallCount += 1
+        if deactivationCallCount == blockedDeactivationCall {
+            deactivationStarted = true
+            deactivationCondition.broadcast()
+            while !deactivationReleased {
+                deactivationCondition.wait()
+            }
+        }
+        deactivationCondition.unlock()
     }
 
     private func record(_ operation: Operation) {
@@ -272,5 +426,19 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         activationReleased = true
         activationCondition.broadcast()
         activationCondition.unlock()
+    }
+
+    func releasePreparation() {
+        preparationCondition.lock()
+        preparationReleased = true
+        preparationCondition.broadcast()
+        preparationCondition.unlock()
+    }
+
+    func releaseDeactivation() {
+        deactivationCondition.lock()
+        deactivationReleased = true
+        deactivationCondition.broadcast()
+        deactivationCondition.unlock()
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -279,6 +279,32 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         try await waitForOperation(.deactivate, count: 2, in: backend)
     }
 
+    func testFailedLateDeactivationStillRefreshesCurrentActivation() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(
+            blockedDeactivationCall: 1,
+            failingDeactivationCall: 1
+        )
+        defer { backend.releaseDeactivation() }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let oldActivation = try await coordinator.activate()
+
+        await coordinator.deactivate(oldActivation)
+        try await waitForDeactivationStart(in: backend)
+
+        let captureRecovered = expectation(description: "capture recovered after failed late deactivation")
+        let retryActivation = try await coordinator.activate(onRecovery: { succeeded in
+            XCTAssertTrue(succeeded)
+            captureRecovered.fulfill()
+        })
+
+        backend.releaseDeactivation()
+        try await waitForOperation(.activate, count: 3, in: backend)
+        await fulfillment(of: [captureRecovered], timeout: 0.25)
+
+        await coordinator.deactivate(retryActivation)
+        try await waitForOperation(.deactivate, count: 2, in: backend)
+    }
+
     func testStaleRefreshFailureDoesNotStopNewerActivation() async throws {
         let backend = StartupWatchdogAudioSessionBackend(
             blockedActivationCall: 3,
@@ -362,6 +388,7 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
 private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend, @unchecked Sendable {
     enum TestError: Error {
         case activationFailed
+        case deactivationFailed
     }
 
     enum Operation: Equatable {
@@ -376,6 +403,7 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
     private let blockedActivationCall: Int?
     private let failingActivationCall: Int?
     private let blockedDeactivationCall: Int?
+    private let failingDeactivationCall: Int?
     private let preparationCondition = NSCondition()
     private var preparationStarted = false
     private var preparationReleased = false
@@ -394,6 +422,7 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         blockedActivationCall = blocksActivation ? 1 : nil
         failingActivationCall = nil
         blockedDeactivationCall = nil
+        failingDeactivationCall = nil
     }
 
     init(blockedActivationCall: Int) {
@@ -401,13 +430,15 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         self.blockedActivationCall = blockedActivationCall
         failingActivationCall = nil
         blockedDeactivationCall = nil
+        failingDeactivationCall = nil
     }
 
-    init(blockedDeactivationCall: Int) {
+    init(blockedDeactivationCall: Int, failingDeactivationCall: Int? = nil) {
         blockedPreparationCall = nil
         blockedActivationCall = nil
         failingActivationCall = nil
         self.blockedDeactivationCall = blockedDeactivationCall
+        self.failingDeactivationCall = failingDeactivationCall
     }
 
     init(blockedPreparationCall: Int) {
@@ -415,6 +446,7 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         blockedActivationCall = nil
         failingActivationCall = nil
         blockedDeactivationCall = nil
+        failingDeactivationCall = nil
     }
 
     init(
@@ -426,6 +458,7 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         self.blockedActivationCall = blockedActivationCall
         self.failingActivationCall = failingActivationCall
         self.blockedDeactivationCall = blockedDeactivationCall
+        failingDeactivationCall = nil
     }
 
     var operations: [Operation] {
@@ -487,10 +520,10 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
 
     func deactivateRecording() throws {
         record(.deactivate)
-        guard let blockedDeactivationCall else { return }
         deactivationCondition.lock()
         deactivationCallCount += 1
-        if deactivationCallCount == blockedDeactivationCall {
+        let currentCall = deactivationCallCount
+        if currentCall == blockedDeactivationCall {
             deactivationStarted = true
             deactivationCondition.broadcast()
             while !deactivationReleased {
@@ -498,6 +531,9 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
             }
         }
         deactivationCondition.unlock()
+        if currentCall == failingDeactivationCall {
+            throw TestError.deactivationFailed
+        }
     }
 
     private func record(_ operation: Operation) {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class AppleVoiceStartupWatchdogTests: XCTestCase {
+    func testArmInvokesOnTimeoutOnceAfterShortTimeout() async {
+        let watchdog = AppleVoiceStartupWatchdog(timeout: .milliseconds(20))
+        let callback = expectation(description: "startup timeout callback")
+        var callbackCount = 0
+
+        let task = watchdog.arm {
+            callbackCount += 1
+            callback.fulfill()
+        }
+
+        await fulfillment(of: [callback], timeout: 0.25)
+        try? await Task.sleep(for: .milliseconds(40))
+        task.cancel()
+
+        XCTAssertEqual(callbackCount, 1)
+    }
+
+    func testCancellingTaskPreventsTimeoutCallback() async {
+        let watchdog = AppleVoiceStartupWatchdog(timeout: .milliseconds(50))
+        var callbackCount = 0
+
+        let task = watchdog.arm {
+            callbackCount += 1
+        }
+        task.cancel()
+
+        try? await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(callbackCount, 0)
+    }
+
+    func testStartupTimedOutHasDiagnosticCodeAndDescription() {
+        let error = AppleSpeechTranscriptionError.startupTimedOut
+
+        XCTAssertEqual(error.diagnosticCode, "startup_timeout")
+        XCTAssertFalse(error.errorDescription?.isEmpty ?? true)
+    }
+
+    func testCancelledQueuedActivationCannotOverrideImmediateRetry() async throws {
+        let backend = StartupWatchdogAudioSessionBackend()
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let waitingToActivate = expectation(description: "old request waiting")
+        let (gate, releaseOldRequest) = AsyncStream<Void>.makeStream()
+
+        let oldRequest = Task {
+            waitingToActivate.fulfill()
+            for await _ in gate.prefix(1) {}
+            return try await coordinator.activate()
+        }
+        await fulfillment(of: [waitingToActivate], timeout: 0.25)
+
+        oldRequest.cancel()
+        let retry = Task {
+            try await coordinator.activate()
+        }
+        releaseOldRequest.yield(())
+        releaseOldRequest.finish()
+
+        do {
+            _ = try await oldRequest.value
+            XCTFail("Cancelled request must not activate the audio session")
+        } catch is CancellationError {
+            // 旧请求按预期失效。
+        }
+
+        let retryActivation = try await retry.value
+        XCTAssertEqual(backend.operations, [.prepare, .activate])
+
+        await coordinator.deactivate(retryActivation)
+        XCTAssertEqual(backend.operations, [.prepare, .activate, .deactivate])
+    }
+
+    func testCancellationDuringActivationIsCleanedUpBeforeRetry() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(blocksActivation: true)
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let oldRequest = Task {
+            try await coordinator.activate()
+        }
+
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while !backend.hasStartedActivation, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        guard backend.hasStartedActivation else {
+            backend.releaseActivation()
+            XCTFail("Audio activation did not start")
+            return
+        }
+
+        oldRequest.cancel()
+        backend.releaseActivation()
+
+        do {
+            _ = try await oldRequest.value
+            XCTFail("Cancelled request must not retain audio activation")
+        } catch is CancellationError {
+            // setActive 返回后检测到取消，并立即配对停用。
+        }
+        XCTAssertEqual(backend.operations, [.prepare, .activate, .deactivate])
+
+        let retryActivation = try await coordinator.activate()
+        XCTAssertEqual(backend.operations, [.prepare, .activate, .deactivate, .prepare, .activate])
+
+        await coordinator.deactivate(retryActivation)
+        XCTAssertEqual(
+            backend.operations,
+            [.prepare, .activate, .deactivate, .prepare, .activate, .deactivate]
+        )
+    }
+}
+
+private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend, @unchecked Sendable {
+    enum Operation: Equatable {
+        case prepare
+        case activate
+        case deactivate
+    }
+
+    private let lock = NSLock()
+    private var storedOperations: [Operation] = []
+    private let blocksActivation: Bool
+    private let activationCondition = NSCondition()
+    private var activationStarted = false
+    private var activationReleased = false
+
+    init(blocksActivation: Bool = false) {
+        self.blocksActivation = blocksActivation
+    }
+
+    var operations: [Operation] {
+        lock.withLock { storedOperations }
+    }
+
+    var hasStartedActivation: Bool {
+        activationCondition.lock()
+        defer { activationCondition.unlock() }
+        return activationStarted
+    }
+
+    func prepareForRecording() throws {
+        record(.prepare)
+    }
+
+    func activateForRecording() throws {
+        record(.activate)
+        guard blocksActivation else { return }
+        activationCondition.lock()
+        activationStarted = true
+        activationCondition.broadcast()
+        while !activationReleased {
+            activationCondition.wait()
+        }
+        activationCondition.unlock()
+    }
+
+    func deactivateRecording() throws {
+        record(.deactivate)
+    }
+
+    private func record(_ operation: Operation) {
+        lock.withLock {
+            storedOperations.append(operation)
+        }
+    }
+
+    func releaseActivation() {
+        activationCondition.lock()
+        activationReleased = true
+        activationCondition.broadcast()
+        activationCondition.unlock()
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -113,6 +113,58 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
             [.prepare, .activate, .deactivate, .prepare, .activate, .deactivate]
         )
     }
+
+    func testRetryDoesNotWaitForBlockedActivation() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(blocksActivation: true)
+        defer { backend.releaseActivation() }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let oldRequest = Task {
+            try await coordinator.activate()
+        }
+
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while !backend.hasStartedActivation, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        guard backend.hasStartedActivation else {
+            XCTFail("Audio activation did not start")
+            return
+        }
+
+        oldRequest.cancel()
+        let retryCompleted = expectation(description: "retry activation completed")
+        var retryActivation: VoiceAudioSessionCoordinator.Activation?
+        var retryError: Error?
+        let retryRequest = Task {
+            do {
+                retryActivation = try await coordinator.activate()
+            } catch {
+                retryError = error
+            }
+            retryCompleted.fulfill()
+        }
+
+        // 第一次 setActive 仍未返回时，重试必须通过独立执行任务完成。
+        await fulfillment(of: [retryCompleted], timeout: 0.25)
+        XCTAssertNil(retryError)
+        XCTAssertEqual(backend.operations, [.prepare, .activate, .prepare, .activate])
+
+        backend.releaseActivation()
+        do {
+            _ = try await oldRequest.value
+            XCTFail("Cancelled request must not retain audio activation")
+        } catch is CancellationError {
+            // 迟到旧请求不能覆盖或关闭已经成功的重试。
+        }
+        await retryRequest.value
+
+        let activation = try XCTUnwrap(retryActivation)
+        await coordinator.deactivate(activation)
+        XCTAssertEqual(
+            backend.operations,
+            [.prepare, .activate, .prepare, .activate, .deactivate]
+        )
+    }
 }
 
 private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend, @unchecked Sendable {
@@ -128,6 +180,7 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
     private let activationCondition = NSCondition()
     private var activationStarted = false
     private var activationReleased = false
+    private var activationCallCount = 0
 
     init(blocksActivation: Bool = false) {
         self.blocksActivation = blocksActivation
@@ -151,10 +204,13 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
         record(.activate)
         guard blocksActivation else { return }
         activationCondition.lock()
-        activationStarted = true
-        activationCondition.broadcast()
-        while !activationReleased {
-            activationCondition.wait()
+        activationCallCount += 1
+        if activationCallCount == 1 {
+            activationStarted = true
+            activationCondition.broadcast()
+            while !activationReleased {
+                activationCondition.wait()
+            }
         }
         activationCondition.unlock()
     }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -165,6 +165,36 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
             [.prepare, .activate, .prepare, .activate, .deactivate]
         )
     }
+
+    func testOldDeactivationDoesNotInterruptPendingRetry() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(blockedActivationCall: 2)
+        defer { backend.releaseActivation() }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let oldActivation = try await coordinator.activate()
+        let retryRequest = Task {
+            try await coordinator.activate()
+        }
+
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while !backend.hasStartedActivation, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        guard backend.hasStartedActivation else {
+            XCTFail("Retry activation did not start")
+            return
+        }
+
+        await coordinator.deactivate(oldActivation)
+        XCTAssertEqual(backend.operations, [.prepare, .activate, .prepare, .activate])
+
+        backend.releaseActivation()
+        let retryActivation = try await retryRequest.value
+        await coordinator.deactivate(retryActivation)
+        XCTAssertEqual(
+            backend.operations,
+            [.prepare, .activate, .prepare, .activate, .deactivate]
+        )
+    }
 }
 
 private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend, @unchecked Sendable {
@@ -176,14 +206,18 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
 
     private let lock = NSLock()
     private var storedOperations: [Operation] = []
-    private let blocksActivation: Bool
+    private let blockedActivationCall: Int?
     private let activationCondition = NSCondition()
     private var activationStarted = false
     private var activationReleased = false
     private var activationCallCount = 0
 
     init(blocksActivation: Bool = false) {
-        self.blocksActivation = blocksActivation
+        blockedActivationCall = blocksActivation ? 1 : nil
+    }
+
+    init(blockedActivationCall: Int) {
+        self.blockedActivationCall = blockedActivationCall
     }
 
     var operations: [Operation] {
@@ -202,10 +236,10 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
 
     func activateForRecording() throws {
         record(.activate)
-        guard blocksActivation else { return }
+        guard let blockedActivationCall else { return }
         activationCondition.lock()
         activationCallCount += 1
-        if activationCallCount == 1 {
+        if activationCallCount == blockedActivationCall {
             activationStarted = true
             activationCondition.broadcast()
             while !activationReleased {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -305,6 +305,40 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         try await waitForOperation(.deactivate, count: 2, in: backend)
     }
 
+    func testPendingActivationRetriesAfterRefreshFailure() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(
+            blockedActivationCall: 2,
+            failingActivationCall: 3,
+            blockedDeactivationCall: 1
+        )
+        defer {
+            backend.releaseActivation()
+            backend.releaseDeactivation()
+        }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let oldActivation = try await coordinator.activate()
+
+        await coordinator.deactivate(oldActivation)
+        try await waitForDeactivationStart(in: backend)
+
+        let retryRequest = Task {
+            try await coordinator.activate()
+        }
+        try await waitForActivationStart(in: backend)
+
+        // 待发布请求的第一次 setActive 已经进入系统调用；旧停用随后落地并触发一次失败补激活。
+        backend.releaseDeactivation()
+        try await waitForOperation(.activate, count: 3, in: backend)
+        try await Task.sleep(for: .milliseconds(40))
+
+        backend.releaseActivation()
+        let retryActivation = try await retryRequest.value
+        XCTAssertEqual(backend.operations.filter { $0 == .activate }.count, 4)
+
+        await coordinator.deactivate(retryActivation)
+        try await waitForOperation(.deactivate, count: 2, in: backend)
+    }
+
     func testStaleRefreshFailureDoesNotStopNewerActivation() async throws {
         let backend = StartupWatchdogAudioSessionBackend(
             blockedActivationCall: 3,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -42,6 +42,29 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         XCTAssertFalse(error.errorDescription?.isEmpty ?? true)
     }
 
+    func testRecoveryGateDefersFailureUntilCaptureInitialization() {
+        var gate = VoiceAudioCaptureRecoveryGate()
+
+        XCTAssertNil(gate.receive(false, isCaptureReady: false))
+        XCTAssertEqual(gate.consumePendingResult(), false)
+        XCTAssertNil(gate.consumePendingResult())
+    }
+
+    func testRecoveryGateKeepsLatestStartupResult() {
+        var gate = VoiceAudioCaptureRecoveryGate()
+
+        XCTAssertNil(gate.receive(false, isCaptureReady: false))
+        XCTAssertNil(gate.receive(true, isCaptureReady: false))
+        XCTAssertEqual(gate.consumePendingResult(), true)
+    }
+
+    func testRecoveryGateReturnsResultImmediatelyAfterCaptureInitialization() {
+        var gate = VoiceAudioCaptureRecoveryGate()
+
+        XCTAssertEqual(gate.receive(false, isCaptureReady: true), false)
+        XCTAssertNil(gate.consumePendingResult())
+    }
+
     func testCancelledQueuedActivationCannotOverrideImmediateRetry() async throws {
         let backend = StartupWatchdogAudioSessionBackend()
         let coordinator = VoiceAudioSessionCoordinator(backend: backend)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -305,7 +305,7 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         try await waitForOperation(.deactivate, count: 2, in: backend)
     }
 
-    func testPendingActivationRetriesAfterRefreshFailure() async throws {
+    func testPendingActivationIgnoresRefreshFailureOlderThanSuccessfulAttempt() async throws {
         let backend = StartupWatchdogAudioSessionBackend(
             blockedActivationCall: 2,
             failingActivationCall: 3,
@@ -321,19 +321,24 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         await coordinator.deactivate(oldActivation)
         try await waitForDeactivationStart(in: backend)
 
+        var recoveryResults: [Bool] = []
         let retryRequest = Task {
-            try await coordinator.activate()
+            try await coordinator.activate(onRecovery: { succeeded in
+                recoveryResults.append(succeeded)
+            })
         }
         try await waitForActivationStart(in: backend)
 
-        // 待发布请求的第一次 setActive 已经进入系统调用；旧停用随后落地并触发一次失败补激活。
+        // 旧停用和失败补激活都先于待发布请求的成功 setActive；迟到失败回调不能误杀该请求。
         backend.releaseDeactivation()
         try await waitForOperation(.activate, count: 3, in: backend)
         try await Task.sleep(for: .milliseconds(40))
 
         backend.releaseActivation()
         let retryActivation = try await retryRequest.value
-        XCTAssertEqual(backend.operations.filter { $0 == .activate }.count, 4)
+        try await Task.sleep(for: .milliseconds(40))
+        XCTAssertEqual(backend.operations.filter { $0 == .activate }.count, 3)
+        XCTAssertFalse(recoveryResults.contains(false))
 
         await coordinator.deactivate(retryActivation)
         try await waitForOperation(.deactivate, count: 2, in: backend)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/AppleVoiceStartupWatchdogTests.swift
@@ -279,6 +279,41 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         try await waitForOperation(.deactivate, count: 2, in: backend)
     }
 
+    func testStaleRefreshFailureDoesNotStopNewerActivation() async throws {
+        let backend = StartupWatchdogAudioSessionBackend(
+            blockedActivationCall: 3,
+            failingActivationCall: 3,
+            blockedDeactivationCall: 1
+        )
+        defer {
+            backend.releaseActivation()
+            backend.releaseDeactivation()
+        }
+        let coordinator = VoiceAudioSessionCoordinator(backend: backend)
+        let firstActivation = try await coordinator.activate()
+
+        await coordinator.deactivate(firstActivation)
+        try await waitForDeactivationStart(in: backend)
+
+        let secondActivation = try await coordinator.activate()
+        backend.releaseDeactivation()
+        try await waitForActivationStart(in: backend)
+
+        var newestRecoveryResults: [Bool] = []
+        let newestActivation = try await coordinator.activate(onRecovery: { succeeded in
+            newestRecoveryResults.append(succeeded)
+        })
+
+        // 第一次补激活属于第二个租约。它迟到失败时，第三个租约已经接管，不能收到 false。
+        backend.releaseActivation()
+        try await Task.sleep(for: .milliseconds(40))
+        XCTAssertFalse(newestRecoveryResults.contains(false))
+
+        await coordinator.deactivate(secondActivation)
+        await coordinator.deactivate(newestActivation)
+        try await waitForOperation(.deactivate, count: 2, in: backend)
+    }
+
     private func waitForOperations(
         _ expected: [StartupWatchdogAudioSessionBackend.Operation],
         in backend: StartupWatchdogAudioSessionBackend
@@ -302,9 +337,33 @@ final class AppleVoiceStartupWatchdogTests: XCTestCase {
         }
         XCTAssertGreaterThanOrEqual(backend.operations.filter { $0 == operation }.count, count)
     }
+
+    private func waitForActivationStart(
+        in backend: StartupWatchdogAudioSessionBackend
+    ) async throws {
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while !backend.hasStartedActivation, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(backend.hasStartedActivation)
+    }
+
+    private func waitForDeactivationStart(
+        in backend: StartupWatchdogAudioSessionBackend
+    ) async throws {
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while !backend.hasStartedDeactivation, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(backend.hasStartedDeactivation)
+    }
 }
 
 private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend, @unchecked Sendable {
+    enum TestError: Error {
+        case activationFailed
+    }
+
     enum Operation: Equatable {
         case prepare
         case activate
@@ -315,6 +374,7 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
     private var storedOperations: [Operation] = []
     private let blockedPreparationCall: Int?
     private let blockedActivationCall: Int?
+    private let failingActivationCall: Int?
     private let blockedDeactivationCall: Int?
     private let preparationCondition = NSCondition()
     private var preparationStarted = false
@@ -332,25 +392,40 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
     init(blocksActivation: Bool = false) {
         blockedPreparationCall = nil
         blockedActivationCall = blocksActivation ? 1 : nil
+        failingActivationCall = nil
         blockedDeactivationCall = nil
     }
 
     init(blockedActivationCall: Int) {
         blockedPreparationCall = nil
         self.blockedActivationCall = blockedActivationCall
+        failingActivationCall = nil
         blockedDeactivationCall = nil
     }
 
     init(blockedDeactivationCall: Int) {
         blockedPreparationCall = nil
         blockedActivationCall = nil
+        failingActivationCall = nil
         self.blockedDeactivationCall = blockedDeactivationCall
     }
 
     init(blockedPreparationCall: Int) {
         self.blockedPreparationCall = blockedPreparationCall
         blockedActivationCall = nil
+        failingActivationCall = nil
         blockedDeactivationCall = nil
+    }
+
+    init(
+        blockedActivationCall: Int,
+        failingActivationCall: Int,
+        blockedDeactivationCall: Int
+    ) {
+        blockedPreparationCall = nil
+        self.blockedActivationCall = blockedActivationCall
+        self.failingActivationCall = failingActivationCall
+        self.blockedDeactivationCall = blockedDeactivationCall
     }
 
     var operations: [Operation] {
@@ -392,10 +467,11 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
 
     func activateForRecording() throws {
         record(.activate)
-        guard let blockedActivationCall else { return }
         activationCondition.lock()
         activationCallCount += 1
-        if activationCallCount == blockedActivationCall {
+        let currentCall = activationCallCount
+        if let blockedActivationCall,
+           currentCall == blockedActivationCall {
             activationStarted = true
             activationCondition.broadcast()
             while !activationReleased {
@@ -403,6 +479,10 @@ private final class StartupWatchdogAudioSessionBackend: VoiceAudioSessionBackend
             }
         }
         activationCondition.unlock()
+        if let failingActivationCall,
+           currentCall == failingActivationCall {
+            throw TestError.activationFailed
+        }
     }
 
     func deactivateRecording() throws {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -548,6 +548,10 @@ extension ConversationDataFlowTests {
         )
 
         await coordinator.deactivate(secondActivation)
+        let deadline = ContinuousClock.now + .milliseconds(250)
+        while backend.operations.last != .deactivate, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
         XCTAssertEqual(
             backend.operations,
             [.prepare, .prepare, .activate, .prepare, .activate, .deactivate]


### PR DESCRIPTION
## 目标

避免 Apple 设备端语音输入偶发一直停留在加载状态，并确保用户可以安全重试。

## 实现

- 为 Apple 语音启动增加 15 秒 watchdog，超时后恢复界面并返回可重试错误。
- 使用同一个 requestID 串联权限、分析器、音频会话和首个音频 buffer 日志。
- 取消或超时后不再等待可能卡住的旧生命周期任务。
- 为音频激活增加取消检查和租约保护，避免迟到的旧请求关闭新会话。
- 仅在停用音频会话时使用 notifyOthersOnDeactivation。

## 验证

- AppleVoiceStartupWatchdogTests：5 个测试通过。
- VoiceAudioSessionCoordinator 相关回归：2 个测试通过。
- 固定 iPad Pro 13-inch (M5) Simulator 测试构建通过。
- USB iPad mini Debug 签名构建通过。
- bash ./scripts/check-source-size.sh 通过。
- git diff --check 通过。
- 独立复审结论：ship。

## 未验证

- 尚未把该构建安装到真机并手动触发麦克风，因此偶发系统卡点仍需真机重复点按验证。