### PR TITLE
MIM-185 阻止 Windows 旧版 Codex 绕过单 writer 保护

### DIFF
--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -947,8 +947,9 @@ func runDoctorFix(
 			}
 		}
 	}
-	if hasFailedCheck(current, "codex") && !needsSetup {
-		// 旧的绝对路径失效时只修复 codex.bin；无法发现替代项则保留原 Doctor 结果继续给出安装指引。
+	if (hasFailedCheck(current, "codex") || hasFailedCheck(current, "codex-app-server")) && !needsSetup {
+		// 旧的绝对路径失效或 Windows CLI 缺少 single-writer 基线时只修复
+		// codex.bin；无法发现安全替代项则保留原 Doctor 结果继续给出升级指引。
 		codexPath, repaired, repairErr := agentsetup.RepairCodexBin(configPath)
 		if repairErr == nil && repaired {
 			fixes = append(fixes, "已恢复 Codex CLI 路径："+codexPath)

--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -1794,7 +1794,7 @@ func ensureCodexCLIAvailable(configPath string) error {
 	// Homebrew service 的 PATH 通常比交互终端更窄。先把有效路径原子写回配置，
 	// 后台进程才不会在本次检查通过后又因找不到同一个 Codex 而失败。
 	if _, _, err := agentsetup.RepairCodexBin(configPath); err != nil {
-		return fmt.Errorf("未找到 Codex CLI，Mimi Remote 助手还不能启动。\n\n已检查配置路径、当前 PATH，以及 ChatGPT/Codex App 内置路径。\n请先在这台电脑安装并登录 Codex，然后重新运行：\n  agentd up")
+		return codexCLIRepairError(err)
 	}
 	cfg, err := config.LoadForDoctor(configPath)
 	if err != nil {
@@ -1808,6 +1808,17 @@ func ensureCodexCLIAvailable(configPath string) error {
 		return fmt.Errorf("未找到 Codex CLI，Mimi Remote 助手还不能启动。\n\n请先在这台电脑安装并登录 Codex，然后重新运行：\n  agentd up")
 	}
 	return nil
+}
+
+func codexCLIRepairError(err error) error {
+	if errors.Is(err, appserver.ErrIndependentWriterCapabilityUnavailable) {
+		return fmt.Errorf(
+			"Codex CLI 版本不兼容，Mimi Remote 助手还不能启动。\n\n%w\n请将这台电脑的 Codex CLI 升级到 >= %s，然后重新运行：\n  agentd up",
+			err,
+			appserver.MinimumIndependentWriterVersion,
+		)
+	}
+	return fmt.Errorf("未找到 Codex CLI，Mimi Remote 助手还不能启动。\n\n已检查配置路径、当前 PATH，以及 ChatGPT/Codex App 内置路径。\n请先在这台电脑安装并登录 Codex，然后重新运行：\n  agentd up")
 }
 
 func printSetupResult(w io.Writer, result agentsetup.Result) {

--- a/cmd/agentd/main_test.go
+++ b/cmd/agentd/main_test.go
@@ -1706,6 +1706,68 @@ func TestEnsureCodexCLIAvailableRepairsStalePathBeforeServiceStart(t *testing.T)
 	}
 }
 
+func TestRunDoctorFixRepairsUnsafeWindowsCodexRuntime(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows single-writer repair is platform-specific")
+	}
+	clearAgentdEnvForMainTest(t)
+
+	binDir := t.TempDir()
+	safeCodex := writeMainTestCodex(t, filepath.Join(binDir, "codex"))
+	unsafeCodex := filepath.Join(t.TempDir(), "codex-old.cmd")
+	if err := os.WriteFile(
+		unsafeCodex,
+		[]byte("@echo off\r\nif \"%~1\"==\"--version\" echo codex-cli 0.145.0\r\nexit /b 0\r\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	configDir := t.TempDir()
+	tokenPath := filepath.Join(configDir, "app-server-token")
+	if err := os.WriteFile(tokenPath, []byte("capability-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "config.json")
+	cfg := config.Config{
+		Listen:    "127.0.0.1:8787",
+		Auth:      config.AuthConfig{Token: "0123456789abcdef0123456789abcdef"},
+		Runtime:   config.RuntimeConfig{Type: "codex_app_server"},
+		AppServer: config.AppServerConfig{Transport: "ws", Managed: true, Listen: "ws://127.0.0.1:4222", WSTokenFile: tokenPath},
+		Codex:     config.CodexConfig{Bin: unsafeCodex},
+		Session:   config.SessionConfig{OutputBufferBytes: 128 * 1024},
+		Projects:  []config.ProjectConfig{{ID: "demo", Name: "Demo", Path: t.TempDir()}},
+	}
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fixes, restartRequired, _, _, err := runDoctorFix(
+		context.Background(),
+		configPath,
+		false,
+		doctor.Results{Checks: []doctor.Check{{Name: "codex-app-server", OK: false}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !restartRequired || len(fixes) == 0 || !strings.Contains(strings.Join(fixes, "\n"), safeCodex) {
+		t.Fatalf("unsafe runtime should be repaired to the safe candidate: restart=%t fixes=%v", restartRequired, fixes)
+	}
+	updated, err := config.Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Clean(updated.Codex.Bin) != filepath.Clean(safeCodex) {
+		t.Fatalf("doctor persisted the wrong Codex runtime: got=%q want=%q", updated.Codex.Bin, safeCodex)
+	}
+}
+
 func clearAgentdEnvForMainTest(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
@@ -1731,7 +1793,7 @@ func writeMainTestCodex(t *testing.T, path string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		path += ".cmd"
-		body := "@echo off\r\nif \"%~1\"==\"app-server\" if \"%~2\"==\"--help\" echo --listen --ws-auth --ws-token-file\r\nexit /b 0\r\n"
+		body := "@echo off\r\nif \"%~1\"==\"--version\" echo codex-cli 0.149.0\r\nif \"%~1\"==\"app-server\" if \"%~2\"==\"--help\" echo --listen --ws-auth --ws-token-file\r\nexit /b 0\r\n"
 		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/agentd/main_test.go
+++ b/cmd/agentd/main_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 	"github.com/gaixianggeng/mimi-remote/internal/config"
 	"github.com/gaixianggeng/mimi-remote/internal/doctor"
 	agentsetup "github.com/gaixianggeng/mimi-remote/internal/setup"
@@ -27,6 +28,23 @@ import (
 func TestVersionDoesNotRequireConfig(t *testing.T) {
 	if err := run([]string{"agentd", "version"}); err != nil {
 		t.Fatalf("version 不应依赖配置：%v", err)
+	}
+}
+
+func TestCodexCLIRepairErrorPreservesCompatibilityGuidance(t *testing.T) {
+	unsafe := fmt.Errorf(
+		"%w：Codex 版本为 0.145.0",
+		appserver.ErrIndependentWriterCapabilityUnavailable,
+	)
+	err := codexCLIRepairError(unsafe)
+	if !errors.Is(err, appserver.ErrIndependentWriterCapabilityUnavailable) {
+		t.Fatalf("启动错误应保留版本不兼容原因：%v", err)
+	}
+	message := err.Error()
+	if !strings.Contains(message, "版本不兼容") ||
+		!strings.Contains(message, ">= "+appserver.MinimumIndependentWriterVersion) ||
+		strings.Contains(message, "未找到 Codex CLI") {
+		t.Fatalf("启动错误应要求升级而不是提示安装：%s", message)
 	}
 }
 

--- a/internal/appserver/managed.go
+++ b/internal/appserver/managed.go
@@ -72,6 +72,9 @@ func StartManaged(ctx context.Context, options ManagedOptions) (*ManagedProcess,
 	if err := ctx.Err(); err != nil {
 		return nil, InitializeResult{}, err
 	}
+	if err := validateManagedCodexRuntime(ctx, bin); err != nil {
+		return nil, InitializeResult{}, fmt.Errorf("拒绝启动不安全的 Codex app-server：%w", err)
+	}
 	// 传入的 ctx 只约束 initialize 握手；子进程寿命由 Shutdown 统一管理。
 	// 否则 startAppServerRuntime 返回时取消握手 ctx，会把托管 app-server 一起杀掉。
 	cmd := exec.CommandContext(context.Background(), bin, "app-server", "--listen", "stdio://")
@@ -125,6 +128,9 @@ func StartManagedWebSocket(ctx context.Context, options ManagedWebSocketOptions)
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+	if err := validateManagedCodexRuntime(ctx, bin); err != nil {
+		return nil, fmt.Errorf("拒绝启动不安全的 Codex app-server WebSocket：%w", err)
 	}
 	listen, err := normalizeWebSocketListen(options.Listen)
 	if err != nil {

--- a/internal/appserver/managed_process_unix.go
+++ b/internal/appserver/managed_process_unix.go
@@ -2,9 +2,14 @@
 
 package appserver
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 func configureManagedCommand(*exec.Cmd) {}
+
+func validateManagedCodexRuntime(context.Context, string) error { return nil }
 
 func terminateManagedProcess(cmd *exec.Cmd) {
 	if cmd != nil && cmd.Process != nil {

--- a/internal/appserver/managed_process_windows.go
+++ b/internal/appserver/managed_process_windows.go
@@ -18,6 +18,11 @@ func configureManagedCommand(cmd *exec.Cmd) {
 	}
 }
 
+func validateManagedCodexRuntime(ctx context.Context, bin string) error {
+	_, err := ValidateIndependentCodexRuntime(ctx, bin)
+	return err
+}
+
 func terminateManagedProcess(cmd *exec.Cmd) {
 	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
 		return

--- a/internal/appserver/managed_process_windows_test.go
+++ b/internal/appserver/managed_process_windows_test.go
@@ -3,9 +3,15 @@
 package appserver
 
 import (
+	"context"
+	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestConfigureManagedCommandCreatesWindowsProcessGroup(t *testing.T) {
@@ -13,5 +19,42 @@ func TestConfigureManagedCommandCreatesWindowsProcessGroup(t *testing.T) {
 	configureManagedCommand(cmd)
 	if cmd.SysProcAttr == nil || cmd.SysProcAttr.CreationFlags&syscall.CREATE_NEW_PROCESS_GROUP == 0 {
 		t.Fatalf("managed app-server must start in a new Windows process group: %#v", cmd.SysProcAttr)
+	}
+}
+
+func TestManagedAppServerRejectsCodexWithoutSingleWriterBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "codex-old.cmd")
+	if err := os.WriteFile(path, []byte("@echo off\r\necho codex-cli 0.145.0\r\nexit /b 0\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	process, _, err := StartManaged(ctx, ManagedOptions{CodexBin: path})
+	if err == nil {
+		if process != nil {
+			_ = process.Shutdown(context.Background())
+		}
+		t.Fatal("unsafe stdio runtime must fail before app-server start")
+	}
+	if !errors.Is(err, ErrIndependentWriterCapabilityUnavailable) ||
+		!strings.Contains(err.Error(), "0.145.0") {
+		t.Fatalf("stdio rejection should report the unsafe version: %v", err)
+	}
+
+	webSocketProcess, err := StartManagedWebSocket(ctx, ManagedWebSocketOptions{
+		CodexBin:       path,
+		Listen:         "ws://127.0.0.1:4222",
+		EarlyExitGrace: time.Millisecond,
+	})
+	if err == nil {
+		if webSocketProcess != nil {
+			_ = webSocketProcess.Shutdown(context.Background())
+		}
+		t.Fatal("unsafe WebSocket runtime must fail before app-server start")
+	}
+	if !errors.Is(err, ErrIndependentWriterCapabilityUnavailable) ||
+		!strings.Contains(err.Error(), "0.145.0") {
+		t.Fatalf("WebSocket rejection should report the unsafe version: %v", err)
 	}
 }

--- a/internal/appserver/managed_test.go
+++ b/internal/appserver/managed_test.go
@@ -159,10 +159,7 @@ while true; do sleep 1; done
 }
 
 func TestManagedWebSocketProcessFailsWhenProcessExitsEarly(t *testing.T) {
-	falseBin, err := exec.LookPath("false")
-	if err != nil {
-		t.Skip("系统缺少 false 命令")
-	}
+	falseBin := writeCodexThatExitsEarly(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -180,6 +177,23 @@ func TestManagedWebSocketProcessFailsWhenProcessExitsEarly(t *testing.T) {
 	if !strings.Contains(err.Error(), "启动后立即退出") {
 		t.Fatalf("错误信息应提示立即退出，got=%v", err)
 	}
+}
+
+func writeCodexThatExitsEarly(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(t.TempDir(), "codex-exits-early.cmd")
+		body := "@echo off\r\nif \"%~1\"==\"--version\" (\r\n  echo codex-cli 0.149.0\r\n  exit /b 0\r\n)\r\nexit /b 1\r\n"
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	falseBin, err := exec.LookPath("false")
+	if err != nil {
+		t.Skip("系统缺少 false 命令")
+	}
+	return falseBin
 }
 
 func TestBuildManagedEnvFiltersDesktopTransportAndOverlaysConfiguredValues(t *testing.T) {

--- a/internal/appserver/runtime_version.go
+++ b/internal/appserver/runtime_version.go
@@ -1,0 +1,88 @@
+package appserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const MinimumIndependentWriterVersion = "0.147.0"
+
+var ErrIndependentWriterCapabilityUnavailable = errors.New("Codex single-writer capability unavailable")
+
+var codexCLIVersionPattern = regexp.MustCompile(`(?m)^codex-cli[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)\s*$`)
+
+type CodexRuntimeVersionInfo struct {
+	Path    string
+	Version string
+}
+
+// ValidateIndependentCodexRuntime verifies the minimum Codex release that
+// enforces the per-thread writer lock used by independent Desktop and Mimi
+// app-server processes. Callers decide which platforms require this gate.
+func ValidateIndependentCodexRuntime(ctx context.Context, bin string) (CodexRuntimeVersionInfo, error) {
+	info, err := inspectCodexRuntimeVersion(ctx, bin)
+	if err != nil {
+		return CodexRuntimeVersionInfo{}, err
+	}
+	if !codexVersionAtLeast(info.Version, MinimumIndependentWriterVersion) {
+		return CodexRuntimeVersionInfo{}, fmt.Errorf(
+			"%w：%s 版本为 %s，需要 >= %s",
+			ErrIndependentWriterCapabilityUnavailable,
+			info.Path,
+			info.Version,
+			MinimumIndependentWriterVersion,
+		)
+	}
+	return info, nil
+}
+
+func inspectCodexRuntimeVersion(ctx context.Context, bin string) (CodexRuntimeVersionInfo, error) {
+	bin = strings.TrimSpace(bin)
+	if bin == "" {
+		bin = "codex"
+	}
+	resolved, err := exec.LookPath(bin)
+	if err != nil {
+		return CodexRuntimeVersionInfo{}, err
+	}
+	absolute, err := filepath.Abs(resolved)
+	if err != nil {
+		return CodexRuntimeVersionInfo{}, err
+	}
+	absolute = filepath.Clean(absolute)
+	output, err := exec.CommandContext(ctx, absolute, "--version").CombinedOutput()
+	if err != nil {
+		return CodexRuntimeVersionInfo{}, fmt.Errorf("执行 Codex 版本检查失败：%w", err)
+	}
+	match := codexCLIVersionPattern.FindStringSubmatch(strings.TrimSpace(string(output)))
+	if len(match) != 2 {
+		return CodexRuntimeVersionInfo{}, fmt.Errorf(
+			"%w：无法识别 %s 的版本输出",
+			ErrIndependentWriterCapabilityUnavailable,
+			absolute,
+		)
+	}
+	return CodexRuntimeVersionInfo{Path: absolute, Version: match[1]}, nil
+}
+
+func codexVersionAtLeast(version string, minimum string) bool {
+	left, leftPre, leftOK := daemonVersionParts(version)
+	right, rightPre, rightOK := daemonVersionParts(minimum)
+	if !leftOK || !rightOK {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return left[index] > right[index]
+		}
+	}
+	if leftPre == rightPre {
+		return true
+	}
+	return rightPre || !leftPre
+}

--- a/internal/appserver/runtime_version_test.go
+++ b/internal/appserver/runtime_version_test.go
@@ -1,0 +1,45 @@
+package appserver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCodexVersionAtLeastSingleWriterBaseline(t *testing.T) {
+	tests := map[string]bool{
+		"0.145.0":              false,
+		"0.147.0-alpha.6.5":    false,
+		"0.147.0":              true,
+		"0.147.1":              true,
+		"0.149.0-alpha.4.1":    true,
+		"1.0.0":                true,
+		"unrecognized-version": false,
+	}
+	for version, want := range tests {
+		if got := codexVersionAtLeast(version, MinimumIndependentWriterVersion); got != want {
+			t.Fatalf("version %q support mismatch: got=%t want=%t", version, got, want)
+		}
+	}
+}
+
+func TestValidateIndependentCodexRuntimeExplainsUnsafeVersion(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows command fixture is platform-specific")
+	}
+	path := filepath.Join(t.TempDir(), "codex-old.cmd")
+	if err := os.WriteFile(path, []byte("@echo off\r\necho codex-cli 0.145.0\r\nexit /b 0\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ValidateIndependentCodexRuntime(context.Background(), path)
+	if !errors.Is(err, ErrIndependentWriterCapabilityUnavailable) ||
+		!strings.Contains(err.Error(), "版本为 0.145.0") ||
+		!strings.Contains(err.Error(), "需要 >= "+MinimumIndependentWriterVersion) {
+		t.Fatalf("unsafe runtime should return an actionable diagnostic: %v", err)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -402,6 +402,21 @@ func (c *Checker) codexAppServerCheck(ctx context.Context) Check {
 	if !commandExists(c.cfg.Codex.Bin) {
 		return Check{Name: "codex-app-server", OK: false, Message: "无法检查 Codex app-server 能力", Fix: "先安装 Codex CLI"}
 	}
+	versionSummary := ""
+	if runtime.GOOS == "windows" {
+		versionCtx, versionCancel := context.WithTimeout(ctx, 3*time.Second)
+		info, err := appserver.ValidateIndependentCodexRuntime(versionCtx, c.cfg.Codex.Bin)
+		versionCancel()
+		if err != nil {
+			return Check{
+				Name:    "codex-app-server",
+				OK:      false,
+				Message: "Codex CLI 不满足 Windows single-writer 安全基线",
+				Fix:     err.Error() + "；请选择或升级到兼容版本后运行 agentd doctor --fix",
+			}
+		}
+		versionSummary = fmt.Sprintf("（%s；%s）", info.Version, info.Path)
+	}
 	runCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(runCtx, c.cfg.Codex.Bin, "app-server", "--help").CombinedOutput()
@@ -426,7 +441,7 @@ func (c *Checker) codexAppServerCheck(ctx context.Context) Check {
 		}
 		return Check{Name: "codex-app-server", OK: true, Message: "Codex app-server Unix daemon 能力可用"}
 	}
-	return Check{Name: "codex-app-server", OK: true, Message: "Codex app-server WebSocket 能力可用"}
+	return Check{Name: "codex-app-server", OK: true, Message: "Codex app-server WebSocket 能力可用" + versionSummary}
 }
 
 func (c *Checker) localDaemonLifecycleCheck(ctx context.Context) Check {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -628,6 +628,58 @@ func TestCheckerFailsWhenCodexAppServerHelpMissingWSFlags(t *testing.T) {
 	}
 }
 
+func TestCheckerRejectsUnsafeWindowsCodexVersion(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows independent runtime safety gate is platform-specific")
+	}
+	path := filepath.Join(t.TempDir(), "codex-old.cmd")
+	body := "@echo off\r\nif \"%~1\"==\"--version\" echo codex-cli 0.145.0\r\nif \"%~1\"==\"app-server\" if \"%~2\"==\"--help\" echo --listen --ws-auth --ws-token-file\r\nexit /b 0\r\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := newTestChecker(t, config.Config{
+		Listen:    "127.0.0.1:8787",
+		Auth:      config.AuthConfig{Token: "0123456789abcdef0123456789abcdef"},
+		Runtime:   config.RuntimeConfig{Type: "codex_app_server"},
+		AppServer: config.AppServerConfig{Transport: "ws", Managed: true, Listen: "ws://127.0.0.1:4222"},
+		Codex:     config.CodexConfig{Bin: path},
+		Projects: []config.ProjectConfig{{
+			ID: "demo", Name: "Demo", Path: t.TempDir(),
+		}},
+	})
+
+	check := checker.codexAppServerCheck(context.Background())
+	if check.OK || !strings.Contains(check.Message, "single-writer") ||
+		!strings.Contains(check.Fix, "0.145.0") ||
+		!strings.Contains(check.Fix, appserver.MinimumIndependentWriterVersion) {
+		t.Fatalf("Doctor should explain the unsafe Windows runtime and recovery: %+v", check)
+	}
+}
+
+func TestCheckerReportsSafeWindowsCodexPathAndVersion(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows independent runtime diagnostics are platform-specific")
+	}
+	path := writeFakeCodexWithAppServerHelp(t, filepath.Join(t.TempDir(), "codex-safe"))
+	checker := newTestChecker(t, config.Config{
+		Listen:    "127.0.0.1:8787",
+		Auth:      config.AuthConfig{Token: "0123456789abcdef0123456789abcdef"},
+		Runtime:   config.RuntimeConfig{Type: "codex_app_server"},
+		AppServer: config.AppServerConfig{Transport: "ws", Managed: true, Listen: "ws://127.0.0.1:4222"},
+		Codex:     config.CodexConfig{Bin: path},
+		Projects: []config.ProjectConfig{{
+			ID: "demo", Name: "Demo", Path: t.TempDir(),
+		}},
+	})
+
+	check := checker.codexAppServerCheck(context.Background())
+	if !check.OK || !strings.Contains(check.Message, "0.149.0") ||
+		!strings.Contains(check.Message, filepath.Clean(path)) {
+		t.Fatalf("Doctor should expose the selected safe Windows runtime: %+v", check)
+	}
+}
+
 func TestSensitiveFileCheckRequiresRegularPrivateFile(t *testing.T) {
 	t.Run("secure regular file", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "secret")
@@ -797,7 +849,7 @@ func writeFakeCodexWithAppServerHelp(t *testing.T, path string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		path += ".cmd"
-		body := "@echo off\r\nif \"%~1\"==\"app-server\" if \"%~2\"==\"--help\" echo --listen --ws-auth --ws-token-file\r\nexit /b 0\r\n"
+		body := "@echo off\r\nif \"%~1\"==\"--version\" echo codex-cli 0.149.0\r\nif \"%~1\"==\"app-server\" if \"%~2\"==\"--help\" echo --listen --ws-auth --ws-token-file\r\nexit /b 0\r\n"
 		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -419,7 +419,7 @@ func resolveClaudeBin(configured string) (string, error) {
 			continue
 		}
 		seen[candidate] = struct{}{}
-		resolved, err := lookupUsableCodexExecutable(candidate)
+		resolved, err := lookupUsableExecutable(candidate)
 		if err != nil {
 			continue
 		}

--- a/internal/setup/claude_candidates_windows_test.go
+++ b/internal/setup/claude_candidates_windows_test.go
@@ -2,10 +2,31 @@ package setup
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestResolveClaudeBinDoesNotApplyCodexVersionParser(t *testing.T) {
+	// git.exe 提供稳定的非 Codex --version 输出，用来确认 Claude 路径探测只检查
+	// 候选程序可启动，不会套用 codex-cli 的版本格式和最低版本限制。
+	probe, err := exec.LookPath("git.exe")
+	if err != nil {
+		t.Skip("当前 Windows 环境没有可用的非 Codex 版本探测程序")
+	}
+	resolved, err := resolveClaudeBin(probe)
+	if err != nil {
+		t.Fatalf("Claude 路径探测不应要求 codex-cli 版本输出：%v", err)
+	}
+	want, err := filepath.Abs(probe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameCleanPath(resolved, want) {
+		t.Fatalf("Claude 路径解析异常：got=%q want=%q", resolved, want)
+	}
+}
 
 func TestClaudeExecutableCandidatesIncludesOfficialNativeInstall(t *testing.T) {
 	home := t.TempDir()

--- a/internal/setup/codex.go
+++ b/internal/setup/codex.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 )
 
 type codexBinResolver func(configured string) (string, error)
@@ -25,6 +28,7 @@ func ResolveCodexBin(configured string) (string, error) {
 func resolveCodexBin(configured string, lookPath executableLookup, platformCandidates []string) (string, error) {
 	candidates := append([]string{strings.TrimSpace(configured), "codex"}, platformCandidates...)
 	seen := map[string]struct{}{}
+	var compatibilityErr error
 	for _, candidate := range candidates {
 		candidate = strings.TrimSpace(candidate)
 		if candidate == "" {
@@ -36,7 +40,13 @@ func resolveCodexBin(configured string, lookPath executableLookup, platformCandi
 		seen[candidate] = struct{}{}
 
 		resolved, err := lookPath(candidate)
-		if err != nil || strings.TrimSpace(resolved) == "" {
+		if err != nil {
+			if compatibilityErr == nil && errors.Is(err, appserver.ErrIndependentWriterCapabilityUnavailable) {
+				compatibilityErr = err
+			}
+			continue
+		}
+		if strings.TrimSpace(resolved) == "" {
 			continue
 		}
 		absolute, err := filepath.Abs(resolved)
@@ -44,6 +54,9 @@ func resolveCodexBin(configured string, lookPath executableLookup, platformCandi
 			continue
 		}
 		return filepath.Clean(absolute), nil
+	}
+	if compatibilityErr != nil {
+		return "", compatibilityErr
 	}
 	return "", fmt.Errorf("配置路径、PATH 和桌面 App 中都没有可执行的 Codex CLI")
 }

--- a/internal/setup/codex_lookup_unix.go
+++ b/internal/setup/codex_lookup_unix.go
@@ -4,6 +4,10 @@ package setup
 
 import "os/exec"
 
-func lookupUsableCodexExecutable(file string) (string, error) {
+func lookupUsableExecutable(file string) (string, error) {
 	return exec.LookPath(file)
+}
+
+func lookupUsableCodexExecutable(file string) (string, error) {
+	return lookupUsableExecutable(file)
 }

--- a/internal/setup/codex_lookup_windows.go
+++ b/internal/setup/codex_lookup_windows.go
@@ -4,10 +4,30 @@ package setup
 
 import (
 	"context"
+	"io"
+	"os/exec"
 	"time"
 
 	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 )
+
+// lookupUsableExecutable 只确认 Windows 候选路径可以真实启动。Claude 与
+// Codex 的版本格式不同，因此通用探测不能附带 Codex 版本规则。
+func lookupUsableExecutable(file string) (string, error) {
+	path, err := exec.LookPath(file)
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "--version")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", exec.ErrNotFound
+	}
+	return path, nil
+}
 
 // WindowsApps package resources can be discoverable by LookPath while their
 // ACL denies CreateProcess to an ordinary desktop process. Probe candidates

--- a/internal/setup/codex_lookup_windows.go
+++ b/internal/setup/codex_lookup_windows.go
@@ -4,26 +4,20 @@ package setup
 
 import (
 	"context"
-	"io"
-	"os/exec"
 	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 )
 
 // WindowsApps package resources can be discoverable by LookPath while their
 // ACL denies CreateProcess to an ordinary desktop process. Probe candidates
 // before persisting them so the service never records an unusable path.
 func lookupUsableCodexExecutable(file string) (string, error) {
-	path, err := exec.LookPath(file)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	info, err := appserver.ValidateIndependentCodexRuntime(ctx, file)
 	if err != nil {
 		return "", err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, path, "--version")
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err != nil {
-		return "", exec.ErrNotFound
-	}
-	return path, nil
+	return info.Path, nil
 }

--- a/internal/setup/codex_test.go
+++ b/internal/setup/codex_test.go
@@ -3,11 +3,14 @@ package setup
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
+
+	"github.com/gaixianggeng/mimi-remote/internal/appserver"
 )
 
 func TestResolveCodexBinFallsBackFromStaleConfiguredPath(t *testing.T) {
@@ -53,6 +56,52 @@ func TestResolveCodexBinFallsBackToDesktopApp(t *testing.T) {
 	want, _ := filepath.Abs(embedded)
 	if resolved != filepath.Clean(want) {
 		t.Fatalf("应恢复桌面 App 内置 Codex：%s", resolved)
+	}
+}
+
+func TestResolveCodexBinSkipsUnsafePATHRuntimeForCompatibleDesktopCandidate(t *testing.T) {
+	oldConfigured := filepath.Join(t.TempDir(), "codex-old")
+	desktop := filepath.Join(t.TempDir(), "codex-desktop")
+	lookups := []string{}
+	lookup := func(candidate string) (string, error) {
+		lookups = append(lookups, candidate)
+		switch candidate {
+		case oldConfigured, "codex":
+			return "", fmt.Errorf(
+				"%w: %s version 0.145.0",
+				appserver.ErrIndependentWriterCapabilityUnavailable,
+				oldConfigured,
+			)
+		case desktop:
+			return desktop, nil
+		default:
+			return "", errors.New("missing")
+		}
+	}
+
+	resolved, err := resolveCodexBin(oldConfigured, lookup, []string{desktop})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := filepath.Abs(desktop)
+	if resolved != filepath.Clean(want) {
+		t.Fatalf("compatible Desktop runtime should win after unsafe PATH candidate: got=%q want=%q", resolved, want)
+	}
+	if !reflect.DeepEqual(lookups, []string{oldConfigured, "codex", desktop}) {
+		t.Fatalf("runtime candidates were checked in the wrong order: %v", lookups)
+	}
+}
+
+func TestResolveCodexBinReturnsUnsafeVersionWhenNoCompatibleCandidateExists(t *testing.T) {
+	unsafeErr := fmt.Errorf(
+		"%w: version 0.145.0",
+		appserver.ErrIndependentWriterCapabilityUnavailable,
+	)
+	_, err := resolveCodexBin("codex", func(string) (string, error) {
+		return "", unsafeErr
+	}, nil)
+	if !errors.Is(err, appserver.ErrIndependentWriterCapabilityUnavailable) {
+		t.Fatalf("unsafe installed runtime should not degrade to a missing CLI error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- On Windows, validate every Codex candidate with `codex --version` and require the independent-writer safety baseline (`>= 0.147.0`) before selecting it.
- Skip an unsafe configured/PATH runtime and continue to a compatible Codex Desktop candidate; return an actionable compatibility error when no safe candidate exists.
- Refuse to spawn managed stdio or WebSocket app-server processes with an unsafe runtime.
- Extend `agentd doctor` to show the selected Windows Codex path/version and let `doctor --fix` replace an unsafe configured runtime with a compatible candidate.
- Keep non-Windows runtime startup behavior unchanged; do not upgrade or overwrite the user's global Codex installation.

Linear: https://linear.app/code89757/issue/MIM-185/windows-app-与-codex-desktop-可同时续写同一会话未触发-writer-保护

## Validation

- `go test ./internal/appserver ./internal/setup ./internal/doctor ./cmd/agentd -count=1`
- `go test ./internal/doctor -run TestCheckerMarksMissingTailscaleAsWarning -count=5 -v`
- `go vet ./internal/appserver ./internal/setup ./internal/doctor ./cmd/agentd`
- Windows `go build ./cmd/agentd`
- `git diff --check origin/main...HEAD`

The affected-package suite was rerun after rebasing onto the latest `main`.

## Follow-up validation

- A full `go test ./...` run on this Windows host is not clean because existing environment-sensitive tests fail without symlink privileges, inherit the host proxy configuration, and the HTTP integration package stalled after concurrent full-suite runs. Both Issue branches reproduced the same unrelated failures; all affected packages above pass serially.
- Windows end-to-end validation is still required with Desktop holding a thread writer while Mimi attempts `thread/resume` / `turn/start`, including reconnect, approval wait, process restart, and handoff.
- Read-only history/external-activity behavior and rollout integrity should be checked in that end-to-end pass.