### PR TITLE
MIM-179 Stabilize Windows managed-service restarts

### DIFF
--- a/cmd/agentd/windows_service.go
+++ b/cmd/agentd/windows_service.go
@@ -99,7 +99,13 @@ func stopWindowsManagedTask(schtasks string, stdout, stderr io.Writer) error {
 						for time.Now().Before(deadline) {
 							if _, err := os.Stat(pidPath); errors.Is(err, os.ErrNotExist) {
 								_ = os.Remove(stopPath)
-								return nil
+								// The service removes its PID file during graceful shutdown, but
+								// Task Scheduler may still report the old instance as Running for a
+								// short window. With MultipleInstances=IgnoreNew, an immediate
+								// restart would then be accepted as a no-op and leave the service
+								// offline. Fall through and synchronize the scheduler state before
+								// returning to the caller.
+								return waitForWindowsManagedTaskStopped(schtasks, stdout, stderr, 10*time.Second)
 							}
 							time.Sleep(100 * time.Millisecond)
 						}
@@ -111,7 +117,59 @@ func stopWindowsManagedTask(schtasks string, stdout, stderr io.Writer) error {
 			}
 		}
 	}
-	return runWindowsTaskAction(schtasks, "End", stdout, stderr, true)
+	return waitForWindowsManagedTaskStopped(schtasks, stdout, stderr, 10*time.Second)
+}
+
+func waitForWindowsManagedTaskStopped(
+	schtasks string,
+	stdout, stderr io.Writer,
+	timeout time.Duration,
+) error {
+	if err := runWindowsTaskAction(schtasks, "End", stdout, stderr, true); err != nil {
+		return err
+	}
+	powershell, err := windowsLookPath("powershell.exe")
+	if err != nil {
+		return fmt.Errorf("未找到 powershell.exe，无法等待 Windows 当前用户计划任务停止：%w", err)
+	}
+	const stateScript = `$task = Get-ScheduledTask -TaskName $env:MIMI_REMOTE_WINDOWS_TASK_NAME -ErrorAction Stop; [Console]::Out.Write([string]$task.State)`
+	deadline := time.Now().Add(timeout)
+	for {
+		var commandStdout, commandStderr bytes.Buffer
+		cmd := windowsExecCommand(powershell, "-NoProfile", "-NonInteractive", "-Command", stateScript)
+		cmd.Env = append(cmd.Environ(), "MIMI_REMOTE_WINDOWS_TASK_NAME="+windowsManagedTaskName)
+		cmd.Stdout = &commandStdout
+		cmd.Stderr = &commandStderr
+		err := cmd.Run()
+		detail := commandStdout.String() + commandStderr.String()
+		if err != nil {
+			_, _ = io.Copy(stdout, &commandStdout)
+			_, _ = io.Copy(stderr, &commandStderr)
+			return fmt.Errorf(
+				"查询 Windows 当前用户计划任务 %q 状态失败：%w%s",
+				windowsManagedTaskName,
+				err,
+				formatWindowsCommandDetail(detail),
+			)
+		}
+		switch strings.ToLower(strings.TrimSpace(commandStdout.String())) {
+		case "ready", "disabled":
+			return nil
+		case "running", "queued":
+			// Keep polling below. /End only submits the stop request, while an
+			// IgnoreNew task cannot safely be restarted until this state clears.
+		default:
+			return fmt.Errorf(
+				"Windows 当前用户计划任务 %q 返回了未知状态%s",
+				windowsManagedTaskName,
+				formatWindowsCommandDetail(detail),
+			)
+		}
+		if timeout <= 0 || time.Now().After(deadline) {
+			return fmt.Errorf("等待 Windows 当前用户计划任务 %q 停止超时", windowsManagedTaskName)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 func forceKillWindowsProcessTree(pid string, stdout, stderr io.Writer) error {

--- a/cmd/agentd/windows_service_test.go
+++ b/cmd/agentd/windows_service_test.go
@@ -86,7 +86,7 @@ func TestWindowsManagedStartAlreadyRunningIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestWindowsManagedStopRequestsGracefulShutdown(t *testing.T) {
+func TestWindowsManagedStopRequestsGracefulShutdownAndSynchronizesTask(t *testing.T) {
 	marker := installFakeWindowsCommands(t)
 	pidPath, err := windowsManagedPIDPath()
 	if err != nil {
@@ -123,11 +123,65 @@ func TestWindowsManagedStopRequestsGracefulShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(raw), "schtasks|/End") {
-		t.Fatalf("优雅退出成功后不应再强制结束计划任务：%s", raw)
+	if !strings.Contains(string(raw), "schtasks|/End|/TN|Mimi Remote agentd") {
+		t.Fatalf("优雅退出成功后必须等待 Task Scheduler 状态收敛：%s", raw)
 	}
 	if _, err := os.Stat(stopPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("优雅退出后应清理 stop marker：%v", err)
+	}
+}
+
+func TestWindowsManagedRestartEndsTaskBeforeStartingReplacement(t *testing.T) {
+	marker := installFakeWindowsCommands(t)
+	if err := runManagedServiceForPlatform("windows", "restart", io.Discard, io.Discard); err != nil {
+		t.Fatalf("Windows restart 失败：%v", err)
+	}
+	raw, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := string(raw)
+	endIndex := strings.Index(calls, "schtasks|/End|/TN|Mimi Remote agentd")
+	runIndex := strings.LastIndex(calls, "schtasks|/Run|/TN|Mimi Remote agentd")
+	if endIndex < 0 || runIndex < 0 || endIndex > runIndex {
+		t.Fatalf("restart 必须先同步停止 Task Scheduler 实例再启动新实例：%s", calls)
+	}
+}
+
+func TestWindowsManagedStopWaitsForSchedulerToReportStopped(t *testing.T) {
+	marker := installFakeWindowsCommands(t)
+	t.Setenv("AGENTD_FAKE_TASK_STATE_TRANSITION", "1")
+	if err := runManagedServiceForPlatform("windows", "stop", io.Discard, io.Discard); err != nil {
+		t.Fatalf("Windows stop 失败：%v", err)
+	}
+	raw, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.Count(string(raw), "Get-ScheduledTask"); count != 2 {
+		t.Fatalf("Task Scheduler 过渡期间应持续探测到明确停止，实际状态查询次数=%d：%s", count, raw)
+	}
+}
+
+func TestWindowsManagedStopDoesNotSwallowUnexpectedSchedulerError(t *testing.T) {
+	installFakeWindowsCommands(t)
+	t.Setenv("AGENTD_FAKE_TASK_END_DENIED", "1")
+	var stderr strings.Builder
+	err := runManagedServiceForPlatform("windows", "stop", io.Discard, &stderr)
+	if err == nil {
+		t.Fatal("Task Scheduler 拒绝停止时必须失败")
+	}
+	if !strings.Contains(err.Error(), "Access is denied") || !strings.Contains(stderr.String(), "Access is denied") {
+		t.Fatalf("Task Scheduler 的意外错误必须保留：err=%v stderr=%q", err, stderr.String())
+	}
+}
+
+func TestWaitForWindowsManagedTaskStoppedTimesOutDuringPersistentTransition(t *testing.T) {
+	installFakeWindowsCommands(t)
+	t.Setenv("AGENTD_FAKE_TASK_STATE_ALWAYS_PENDING", "1")
+	err := waitForWindowsManagedTaskStopped("schtasks", io.Discard, io.Discard, 50*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "停止超时") {
+		t.Fatalf("Task Scheduler 持续过渡时必须超时失败：%v", err)
 	}
 }
 
@@ -256,11 +310,30 @@ func TestWindowsCommandProbe(t *testing.T) {
 				os.Exit(1)
 			}
 		case "/End":
+			if os.Getenv("AGENTD_FAKE_TASK_END_DENIED") == "1" {
+				fmt.Fprintln(os.Stderr, "ERROR: Access is denied.")
+				os.Exit(1)
+			}
 			fmt.Fprintln(os.Stderr, "ERROR: The task is not currently running.")
 			os.Exit(1)
 		}
 	}
 	if os.Args[3] == "powershell.exe" {
+		if strings.Contains(strings.Join(commandArgs, " "), "Get-ScheduledTask") {
+			if os.Getenv("AGENTD_FAKE_TASK_STATE_ALWAYS_PENDING") == "1" {
+				fmt.Fprint(os.Stdout, "Running")
+				os.Exit(0)
+			}
+			if os.Getenv("AGENTD_FAKE_TASK_STATE_TRANSITION") == "1" {
+				raw, _ := os.ReadFile(marker)
+				if strings.Count(string(raw), "Get-ScheduledTask") == 1 {
+					fmt.Fprint(os.Stdout, "Running")
+					os.Exit(0)
+				}
+			}
+			fmt.Fprint(os.Stdout, "Ready")
+			os.Exit(0)
+		}
 		fmt.Fprintln(os.Stdout, "followed")
 	}
 	os.Exit(0)

--- a/internal/config/test_main_test.go
+++ b/internal/config/test_main_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain keeps package tests away from the signed-in user's real config.
+// On Windows os.UserConfigDir ignores HOME and uses APPDATA, so tests that only
+// redirected HOME could overwrite %APPDATA%\mimi-remote\config.json.
+func TestMain(m *testing.M) {
+	root, err := os.MkdirTemp("", "mimi-remote-config-tests-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "create isolated config test home:", err)
+		os.Exit(1)
+	}
+
+	for key, value := range map[string]string{
+		"HOME":            root,
+		"USERPROFILE":     root,
+		"APPDATA":         filepath.Join(root, "AppData", "Roaming"),
+		"LOCALAPPDATA":    filepath.Join(root, "AppData", "Local"),
+		"XDG_CONFIG_HOME": filepath.Join(root, ".config"),
+		"XDG_CACHE_HOME":  filepath.Join(root, ".cache"),
+	} {
+		if err := os.Setenv(key, value); err != nil {
+			fmt.Fprintf(os.Stderr, "set isolated config test environment %s: %v\n", key, err)
+			_ = os.RemoveAll(root)
+			os.Exit(1)
+		}
+	}
+
+	code := m.Run()
+	if err := os.RemoveAll(root); err != nil && code == 0 {
+		fmt.Fprintln(os.Stderr, "remove isolated config test home:", err)
+		code = 1
+	}
+	os.Exit(code)
+}

--- a/packaging/windows/mimi-remote.iss
+++ b/packaging/windows/mimi-remote.iss
@@ -169,7 +169,7 @@ procedure InitializeAndVerifyManagedService;
 var
   ResultCode: Integer;
 begin
-  if not Exec(ExpandConstant('{app}\agentd.exe'), 'up --no-pair', '', SW_SHOW, ewWaitUntilTerminated, ResultCode) then begin
+  if not Exec(ExpandConstant('{app}\agentd.exe'), 'up --no-pair --wait 30s', '', SW_SHOW, ewWaitUntilTerminated, ResultCode) then begin
     PostInstallFailed := True;
     RaiseException('Unable to initialize Mimi Remote after installation.');
   end;
@@ -206,7 +206,7 @@ var
 begin
   SetLANAccessPolicy(Enabled);
   if not Exec(ExpandConstant('{app}\agentd.exe'),
-    'restart --no-pair',
+    'restart --no-pair --wait 30s',
     '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then begin
     PostInstallFailed := True;
     RaiseException('Unable to restart Mimi Remote after applying the Windows LAN access policy.');

--- a/packaging/windows/register-service.ps1
+++ b/packaging/windows/register-service.ps1
@@ -8,6 +8,25 @@ param(
 $ErrorActionPreference = 'Stop'
 $AgentPath = (Resolve-Path -LiteralPath $AgentPath).Path
 $identity = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+
+# agentd removes its PID file before Task Scheduler necessarily transitions the
+# previous action from Running to Ready. The task uses IgnoreNew, so registering
+# and immediately starting during that window can silently discard the start
+# request and leave an upgrade offline. The installer has already stopped and
+# unlocked agentd.exe; synchronize the scheduler before replacing the task.
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing -and $existing.State -in @('Running', 'Queued')) {
+    Stop-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+    $deadline = [DateTime]::UtcNow.AddSeconds(10)
+    do {
+        Start-Sleep -Milliseconds 100
+        $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    } while ($existing -and $existing.State -in @('Running', 'Queued') -and [DateTime]::UtcNow -lt $deadline)
+    if ($existing -and $existing.State -in @('Running', 'Queued')) {
+        throw "Scheduled task did not stop within 10 seconds: $TaskName"
+    }
+}
+
 $action = New-ScheduledTaskAction -Execute $AgentPath -Argument "serve --managed-service --log-file `"$LogPath`""
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $identity
 $principal = New-ScheduledTaskPrincipal -UserId $identity -LogonType Interactive -RunLevel Limited

--- a/scripts/test-windows-install.ps1
+++ b/scripts/test-windows-install.ps1
@@ -29,8 +29,11 @@ if ($postInstallSource.IndexOf('ConfigurePrivateLanFirewallRule(True)') -gt $pos
     throw 'Unsafe inbound rules must be repaired before the upgraded scheduled task is registered or started.'
 }
 $registerSource = Get-Content -LiteralPath $register -Raw
-foreach ($expected in @('New-ScheduledTaskTrigger -AtLogOn', 'New-ScheduledTaskPrincipal', '-LogonType Interactive', '-RunLevel Limited', 'serve --managed-service --log-file', 'ExecutionTimeLimit ([TimeSpan]::Zero)')) {
+foreach ($expected in @('New-ScheduledTaskTrigger -AtLogOn', 'New-ScheduledTaskPrincipal', '-LogonType Interactive', '-RunLevel Limited', 'serve --managed-service --log-file', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'Stop-ScheduledTask -TaskName $TaskName', "State -in @('Running', 'Queued')", 'Scheduled task did not stop within 10 seconds')) {
     if (-not $registerSource.Contains($expected)) { throw "Task registration script is missing required policy: $expected" }
+}
+foreach ($expected in @('up --no-pair --wait 30s', 'restart --no-pair --wait 30s')) {
+    if (-not $source.Contains($expected)) { throw "Installer source is missing the extended cold-start readiness window: $expected" }
 }
 $firewallSource = Get-Content -LiteralPath $firewall -Raw
 foreach ($expected in @("ValidateSet('Enable', 'Disable', 'Validate', 'ValidateNetwork')", 'Get-NetConnectionProfile', 'Get-UnmanagedInboundAllowRules', 'Remove-UnmanagedInboundAllowRules', '-Profile Private', '-RemoteAddress LocalSubnet', '-Program $AgentPath', 'Get-NetFirewallApplicationFilter', 'Get-NetFirewallAddressFilter')) {


### PR DESCRIPTION
## Summary

- wait for the existing Windows scheduled task to settle after `/End` before starting it again
- stop and poll an already-running task before installer re-registration
- extend installer and LAN restart readiness waits to 30 seconds
- isolate `internal/config` tests from the signed-in Windows user's real APPDATA/LOCALAPPDATA config and cache directories
- cover command ordering, transitional states, timeout handling, unexpected scheduler errors, installer invariants, and Windows config-test isolation

## Why

`schtasks /End` can return success before the task has reached `Ready`. Starting or replacing the task during that transition can leave the managed service offline. The restart path now treats the task's structured PowerShell state as the source of truth and fails closed on timeout or unexpected query errors.

A second failure was reproduced while another worktree ran `go test ./...`: Windows `os.UserConfigDir()` ignores a test-only `HOME` override and continued to resolve the signed-in user's `%APPDATA%\mimi-remote\config.json`. `internal/config` tests then overwrote the live config with `{}`, removing auth and making the next managed start fail. Package `TestMain` now redirects `HOME`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `XDG_CONFIG_HOME`, and `XDG_CACHE_HOME` to a package-private temporary root.

## Validation

- targeted Go tests for Windows managed-service behavior passed
- Windows installer static validation passed
- config path identity tests that previously touched the live Windows profile passed under the isolated test environment
- the real installed config retained the same size, write timestamp, 17 top-level sections, and valid auth after the isolation regression test
- installer `0.3.7-mim179.restart.450aba42` built and deployed on Windows
- two consecutive real restarts completed with exit code 0 and new PIDs
- post-restart task remained `Running` with exactly one agent process and one port 8787 listener
- `status`: `process_ok=true`, `service_ok=true`, `doctor_ok=true`; server/client versions matched
- Claude and Codex runtimes loaded; private-LAN firewall policy passed with zero unsafe rules

Linear: MIM-179