### PR TITLE
MIM-22 Fix Windows thread permission state regression

### DIFF
--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -1405,11 +1405,11 @@ func sanitizedGatewayThreadParams(runtimeID string, method string, params map[st
 			safe["initialTurnsPage"] = sanitizedGatewayInitialTurnsPage(page)
 		}
 	}
-	if method == "thread/resume" && gatewayPreservesThreadPermissionSettings(params) {
-		return safe
-	}
 	workspaceWrite := false
-	if runtimeID == "codex" {
+	if method == "thread/resume" && gatewayPreservesThreadPermissionSettings(params) {
+		// 只沿用已有 Thread 的文件系统 sandbox / permission profile。远端审批策略仍必须
+		// 由可信 gateway 显式覆盖，不能继承本地创建 Thread 时可能使用的 never。
+	} else if runtimeID == "codex" {
 		if profileID, ok := gatewayPermissionProfileID(params["permissions"]); ok {
 			safe["permissions"] = profileID
 		} else {
@@ -1467,8 +1467,8 @@ func sanitizedGatewayTurnParams(runtimeID string, params map[string]any, cwd str
 	if collaborationMode, ok := sanitizedGatewayCollaborationMode(params["collaborationMode"]); ok {
 		safe["collaborationMode"] = collaborationMode
 	}
+	workspaceWrite := false
 	if !gatewayPreservesThreadPermissionSettings(params) {
-		workspaceWrite := false
 		if runtimeID == "codex" {
 			if profileID, ok := gatewayPermissionProfileID(params["permissions"]); ok {
 				safe["permissions"] = profileID
@@ -1482,8 +1482,8 @@ func sanitizedGatewayTurnParams(runtimeID string, params map[string]any, cwd str
 			sandboxPolicy := safe["sandboxPolicy"].(map[string]any)
 			workspaceWrite = normalizePolicyValue(sandboxPolicy["type"].(string)) == "workspacewrite"
 		}
-		safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params, workspaceWrite)
 	}
+	safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params, workspaceWrite)
 	// 默认模型必须交给 app-server 按账号 rollout 决定；gateway 只透传用户显式选择的 model。
 	if effort, ok := gatewayStringParam(safe, "effort"); !ok || strings.TrimSpace(effort) == "" {
 		safe["effort"] = defaultCodexReasoningEffort

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -1405,6 +1405,9 @@ func sanitizedGatewayThreadParams(runtimeID string, method string, params map[st
 			safe["initialTurnsPage"] = sanitizedGatewayInitialTurnsPage(page)
 		}
 	}
+	if method == "thread/resume" && gatewayPreservesThreadPermissionSettings(params) {
+		return safe
+	}
 	workspaceWrite := false
 	if runtimeID == "codex" {
 		if profileID, ok := gatewayPermissionProfileID(params["permissions"]); ok {
@@ -1464,26 +1467,33 @@ func sanitizedGatewayTurnParams(runtimeID string, params map[string]any, cwd str
 	if collaborationMode, ok := sanitizedGatewayCollaborationMode(params["collaborationMode"]); ok {
 		safe["collaborationMode"] = collaborationMode
 	}
-	workspaceWrite := false
-	if runtimeID == "codex" {
-		if profileID, ok := gatewayPermissionProfileID(params["permissions"]); ok {
-			safe["permissions"] = profileID
+	if !gatewayPreservesThreadPermissionSettings(params) {
+		workspaceWrite := false
+		if runtimeID == "codex" {
+			if profileID, ok := gatewayPermissionProfileID(params["permissions"]); ok {
+				safe["permissions"] = profileID
+			} else {
+				safe["sandboxPolicy"] = sanitizedGatewaySandboxPolicy(runtimeID, params["sandboxPolicy"], cwd)
+				sandboxPolicy := safe["sandboxPolicy"].(map[string]any)
+				workspaceWrite = normalizePolicyValue(sandboxPolicy["type"].(string)) == "workspacewrite"
+			}
 		} else {
 			safe["sandboxPolicy"] = sanitizedGatewaySandboxPolicy(runtimeID, params["sandboxPolicy"], cwd)
 			sandboxPolicy := safe["sandboxPolicy"].(map[string]any)
 			workspaceWrite = normalizePolicyValue(sandboxPolicy["type"].(string)) == "workspacewrite"
 		}
-	} else {
-		safe["sandboxPolicy"] = sanitizedGatewaySandboxPolicy(runtimeID, params["sandboxPolicy"], cwd)
-		sandboxPolicy := safe["sandboxPolicy"].(map[string]any)
-		workspaceWrite = normalizePolicyValue(sandboxPolicy["type"].(string)) == "workspacewrite"
+		safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params, workspaceWrite)
 	}
-	safe["approvalPolicy"], safe["approvalsReviewer"] = sanitizedGatewayApproval(params, workspaceWrite)
 	// 默认模型必须交给 app-server 按账号 rollout 决定；gateway 只透传用户显式选择的 model。
 	if effort, ok := gatewayStringParam(safe, "effort"); !ok || strings.TrimSpace(effort) == "" {
 		safe["effort"] = defaultCodexReasoningEffort
 	}
 	return safe
+}
+
+func gatewayPreservesThreadPermissionSettings(params map[string]any) bool {
+	preserve, _ := params[gatewayPreserveThreadPermissionsParam].(bool)
+	return preserve
 }
 
 func sanitizedGatewayTurnSteerParams(params map[string]any) map[string]any {

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -2112,9 +2112,12 @@ func TestAppServerGatewayPreservesExistingThreadPermissionsWithoutForwardingMark
 		t.Fatal(err)
 	}
 	params := decodeGatewayParamsForTest(t, readUpstreamFrame(t, received))
-	assertGatewayParamsOnly(t, params, "threadId", "cwd", "input", "effort")
+	assertGatewayParamsOnly(t, params, "threadId", "cwd", "input", "approvalPolicy", "approvalsReviewer", "effort")
 	if params["threadId"] != "thread-preserve" || params["cwd"] != projectDir {
 		t.Fatalf("turn/start 必须保留 Thread 与授权工作区：%v", params)
+	}
+	if params["approvalPolicy"] != "on-request" || params["approvalsReviewer"] != "user" {
+		t.Fatalf("turn/start 沿用文件权限时仍必须强制远端审批：%v", params)
 	}
 
 	resumeParams := sanitizedGatewayThreadParams("codex", "thread/resume", map[string]any{
@@ -2123,7 +2126,10 @@ func TestAppServerGatewayPreservesExistingThreadPermissionsWithoutForwardingMark
 		"initialTurnsPage":                    map[string]any{"limit": float64(5), "itemsView": "summary"},
 		gatewayPreserveThreadPermissionsParam: true,
 	})
-	assertGatewayParamsOnly(t, resumeParams, "threadId", "cwd", "excludeTurns", "initialTurnsPage")
+	assertGatewayParamsOnly(t, resumeParams, "threadId", "cwd", "excludeTurns", "initialTurnsPage", "approvalPolicy", "approvalsReviewer")
+	if resumeParams["approvalPolicy"] != "on-request" || resumeParams["approvalsReviewer"] != "user" {
+		t.Fatalf("thread/resume 沿用文件权限时仍必须覆盖本地审批策略：%v", resumeParams)
+	}
 }
 
 func TestAppServerGatewayServerRequestPendingUsesLongerTTLThanThreadResponses(t *testing.T) {

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -2079,6 +2079,53 @@ func TestAppServerGatewayUsesNamedPermissionProfileWithoutLegacySandbox(t *testi
 	}
 }
 
+func TestAppServerGatewayPreservesExistingThreadPermissionsWithoutForwardingMarker(t *testing.T) {
+	var projectDir string
+	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		respondToThreadListAuthorization(t, conn, payload, projectDir, "thread-preserve")
+	})
+	handler, dir := appServerGatewayRouterFixture(t, upstreamURL)
+	projectDir = dir
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	conn := dialAuthedGateway(t, server.URL)
+	defer conn.Close()
+	authorizeGatewayThread(t, conn, received, projectDir, "thread-preserve")
+
+	conflict := []byte(fmt.Sprintf(
+		`{"id":173,"method":"turn/start","params":{"threadId":"thread-preserve","cwd":%q,"input":[{"type":"text","text":"conflict"}],"mimiPreserveThreadPermissions":true,"approvalPolicy":"on-request"}}`,
+		projectDir,
+	))
+	if err := conn.WriteMessage(websocket.TextMessage, conflict); err != nil {
+		t.Fatal(err)
+	}
+	if errFrame := readGatewayError(t, conn); !strings.Contains(errFrame.message, "不能与 approvalPolicy 同时发送") {
+		t.Fatalf("沿用 Thread 权限不能夹带覆盖值：%+v", errFrame)
+	}
+
+	request := []byte(fmt.Sprintf(
+		`{"id":174,"method":"turn/start","params":{"threadId":"thread-preserve","cwd":%q,"input":[{"type":"text","text":"preserve"}],"mimiPreserveThreadPermissions":true}}`,
+		projectDir,
+	))
+	if err := conn.WriteMessage(websocket.TextMessage, request); err != nil {
+		t.Fatal(err)
+	}
+	params := decodeGatewayParamsForTest(t, readUpstreamFrame(t, received))
+	assertGatewayParamsOnly(t, params, "threadId", "cwd", "input", "effort")
+	if params["threadId"] != "thread-preserve" || params["cwd"] != projectDir {
+		t.Fatalf("turn/start 必须保留 Thread 与授权工作区：%v", params)
+	}
+
+	resumeParams := sanitizedGatewayThreadParams("codex", "thread/resume", map[string]any{
+		"threadId":                            "thread-preserve",
+		"cwd":                                 projectDir,
+		"initialTurnsPage":                    map[string]any{"limit": float64(5), "itemsView": "summary"},
+		gatewayPreserveThreadPermissionsParam: true,
+	})
+	assertGatewayParamsOnly(t, resumeParams, "threadId", "cwd", "excludeTurns", "initialTurnsPage")
+}
+
 func TestAppServerGatewayServerRequestPendingUsesLongerTTLThanThreadResponses(t *testing.T) {
 	oldThreadTTL := appServerGatewayPendingThreadTTL
 	oldServerTTL := appServerGatewayPendingServerRequestTTL

--- a/internal/httpapi/appserver_gateway_scope.go
+++ b/internal/httpapi/appserver_gateway_scope.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	gatewayLocalImageMaxBytes  int64 = 20 << 20
-	gatewayLocalImageMaxPixels int64 = 50_000_000
+	gatewayLocalImageMaxBytes             int64 = 20 << 20
+	gatewayLocalImageMaxPixels            int64 = 50_000_000
+	gatewayPreserveThreadPermissionsParam       = "mimiPreserveThreadPermissions"
 )
 
 func (r *Router) validateGatewayPolicyParams(runtimeID string, method string, params map[string]any) (appServerGatewayValidatedParams, error) {
@@ -34,6 +35,17 @@ func (r *Router) validateGatewayPolicyParams(runtimeID string, method string, pa
 			r.releaseManagedWorktreePendingUse(validated.pendingManagedWorktreePath)
 		}
 	}()
+	if value, exists := params[gatewayPreserveThreadPermissionsParam]; exists {
+		preserve, ok := value.(bool)
+		if !ok || !preserve || runtimeID != "codex" || (method != "thread/resume" && method != "turn/start") {
+			return validated, fmt.Errorf("%s 只允许 Codex thread/resume 或 turn/start 使用 true", gatewayPreserveThreadPermissionsParam)
+		}
+		for _, key := range []string{"approvalPolicy", "approvalsReviewer", "permissions", "sandbox", "sandboxPolicy"} {
+			if override, present := params[key]; present && override != nil {
+				return validated, fmt.Errorf("%s 不能与 %s 同时发送", gatewayPreserveThreadPermissionsParam, key)
+			}
+		}
+	}
 	if hasApprovalPolicyNever(params) {
 		return validated, fmt.Errorf("approvalPolicy=never 不允许远程使用")
 	}

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -7816,13 +7816,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Default run permissions for new input areas and after switching sessions. The permission buttons in the input area will also update this global default value simultaneously."
+            "value": "Default run permissions for new conversations. Existing threads keep their current permissions until you explicitly change them in the input area."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "用于新输入区和切换会话后的默认运行权限。输入区里的权限按钮也会同步更新这个全局默认值。"
+            "value": "用于新对话的默认运行权限。已有会话会沿用当前权限，直到你在输入区中明确修改。"
           }
         }
       }
@@ -39097,6 +39097,13 @@
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "Active profile: %@" } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "当前生效档案：%@" } }
+      }
+    },
+    "ui.follow_the_current_thread_permissions": {
+      "comment": "Indicates that an existing thread keeps its current App Server permission settings.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Use current thread permissions" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "沿用当前会话权限" } }
       }
     },
     "ui.additional_permissions": {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -2226,12 +2226,17 @@ actor CodexAppServerSessionRuntime {
         connection: CodexAppServerConnection,
         retryThreadHandoffInProgress: Bool = true
     ) async throws {
+        var passiveResumeOptions = CodexAppServerTurnOptions.default
+        // 被动监听/重连不能把 Mimi 的安全默认重新写进已有 Codex Thread；否则 Windows
+        // managed permission profiles 会把原来的 :danger-full-access 静默改成 :workspace。
+        passiveResumeOptions.preservesThreadPermissionSettings = runtimeProvider == "codex"
+        let scopedPassiveResumeOptions = runtimeScopedThreadOptions(passiveResumeOptions)
         let result: CodexAppServerJSONValue?
         do {
             let request = try builder.threadResume(
                 threadID: sessionID,
                 cwd: cwd,
-                options: runtimeScopedThreadOptions(.default)
+                options: scopedPassiveResumeOptions
             )
             if retryThreadHandoffInProgress {
                 result = try await sendRetryingThreadHandoffInProgress(
@@ -2250,7 +2255,7 @@ actor CodexAppServerSessionRuntime {
                 let request = try builder.threadResume(
                     threadID: sessionID,
                     cwd: cwd,
-                    options: runtimeScopedThreadOptions(.default),
+                    options: scopedPassiveResumeOptions,
                     includeInitialTurnsPage: false
                 )
                 if retryThreadHandoffInProgress {

--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -624,6 +624,9 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
     var approvalsReviewer: String
     var sandboxMode: CodexAppServerSandboxMode
     var networkAccess: Bool
+    // 已存在 Thread 在用户没有显式改权限时沿用服务端当前设置。该标记只发给 Mimi gateway，
+    // gateway 剥离后不向 app-server 注入 approval / sandbox 覆盖值。
+    var preservesThreadPermissionSettings: Bool
     // 命名权限配置档案由 app-server 解析。存在时必须替代旧 sandbox 字段，不能叠加发送。
     var permissionProfileID: String?
     var personality: CodexAppServerPersonality?
@@ -650,6 +653,7 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
         case approvalsReviewer = "approvals_reviewer"
         case sandboxMode = "sandbox_mode"
         case networkAccess = "network_access"
+        case preservesThreadPermissionSettings = "preserves_thread_permission_settings"
         case permissionProfileID = "permission_profile_id"
         case personality
         case config
@@ -674,6 +678,7 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
         approvalsReviewer: String = "user",
         sandboxMode: CodexAppServerSandboxMode = .dangerFullAccess,
         networkAccess: Bool = false,
+        preservesThreadPermissionSettings: Bool = false,
         permissionProfileID: String? = nil,
         personality: CodexAppServerPersonality? = nil,
         config: CodexAppServerJSONValue? = nil,
@@ -696,6 +701,7 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
         self.approvalsReviewer = approvalsReviewer
         self.sandboxMode = sandboxMode
         self.networkAccess = networkAccess
+        self.preservesThreadPermissionSettings = preservesThreadPermissionSettings
         self.permissionProfileID = permissionProfileID?.trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty
         self.personality = personality
         self.config = config
@@ -722,6 +728,7 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
             approvalsReviewer: try container.decodeIfPresent(String.self, forKey: .approvalsReviewer) ?? "user",
             sandboxMode: try container.decodeIfPresent(CodexAppServerSandboxMode.self, forKey: .sandboxMode) ?? .dangerFullAccess,
             networkAccess: try container.decodeIfPresent(Bool.self, forKey: .networkAccess) ?? false,
+            preservesThreadPermissionSettings: try container.decodeIfPresent(Bool.self, forKey: .preservesThreadPermissionSettings) ?? false,
             permissionProfileID: try container.decodeIfPresent(String.self, forKey: .permissionProfileID),
             personality: try container.decodeIfPresent(CodexAppServerPersonality.self, forKey: .personality),
             config: try container.decodeIfPresent(CodexAppServerJSONValue.self, forKey: .config),
@@ -747,6 +754,7 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
         approvalsReviewer: "user",
         sandboxMode: .dangerFullAccess,
         networkAccess: false,
+        preservesThreadPermissionSettings: false,
         permissionProfileID: nil,
         personality: nil,
         config: nil,
@@ -803,6 +811,13 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
     }
 
     private mutating func applyStandardComposerPermissionPreset() {
+        if preservesThreadPermissionSettings {
+            permissionProfileID = nil
+            approvalPolicy = .onRequest
+            approvalsReviewer = "user"
+            networkAccess = false
+            return
+        }
         if permissionProfileID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
             approvalPolicy = .onRequest
             approvalsReviewer = "user"
@@ -831,16 +846,18 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
     }
 
     func turnParams(projectPath: String) -> [String: CodexAppServerJSONValue?] {
-        let profileID = permissionProfileID.flatMap(nonEmptyString)
+        let preservesPermissions = preservesThreadPermissionSettings
+        let profileID = preservesPermissions ? nil : permissionProfileID.flatMap(nonEmptyString)
         return [
             "model": model.flatMap(nonEmptyString).map { .string($0) },
             "serviceTier": serviceTier.flatMap(nonEmptyString).map { .string($0) },
             "effort": reasoningEffort.map { .string($0.rawValue) },
             "summary": reasoningSummary.map { .string($0.rawValue) },
-            "approvalPolicy": .string(approvalPolicy.rawValue),
-            "approvalsReviewer": .string(approvalsReviewer),
+            "approvalPolicy": preservesPermissions ? nil : .string(approvalPolicy.rawValue),
+            "approvalsReviewer": preservesPermissions ? nil : .string(approvalsReviewer),
             "permissions": profileID.map { .string($0) },
-            "sandboxPolicy": profileID == nil ? sandboxPolicy(projectPath: projectPath) : nil,
+            "sandboxPolicy": preservesPermissions || profileID != nil ? nil : sandboxPolicy(projectPath: projectPath),
+            "mimiPreserveThreadPermissions": preservesPermissions ? .bool(true) : nil,
             "personality": personality.map { .string($0.rawValue) },
             "outputSchema": outputSchema,
             // app-server 会把 collaboration mode 作为 turn 级状态处理；普通模式也必须显式发送
@@ -850,15 +867,17 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
     }
 
     func threadParams(projectPath: String) -> [String: CodexAppServerJSONValue?] {
-        let profileID = permissionProfileID.flatMap(nonEmptyString)
+        let preservesPermissions = preservesThreadPermissionSettings
+        let profileID = preservesPermissions ? nil : permissionProfileID.flatMap(nonEmptyString)
         return [
             "model": model.flatMap(nonEmptyString).map { .string($0) },
             "modelProvider": modelProvider.flatMap(nonEmptyString).map { .string($0) },
             "serviceTier": serviceTier.flatMap(nonEmptyString).map { .string($0) },
-            "approvalPolicy": .string(approvalPolicy.rawValue),
-            "approvalsReviewer": .string(approvalsReviewer),
+            "approvalPolicy": preservesPermissions ? nil : .string(approvalPolicy.rawValue),
+            "approvalsReviewer": preservesPermissions ? nil : .string(approvalsReviewer),
             "permissions": profileID.map { .string($0) },
-            "sandbox": profileID == nil ? .string(threadSandboxValue) : nil,
+            "sandbox": preservesPermissions || profileID != nil ? nil : .string(threadSandboxValue),
+            "mimiPreserveThreadPermissions": preservesPermissions ? .bool(true) : nil,
             "personality": personality.map { .string($0.rawValue) },
             "config": config,
             "serviceName": serviceName.flatMap(nonEmptyString).map { .string($0) },

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -874,6 +874,10 @@ extension ComposerView {
     }
 
     var permissionTitle: String {
+        if composerState.turnOptions.preservesThreadPermissionSettings,
+           activePermissionProfile == nil {
+            return L10n.text("ui.follow_the_current_thread_permissions")
+        }
         if let profileID = selectedPermissionProfileID {
             return activePermissionProfile.map {
                 L10n.format("ui.active_permission_profile_value", $0.id)
@@ -883,6 +887,11 @@ extension ComposerView {
     }
 
     var permissionWireSummary: String {
+        if composerState.turnOptions.preservesThreadPermissionSettings {
+            return activePermissionProfile.map {
+                L10n.format("ui.active_permission_profile_value", $0.id)
+            } ?? L10n.text("ui.follow_the_current_thread_permissions")
+        }
         if let profileID = selectedPermissionProfileID {
             return L10n.format("ui.permission_profile_wire_value", profileID)
         }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -455,6 +455,7 @@ enum ComposerPermissionMode: String, CaseIterable, Identifiable {
 
     func apply(to options: inout CodexAppServerTurnOptions) {
         // 选择旧权限预设表示显式退出命名档案，确保请求只走一条权限通道。
+        options.preservesThreadPermissionSettings = false
         options.permissionProfileID = nil
         options.approvalPolicy = approvalPolicy
         options.approvalsReviewer = approvalsReviewer
@@ -464,6 +465,56 @@ enum ComposerPermissionMode: String, CaseIterable, Identifiable {
     }
 
     private static let autoReviewer = "auto_review"
+}
+
+struct ComposerPermissionSelectionSnapshot: Equatable {
+    var preservesThreadSettings: Bool
+    var profileID: String?
+    var mode: ComposerPermissionMode
+
+    init(options: CodexAppServerTurnOptions) {
+        preservesThreadSettings = options.preservesThreadPermissionSettings
+        profileID = options.permissionProfileID?
+            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty
+        mode = ComposerPermissionMode(options: options)
+    }
+
+    func apply(to options: inout CodexAppServerTurnOptions) {
+        if preservesThreadSettings {
+            options.preservesThreadPermissionSettings = true
+            options.permissionProfileID = nil
+            options.networkAccess = false
+        } else if let profileID {
+            options.preservesThreadPermissionSettings = false
+            options.permissionProfileID = profileID
+            options.approvalPolicy = .onRequest
+            options.approvalsReviewer = "user"
+            options.networkAccess = false
+        } else {
+            mode.apply(to: &options)
+        }
+    }
+}
+
+struct ComposerPermissionSelectionCache {
+    private var snapshotsByScope: [ComposerDraftScopeKey: ComposerPermissionSelectionSnapshot] = [:]
+
+    mutating func save(_ snapshot: ComposerPermissionSelectionSnapshot, for scope: ComposerDraftScopeKey) {
+        guard scope != .none else { return }
+        snapshotsByScope[scope] = snapshot
+    }
+
+    func snapshot(for scope: ComposerDraftScopeKey) -> ComposerPermissionSelectionSnapshot? {
+        snapshotsByScope[scope]
+    }
+
+    mutating func remove(scope: ComposerDraftScopeKey) {
+        snapshotsByScope.removeValue(forKey: scope)
+    }
+
+    mutating func removeAll() {
+        snapshotsByScope.removeAll(keepingCapacity: false)
+    }
 }
 
 enum ComposerSendMode: String, CaseIterable, Identifiable {
@@ -680,6 +731,22 @@ struct ComposerState {
 
     mutating func restoreModelSelectionSnapshot(_ snapshot: ComposerModelSelectionSnapshot) {
         snapshot.apply(to: &turnOptions)
+    }
+
+    func permissionSelectionSnapshot() -> ComposerPermissionSelectionSnapshot {
+        ComposerPermissionSelectionSnapshot(options: turnOptions)
+    }
+
+    mutating func restorePermissionSelectionSnapshot(_ snapshot: ComposerPermissionSelectionSnapshot) {
+        snapshot.apply(to: &turnOptions)
+    }
+
+    mutating func preserveThreadPermissionSettings() {
+        updateTurnOptions { options in
+            options.preservesThreadPermissionSettings = true
+            options.permissionProfileID = nil
+            options.networkAccess = false
+        }
     }
 
     mutating func addAttachment(_ input: CodexAppServerUserInput) {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -1863,7 +1863,7 @@ struct ComposerView: View {
         // 设置页的“默认权限”只面向新会话。已有 Thread 在用户未点击当前输入区的
         // 权限按钮时必须继续沿用服务端设置，不能因全局偏好变化而被静默覆盖。
         switch activeComposerDraftScope {
-        case .project:
+        case .newSession:
             applyDefaultPermissionMode()
         case .session(let sessionID) where sessionID.hasPrefix("local:"):
             applyDefaultPermissionMode()

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -239,7 +239,16 @@ struct ComposerView: View {
             showsAdvancedOptionsSheet = false
         }
         .onChange(of: defaultPermissionModeID) { _, _ in
-            applyDefaultPermissionMode()
+            // 设置页的“默认权限”只面向新会话。已有 Thread 在用户未点击当前输入区的
+            // 权限按钮时必须继续沿用服务端设置，不能因全局偏好变化而被静默覆盖。
+            switch activeComposerDraftScope {
+            case .project:
+                applyDefaultPermissionMode()
+            case .session(let sessionID) where sessionID.hasPrefix("local:"):
+                applyDefaultPermissionMode()
+            case .none, .session:
+                break
+            }
         }
         .onChange(of: voiceInputProviderRawValue) { _, _ in
             // 提供方变化是语音会话边界；旧引擎的迟到结果不能写入新选择下的草稿。
@@ -261,6 +270,9 @@ struct ComposerView: View {
         .onChange(of: composerState.modelSelectionSnapshot()) { _, snapshot in
             // 模型偏好独立于正文保存；空输入、发送成功和视图重建都不能清掉会话选择。
             sessionStore.saveComposerModelSelection(snapshot, for: activeComposerDraftScope)
+        }
+        .onChange(of: composerState.permissionSelectionSnapshot()) { _, snapshot in
+            sessionStore.saveComposerPermissionSelection(snapshot, for: activeComposerDraftScope)
         }
         .onChange(of: sessionStore.latestFileUploadCompletion) { _, completion in
             guard let completion,
@@ -324,6 +336,10 @@ struct ComposerView: View {
                 composerState.modelSelectionSnapshot(),
                 for: activeComposerDraftScope
             )
+            sessionStore.saveComposerPermissionSelection(
+                composerState.permissionSelectionSnapshot(),
+                for: activeComposerDraftScope
+            )
             cancelVoiceInteraction(clearStatus: true)
             activeSkillQuery = nil
         }
@@ -333,7 +349,7 @@ struct ComposerView: View {
     private func prepareComposer() async {
         switchComposerDraftScope(to: currentComposerDraftScope)
         clampModelSelectionToSelectedSessionRuntime()
-        applyDefaultPermissionMode()
+        restoreComposerPermissionSelection(for: currentComposerDraftScope)
         voiceInput.prewarm()
         await sessionStore.refreshAppServerModelOptions()
         await sessionStore.refreshCapabilities()
@@ -479,25 +495,29 @@ struct ComposerView: View {
         synchronizeComposerTextBeforeDraftScopeChange()
         let outgoingDraft = composerState.draftSnapshot()
         let outgoingModelSelection = composerState.modelSelectionSnapshot()
+        let outgoingPermissionSelection = composerState.permissionSelectionSnapshot()
         sessionStore.saveComposerDraft(outgoingDraft, for: previousScope)
         sessionStore.saveComposerModelSelection(outgoingModelSelection, for: previousScope)
+        sessionStore.saveComposerPermissionSelection(outgoingPermissionSelection, for: previousScope)
         if isOptimisticHandoff {
             // local:* 只是创建接口返回前的临时身份。服务端 ID 回来时迁移当前可见草稿，
             // 避免用户正在输入的追加指令和模型选择被新 scope 的默认值覆盖。
             sessionStore.saveComposerDraft(outgoingDraft, for: nextScope)
             sessionStore.saveComposerModelSelection(outgoingModelSelection, for: nextScope)
+            sessionStore.saveComposerPermissionSelection(outgoingPermissionSelection, for: nextScope)
             sessionStore.removeComposerDraft(for: previousScope)
             sessionStore.removeComposerModelSelection(for: previousScope)
+            sessionStore.removeComposerPermissionSelection(for: previousScope)
         }
         cancelVoiceInteraction(clearStatus: true)
 
-        applyDefaultPermissionMode()
         // 先切 scope 再恢复，避免 restore 触发的 onChange 把新会话草稿误写回旧 scope。
         activeComposerDraftScope = nextScope
         composerState.setSendMode(restoredSendMode)
         persistComposerSendMode(restoredSendMode, for: nextScope)
         composerState.restoreDraftSnapshot(sessionStore.composerDraft(for: nextScope))
         restoreComposerModelSelection(for: nextScope)
+        restoreComposerPermissionSelection(for: nextScope)
         clampModelSelectionToSelectedSessionRuntime()
         composerTextExternalRevision += 1
         guidedFollowUpEnabled = false
@@ -533,6 +553,18 @@ struct ComposerView: View {
             ?? normalizedRuntimeProvider(composerState.turnOptions.runtimeProvider)
         composerState.updateTurnOptions { options in
             applyPreferredDefaultModel(runtimeProvider: runtimeProvider, to: &options)
+        }
+    }
+
+    func restoreComposerPermissionSelection(for scope: ComposerDraftScopeKey) {
+        if let snapshot = sessionStore.composerPermissionSelection(for: scope) {
+            composerState.restorePermissionSelectionSnapshot(snapshot)
+        } else if case .session(let sessionID) = scope,
+                  !sessionID.hasPrefix("local:"),
+                  selectedSessionRuntimeProviderForModelMenu != "claude" {
+            composerState.preserveThreadPermissionSettings()
+        } else {
+            applyDefaultPermissionMode()
         }
     }
 
@@ -1840,6 +1872,7 @@ struct ComposerView: View {
 
     func setPermissionProfile(_ profile: CodexAppServerPermissionProfileSummary) {
         composerState.updateTurnOptions { options in
+            options.preservesThreadPermissionSettings = false
             options.permissionProfileID = profile.id
             options.approvalPolicy = .onRequest
             options.approvalsReviewer = "user"
@@ -1862,8 +1895,13 @@ struct ComposerView: View {
     }
 
     var selectedPermissionProfileID: String? {
-        composerState.turnOptions.permissionProfileID?
-            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty
+        if let profileID = composerState.turnOptions.permissionProfileID?
+            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty {
+            return profileID
+        }
+        return composerState.turnOptions.preservesThreadPermissionSettings
+            ? activePermissionProfile?.id
+            : nil
     }
 
     var activePermissionProfile: CodexAppServerActivePermissionProfile? {
@@ -1874,8 +1912,9 @@ struct ComposerView: View {
     }
 
     func clampPermissionProfileToAvailableOptions() {
-        guard let selectedPermissionProfileID else { return }
-        guard availablePermissionProfiles.contains(where: { $0.id == selectedPermissionProfileID }) else {
+        guard let explicitProfileID = composerState.turnOptions.permissionProfileID?
+            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty else { return }
+        guard availablePermissionProfiles.contains(where: { $0.id == explicitProfileID }) else {
             composerState.updateTurnOptions { options in
                 options.permissionProfileID = nil
             }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -227,7 +227,7 @@ struct ComposerView: View {
             Text(issue.message)
         }
 
-        let observedContent = presentedContent
+        let scopeObservedContent = presentedContent
         .onChange(of: developerModeEnabled) { _, enabled in
             guard !enabled else {
                 return
@@ -239,16 +239,7 @@ struct ComposerView: View {
             showsAdvancedOptionsSheet = false
         }
         .onChange(of: defaultPermissionModeID) { _, _ in
-            // 设置页的“默认权限”只面向新会话。已有 Thread 在用户未点击当前输入区的
-            // 权限按钮时必须继续沿用服务端设置，不能因全局偏好变化而被静默覆盖。
-            switch activeComposerDraftScope {
-            case .project:
-                applyDefaultPermissionMode()
-            case .session(let sessionID) where sessionID.hasPrefix("local:"):
-                applyDefaultPermissionMode()
-            case .none, .session:
-                break
-            }
+            applyDefaultPermissionModeForActiveScope()
         }
         .onChange(of: voiceInputProviderRawValue) { _, _ in
             // 提供方变化是语音会话边界；旧引擎的迟到结果不能写入新选择下的草稿。
@@ -263,6 +254,8 @@ struct ComposerView: View {
         .onChange(of: pendingUserInputSelectionIdentity) { previous, current in
             synchronizePendingUserInputPresentation(previous: previous, current: current)
         }
+
+        let observedContent = scopeObservedContent
         .onChange(of: composerState.draftSnapshot()) { _, snapshot in
             // 每次确认文字或附件变化都写入稳定内存仓，视图突然重建时也能恢复最新草稿。
             sessionStore.saveComposerDraft(snapshot, for: activeComposerDraftScope)
@@ -270,9 +263,6 @@ struct ComposerView: View {
         .onChange(of: composerState.modelSelectionSnapshot()) { _, snapshot in
             // 模型偏好独立于正文保存；空输入、发送成功和视图重建都不能清掉会话选择。
             sessionStore.saveComposerModelSelection(snapshot, for: activeComposerDraftScope)
-        }
-        .onChange(of: composerState.permissionSelectionSnapshot()) { _, snapshot in
-            sessionStore.saveComposerPermissionSelection(snapshot, for: activeComposerDraftScope)
         }
         .onChange(of: sessionStore.latestFileUploadCompletion) { _, completion in
             guard let completion,
@@ -566,6 +556,10 @@ struct ComposerView: View {
         } else {
             applyDefaultPermissionMode()
         }
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: scope
+        )
     }
 
     func resetComposerSendModeAfterSubmit() {
@@ -1859,6 +1853,23 @@ struct ComposerView: View {
     func applyDefaultPermissionMode() {
         let stored = ComposerPermissionMode.stored(defaultPermissionModeID)
         composerState.applyPermissionMode(safePermissionMode(stored))
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: activeComposerDraftScope
+        )
+    }
+
+    func applyDefaultPermissionModeForActiveScope() {
+        // 设置页的“默认权限”只面向新会话。已有 Thread 在用户未点击当前输入区的
+        // 权限按钮时必须继续沿用服务端设置，不能因全局偏好变化而被静默覆盖。
+        switch activeComposerDraftScope {
+        case .project:
+            applyDefaultPermissionMode()
+        case .session(let sessionID) where sessionID.hasPrefix("local:"):
+            applyDefaultPermissionMode()
+        case .none, .session:
+            break
+        }
     }
 
     func setPermissionMode(_ mode: ComposerPermissionMode) {
@@ -1868,6 +1879,10 @@ struct ComposerView: View {
             defaultPermissionModeID = safeMode.rawValue
         }
         composerState.applyPermissionMode(safeMode)
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: activeComposerDraftScope
+        )
     }
 
     func setPermissionProfile(_ profile: CodexAppServerPermissionProfileSummary) {
@@ -1878,6 +1893,10 @@ struct ComposerView: View {
             options.approvalsReviewer = "user"
             options.networkAccess = false
         }
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: activeComposerDraftScope
+        )
     }
 
     var permissionProfileCWD: String? {

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -274,6 +274,8 @@ final class SessionStore: ObservableObject {
     // 模型与推理强度按会话保留，但只存在当前连接的内存生命周期内。
     // 与内容草稿分开后，空输入或发送成功也不会误删模型偏好。
     var composerModelSelectionCache = ComposerModelSelectionCache()
+    // 权限选择按会话保留；未显式选择的既有 Thread 使用“沿用服务端当前设置”。
+    var composerPermissionSelectionCache = ComposerPermissionSelectionCache()
 
     func storeCompletedFileUpload(_ attachment: UploadedFileAttachment, for scope: ComposerDraftScopeKey) {
         guard scope != .none else {
@@ -834,6 +836,23 @@ final class SessionStore: ObservableObject {
 
     func removeComposerModelSelection(for scope: ComposerDraftScopeKey) {
         composerModelSelectionCache.remove(scope: scope)
+    }
+
+    func saveComposerPermissionSelection(
+        _ snapshot: ComposerPermissionSelectionSnapshot,
+        for scope: ComposerDraftScopeKey
+    ) {
+        composerPermissionSelectionCache.save(snapshot, for: scope)
+    }
+
+    func composerPermissionSelection(
+        for scope: ComposerDraftScopeKey
+    ) -> ComposerPermissionSelectionSnapshot? {
+        composerPermissionSelectionCache.snapshot(for: scope)
+    }
+
+    func removeComposerPermissionSelection(for scope: ComposerDraftScopeKey) {
+        composerPermissionSelectionCache.remove(scope: scope)
     }
 
     func composerSendModeForScopeActivation(

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -2461,6 +2461,7 @@ extension SessionStore {
         clearFileUploadsForConnectionChange()
         composerDraftCache.removeAll()
         composerModelSelectionCache.removeAll()
+        composerPermissionSelectionCache.removeAll()
         composerSendModeCache.removeAll()
         stopAllQueuedSessionMonitoring()
         queuedRunningTurnsBySessionID.removeAll()

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -2525,6 +2525,37 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertNil(turnParams["sandboxPolicy"])
     }
 
+    func testPreservingThreadPermissionsUsesGatewayMarkerWithoutOverrides() throws {
+        let project = AgentProject(id: "repo", name: "Repo", path: "/Users/me/repo")
+        let builder = CodexAppServerRequestBuilder(allowlistedProjects: [project])
+        var options = CodexAppServerTurnOptions.default
+        options.preservesThreadPermissionSettings = true
+
+        let resume = try builder.threadResume(
+            threadID: "thread-1",
+            projectID: project.id,
+            options: options
+        )
+        let resumeParams = try XCTUnwrap(resume.params?.objectValue)
+        XCTAssertEqual(resumeParams["mimiPreserveThreadPermissions"]?.boolValue, true)
+        XCTAssertNil(resumeParams["approvalPolicy"])
+        XCTAssertNil(resumeParams["approvalsReviewer"])
+        XCTAssertNil(resumeParams["permissions"])
+        XCTAssertNil(resumeParams["sandbox"])
+
+        let turn = try builder.turnStart(
+            threadID: "thread-1",
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "继续", options: options)
+        )
+        let turnParams = try XCTUnwrap(turn.params?.objectValue)
+        XCTAssertEqual(turnParams["mimiPreserveThreadPermissions"]?.boolValue, true)
+        XCTAssertNil(turnParams["approvalPolicy"])
+        XCTAssertNil(turnParams["approvalsReviewer"])
+        XCTAssertNil(turnParams["permissions"])
+        XCTAssertNil(turnParams["sandboxPolicy"])
+    }
+
     func testPermissionProfileListFiltersDisallowedAndDuplicateProfiles() {
         let result: CodexAppServerJSONValue = .object([
             "data": .array([

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -3050,6 +3050,26 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertFalse(composerState.turnOptions.networkAccess)
     }
 
+    func testComposerPermissionSelectionCacheKeepsExistingThreadPreservationUntilExplicitOverride() throws {
+        var state = ComposerState()
+        state.preserveThreadPermissionSettings()
+        XCTAssertTrue(state.turnOptions.preservesThreadPermissionSettings)
+
+        let sessionScope = ComposerDraftScopeKey.session("thread-1")
+        var cache = ComposerPermissionSelectionCache()
+        cache.save(state.permissionSelectionSnapshot(), for: sessionScope)
+
+        state.applyPermissionMode(.readOnly)
+        XCTAssertFalse(state.turnOptions.preservesThreadPermissionSettings)
+        state.restorePermissionSelectionSnapshot(try XCTUnwrap(cache.snapshot(for: sessionScope)))
+        XCTAssertTrue(state.turnOptions.preservesThreadPermissionSettings)
+        XCTAssertNil(state.turnOptions.permissionProfileID)
+
+        state.applyPermissionMode(.fullAccess)
+        XCTAssertFalse(state.turnOptions.preservesThreadPermissionSettings)
+        XCTAssertEqual(state.turnOptions.sandboxMode, .dangerFullAccess)
+    }
+
     func testComposerCanInitializeWithGlobalDefaultPermissionMode() {
         let composerState = ComposerState(defaultPermissionMode: .requestApproval)
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1780,6 +1780,11 @@ extension ConversationDataFlowTests {
         let resumeRequest = try decodeAppServerRequest(resumeMessages[3])
         XCTAssertEqual(resumeRequest.method, "thread/resume", "首次 turn/start 前应先在当前连接 resume thread")
         XCTAssertEqual(resumeRequest.params?["threadId"]?.stringValue, "thr_idle_guard")
+        XCTAssertEqual(resumeRequest.params?["mimiPreserveThreadPermissions"]?.boolValue, true)
+        XCTAssertNil(resumeRequest.params?["approvalPolicy"])
+        XCTAssertNil(resumeRequest.params?["approvalsReviewer"])
+        XCTAssertNil(resumeRequest.params?["permissions"])
+        XCTAssertNil(resumeRequest.params?["sandbox"])
         transport.enqueue(#"{"id":\#(try jsonFragment(for: resumeRequest.id)),"result":{"thread":{"id":"thr_idle_guard","sessionId":"thr_idle_guard","preview":"上次的会话","ephemeral":false,"modelProvider":"openai","createdAt":1780490300,"updatedAt":1780490302,"status":{"type":"idle"},"path":null,"cwd":"/tmp/resume-guard","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"上次的会话","turns":[]}}}"#)
 
         let firstTurnMessages = try await waitForFakeAppServerMessages(transport, count: 5)


### PR DESCRIPTION
## Summary
- preserve existing Codex Thread approval and permission-profile state during passive resume and ordinary turns
- keep permission selection scoped per conversation; global defaults now apply only to new conversations
- strip the private preservation marker in the gateway and reject mixed or unsupported permission overrides fail-closed
- keep App/Connector approval independent from file-system permission profiles

## Tests
- PASS: targeted MIM-22 gateway preservation regression
- PASS: internal/httpapi suite excluding one Windows symlink-privilege-only test
- PASS: source-size guard, gofmt, diff check, localization JSON validation
- NOT RUN: iOS XCTest/build (Windows host has no Xcode)
- Baseline note: repository-wide Go tests also contain unrelated Windows failures for symlink privileges and inherited proxy environment behavior