### PR TITLE
MIM-182 修复 Windows Codex Desktop 活跃会话状态识别

### DIFF
--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -74,6 +74,41 @@ func TestExternalActivityReadsStateDatabaseWithoutSQLiteCLI(t *testing.T) {
 	}
 }
 
+func TestExternalActivityMatchesWindowsExtendedNamespaceCWD(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows extended-length paths are platform-specific")
+	}
+
+	fixture := newExternalActivityTrackerFixture(t)
+	path := fixture.writeRollout(
+		"thread-windows-namespace",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLine("task_started", "turn-windows-namespace"),
+	)
+	fixture.rows = []externalActivityTestRow{{
+		ID:           "thread-windows-namespace",
+		CWD:          `\\?\` + fixture.projectDir,
+		Source:       "vscode",
+		ThreadSource: "user",
+		RolloutPath:  path,
+	}}
+
+	activities := fixture.snapshot(t)
+	if len(activities) != 1 ||
+		activities[0].ThreadID != "thread-windows-namespace" ||
+		activities[0].ProjectID != "demo" ||
+		activities[0].TurnID != "turn-windows-namespace" ||
+		activities[0].State != "running" {
+		t.Fatalf("Windows namespace cwd should project active Desktop work: %+v", activities)
+	}
+
+	fixture.appendLine(path, externalEventLine("task_complete", "turn-windows-namespace"))
+	if activities := fixture.snapshot(t); len(activities) != 0 {
+		t.Fatalf("terminal lifecycle should clear Windows namespace activity: %+v", activities)
+	}
+}
+
 func TestExternalActivityDatabasePathUsesConfiguredCodexHome(t *testing.T) {
 	configuredHome := filepath.Join(t.TempDir(), "configured-codex-home")
 	processHome := filepath.Join(t.TempDir(), "process-codex-home")

--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -106,6 +107,10 @@ func (r *Registry) Get(id string) (Project, bool) {
 }
 
 func (r *Registry) FindByPath(path string) (Project, bool) {
+	path, ok := pathForProjectMatch(path)
+	if !ok {
+		return Project{}, false
+	}
 	cacheKey := ""
 	absPath, err := filepath.Abs(path)
 	if err == nil {
@@ -136,6 +141,38 @@ func (r *Registry) FindByPath(path string) (Project, bool) {
 		r.storePathMatch(cleanRealPath, project, ok)
 	}
 	return project, ok
+}
+
+// pathForProjectMatch accepts the Windows extended-length spelling that Codex
+// persists for local drive paths while keeping device and network namespaces
+// outside the project allowlist. filepath.Rel does not consider
+// `\\?\C:\dir` equivalent to `C:\dir`, even though both names address the
+// same local directory on Windows.
+func pathForProjectMatch(path string) (string, bool) {
+	if runtime.GOOS != "windows" {
+		return path, true
+	}
+
+	clean := filepath.Clean(path)
+	const extendedPrefix = `\\?\`
+	if strings.HasPrefix(clean, extendedPrefix) {
+		localPath := strings.TrimPrefix(clean, extendedPrefix)
+		volume := filepath.VolumeName(localPath)
+		if len(volume) != 2 || volume[1] != ':' ||
+			!((volume[0] >= 'A' && volume[0] <= 'Z') ||
+				(volume[0] >= 'a' && volume[0] <= 'z')) ||
+			len(localPath) <= len(volume) || !os.IsPathSeparator(localPath[len(volume)]) {
+			return "", false
+		}
+		return filepath.Clean(localPath), true
+	}
+
+	// Do not let Win32 device or NT object-manager spellings pass through Abs
+	// and accidentally compare equal to an authorized local project.
+	if strings.HasPrefix(clean, `\\.\`) || strings.HasPrefix(clean, `\??\`) {
+		return "", false
+	}
+	return clean, true
 }
 
 func (r *Registry) findByCleanPath(cleanPath string) (Project, bool) {

--- a/internal/projects/projects_windows_test.go
+++ b/internal/projects/projects_windows_test.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package projects
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+func TestFindByPathMatchesWindowsExtendedLocalPath(t *testing.T) {
+	root := t.TempDir()
+	registry, err := NewRegistry([]config.ProjectConfig{{ID: "demo", Name: "Demo", Path: root}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespacedChild := `\\?\` + filepath.Join(root, "Sources", "Missing.swift")
+	project, ok := registry.FindByPath(namespacedChild)
+	if !ok || project.ID != "demo" {
+		t.Fatalf("extended local path should match the configured project: %+v ok=%v", project, ok)
+	}
+}
+
+func TestFindByPathDoesNotExpandAllowlistForWindowsNamespaces(t *testing.T) {
+	root := t.TempDir()
+	registry, err := NewRegistry([]config.ProjectConfig{{ID: "demo", Name: "Demo", Path: root}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside")
+	tests := map[string]string{
+		"local path outside project": `\\?\` + outside,
+		"local traversal outside":    `\\?\` + filepath.Join(root, "..", "escaped"),
+		"extended UNC":               `\\?\UNC\server\share\project`,
+		"Win32 device":               `\\.\C:\project`,
+		"NT object manager":          `\??\C:\project`,
+		"GLOBALROOT":                 `\\?\GLOBALROOT\Device\HarddiskVolume1\project`,
+		"volume GUID":                `\\?\Volume{00000000-0000-0000-0000-000000000000}\project`,
+		"drive relative namespace":   `\\?\C:relative\project`,
+		"missing volume namespace":   `\\?\\project`,
+		"ordinary UNC":               `\\server\share\project`,
+	}
+	for name, path := range tests {
+		t.Run(name, func(t *testing.T) {
+			if project, ok := registry.FindByPath(path); ok {
+				t.Fatalf("path outside the local project allowlist matched %+v", project)
+			}
+		})
+	}
+}
+
+func TestPathForProjectMatchRejectsUnsafeWindowsNamespaces(t *testing.T) {
+	tests := []string{
+		`\\?\UNC\server\share\project`,
+		`\\?\GLOBALROOT\Device\HarddiskVolume1\project`,
+		`\\?\Volume{00000000-0000-0000-0000-000000000000}\project`,
+		`\\?\C:relative\project`,
+		`\\.\C:\project`,
+		`\??\C:\project`,
+	}
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			if normalized, ok := pathForProjectMatch(path); ok {
+				t.Fatalf("unsafe namespace normalized to %q", normalized)
+			}
+		})
+	}
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ExternalActivitySessionStoreTests.swift
@@ -217,6 +217,74 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(client.requestedMessageLimits, [20, 1, 20])
     }
 
+    func testExternalActivitySnapshotDrivesProcessingSidebarAndReadOnlyComposerLifecycle() async throws {
+        let project = makeProject(id: "proj_external_activity_presentation")
+        let threadID = "thread-external-presentation"
+        let turnID = "turn-external-presentation"
+        let history = makeSession(
+            id: threadID,
+            projectID: project.id,
+            title: "Desktop session",
+            status: SessionStatus.history.rawValue,
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: threadID
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [history],
+            workspacePages: [project.id: SessionsPage(sessions: [history])],
+            externalActivityResponses: [
+                ExternalActivityResponse(
+                    activities: [makeExternalActivity(
+                        threadID: threadID,
+                        projectID: project.id,
+                        turnID: turnID,
+                        revision: "rev-external-presentation"
+                    )],
+                    scannedAt: Date()
+                ),
+                ExternalActivityResponse(activities: [], scannedAt: Date())
+            ]
+        )
+        let store = makeExternalActivityStore(project: project, session: history, client: client)
+        store.selectedProjectID = project.id
+        store.selectedSessionID = threadID
+
+        let activeRefresh = await store.refreshExternalActivities(client: client)
+        XCTAssertTrue(activeRefresh)
+
+        let external = try XCTUnwrap(store.sessionsByID[threadID])
+        let externalStatus = external.displayStatus(foregroundActivity: nil)
+        XCTAssertEqual(external.status, SessionStatus.running.rawValue)
+        XCTAssertEqual(external.activeTurnID, turnID)
+        XCTAssertEqual(externalStatus.title, L10n.text("ui.processing"))
+        XCTAssertFalse(externalStatus.showsSpinner)
+        let activeSections = SessionListPresentation.sidebarSections(store.sessions)
+        let runningSection = try XCTUnwrap(activeSections.first(where: { $0.kind == .running }))
+        XCTAssertEqual(runningSection.sessions.map(\.id), [threadID])
+        XCTAssertTrue(store.isExternalReadOnlySession(external))
+        XCTAssertTrue(store.isSelectedSessionObserving)
+        XCTAssertFalse(store.canSendInSelectedSession)
+        XCTAssertFalse(store.selectedSessionAllowsTakeOver)
+        XCTAssertEqual(store.selectedSessionControlNotice, L10n.text("ui.mac_observe_only"))
+
+        let terminalRefresh = await store.refreshExternalActivities(client: client)
+        XCTAssertTrue(terminalRefresh)
+
+        let released = try XCTUnwrap(store.sessionsByID[threadID])
+        XCTAssertEqual(released.status, SessionStatus.history.rawValue)
+        XCTAssertNil(released.activeTurnID)
+        XCTAssertFalse(
+            SessionListPresentation.sidebarSections(store.sessions)
+                .contains(where: { $0.kind == .running && $0.sessions.contains(where: { $0.id == threadID }) })
+        )
+        XCTAssertFalse(store.isExternalReadOnlySession(released))
+        XCTAssertFalse(store.isSelectedSessionObserving)
+        XCTAssertTrue(store.canSendInSelectedSession)
+        XCTAssertNil(store.selectedSessionControlNotice)
+    }
+
     func testExternalActivityRevisionMergesLatestTurnWithoutReplacingLoadedHistoryCursor() async throws {
         let project = makeProject(id: "proj_external_tail_refresh")
         let threadID = "thread-external-tail"


### PR DESCRIPTION
## Summary

- Normalize Windows local-drive extended namespace paths such as \\?\C:\... before project allowlist matching.
- Reject extended UNC, device namespace, GLOBALROOT, volume GUID, drive-relative, and malformed namespace inputs so the existing allowlist boundary is preserved.
- Add Windows Registry and external-activity lifecycle regression coverage.
- Add an iOS lifecycle regression covering processing/read-only projection and terminal-state recovery.

This keeps the existing single-writer protection unchanged: Mimi observes a Codex Desktop turn but does not take over or write to it.

Linear: https://linear.app/code89757/issue/MIM-182/windows-codex-desktop-运行中的会话在-app-中显示为历史状态

## Validation

- go test -mod=readonly ./internal/projects ./internal/codexhistory -count=1
- go vet ./...
- bash ./scripts/check-source-size.sh
- git diff --check origin/main...HEAD

The targeted Go tests were rerun after rebasing onto the latest main.

## Follow-up validation

- iOS XCTest still needs to run on the fixed iPad Pro 13-inch (M5) Simulator because the current host is Windows.
- Windows end-to-end validation with multiple concurrent Codex Desktop turns remains pending.