### PR TITLE
fix(iOS): 稳定会话详情首屏定位 (MIM-188)

### DIFF
--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
@@ -27,7 +27,9 @@ struct ConversationTimelineView: View {
     // 滚动任务 bookkeeping 不属于界面状态，放在引用对象中避免每次取消/重排任务都触发 body 失效。
     @State private var tailScrollCoordinator = ConversationTailScrollCoordinator()
     @State private var isUserScrollingTimeline = false
+    @State private var timelinePresentationGeneration = 0
     @State private var initialTailScrollAttemptedIdentity: ConversationTimelineListIdentity?
+    @State private var visibleTailSentinelIdentity: ConversationTimelineListIdentity?
     @State private var presentedTimelineIdentity: ConversationTimelineListIdentity?
 
     private let messageTailFollowThreshold: CGFloat = 120
@@ -63,7 +65,8 @@ struct ConversationTimelineView: View {
                 profileID: hostProfileID,
                 sessionID: displayedSessionID ?? "__none__"
             ),
-            hasTimelineContent: !timelineItems.isEmpty
+            hasTimelineContent: !timelineItems.isEmpty,
+            presentationGeneration: timelinePresentationGeneration
         )
         let isTimelineReadable = timelineItems.isEmpty
             || presentedTimelineIdentity == timelineListIdentity
@@ -131,6 +134,19 @@ struct ConversationTimelineView: View {
                         // Section，scrollTo 不会把新快照行号用于旧 UICollectionView 快照。
                         Color.clear
                             .frame(height: 1)
+                            .onScrollVisibilityChange(threshold: 0.5) { isVisible in
+                                if isVisible {
+                                    visibleTailSentinelIdentity = timelineListIdentity
+                                    confirmTimelinePresentationIfReady(
+                                        timelineListIdentity,
+                                        hasTimelineContent: !timelineItems.isEmpty
+                                    )
+                                } else if visibleTailSentinelIdentity == timelineListIdentity {
+                                    visibleTailSentinelIdentity = nil
+                                }
+                            }
+                            // ID 必须标记可见性包装后的整行，否则 ScrollViewReader 可能只找到
+                            // 尚未进入 List 快照的内部 Color，首屏 scrollTo 会一直无效。
                             .id(Self.timelineTailSentinelID)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets())
@@ -165,10 +181,6 @@ struct ConversationTimelineView: View {
                     if nearBottom {
                         shouldFollowMessageTail = true
                         hasUnseenTailMessage = false
-                        if !timelineItems.isEmpty,
-                           initialTailScrollAttemptedIdentity == timelineListIdentity {
-                            presentedTimelineIdentity = timelineListIdentity
-                        }
                     } else if !isTailFollowLocked {
                         shouldFollowMessageTail = false
                     }
@@ -203,7 +215,7 @@ struct ConversationTimelineView: View {
 
                 if !isTimelineReadable {
                     // List 必须先进入视图层级才能获得真实高度并执行 scrollTo。用真实画布
-                    // 覆盖这段布局窗口；贴底几何确认后整块移除，不展示顶部或中间位置。
+                    // 覆盖这段布局窗口；尾部哨兵确认可见后整块移除，不展示顶部或中间位置。
                     ConversationTimelineStabilizingCover(
                         backgroundColor: UIColor(tokens.conversationCanvasBackground)
                     )
@@ -224,6 +236,9 @@ struct ConversationTimelineView: View {
                 isTimelineNearBottom = true
                 isPreservingHistoryScroll = false
                 isUserScrollingTimeline = false
+                // 每次进入会话都生成新的 List/展示身份。不能只清空 Optional 状态，
+                // 否则 onChange 与新 task 的执行顺序可能再次取消正确的首屏定位。
+                timelinePresentationGeneration += 1
                 expandedActivityIDs.removeAll()
                 expandedActivityGroupIDs.removeAll()
                 workGroupExpansionOverrides.removeAll()
@@ -236,6 +251,7 @@ struct ConversationTimelineView: View {
                 shouldFollowMessageTail = true
                 forceNextMessageTailScroll = true
                 isTailFollowLocked = displayedSessionID != nil
+                timelinePresentationGeneration += 1
                 if !messages.isEmpty {
                     HostSwitchSignpost.event("first_text_visible")
                 }
@@ -352,8 +368,8 @@ struct ConversationTimelineView: View {
                       presentedTimelineIdentity != timelineListIdentity else {
                     return
                 }
-                // List 尚不可见时只执行一次布局后贴底。几何确认贴底后再放开正文，
-                // 不需要延迟 900ms 的第二次重锚。
+                // List 尚不可见时在首轮布局内贴底。尾部哨兵确认可见后再放开正文，
+                // 不需要延迟 900ms 后制造一次用户可见的重锚。
                 let expectedSessionID = displayedSessionID
                 let expectedTailItemID = timelineItems.last?.id
                 await Task.yield()
@@ -363,22 +379,31 @@ struct ConversationTimelineView: View {
                     return
                 }
                 initialTailScrollAttemptedIdentity = timelineListIdentity
-                forceScrollToTimelineTail(
-                    timelineItems: timelineItems,
-                    proxy: proxy,
-                    animated: false
-                )
-                await Task.yield()
-                guard !Task.isCancelled,
-                      displayedSessionID == expectedSessionID,
-                      initialTailScrollAttemptedIdentity == timelineListIdentity,
-                      isTimelineNearBottom else {
-                    return
+                // List 的 UIKit 快照可能晚于 SwiftUI task 提交。所有重试都发生在稳定遮罩下，
+                // 并且只由尾部哨兵真实可见来结束，不能再把“已调用 scrollTo”当成成功。
+                for _ in 0..<8 {
+                    guard !Task.isCancelled,
+                          displayedSessionID == expectedSessionID,
+                          currentTimelineTailItemID() == expectedTailItemID,
+                          initialTailScrollAttemptedIdentity == timelineListIdentity,
+                          presentedTimelineIdentity != timelineListIdentity else {
+                        return
+                    }
+                    forceScrollToTimelineTail(
+                        timelineItems: timelineItems,
+                        proxy: proxy,
+                        animated: false
+                    )
+                    try? await Task.sleep(nanoseconds: 32_000_000)
+                    confirmTimelinePresentationIfReady(
+                        timelineListIdentity,
+                        hasTimelineContent: true
+                    )
                 }
-                presentedTimelineIdentity = timelineListIdentity
             }
             .onDisappear {
                 cancelPendingTailScrollAttempts()
+                timelinePresentationGeneration += 1
             }
         }
     }
@@ -768,6 +793,14 @@ struct ConversationTimelineView: View {
             && !hasHistorySavingsNotice
     }
 
+    static func shouldPresentStabilizedTimeline(
+        hasTimelineContent: Bool,
+        didAttemptInitialTailScroll: Bool,
+        isTailSentinelVisible: Bool
+    ) -> Bool {
+        hasTimelineContent && didAttemptInitialTailScroll && isTailSentinelVisible
+    }
+
     private func loadEarlierRow(proxy: ScrollViewProxy, timelineItems: [ConversationTimelineItem]) -> some View {
         HStack {
             Spacer()
@@ -954,7 +987,6 @@ struct ConversationTimelineView: View {
         }
         shouldFollowMessageTail = true
         hasUnseenTailMessage = false
-        isTimelineNearBottom = true
         forceNextMessageTailScroll = false
         scrollToTimelineTail(proxy: proxy, animated: animated)
     }
@@ -1089,11 +1121,26 @@ struct ConversationTimelineView: View {
     private func currentTimelineTailItemID() -> String? {
         timelineItemCache.tailItemID
     }
+
+    private func confirmTimelinePresentationIfReady(
+        _ identity: ConversationTimelineListIdentity,
+        hasTimelineContent: Bool
+    ) {
+        guard Self.shouldPresentStabilizedTimeline(
+            hasTimelineContent: hasTimelineContent,
+            didAttemptInitialTailScroll: initialTailScrollAttemptedIdentity == identity,
+            isTailSentinelVisible: visibleTailSentinelIdentity == identity
+        ) else {
+            return
+        }
+        presentedTimelineIdentity = identity
+    }
 }
 
 private struct ConversationTimelineListIdentity: Hashable {
     let scope: ScopedSessionID
     let hasTimelineContent: Bool
+    let presentationGeneration: Int
 }
 
 private struct ConversationTimelineStabilizingCover: UIViewRepresentable {

--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
@@ -380,8 +380,9 @@ struct ConversationTimelineView: View {
                 }
                 initialTailScrollAttemptedIdentity = timelineListIdentity
                 // List 的 UIKit 快照可能晚于 SwiftUI task 提交。所有重试都发生在稳定遮罩下，
-                // 并且只由尾部哨兵真实可见来结束，不能再把“已调用 scrollTo”当成成功。
-                for _ in 0..<8 {
+                // 并且只由尾部哨兵真实可见或任务取消来结束，不能用固定次数制造永久空白。
+                var attempt = 0
+                while true {
                     guard !Task.isCancelled,
                           displayedSessionID == expectedSessionID,
                           currentTimelineTailItemID() == expectedTailItemID,
@@ -394,7 +395,15 @@ struct ConversationTimelineView: View {
                         proxy: proxy,
                         animated: false
                     )
-                    try? await Task.sleep(nanoseconds: 32_000_000)
+                    attempt += 1
+                    // 首轮快速覆盖常规 List 快照延迟；慢布局随后降频，避免长历史在
+                    // 遮罩期间持续高频占用 MainActor，同时仍能在快照就绪后自行恢复。
+                    let retryDelay = attempt <= 8 ? 32_000_000 : 160_000_000
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(retryDelay))
+                    } catch {
+                        return
+                    }
                     confirmTimelinePresentationIfReady(
                         timelineListIdentity,
                         hasTimelineContent: true
@@ -1037,6 +1046,29 @@ struct ConversationTimelineView: View {
                 timelineItems: timelineItems,
                 proxy: proxy,
                 animated: animatedFirstAttempt
+            )
+
+            // 新行插入或 Markdown 行高增长可能晚于第一轮 scrollTo 完成。等一个短的
+            // 布局窗口后再无动画校正一次，保证已展示会话继续贴尾；初始进入仍由遮罩
+            // 隔离，不恢复原先 900ms 后用户可见的重锚。
+            do {
+                try await Task.sleep(nanoseconds: 180_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled,
+                  tailScrollCoordinator.attemptGeneration == attemptGeneration,
+                  tailScrollCoordinator.userScrollAwayGeneration == scrollAwayGeneration,
+                  displayedSessionID == sessionID,
+                  currentTimelineTailItemID() == expectedTailItemID,
+                  !isPreservingHistoryScroll
+            else {
+                return
+            }
+            forceScrollToTimelineTail(
+                timelineItems: timelineItems,
+                proxy: proxy,
+                animated: false
             )
         }
     }

--- a/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Timeline/ConversationTimelineView.swift
@@ -27,9 +27,12 @@ struct ConversationTimelineView: View {
     // 滚动任务 bookkeeping 不属于界面状态，放在引用对象中避免每次取消/重排任务都触发 body 失效。
     @State private var tailScrollCoordinator = ConversationTailScrollCoordinator()
     @State private var isUserScrollingTimeline = false
+    @State private var initialTailScrollAttemptedIdentity: ConversationTimelineListIdentity?
+    @State private var presentedTimelineIdentity: ConversationTimelineListIdentity?
 
     private let messageTailFollowThreshold: CGFloat = 120
     private static let timelineTailSentinelID = "__conversation_timeline_safe_tail__"
+    static let stabilizingCoverAccessibilityIdentifier = "conversation.timeline.stabilizing-cover"
 
     init(
         layout: ConversationLayout,
@@ -55,10 +58,15 @@ struct ConversationTimelineView: View {
         )
         let timelineItems = timelineSnapshot.items
         let timelineItemIDs = timelineSnapshot.itemIDs
-        let tailFollowTaskKey = Self.tailFollowTaskKey(
-            sessionID: displayedSessionID,
-            tailItemID: timelineItems.last?.id
+        let timelineListIdentity = ConversationTimelineListIdentity(
+            scope: ScopedSessionID(
+                profileID: hostProfileID,
+                sessionID: displayedSessionID ?? "__none__"
+            ),
+            hasTimelineContent: !timelineItems.isEmpty
         )
+        let isTimelineReadable = timelineItems.isEmpty
+            || presentedTimelineIdentity == timelineListIdentity
         let activeUserDeliveryMessageID = Self.activeUserDeliveryMessageID(in: messages)
         let crossSessionOriginMessageID = Self.crossSessionOriginMessageID(
             session: displayedSessionID.flatMap { sessionStore.sessionsByID[$0] },
@@ -130,12 +138,14 @@ struct ConversationTimelineView: View {
                     }
                 }
                 .listStyle(.plain)
+                // 支持该语义的系统会在 List 首次提交前计算底部 offset；其余系统由下方
+                // 的稳定遮罩兜住首次布局，不能让尚未贴底的正文成为可读画面。
+                .defaultScrollAnchor(.bottom, for: .initialOffset)
                 // 每个会话使用独立的 List 身份，避免复用上一个会话的 contentOffset；
-                // 挂载后再定位到固定尾部哨兵。
-                .id(ScopedSessionID(
-                    profileID: hostProfileID,
-                    sessionID: displayedSessionID ?? "__none__"
-                ))
+                // 空占位变成正文时也重建一次，让未缓存会话重新应用初始底部锚点。
+                .id(timelineListIdentity)
+                .allowsHitTesting(isTimelineReadable)
+                .accessibilityHidden(!isTimelineReadable)
                 .scrollContentBackground(.hidden)
                 .scrollDismissesKeyboard(.interactively)
                 .background(tokens.conversationCanvasBackground)
@@ -155,6 +165,10 @@ struct ConversationTimelineView: View {
                     if nearBottom {
                         shouldFollowMessageTail = true
                         hasUnseenTailMessage = false
+                        if !timelineItems.isEmpty,
+                           initialTailScrollAttemptedIdentity == timelineListIdentity {
+                            presentedTimelineIdentity = timelineListIdentity
+                        }
                     } else if !isTailFollowLocked {
                         shouldFollowMessageTail = false
                     }
@@ -186,6 +200,15 @@ struct ConversationTimelineView: View {
                     // 放在输入区正上方的视觉中轴，不与用户气泡或右侧滚动条争抢空间。
                     .padding(.bottom, 10)
                 }
+
+                if !isTimelineReadable {
+                    // List 必须先进入视图层级才能获得真实高度并执行 scrollTo。用真实画布
+                    // 覆盖这段布局窗口；贴底几何确认后整块移除，不展示顶部或中间位置。
+                    ConversationTimelineStabilizingCover(
+                        backgroundColor: UIColor(tokens.conversationCanvasBackground)
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
             .onChange(of: displayedSessionID) { oldID, newID in
                 let shouldPreserveTailFollowLock = isTailFollowLocked
@@ -206,22 +229,6 @@ struct ConversationTimelineView: View {
                 workGroupExpansionOverrides.removeAll()
                 timelineItemCache.removeAll()
                 cancelPendingTailScrollAttempts()
-                if newID != nil {
-                    // onChange 与新 body 的 task(id:) 在高负载下没有固定先后顺序；闭包捕获的
-                    // timelineItems 可能仍属于 oldID。必须按 newID 重新取值，否则旧尾 ID 会
-                    // 取消正确的新会话滚动任务，最终停在上一会话的 contentOffset。
-                    let newTimelineItems = timelineItemCache.snapshot(
-                        from: conversationStore.messages(for: newID)
-                    ).items
-                    queueTailScrollAttempts(
-                        timelineItems: newTimelineItems,
-                        proxy: proxy,
-                        sessionID: newID,
-                        expectedTailItemID: newTimelineItems.last?.id,
-                        animatedFirstAttempt: false,
-                        force: true
-                    )
-                }
             }
             .onChange(of: hostProfileID) { _, _ in
                 timelineItemCache.removeAll()
@@ -258,8 +265,7 @@ struct ConversationTimelineView: View {
                     sessionID: displayedSessionID,
                     expectedTailItemID: timelineItems.last?.id,
                     animatedFirstAttempt: false,
-                    force: true,
-                    retriesAfterLayout: false
+                    force: true
                 )
             }
             .onChange(of: messages.last?.id) { _, newID in
@@ -290,8 +296,8 @@ struct ConversationTimelineView: View {
                     return
                 }
                 if forceNextMessageTailScroll {
-                    // 首屏/切换会话：List 拿到首页数据后无动画贴底，并在下一拍补一次，
-                    // 覆盖首次布局时机，确保落在真正的底部而不是空白区。
+                    // 首屏/切换会话：List 拿到首页数据后，在下一拍无动画贴底，
+                    // 确保落在真正的底部而不是空白区。
                     queueTailScrollAttempts(
                         timelineItems: timelineItems,
                         proxy: proxy,
@@ -327,8 +333,7 @@ struct ConversationTimelineView: View {
                     sessionID: displayedSessionID,
                     expectedTailItemID: timelineItems.last?.id,
                     animatedFirstAttempt: false,
-                    force: false,
-                    retriesAfterLayout: false
+                    force: false
                 )
             }
             .onChange(of: timelineItemIDs) { _, _ in
@@ -339,26 +344,38 @@ struct ConversationTimelineView: View {
                     sessionID: displayedSessionID,
                     expectedTailItemID: timelineItems.last?.id,
                     animatedFirstAttempt: false,
-                    force: false,
-                    retriesAfterLayout: false
+                    force: false
                 )
             }
-            .task(id: tailFollowTaskKey) {
-                guard tailFollowTaskKey != nil else {
+            .task(id: timelineListIdentity) {
+                guard !timelineItems.isEmpty,
+                      presentedTimelineIdentity != timelineListIdentity else {
                     return
                 }
-                // 进入一个已经有缓存消息的会话时，messages.last 不一定再触发 onChange；
-                // 用 task(id:) 补一条首帧重锚路径，避免 List 默认停在最早消息。
-                queueTailScrollAttempts(
+                // List 尚不可见时只执行一次布局后贴底。几何确认贴底后再放开正文，
+                // 不需要延迟 900ms 的第二次重锚。
+                let expectedSessionID = displayedSessionID
+                let expectedTailItemID = timelineItems.last?.id
+                await Task.yield()
+                guard !Task.isCancelled,
+                      displayedSessionID == expectedSessionID,
+                      currentTimelineTailItemID() == expectedTailItemID else {
+                    return
+                }
+                initialTailScrollAttemptedIdentity = timelineListIdentity
+                forceScrollToTimelineTail(
                     timelineItems: timelineItems,
                     proxy: proxy,
-                    sessionID: displayedSessionID,
-                    expectedTailItemID: timelineItems.last?.id,
-                    animatedFirstAttempt: false,
-                    // 首次打开/切换会话不能被尚未稳定的滚动几何拦截；
-                    // 后续新消息仍尊重用户主动上翻，不会强行抢回底部。
-                    force: forceNextMessageTailScroll
+                    animated: false
                 )
+                await Task.yield()
+                guard !Task.isCancelled,
+                      displayedSessionID == expectedSessionID,
+                      initialTailScrollAttemptedIdentity == timelineListIdentity,
+                      isTimelineNearBottom else {
+                    return
+                }
+                presentedTimelineIdentity = timelineListIdentity
             }
             .onDisappear {
                 cancelPendingTailScrollAttempts()
@@ -948,8 +965,7 @@ struct ConversationTimelineView: View {
         sessionID: SessionID?,
         expectedTailItemID: String?,
         animatedFirstAttempt: Bool,
-        force: Bool,
-        retriesAfterLayout: Bool = true
+        force: Bool
     ) {
         guard let sessionID, let expectedTailItemID, !timelineItems.isEmpty else {
             return
@@ -990,23 +1006,6 @@ struct ConversationTimelineView: View {
                 proxy: proxy,
                 animated: animatedFirstAttempt
             )
-
-            guard retriesAfterLayout else {
-                return
-            }
-            // 首次挂载和 Markdown 排版可能跨布局周期完成，只保留一次兜底重锚。
-            // 后续真实快照变化仍会由 onChange 重新调度，不再固定制造四次 scrollTo。
-            try? await Task.sleep(nanoseconds: 900_000_000)
-            guard !Task.isCancelled,
-                  tailScrollCoordinator.attemptGeneration == attemptGeneration,
-                  tailScrollCoordinator.userScrollAwayGeneration == scrollAwayGeneration,
-                  displayedSessionID == sessionID,
-                  currentTimelineTailItemID() == expectedTailItemID,
-                  !isPreservingHistoryScroll
-            else {
-                return
-            }
-            forceScrollToTimelineTail(timelineItems: timelineItems, proxy: proxy, animated: false)
         }
     }
 
@@ -1030,8 +1029,7 @@ struct ConversationTimelineView: View {
             sessionID: displayedSessionID,
             expectedTailItemID: timelineItems.last?.id,
             animatedFirstAttempt: true,
-            force: true,
-            retriesAfterLayout: false
+            force: true
         )
     }
 
@@ -1088,15 +1086,29 @@ struct ConversationTimelineView: View {
         }
     }
 
-    private static func tailFollowTaskKey(sessionID: SessionID?, tailItemID: String?) -> String? {
-        guard let sessionID, let tailItemID else {
-            return nil
-        }
-        return "\(sessionID):\(tailItemID)"
-    }
-
     private func currentTimelineTailItemID() -> String? {
         timelineItemCache.tailItemID
+    }
+}
+
+private struct ConversationTimelineListIdentity: Hashable {
+    let scope: ScopedSessionID
+    let hasTimelineContent: Bool
+}
+
+private struct ConversationTimelineStabilizingCover: UIViewRepresentable {
+    let backgroundColor: UIColor
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = backgroundColor
+        view.accessibilityIdentifier = ConversationTimelineView.stabilizingCoverAccessibilityIdentifier
+        view.isAccessibilityElement = false
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        uiView.backgroundColor = backgroundColor
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -1119,10 +1119,28 @@ struct UnifiedWorkbenchShell: View {
     }
 
     private func sessionDetail(layout: WorkbenchLayout, tokens: ThemeTokens) -> some View {
-        WorkspaceView {
-            open(.workspaces, layout: layout)
+        let detailSessionID = navigationState.route.detailSessionID
+        let canPresentSessionDetail = navigationState.canPresentSessionDetail(
+            selectedSessionID: sessionStore.selectedSessionID
+        )
+        let detailSession = detailSessionID.flatMap { sessionStore.sessionsByID[$0] }
+        let detailTitle = detailSession?.title
+            ?? (canPresentSessionDetail ? sessionStore.selectedSession?.title : nil)
+            ?? L10n.text("ui.session")
+
+        return Group {
+            if canPresentSessionDetail {
+                WorkspaceView {
+                    open(.workspaces, layout: layout)
+                }
+            } else {
+                // 导航已经指向目标会话、SessionStore 还未提交选择时，只保留稳定底板。
+                // 这段窗口通常不足一帧，但不能让上一个会话的正文或空态借机出现。
+                tokens.conversationCanvasBackground
+                    .accessibilityHidden(true)
+            }
         }
-        .navigationTitle(sessionStore.selectedSession?.title ?? L10n.text("ui.session"))
+        .navigationTitle(detailTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             if navigationState.showsWorkspaceBackButton(
@@ -1143,93 +1161,102 @@ struct UnifiedWorkbenchShell: View {
                     .accessibilityIdentifier("sessionDetail.workspaceBack")
                 }
             }
-            ToolbarItem(placement: .principal) {
-                Group {
-                    if sessionStore.selectedRuntimeActivitySnapshot != nil {
-                        TimelineView(.periodic(from: .now, by: 1)) { context in
+            if canPresentSessionDetail {
+                ToolbarItem(placement: .principal) {
+                    Group {
+                        if sessionStore.selectedRuntimeActivitySnapshot != nil {
+                            TimelineView(.periodic(from: .now, by: 1)) { context in
+                                sessionDetailNavigationTitle(
+                                    layout: layout,
+                                    tokens: tokens,
+                                    now: context.date
+                                )
+                            }
+                        } else {
                             sessionDetailNavigationTitle(
                                 layout: layout,
                                 tokens: tokens,
-                                now: context.date
+                                now: Date()
                             )
                         }
-                    } else {
-                        sessionDetailNavigationTitle(
-                            layout: layout,
-                            tokens: tokens,
-                            now: Date()
-                        )
                     }
                 }
-            }
-            if layout.usesCompactNavigation {
-                workbenchChromeToolbarItem(placement: .topBarTrailing) {
-                    Menu {
-                        if let session = sessionStore.selectedSession {
-                            SessionActionMenuContent(
-                                session: session,
-                                presentation: $sessionActionPresentation
-                            )
-                            Divider()
-                        }
-
-                        Button {
-                            Task { await sessionStore.refreshCurrentContext() }
-                        } label: {
-                            Label(L10n.text("ui.refresh_current_session"), systemImage: "arrow.clockwise")
-                        }
-                        .disabled(sessionStore.isRefreshingSelectedSession || sessionStore.isLoading)
-
-                        Button {
-                            toggleInspector(layout: layout)
-                        } label: {
-                            Label(
-                                showingInspector ? L10n.text("ui.hide_details") : L10n.text("ui.show_details"),
-                                systemImage: "sidebar.right"
-                            )
-                        }
-                    } label: {
-                        WorkbenchChromeIcon(systemName: "ellipsis")
-                            .foregroundStyle(tokens.primaryText.opacity(0.72))
-                            .workbenchToolbarChromeCircle(tokens: tokens)
-                    }
-                    .accessibilityLabel(L10n.text("ui.options"))
-                }
-            } else {
-                if let session = sessionStore.selectedSession {
+                if layout.usesCompactNavigation {
                     workbenchChromeToolbarItem(placement: .topBarTrailing) {
                         Menu {
-                            SessionActionMenuContent(
-                                session: session,
-                                presentation: $sessionActionPresentation
-                            )
+                            if let session = sessionStore.selectedSession {
+                                SessionActionMenuContent(
+                                    session: session,
+                                    presentation: $sessionActionPresentation
+                                )
+                                Divider()
+                            }
+
+                            Button {
+                                Task { await sessionStore.refreshCurrentContext() }
+                            } label: {
+                                Label(L10n.text("ui.refresh_current_session"), systemImage: "arrow.clockwise")
+                            }
+                            .disabled(sessionStore.isRefreshingSelectedSession || sessionStore.isLoading)
+
+                            Button {
+                                toggleInspector(layout: layout)
+                            } label: {
+                                Label(
+                                    showingInspector ? L10n.text("ui.hide_details") : L10n.text("ui.show_details"),
+                                    systemImage: "sidebar.right"
+                                )
+                            }
                         } label: {
                             WorkbenchChromeIcon(systemName: "ellipsis")
-                                .foregroundStyle(tokens.secondaryText)
+                                .foregroundStyle(tokens.primaryText.opacity(0.72))
                                 .workbenchToolbarChromeCircle(tokens: tokens)
                         }
                         .accessibilityLabel(L10n.text("ui.options"))
                     }
+                } else {
+                    if let session = sessionStore.selectedSession {
+                        workbenchChromeToolbarItem(placement: .topBarTrailing) {
+                            Menu {
+                                SessionActionMenuContent(
+                                    session: session,
+                                    presentation: $sessionActionPresentation
+                                )
+                            } label: {
+                                WorkbenchChromeIcon(systemName: "ellipsis")
+                                    .foregroundStyle(tokens.secondaryText)
+                                    .workbenchToolbarChromeCircle(tokens: tokens)
+                            }
+                            .accessibilityLabel(L10n.text("ui.options"))
+                        }
+                        if #available(iOS 26.0, *) {
+                            ToolbarSpacer(.fixed, placement: .topBarTrailing)
+                        }
+                    }
+
+                    workbenchChromeToolbarItem(placement: .topBarTrailing) {
+                        workbenchToolbarIconButton(
+                            systemImage: "arrow.clockwise",
+                            accessibilityLabel: L10n.text("ui.refresh_current_session"),
+                            tokens: tokens,
+                            isDisabled: sessionStore.isRefreshingSelectedSession || sessionStore.isLoading
+                        ) {
+                            Task { await sessionStore.refreshCurrentContext() }
+                        }
+                    }
+                    // 顶栏按钮各自独立，用固定间隔把磨砂圆之间的距离钉死，不靠系统按内容估算。
                     if #available(iOS 26.0, *) {
                         ToolbarSpacer(.fixed, placement: .topBarTrailing)
                     }
+                    inspectorToolbarItem(layout: layout, tokens: tokens)
                 }
-
-                workbenchChromeToolbarItem(placement: .topBarTrailing) {
-                    workbenchToolbarIconButton(
-                        systemImage: "arrow.clockwise",
-                        accessibilityLabel: L10n.text("ui.refresh_current_session"),
-                        tokens: tokens,
-                        isDisabled: sessionStore.isRefreshingSelectedSession || sessionStore.isLoading
-                    ) {
-                        Task { await sessionStore.refreshCurrentContext() }
-                    }
+            } else {
+                ToolbarItem(placement: .principal) {
+                    Text(detailTitle)
+                        .font(themeStore.uiFont(.headline, weight: .semibold))
+                        .foregroundStyle(tokens.primaryText)
+                        .lineLimit(1)
                 }
-                // 顶栏按钮各自独立，用固定间隔把磨砂圆之间的距离钉死，不靠系统按内容估算。
-                if #available(iOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
-                }
-                inspectorToolbarItem(layout: layout, tokens: tokens)
             }
         }
         .background(tokens.conversationCanvasBackground.ignoresSafeArea())

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -642,7 +642,8 @@ extension SessionStore {
                     clearRuntimeActivity(sessionID: session.id)
                 }
             } else if conversationStore.hasLoadedHistory(sessionID: session.id) {
-                scheduleQuietHistoryRefresh(for: session, showsProgress: true)
+                // 已有缓存就是可读首屏；后台对账保持静默，避免尾部临时加载行改变布局。
+                scheduleQuietHistoryRefresh(for: session)
                 didRefreshHistory = true
             } else {
                 didRefreshHistory = await loadHistoryIfNeeded(for: session)

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -151,6 +151,14 @@ struct WorkbenchNavigationState: Equatable {
         return sessionID
     }
 
+    /// 路由先于 SessionStore 选择提交时，详情只能显示稳定底板，不能短暂复用上一个会话。
+    func canPresentSessionDetail(selectedSessionID: SessionID?) -> Bool {
+        guard let detailSessionID = route.detailSessionID else {
+            return true
+        }
+        return selectedSessionID == detailSessionID
+    }
+
     /// 宽屏详情不是一次 push，系统不会自动提供返回工作区的按钮；紧凑布局由外层
     /// `NavigationStack` 管理 path，保留系统返回即可，避免顶栏出现两个返回控件。
     func showsWorkspaceBackButton(usesCompactNavigation: Bool) -> Bool {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -588,7 +588,7 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertNotEqual(refreshed.itemIDs, suspended.itemIDs)
     }
 
-    func testConversationTimelineAllowsInitialTailRetryButRespectsUserScrollAway() {
+    func testConversationTimelineAllowsInitialTailAttemptButRespectsUserScrollAway() {
         XCTAssertTrue(ConversationTimelineView.shouldAttemptTailScroll(
             force: false,
             shouldFollowMessageTail: false,
@@ -674,6 +674,16 @@ final class ConversationDataFlowTests: XCTestCase {
         host.view.frame = window.bounds
         host.view.layoutIfNeeded()
 
+        let firstReadableScrollView = try XCTUnwrap(
+            conversationTimelineScrollView(in: host.view),
+            "缓存时间线应在首轮布局形成可读 List"
+        )
+        XCTAssertTrue(
+            distanceFromBottom(firstReadableScrollView) <= 4
+                || conversationTimelineIsStabilizing(in: host.view),
+            "首轮布局若尚未贴底，时间线必须保持不可见，不能暴露顶部画面"
+        )
+
         // 全量套件下 List 快照提交可能明显晚于固定 sleep；轮询真实几何但不主动滚动，
         // 仍严格要求业务逻辑自行收敛到尾部 4pt 内。
         let firstScrollView = try await waitForConversationTimelineAtBottom(
@@ -681,6 +691,7 @@ final class ConversationDataFlowTests: XCTestCase {
             timeout: 8
         )
         XCTAssertLessThanOrEqual(distanceFromBottom(firstScrollView), 4)
+        XCTAssertFalse(conversationTimelineIsStabilizing(in: host.view))
 
         // 先把会话 A 人工停在顶部，再切换会话；会话 B 必须丢弃旧 contentOffset 并默认展示最新消息。
         firstScrollView.setContentOffset(
@@ -689,11 +700,31 @@ final class ConversationDataFlowTests: XCTestCase {
         )
         sessionStore.selectedSessionID = secondSessionID
 
+        var secondSessionOffsetSamples: [CGFloat] = []
+        let samplingDeadline = Date().addingTimeInterval(1.1)
+        repeat {
+            host.view.layoutIfNeeded()
+            if let candidate = conversationTimelineScrollView(in: host.view),
+               candidate !== firstScrollView,
+               !conversationTimelineIsStabilizing(in: host.view) {
+                secondSessionOffsetSamples.append(distanceFromBottom(candidate))
+            }
+            try await Task.sleep(nanoseconds: 16_000_000)
+        } while Date() < samplingDeadline
+
+        XCTAssertFalse(secondSessionOffsetSamples.isEmpty, "切换会话后应建立独立的 List")
+        XCTAssertLessThanOrEqual(
+            secondSessionOffsetSamples.max() ?? .infinity,
+            4,
+            "切换后的首帧和 900ms 旧兜底窗口内都不能出现可见的顶部跳转"
+        )
+
         let secondScrollView = try await waitForConversationTimelineAtBottom(
             in: host.view,
             timeout: 8
         )
         XCTAssertLessThanOrEqual(distanceFromBottom(secondScrollView), 4)
+        XCTAssertFalse(conversationTimelineIsStabilizing(in: host.view))
     }
 
     func testConversationTopUnderlapOnlyDependsOnTransparencyPreference() {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -632,6 +632,24 @@ final class ConversationDataFlowTests: XCTestCase {
         ))
     }
 
+    func testConversationTimelineOnlyRevealsAfterTailSentinelIsVisible() {
+        XCTAssertFalse(ConversationTimelineView.shouldPresentStabilizedTimeline(
+            hasTimelineContent: true,
+            didAttemptInitialTailScroll: true,
+            isTailSentinelVisible: false
+        ))
+        XCTAssertFalse(ConversationTimelineView.shouldPresentStabilizedTimeline(
+            hasTimelineContent: true,
+            didAttemptInitialTailScroll: false,
+            isTailSentinelVisible: true
+        ))
+        XCTAssertTrue(ConversationTimelineView.shouldPresentStabilizedTimeline(
+            hasTimelineContent: true,
+            didAttemptInitialTailScroll: true,
+            isTailSentinelVisible: true
+        ))
+    }
+
     func testConversationTimelineStartsAtTailAfterSwitchingFromScrolledSession() async throws {
         let firstSessionID = "tail-position-first"
         let secondSessionID = "tail-position-second"

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
@@ -928,6 +928,41 @@ func distanceFromBottom(_ scrollView: UIScrollView) -> CGFloat {
 }
 
 @MainActor
+func isViewEffectivelyVisible(_ view: UIView, within rootView: UIView) -> Bool {
+    var currentView: UIView? = view
+    while let candidate = currentView {
+        if candidate.isHidden || candidate.alpha <= 0.01 || candidate.layer.opacity <= 0.01 {
+            return false
+        }
+        if candidate === rootView {
+            return true
+        }
+        currentView = candidate.superview
+    }
+    return false
+}
+
+@MainActor
+func conversationTimelineIsStabilizing(in rootView: UIView) -> Bool {
+    func findMarker(from view: UIView) -> UIView? {
+        if view.accessibilityIdentifier == ConversationTimelineView.stabilizingCoverAccessibilityIdentifier {
+            return view
+        }
+        for subview in view.subviews {
+            if let marker = findMarker(from: subview) {
+                return marker
+            }
+        }
+        return nil
+    }
+
+    guard let marker = findMarker(from: rootView) else {
+        return false
+    }
+    return isViewEffectivelyVisible(marker, within: rootView)
+}
+
+@MainActor
 func waitForConversationTimelineAtBottom(
     in rootView: UIView,
     tolerance: CGFloat = 4,
@@ -940,7 +975,9 @@ func waitForConversationTimelineAtBottom(
         rootView.layoutIfNeeded()
         if let scrollView = conversationTimelineScrollView(in: rootView) {
             latestScrollView = scrollView
-            if distanceFromBottom(scrollView) <= tolerance {
+            if distanceFromBottom(scrollView) <= tolerance,
+               isViewEffectivelyVisible(scrollView, within: rootView),
+               !conversationTimelineIsStabilizing(in: rootView) {
                 return scrollView
             }
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
@@ -3,6 +3,7 @@ import Combine
 import Security
 import SwiftUI
 import UIKit
+import SnapshotTesting
 @testable import MimiRemote
 
 extension XCTestCase {
@@ -960,6 +961,52 @@ func conversationTimelineIsStabilizing(in rootView: UIView) -> Bool {
         return false
     }
     return isViewEffectivelyVisible(marker, within: rootView)
+}
+
+@MainActor
+func assertStabilizedConversationSnapshot<Content: View>(
+    of view: Content,
+    size: CGSize,
+    precision: Float = 0.98,
+    named: String? = nil,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line
+) async throws {
+    let host = UIHostingController(rootView: view)
+    let windowScene = try XCTUnwrap(
+        UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+    )
+    let window = UIWindow(windowScene: windowScene)
+    window.frame = CGRect(origin: .zero, size: size)
+    window.rootViewController = host
+    window.makeKeyAndVisible()
+    defer { window.isHidden = true }
+
+    host.view.frame = window.bounds
+    host.view.setNeedsLayout()
+    host.view.layoutIfNeeded()
+    let presentationDeadline = Date().addingTimeInterval(8)
+    while conversationTimelineIsStabilizing(in: host.view),
+          Date() < presentationDeadline {
+        host.view.layoutIfNeeded()
+        try await Task.sleep(nanoseconds: 16_000_000)
+    }
+    XCTAssertFalse(
+        conversationTimelineIsStabilizing(in: host.view),
+        "会话快照必须等时间线完成首屏定位后再截图"
+    )
+
+    // 会话快照验证稳定后的内容与样式。先把真实 List 放进窗口并完成首屏定位，
+    // 避免离屏 SwiftUI 快照只截到稳定遮罩。
+    assertSnapshot(
+        of: host.view,
+        as: .image(precision: precision, size: size),
+        named: named,
+        file: file,
+        testName: testName,
+        line: line
+    )
 }
 
 @MainActor

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -2693,6 +2693,25 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(state.compactWorkspacePath, [.session("session-1")])
     }
 
+    func testWorkbenchSessionDetailWaitsForMatchingStoreSelection() {
+        for source in [WorkbenchRootPage.sessions, .workspaces] {
+            var state = WorkbenchNavigationState(route: source == .sessions ? .sessions : .workspaces)
+
+            _ = state.reduce(
+                .open(.session("session-target"), source: source),
+                usesCompactNavigation: true,
+                selectedSessionID: "session-previous"
+            )
+
+            XCTAssertFalse(
+                state.canPresentSessionDetail(selectedSessionID: "session-previous"),
+                "从 \(source) 进入详情后不得短暂展示上一个会话"
+            )
+            XCTAssertFalse(state.canPresentSessionDetail(selectedSessionID: nil))
+            XCTAssertTrue(state.canPresentSessionDetail(selectedSessionID: "session-target"))
+        }
+    }
+
     func testWorkbenchNavigationPushesSubagentWhileKeepingParentSelected() {
         var state = WorkbenchNavigationState(
             route: .session(id: "parent-thread", source: .sessions)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSnapshotTests.swift
@@ -874,29 +874,17 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
             .frame(width: 430, height: 900)
     }
 
-    func testConversationBubbleAlignment() {
-        assertSnapshot(
+    func testConversationBubbleAlignment() async throws {
+        try await assertStabilizedConversationSnapshot(
             of: makeSeededConversation(),
-            as: .wait(
-                for: 0.8,
-                on: .image(
-                    precision: 0.98,
-                    layout: .fixed(width: 1024, height: 768)
-                )
-            )
+            size: CGSize(width: 1024, height: 768)
         )
     }
 
-    func testDefaultDarkConversationPalette() {
-        assertSnapshot(
+    func testDefaultDarkConversationPalette() async throws {
+        try await assertStabilizedConversationSnapshot(
             of: makeSeededConversation(colorScheme: .dark),
-            as: .wait(
-                for: 0.8,
-                on: .image(
-                    precision: 0.98,
-                    layout: .fixed(width: 1024, height: 768)
-                )
-            )
+            size: CGSize(width: 1024, height: 768)
         )
     }
 
@@ -932,10 +920,10 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
         )
     }
 
-    func testRichMarkdownConversationRendering() {
-        assertSnapshot(
+    func testRichMarkdownConversationRendering() async throws {
+        try await assertStabilizedConversationSnapshot(
             of: makeRichMarkdownConversation(),
-            as: .image(precision: 0.98, layout: .fixed(width: 1024, height: 768))
+            size: CGSize(width: 1024, height: 768)
         )
     }
 
@@ -952,18 +940,12 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
         )
     }
 
-    func testMixedActivityAndImageConversationRendering() async {
+    func testMixedActivityAndImageConversationRendering() async throws {
         let view = await makeMixedActivityConversation()
 
-        assertSnapshot(
+        try await assertStabilizedConversationSnapshot(
             of: view,
-            as: .wait(
-                for: 0.8,
-                on: .image(
-                    precision: 0.98,
-                    layout: .fixed(width: 1024, height: 900)
-                )
-            )
+            size: CGSize(width: 1024, height: 900)
         )
     }
 
@@ -1021,10 +1003,10 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
         )
     }
 
-    func testUnavailableUserImageGalleryRemainsLegibleInLightTheme() {
-        assertSnapshot(
+    func testUnavailableUserImageGalleryRemainsLegibleInLightTheme() async throws {
+        try await assertStabilizedConversationSnapshot(
             of: makeUnavailableUserImageGallery(),
-            as: .image(precision: 0.98, layout: .fixed(width: 1024, height: 900))
+            size: CGSize(width: 1024, height: 900)
         )
     }
 
@@ -1049,10 +1031,10 @@ final class ConversationSnapshotTests: SimplifiedChineseSnapshotTestCase {
         )
     }
 
-    func testCommentaryAndTrailingProcessRendering() {
-        assertSnapshot(
+    func testCommentaryAndTrailingProcessRendering() async throws {
+        try await assertStabilizedConversationSnapshot(
             of: makeCommentaryAndTrailingProcessConversation(),
-            as: .image(precision: 0.98, layout: .fixed(width: 430, height: 900))
+            size: CGSize(width: 430, height: 900)
         )
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -3921,11 +3921,11 @@ extension ConversationDataFlowTests {
         await store.selectSession(updated)
         await client.waitForHistoryRequestCount(2)
 
-        // 后台补拉只显示时间线内轻量进度，不能把 savings 或失败横幅盖到已有会话上。
+        // 缓存已经形成可读首屏，后台补拉不能再插入会改变尾部布局的临时进度行。
         XCTAssertTrue(conversationStore.messages(for: history.id).contains { $0.content == "已缓存历史" })
-        XCTAssertNotNil(
+        XCTAssertNil(
             store.historyLoadProgress(sessionID: history.id),
-            "缓存消息可见时，签名变化触发的静默补拉仍需给出轻量进度"
+            "缓存消息可见时，静默补拉必须保持不可见"
         )
         XCTAssertNil(store.selectedHistorySavingsNotice)
         client.failHistoryRequest(at: 1, with: MockError.timeout)


### PR DESCRIPTION
## 变更

- 进入或切换会话时，在稳定遮罩内完成首屏尾部定位，避免正文来回跳动。
- 仅在尾部哨兵真实可见后展示正文，避免随机停在最老一条。
- 为每次进入会话生成新的展示身份，防止快速切换时复用上一会话的定位状态。
- 修正尾部目标 ID 的包装顺序，避免真机上遮罩无法解除。

## 验证

- `bash ./scripts/ios-dev.sh test` 的 3 项 MIM-188 针对性测试通过，0 失败。
- `bash ./scripts/check-source-size.sh` 通过。
- `git diff --check` 通过。
- 已构建、安装并启动到 wired iPad mini，用户实机确认通过。

Linear: https://linear.app/code89757/issue/MIM-188/进入会话详情会先闪动并多次跳转后才停在最新消息