### PR TITLE
MIM-128: show release version in Windows control panel

### DIFF
--- a/cmd/mimi-remote-tray/control_panel_windows.go
+++ b/cmd/mimi-remote-tray/control_panel_windows.go
@@ -190,21 +190,22 @@ type controlPanel struct {
 	detailBrush     uintptr
 	statusBrush     uintptr
 
-	titleLabel     uintptr
-	subtitleLabel  uintptr
-	badgeLabel     uintptr
-	statusDotLabel uintptr
-	statusLabel    uintptr
-	summaryLabel   uintptr
-	endpointLabel  uintptr
-	endpointValue  uintptr
-	versionLabel   uintptr
-	versionValue   uintptr
-	networkLabel   uintptr
-	networkValue   uintptr
-	projectsLabel  uintptr
-	projectsValue  uintptr
-	footerLabel    uintptr
+	titleLabel      uintptr
+	appVersionLabel uintptr
+	subtitleLabel   uintptr
+	badgeLabel      uintptr
+	statusDotLabel  uintptr
+	statusLabel     uintptr
+	summaryLabel    uintptr
+	endpointLabel   uintptr
+	endpointValue   uintptr
+	versionLabel    uintptr
+	versionValue    uintptr
+	networkLabel    uintptr
+	networkValue    uintptr
+	projectsLabel   uintptr
+	projectsValue   uintptr
+	footerLabel     uintptr
 
 	refresh   uintptr
 	start     uintptr
@@ -471,7 +472,8 @@ func (p *controlPanel) createFonts() {
 }
 
 func (p *controlPanel) createControls(instance uintptr) error {
-	p.titleLabel = p.createControl(instance, "STATIC", "Mimi Remote", wsChild|wsVisible|ssLeft|ssNoPrefix, 70, 16, 300, 30, 0)
+	p.titleLabel = p.createControl(instance, "STATIC", "Mimi Remote", wsChild|wsVisible|ssLeft|ssNoPrefix, 70, 16, 160, 30, 0)
+	p.appVersionLabel = p.createControl(instance, "STATIC", "应用 "+formatReleaseVersion(releaseVersion), wsChild|wsVisible|ssLeft|ssNoPrefix, 238, 25, 140, 22, 0)
 	p.subtitleLabel = p.createControl(instance, "STATIC", "Windows 控制面板", wsChild|wsVisible|ssLeft|ssNoPrefix, 70, 45, 300, 22, 0)
 	p.badgeLabel = p.createControl(instance, "STATIC", "正在检查", wsChild|wsVisible|ssCenter|ssNoPrefix, 434, 25, 118, 24, 0)
 	p.statusDotLabel = p.createControl(instance, "STATIC", "●", wsChild|wsVisible|ssCenter|ssNoPrefix, 31, 94, 24, 28, 0)
@@ -480,7 +482,7 @@ func (p *controlPanel) createControls(instance uintptr) error {
 
 	p.endpointLabel = p.createControl(instance, "STATIC", "连接地址", wsChild|wsVisible|ssLeft|ssNoPrefix, 48, 168, 76, 20, 0)
 	p.endpointValue = p.createControl(instance, "STATIC", "—", wsChild|wsVisible|ssLeft|ssNoPrefix, 134, 168, 144, 20, 0)
-	p.versionLabel = p.createControl(instance, "STATIC", "版本", wsChild|wsVisible|ssLeft|ssNoPrefix, 314, 168, 58, 20, 0)
+	p.versionLabel = p.createControl(instance, "STATIC", "服务版本", wsChild|wsVisible|ssLeft|ssNoPrefix, 314, 168, 58, 20, 0)
 	p.versionValue = p.createControl(instance, "STATIC", "—", wsChild|wsVisible|ssLeft|ssNoPrefix, 382, 168, 158, 20, 0)
 	p.networkLabel = p.createControl(instance, "STATIC", "网络", wsChild|wsVisible|ssLeft|ssNoPrefix, 48, 207, 76, 20, 0)
 	p.networkValue = p.createControl(instance, "STATIC", "—", wsChild|wsVisible|ssLeft|ssNoPrefix, 134, 207, 144, 20, 0)
@@ -508,7 +510,7 @@ func (p *controlPanel) createControls(instance uintptr) error {
 	p.pairRefresh = p.createControl(instance, "BUTTON", "刷新二维码", wsChild|wsTabStop|bsOwnerDraw, 392, 366, 160, 50, panelPairRefresh)
 
 	controls := []uintptr{
-		p.titleLabel, p.subtitleLabel, p.badgeLabel, p.statusDotLabel, p.statusLabel, p.summaryLabel,
+		p.titleLabel, p.appVersionLabel, p.subtitleLabel, p.badgeLabel, p.statusDotLabel, p.statusLabel, p.summaryLabel,
 		p.endpointLabel, p.endpointValue, p.versionLabel, p.versionValue,
 		p.networkLabel, p.networkValue, p.projectsLabel, p.projectsValue,
 		p.refresh, p.start, p.restart, p.stop, p.pair, p.doctor, p.doctorFix, p.logs,
@@ -537,7 +539,7 @@ func (p *controlPanel) createControls(instance uintptr) error {
 
 func (p *controlPanel) applyFonts() {
 	for _, control := range []uintptr{
-		p.titleLabel, p.subtitleLabel, p.badgeLabel, p.statusDotLabel, p.statusLabel, p.summaryLabel,
+		p.titleLabel, p.appVersionLabel, p.subtitleLabel, p.badgeLabel, p.statusDotLabel, p.statusLabel, p.summaryLabel,
 		p.endpointLabel, p.endpointValue, p.versionLabel, p.versionValue,
 		p.networkLabel, p.networkValue, p.projectsLabel, p.projectsValue,
 		p.refresh, p.start, p.restart, p.stop, p.pair, p.doctor, p.doctorFix, p.logs,
@@ -554,7 +556,7 @@ func (p *controlPanel) applyFonts() {
 	setControlPanelFont(p.versionValue, p.valueFont)
 	setControlPanelFont(p.networkValue, p.valueFont)
 	setControlPanelFont(p.projectsValue, p.valueFont)
-	for _, control := range []uintptr{p.subtitleLabel, p.badgeLabel, p.endpointLabel, p.versionLabel, p.networkLabel, p.projectsLabel, p.pairEndpoint, p.pairExpiry, p.pairWarning, p.footerLabel} {
+	for _, control := range []uintptr{p.appVersionLabel, p.subtitleLabel, p.badgeLabel, p.endpointLabel, p.versionLabel, p.networkLabel, p.projectsLabel, p.pairEndpoint, p.pairExpiry, p.pairWarning, p.footerLabel} {
 		setControlPanelFont(control, p.smallFont)
 	}
 	for _, control := range []uintptr{p.refresh, p.start, p.restart, p.stop, p.pair, p.doctor, p.doctorFix, p.logs, p.pairBack, p.pairCopy, p.pairRefresh} {
@@ -568,7 +570,8 @@ func (p *controlPanel) layoutControls() {
 		x, y, width, height int
 	}
 	for _, item := range []layout{
-		{p.titleLabel, 70, 16, 300, 30},
+		{p.titleLabel, 70, 16, 160, 30},
+		{p.appVersionLabel, 238, 25, 140, 22},
 		{p.subtitleLabel, 70, 45, 300, 22},
 		{p.badgeLabel, 434, 25, 118, 24},
 		{p.statusDotLabel, 31, 94, 24, 28},
@@ -1202,7 +1205,7 @@ func (p *controlPanel) staticTextColor(control uintptr) uint32 {
 
 func (p *controlPanel) staticBackgroundBrush(control uintptr) uintptr {
 	switch control {
-	case p.titleLabel, p.subtitleLabel, p.footerLabel:
+	case p.titleLabel, p.appVersionLabel, p.subtitleLabel, p.footerLabel:
 		return p.backgroundBrush
 	case p.badgeLabel:
 		return p.statusBrush

--- a/cmd/mimi-remote-tray/release_version.go
+++ b/cmd/mimi-remote-tray/release_version.go
@@ -1,0 +1,20 @@
+package main
+
+import "strings"
+
+// releaseVersion is injected by the Windows packaging script from the same
+// version value used for the installer and GitHub Release tag.
+var releaseVersion = "dev"
+
+func formatReleaseVersion(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "dev") {
+		return "开发版"
+	}
+	value = strings.TrimPrefix(value, "v")
+	value = strings.TrimPrefix(value, "V")
+	if value == "" {
+		return "开发版"
+	}
+	return "v" + value
+}

--- a/cmd/mimi-remote-tray/release_version_test.go
+++ b/cmd/mimi-remote-tray/release_version_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestFormatReleaseVersion(t *testing.T) {
+	tests := map[string]string{
+		"0.3.7":  "v0.3.7",
+		"v0.3.7": "v0.3.7",
+		"V0.3.7": "v0.3.7",
+		" dev ":  "开发版",
+		"":       "开发版",
+	}
+	for input, want := range tests {
+		if got := formatReleaseVersion(input); got != want {
+			t.Fatalf("formatReleaseVersion(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -68,7 +68,7 @@ try {
     $env:CGO_ENABLED = '0'; $env:GOOS = 'windows'; $env:GOARCH = 'amd64'
     & go build -trimpath -ldflags "-s -w -X main.version=$Version" -o (Join-Path $stage 'agentd.exe') ./cmd/agentd
     if ($LASTEXITCODE -ne 0) { throw 'go build failed.' }
-    & go build -trimpath -ldflags "-s -w -H=windowsgui" -o (Join-Path $stage 'mimi-remote-tray.exe') ./cmd/mimi-remote-tray
+    & go build -trimpath -ldflags "-s -w -H=windowsgui -X main.releaseVersion=$Version" -o (Join-Path $stage 'mimi-remote-tray.exe') ./cmd/mimi-remote-tray
     if ($LASTEXITCODE -ne 0) { throw 'Windows tray build failed.' }
     if ($BridgeBinary) {
         & $BridgeBinary --version

--- a/scripts/test-windows-install.ps1
+++ b/scripts/test-windows-install.ps1
@@ -44,6 +44,7 @@ if (-not $buildSource.Contains('/DMySignTool=mimi-authenticode')) { throw 'Relea
 if (-not $buildSource.Contains('[switch]$AllowUnsignedRelease')) { throw 'Unsigned release builds must require an explicit switch.' }
 if (-not $buildSource.Contains("'unsigned-release'")) { throw 'Unsigned release builds must record their signing mode in metadata.' }
 if (-not $buildSource.Contains('Mimi-Remote-Setup-$Version-unsigned')) { throw 'Unsigned release filenames must identify that they are unsigned.' }
+if (-not $buildSource.Contains('-X main.releaseVersion=$Version')) { throw 'Windows tray builds must embed the installer and GitHub Release version.' }
 $checkSource = Get-Content -LiteralPath $check -Raw
 if (-not $checkSource.Contains("'unsigned-release'")) { throw 'Installer validation must recognize unsigned release metadata.' }
 $releaseSource = Get-Content -LiteralPath $releaseWorkflow -Raw


### PR DESCRIPTION
## Summary

- show the packaged app release beside the Mimi Remote title in the Windows control panel
- distinguish the app release from the running agentd service build version
- inject the same validated packaging version into the tray binary, with an explicit development-build fallback
- add regression coverage for version formatting and installer version injection

## Verification

- `go test ./cmd/mimi-remote-tray`
- `go vet ./cmd/mimi-remote-tray`
- `go vet ./...`
- `powershell -File scripts/test-windows-install.ps1 -RepositoryRoot .`
- Windows amd64 release build with `main.releaseVersion=0.3.7`; confirmed `0.3.7` is embedded in the produced executable

`go test ./...` was also attempted. It is not green in this Windows environment because tests outside the changed packages fail under the inherited proxy environment, unavailable symlink privilege, and existing HTTP API test conditions; the changed tray package passes.

Linear: MIM-128