### PR TITLE
fix(ios): MIM-178 修复旧版 iPadOS 底部 Tab Bar 判断

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -225,9 +225,11 @@ struct UnifiedWorkbenchShell: View {
         }
         let hasBottomTabBar = WorkbenchPageLayout.hasBottomTabBar(
             isPhone: layout.isPhone,
+            isHorizontallyCompact: horizontalSizeClass == .compact,
             isIOS26OrLater: isIOS26OrLater
         )
-        // iPadOS 26 把紧凑 TabView 的 Tab 栏渲染在**顶部**，底部没有任何浮动 chrome。
+        // iPadOS 18 起 regular-width iPad 已把 Tab 栏放在顶部；18–25 只有 compact-width
+        // iPad 仍回到底部，26 起两种 iPad 宽度都在顶部。iPhone 始终保留底部 Tab 栏。
         // 仍按底部 Tab 栏预留 118pt，会在列表底部留下一整块空气，
         // 也会把右下角浮起的新建按钮顶离屏幕边缘、看起来既不贴边又压住内容。
         let bottomChromeClearance = hasBottomTabBar
@@ -301,8 +303,7 @@ struct UnifiedWorkbenchShell: View {
         .compactTabBarChrome(tokens: tokens, reduceTransparency: reduceTransparency)
         .environment(\.workbenchBottomChromeClearance, bottomChromeClearance)
         .environment(\.workbenchHasCompactTabBar, true)
-        // iPhone 的 Tab 栏浮在底部，iPadOS 26 把它渲染在顶部。
-        // 页面据此决定右下角能不能放浮起按钮。
+        // 页面按系统 Tab 栏的实际位置决定右下角能不能放浮起按钮。
         .environment(\.workbenchHasBottomTabBar, hasBottomTabBar)
         .themedWorkbenchNavigationChrome(
             tokens: tokens,

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -217,10 +217,20 @@ struct UnifiedWorkbenchShell: View {
         tokens: ThemeTokens,
         bottomSafeAreaInset: CGFloat
     ) -> some View {
+        let isIOS26OrLater: Bool
+        if #available(iOS 26.0, *) {
+            isIOS26OrLater = true
+        } else {
+            isIOS26OrLater = false
+        }
+        let hasBottomTabBar = WorkbenchPageLayout.hasBottomTabBar(
+            isPhone: layout.isPhone,
+            isIOS26OrLater: isIOS26OrLater
+        )
         // iPadOS 26 把紧凑 TabView 的 Tab 栏渲染在**顶部**，底部没有任何浮动 chrome。
-        // 仍按 iPhone 那套预留 118pt，会在列表底部留下一整块空气，
+        // 仍按底部 Tab 栏预留 118pt，会在列表底部留下一整块空气，
         // 也会把右下角浮起的新建按钮顶离屏幕边缘、看起来既不贴边又压住内容。
-        let bottomChromeClearance = layout.isPhone
+        let bottomChromeClearance = hasBottomTabBar
             ? WorkbenchPageLayout.compactBottomChromeClearance(
                 bottomSafeAreaInset: bottomSafeAreaInset
             )
@@ -293,7 +303,7 @@ struct UnifiedWorkbenchShell: View {
         .environment(\.workbenchHasCompactTabBar, true)
         // iPhone 的 Tab 栏浮在底部，iPadOS 26 把它渲染在顶部。
         // 页面据此决定右下角能不能放浮起按钮。
-        .environment(\.workbenchHasBottomTabBar, layout.isPhone)
+        .environment(\.workbenchHasBottomTabBar, hasBottomTabBar)
         .themedWorkbenchNavigationChrome(
             tokens: tokens,
             colorScheme: themeStore.resolvedColorScheme(for: colorScheme)

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -1386,6 +1386,14 @@ enum WorkbenchPageLayout {
             + max(compactTabBarMinimumSafeArea, bottomSafeAreaInset)
             + compactTabBarBreathingRoom
     }
+
+    // 把系统可用性结果显式传入，让 iPadOS 26 的位置变化可脱离真实运行环境单测。
+    static func hasBottomTabBar(
+        isPhone: Bool,
+        isIOS26OrLater: Bool
+    ) -> Bool {
+        isPhone || !isIOS26OrLater
+    }
 }
 
 private struct WorkbenchBottomChromeClearanceKey: EnvironmentKey {

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -1390,9 +1390,10 @@ enum WorkbenchPageLayout {
     // 把系统可用性结果显式传入，让 iPadOS 26 的位置变化可脱离真实运行环境单测。
     static func hasBottomTabBar(
         isPhone: Bool,
+        isHorizontallyCompact: Bool,
         isIOS26OrLater: Bool
     ) -> Bool {
-        isPhone || !isIOS26OrLater
+        isPhone || (isHorizontallyCompact && !isIOS26OrLater)
     }
 }
 
@@ -1404,7 +1405,7 @@ private struct WorkbenchHasCompactTabBarKey: EnvironmentKey {
     static let defaultValue = false
 }
 
-/// Tab 栏是否位于屏幕**底部**。iPhone 是，iPadOS 26 的紧凑 TabView 把它渲染在顶部。
+/// Tab 栏是否位于屏幕**底部**。iPhone 始终是；iPad 按横向 size class 与系统版本适配。
 ///
 /// 这不等同于 `workbenchHasCompactTabBar`：那个只回答「有没有紧凑 Tab 栏」，
 /// 两个平台都为真。页面要决定「右下角能不能放浮起按钮」时必须问这一个——

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
@@ -2,6 +2,33 @@ import XCTest
 @testable import MimiRemote
 
 final class WorkspaceStripPresentationTests: XCTestCase {
+    func testBottomTabBarMappingUsesDeviceAndSystemGeneration() {
+        XCTAssertTrue(
+            WorkbenchPageLayout.hasBottomTabBar(
+                isPhone: false,
+                isIOS26OrLater: false
+            )
+        )
+        XCTAssertFalse(
+            WorkbenchPageLayout.hasBottomTabBar(
+                isPhone: false,
+                isIOS26OrLater: true
+            )
+        )
+        XCTAssertTrue(
+            WorkbenchPageLayout.hasBottomTabBar(
+                isPhone: true,
+                isIOS26OrLater: false
+            )
+        )
+        XCTAssertTrue(
+            WorkbenchPageLayout.hasBottomTabBar(
+                isPhone: true,
+                isIOS26OrLater: true
+            )
+        )
+    }
+
     func testBottomTabBarAlwaysKeepsRuntimeMenuAndInlineNewSessionEntry() {
         XCTAssertFalse(
             WorkspaceStripLayout.usesInlineRuntimePicker(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
@@ -2,28 +2,46 @@ import XCTest
 @testable import MimiRemote
 
 final class WorkspaceStripPresentationTests: XCTestCase {
-    func testBottomTabBarMappingUsesDeviceAndSystemGeneration() {
+    func testBottomTabBarMappingUsesDeviceSizeClassAndSystemGeneration() {
         XCTAssertTrue(
             WorkbenchPageLayout.hasBottomTabBar(
-                isPhone: false,
+                isPhone: true,
+                isHorizontallyCompact: false,
                 isIOS26OrLater: false
             )
         )
         XCTAssertFalse(
             WorkbenchPageLayout.hasBottomTabBar(
                 isPhone: false,
+                isHorizontallyCompact: false,
+                isIOS26OrLater: false
+            )
+        )
+        XCTAssertTrue(
+            WorkbenchPageLayout.hasBottomTabBar(
+                isPhone: false,
+                isHorizontallyCompact: true,
+                isIOS26OrLater: false
+            )
+        )
+        XCTAssertFalse(
+            WorkbenchPageLayout.hasBottomTabBar(
+                isPhone: false,
+                isHorizontallyCompact: false,
+                isIOS26OrLater: true
+            )
+        )
+        XCTAssertFalse(
+            WorkbenchPageLayout.hasBottomTabBar(
+                isPhone: false,
+                isHorizontallyCompact: true,
                 isIOS26OrLater: true
             )
         )
         XCTAssertTrue(
             WorkbenchPageLayout.hasBottomTabBar(
                 isPhone: true,
-                isIOS26OrLater: false
-            )
-        )
-        XCTAssertTrue(
-            WorkbenchPageLayout.hasBottomTabBar(
-                isPhone: true,
+                isHorizontallyCompact: true,
                 isIOS26OrLater: true
             )
         )


### PR DESCRIPTION
## 变更

- iPhone 在所有支持版本继续按底部 Tab Bar 布局。
- iPadOS 18–25 正确保留底部 Tab Bar 的内容让位和行内新建入口。
- iPadOS 26+ 继续使用顶部 Tab Bar 与右下角浮动新建按钮。
- 底部留白与按钮位置共用同一个判断，并补齐设备和系统代际单测。

## 验证

- git diff --check
- bash ./scripts/check-source-size.sh
- bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/WorkspaceStripPresentationTests（4 个测试，0 失败）

这是 PR #244 合并后对未实际修复的第二条 P1 review comment 的补丁。