### PR TITLE
MIM-187 Restore iPad takeover disclosure

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerStatusViews.swift
@@ -470,11 +470,11 @@ struct ComposerStatusTray: View {
         sessionControlNotice != nil || quotaNotice != nil || usage != nil
     }
 
-    /// 展开只会多出目标详情、额度完整文案和刷新入口。只挂着「仅观察」时，展开态和
-    /// 收起态渲染的内容完全一样，那颗 chevron 点了什么也不会发生，纯属噪声。
-    /// 目标、额度这类真的有下文的状态继续保留开合。
+    /// 展开只为真正的次级内容或操作保留：目标详情、额度完整文案和刷新入口，
+    /// 以及观察态中可执行的接管操作。不可接管的只读观察没有下文，继续隐藏 disclosure。
     var hasExpandableDetail: Bool {
-        goal != nil || quotaNotice != nil || usage != nil
+        goal != nil || quotaNotice != nil || usage != nil ||
+            (sessionControlNotice != nil && allowsTakeOver)
     }
 
     /// 没有可展开内容时忽略外部的展开状态，避免目标被清空后停在一个收不回去的展开态。

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
@@ -736,6 +736,29 @@ extension ConversationDataFlowTests {
 
 @MainActor
 final class ComposerStatusTrayBehaviorTests: XCTestCase {
+    func testTakeoverCapableObservationOffersDisclosure() {
+        let notice = "Takeover is available."
+
+        XCTAssertTrue(
+            makeTray(
+                sessionControlNotice: notice,
+                allowsTakeOver: true
+            ).hasExpandableDetail,
+            "A takeover-capable observation must reveal the existing takeover action"
+        )
+        XCTAssertFalse(
+            makeTray(
+                sessionControlNotice: notice,
+                allowsTakeOver: false
+            ).hasExpandableDetail,
+            "A read-only observation must not reveal an empty disclosure"
+        )
+        XCTAssertFalse(
+            makeTray(allowsTakeOver: true).hasExpandableDetail,
+            "Takeover capability alone must not create an empty disclosure"
+        )
+    }
+
     /// 「仅观察」展开前后没有更多内容时，不应该展示无效的 disclosure。
     func testStatusTrayOnlyOffersDisclosureWhenExpandingRevealsSomething() {
         XCTAssertFalse(
@@ -853,7 +876,8 @@ final class ComposerStatusTrayBehaviorTests: XCTestCase {
         sessionControlNotice: String? = nil,
         quotaNotice: CodexQuotaNotice? = nil,
         usage: CodexUsageDisplaySummary? = nil,
-        goal: ThreadGoal? = nil
+        goal: ThreadGoal? = nil,
+        allowsTakeOver: Bool = false
     ) -> ComposerStatusTray {
         ComposerStatusTray(
             sessionControlNotice: sessionControlNotice,
@@ -865,7 +889,7 @@ final class ComposerStatusTrayBehaviorTests: XCTestCase {
             isGoalUpdating: false,
             goalErrorMessage: nil,
             isRefreshDisabled: false,
-            allowsTakeOver: true,
+            allowsTakeOver: allowsTakeOver,
             onTakeOver: {},
             onRefreshUsage: {},
             onEditGoal: {},


### PR DESCRIPTION
Restores the expandable disclosure when an observed session has a valid takeover action, while keeping read-only observations compact. Adds regression coverage for takeover-capable, read-only, and missing-notice states. Local checks: git diff --check and source-size gate passed. iOS build/test is delegated to PR CI because this Windows host has no xcrun/xcodebuild.