### PR TITLE
MIM-190 统一主界面与设置页背景

### DIFF
--- a/ios/MimiRemote/Sources/Features/Diagnostics/DoctorView.swift
+++ b/ios/MimiRemote/Sources/Features/Diagnostics/DoctorView.swift
@@ -266,7 +266,7 @@ struct DoctorView: View {
             .frame(maxWidth: 760, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .top)
         }
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(L10n.text("ui.diagnosis"))
         .tint(tokens.accent)
         .task {

--- a/ios/MimiRemote/Sources/Features/Diagnostics/DoctorView.swift
+++ b/ios/MimiRemote/Sources/Features/Diagnostics/DoctorView.swift
@@ -266,7 +266,7 @@ struct DoctorView: View {
             .frame(maxWidth: 760, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .top)
         }
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(L10n.text("ui.diagnosis"))
         .tint(tokens.accent)
         .task {

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -527,7 +527,7 @@ struct SessionListView: View {
             text: $sessionStore.sessionSearchQuery,
             prompt: Text(L10n.text("ui.search_session")),
             tintColor: tokens.primaryText,
-            toolbarSurface: tokens.background,
+            toolbarSurface: tokens.workbenchCanvasBackground,
             colorScheme: colorScheme,
             onSubmit: dismissSessionSearchKeyboard
         )

--- a/ios/MimiRemote/Sources/Features/Settings/LegalDocumentView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/LegalDocumentView.swift
@@ -76,7 +76,7 @@ struct LegalDocumentView: View {
             .padding(.vertical, 16)
             .textSelection(.enabled)
         }
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(document.title)
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/LegalDocumentView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/LegalDocumentView.swift
@@ -76,7 +76,7 @@ struct LegalDocumentView: View {
             .padding(.vertical, 16)
             .textSelection(.enabled)
         }
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(document.title)
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsChoiceRow.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsChoiceRow.swift
@@ -224,7 +224,7 @@ struct SettingsOptionListView<Option: SettingsChoiceOption>: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -315,7 +315,7 @@ struct LanguageSettingsView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(L10n.text("ui.language"))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsChoiceRow.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsChoiceRow.swift
@@ -224,7 +224,7 @@ struct SettingsOptionListView<Option: SettingsChoiceOption>: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -315,7 +315,7 @@ struct LanguageSettingsView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(L10n.text("ui.language"))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
@@ -19,7 +19,7 @@ struct InitialPairingView: View {
         // 连接是短表单而不是数据表；宽窗口里限制行长，按钮和输入框不会被拉成整屏。
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
     }
 }
 private struct SettingsDashboardSection<Content: View>: View {

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
@@ -19,7 +19,7 @@ struct InitialPairingView: View {
         // 连接是短表单而不是数据表；宽窗口里限制行长，按钮和输入框不会被拉成整屏。
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
     }
 }
 private struct SettingsDashboardSection<Content: View>: View {

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
@@ -730,7 +730,7 @@ struct AppearanceView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(L10n.text("ui.personalization"))
         .preferredColorScheme(resolvedColorScheme)
         .environment(\.colorScheme, resolvedColorScheme)
@@ -1197,7 +1197,7 @@ struct DefaultModelSettingsView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(L10n.text("ui.default_model"))
         .navigationBarTitleDisplayMode(.inline)
         .tint(tokens.accent)
@@ -1527,6 +1527,6 @@ struct ExperimentalFeaturesSettingsView: View {
 extension View {
     func themedSettingsForm(tokens: ThemeTokens) -> some View {
         scrollContentBackground(.hidden)
-            .background(tokens.background.ignoresSafeArea())
+            .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
     }
 }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
@@ -730,7 +730,7 @@ struct AppearanceView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(L10n.text("ui.personalization"))
         .preferredColorScheme(resolvedColorScheme)
         .environment(\.colorScheme, resolvedColorScheme)
@@ -1197,7 +1197,7 @@ struct DefaultModelSettingsView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(L10n.text("ui.default_model"))
         .navigationBarTitleDisplayMode(.inline)
         .tint(tokens.accent)
@@ -1525,8 +1525,40 @@ struct ExperimentalFeaturesSettingsView: View {
 }
 
 extension View {
+    func settingsCanvasBackground(tokens: ThemeTokens) -> some View {
+        modifier(SettingsCanvasBackgroundModifier(tokens: tokens))
+    }
+
     func themedSettingsForm(tokens: ThemeTokens) -> some View {
         scrollContentBackground(.hidden)
-            .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+            .settingsCanvasBackground(tokens: tokens)
+    }
+}
+
+private struct SettingsCanvasBackgroundModifier: ViewModifier {
+    @Environment(\.settingsUsesWorkbenchCanvas) private var settingsUsesWorkbenchCanvas
+
+    let tokens: ThemeTokens
+
+    func body(content: Content) -> some View {
+        content.background(
+            (settingsUsesWorkbenchCanvas
+                ? tokens.workbenchCanvasBackground
+                : tokens.background
+            ).ignoresSafeArea()
+        )
+    }
+}
+
+/// 同一套设置详情既会从“我的”进入，也会在独立设置 sheet 内导航；
+/// 由入口传递画布类型，避免详情页自行猜测呈现方式。
+private struct SettingsUsesWorkbenchCanvasKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var settingsUsesWorkbenchCanvas: Bool {
+        get { self[SettingsUsesWorkbenchCanvasKey.self] }
+        set { self[SettingsUsesWorkbenchCanvasKey.self] = newValue }
     }
 }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -144,6 +144,9 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func settingsContent(tokens: ThemeTokens, resolvedColorScheme: ColorScheme) -> some View {
+        // 顶层“我的”与会话、工作区共用画布；独立设置 sheet 继续保留主题背景。
+        let canvasBackground = showsDoneButton ? tokens.background : tokens.workbenchCanvasBackground
+
         Group {
             if isInitialSetup {
                 InitialPairingView(
@@ -151,10 +154,10 @@ struct SettingsView: View {
                     onRequestProfileRename: { profileRenamePresentation.present($0) }
                 )
             } else {
-                settingsForm(tokens: tokens)
+                settingsForm(tokens: tokens, canvasBackground: canvasBackground)
                     .frame(maxWidth: 920)
                     .frame(maxWidth: .infinity)
-                    .background(tokens.background.ignoresSafeArea())
+                    .background(canvasBackground.ignoresSafeArea())
             }
         }
         // 首配流程需要标题说明「要做什么」；进到「我的」之后，Tab 标签已经写着「我的」，
@@ -214,7 +217,7 @@ struct SettingsView: View {
         )
     }
 
-    private func settingsForm(tokens: ThemeTokens) -> some View {
+    private func settingsForm(tokens: ThemeTokens, canvasBackground: Color) -> some View {
         let codexUsage = sessionStore.accountCodexUsageWindowsDisplay
         let claudeUsage = sessionStore.accountClaudeUsageWindowsDisplay
 
@@ -406,7 +409,8 @@ struct SettingsView: View {
         // 分组之间靠留白划分，行本身不再套在圆角白卡里。
         .listSectionSpacing(SettingsLayoutMetrics.sectionSpacing)
         .listRowBackground(Color.clear)
-        .themedSettingsForm(tokens: tokens)
+        .scrollContentBackground(.hidden)
+        .background(canvasBackground.ignoresSafeArea())
         // 紧凑 Tab 下允许内容经过玻璃栏，但最后一组必须能完整滚到栏上方。
         .contentMargins(
             .bottom,
@@ -644,7 +648,7 @@ private struct ConnectionManagementView: View {
         .themedSettingsForm(tokens: themeStore.tokens(for: colorScheme))
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(themeStore.tokens(for: colorScheme).background.ignoresSafeArea())
+        .background(themeStore.tokens(for: colorScheme).workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(L10n.text("ui.mac_connection"))
     }
 }
@@ -764,7 +768,7 @@ private struct ConnectionSpeedTestView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(L10n.text("ui.connection_speed_test"))
         .tint(tokens.accent)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -114,6 +114,7 @@ struct SettingsView: View {
                 settingsContent(tokens: tokens, resolvedColorScheme: resolvedColorScheme)
             }
         }
+        .environment(\.settingsUsesWorkbenchCanvas, !showsDoneButton)
         // 扫码 Cover 固定挂在 SettingsView 根层。首次系统相机权限弹窗会触发 Form
         // 重建，但不会再销毁负责呈现相机的宿主。
         .fullScreenCover(
@@ -648,7 +649,7 @@ private struct ConnectionManagementView: View {
         .themedSettingsForm(tokens: themeStore.tokens(for: colorScheme))
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(themeStore.tokens(for: colorScheme).workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: themeStore.tokens(for: colorScheme))
         .navigationTitle(L10n.text("ui.mac_connection"))
     }
 }
@@ -768,7 +769,7 @@ private struct ConnectionSpeedTestView: View {
         .themedSettingsForm(tokens: tokens)
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(L10n.text("ui.connection_speed_test"))
         .tint(tokens.accent)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/ThirdPartyNoticesView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ThirdPartyNoticesView.swift
@@ -58,7 +58,7 @@ struct ThirdPartyNoticesView: View {
             .padding(.vertical, 16)
             .textSelection(.enabled)
         }
-        .background(tokens.background.ignoresSafeArea())
+        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
         .navigationTitle(L10n.text("ui.open_source_license"))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ios/MimiRemote/Sources/Features/Settings/ThirdPartyNoticesView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ThirdPartyNoticesView.swift
@@ -58,7 +58,7 @@ struct ThirdPartyNoticesView: View {
             .padding(.vertical, 16)
             .textSelection(.enabled)
         }
-        .background(tokens.workbenchCanvasBackground.ignoresSafeArea())
+        .settingsCanvasBackground(tokens: tokens)
         .navigationTitle(L10n.text("ui.open_source_license"))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -557,12 +557,12 @@ struct WorkbenchNavigationState: Equatable {
 extension View {
     func themedWorkbenchNavigationChrome(tokens: ThemeTokens, colorScheme: ColorScheme) -> some View {
         // 会话工作台嵌在 NavigationSplitView 里，系统导航栏默认会透出平台背景。
-        // 这里统一让导航栏和状态栏区域吃主题色，避免 iPad 横屏顶部出现黑色断层。
+        // 这里统一让导航栏和状态栏区域吃工作台画布色，避免滚动边缘露出另一种色温。
         //
         // 但底色只在滚动到边缘时才该出现：强制 `.visible` 会钉死一条不透明实色条和一道发丝线，
         // 同时把顶栏按钮压成贴在实色上的图标。这里改为把主题色交给 scroll edge effect，
         // 让系统自己决定何时显形。
-        toolbarBackground(tokens.background, for: .navigationBar)
+        toolbarBackground(tokens.workbenchCanvasBackground, for: .navigationBar)
             .toolbarColorScheme(colorScheme, for: .navigationBar)
     }
 


### PR DESCRIPTION
## 变更
- 会话、工作区和“我的”主界面统一使用工作台画布背景
- “我的”下所有可达设置详情页统一使用相同画布背景
- 保留卡片、表单行和圆角内容块原有表面色

## 验证
- iPad mini 真机构建通过
- 已在 iPad mini 覆盖安装并完成视觉验收
- git diff --check 通过
- 本次修改的生产 Swift 文件均低于源码行数上限

Closes MIM-190