### PR TITLE
允许移出当前选中的工作区目录

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -956,7 +956,7 @@ struct WorkspaceRootView: View {
     }
 
     private func removeWorkspace(_ project: AgentProject) {
-        guard selectedWorkspaceID != project.id else { return }
+        // 当前浏览选择可以被移出；目录列表变化后，现有同步逻辑会选择剩余目录。
         runtimeSessionPagesByKey = runtimeSessionPagesByKey.filter { $0.key.workspaceID != project.id }
         sessionLoadStates = sessionLoadStates.filter { $0.key.workspaceID != project.id }
         sessionLoadInvocationTokens.remove { $0.workspaceID == project.id }
@@ -1335,14 +1335,12 @@ private struct WorkspaceProjectChip: View {
             .accessibilityIdentifier("workspace.card.icon.\(project.id)")
         }
 
-        if !isSelected {
-            Button(role: .destructive) {
-                isPresentingRemoveConfirmation = true
-            } label: {
-                Label(L10n.text("ui.remove_directory"), systemImage: "xmark.circle")
-            }
-            .accessibilityIdentifier("workspace.remove.request.\(project.id)")
+        Button(role: .destructive) {
+            isPresentingRemoveConfirmation = true
+        } label: {
+            Label(L10n.text("ui.remove_directory"), systemImage: "xmark.circle")
         }
+        .accessibilityIdentifier("workspace.remove.request.\(project.id)")
     }
 
     @ViewBuilder

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -908,14 +908,14 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         }
     }
 
-    func testWorkspaceRemoveDirectoryConfirmationAnchorsToCardAcrossIPadLayouts() throws {
+    func testSelectedWorkspaceRemoveDirectoryConfirmationAnchorsToCardAcrossIPadLayouts() throws {
         try XCTSkipUnless(
             UIDevice.current.userInterfaceIdiom == .pad,
             "目录移除确认的 popover 锚点只在 iPad regular width 下验收。"
         )
         try relaunchDirectlyIntoWorkspaces()
 
-        let projectID = "debug-sample-app"
+        let projectID = "debug-mimi-demo"
         for (orientation, attachmentName) in [
             (UIDeviceOrientation.landscapeLeft, "landscape-sidebar"),
             (.portrait, "portrait")
@@ -924,11 +924,12 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
 
             let source = app.descendant(identifier: "workspace.card.\(projectID)")
             XCTAssertTrue(source.waitForExistence(timeout: 10), "旋转后工作区项目胶囊应保持可见")
+            XCTAssertTrue(source.isSelected, "当前选中的工作区应保持选中状态")
             assertMinimumTouchTarget(source, named: "工作区项目胶囊")
             source.press(forDuration: 1.0)
 
             let request = app.descendant(identifier: "workspace.remove.request.\(projectID)")
-            XCTAssertTrue(request.waitForExistence(timeout: 6), "长按菜单应提供移除目录入口")
+            XCTAssertTrue(request.waitForExistence(timeout: 6), "当前选中工作区的长按菜单应提供移除目录入口")
             request.tap()
 
             let confirmation = app.descendant(identifier: "workspace.remove.confirm.\(projectID)")
@@ -959,7 +960,7 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
 
         XCTAssertTrue(
             source.waitForNonExistence(timeout: 8),
-            "确认后只应从当前工作区列表移除 Debug 样例目录"
+            "确认后应从当前工作区列表移除选中的 Debug 样例目录"
         )
     }
 


### PR DESCRIPTION
## 目标

允许用户从工作区项目列表移出当前选中的目录。

## 实现

- 当前选中项目的长按菜单始终显示“移出目录”。
- 移除执行阶段对当前浏览选择的拦截。
- 保留确认弹窗和只从列表移除、不删除 Mac 文件的现有语义。
- 将 UI 回归用例改为覆盖当前选中的工作区。

## 验证

- 通过：目录移除状态测试。
- 通过：工作区视觉快照测试。
- 通过：git diff --check。
- 修改后的生产文件为 1974 行，UI 测试文件为 1583 行，均低于对应上限。

## 已知限制

- 全量 1347 项测试中有 18 个会话状态托盘和 Skill 卡片视觉快照不匹配；工作区视觉快照通过。
- MimiRemoteUITests 不属于规定的 MimiRemote Scheme，因此本次更新的直接 UI 交互用例未实际运行。
- 源码体积门禁会扫描 .claude/worktrees，其中已有多个超限文件，因此门禁整体未通过。