### PR TITLE
MIM-193 修复连接诊断布局并增加手动测试

### DIFF
--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -263,6 +263,31 @@ struct InitialConnectionSettingsSections: View {
                             .font(themeStore.uiFont(size: 13))
                     }
 
+                    if appStore.isConfigured {
+                        Button {
+                            Task {
+                                await appStore.testConnection(
+                                    endpoint: appStore.endpoint,
+                                    token: appStore.token
+                                )
+                            }
+                        } label: {
+                            HStack(spacing: 8) {
+                                if isConnectionTesting {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Image(systemName: "bolt.horizontal.circle")
+                                }
+                                Text(isConnectionTesting ? L10n.text("ui.under_test") : L10n.text("ui.test_connection"))
+                            }
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(isConnectionTesting)
+                        .accessibilityIdentifier("settings.connection.test")
+                    }
+
                     if connectionTestDurationText != nil || appStore.lastConnectionTestReport != nil {
                         DisclosureGroup(L10n.text("ui.connection_diagnostics")) {
                             if let connectionTestDurationText {
@@ -294,6 +319,8 @@ struct InitialConnectionSettingsSections: View {
                                 }
                             }
                         }
+                        // Form 可能向展开内容提案整屏高度；诊断行只应占实际内容高度，避免路径与慢速环节之间出现大片留白。
+                        .fixedSize(horizontal: false, vertical: true)
                     }
                 } header: {
                     Text(L10n.text("ui.status"))

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -635,6 +635,8 @@ struct SettingsValueLabel: View {
 
 private struct ConnectionManagementView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.workbenchBottomChromeClearance) private var bottomChromeClearance
+    @Environment(\.workbenchHasCompactTabBar) private var hasCompactTabBar
     @EnvironmentObject private var themeStore: ThemeStore
     @ObservedObject var qrScannerPresentation: ConnectionQRCodeScannerPresentation
     let onRequestProfileRename: (ConnectionProfile) -> Void
@@ -650,6 +652,12 @@ private struct ConnectionManagementView: View {
         .frame(maxWidth: 720)
         .frame(maxWidth: .infinity)
         .settingsCanvasBackground(tokens: themeStore.tokens(for: colorScheme))
+        // 详情页仍在紧凑 Tab Bar 下滚动；保留栏高，最后一行才能完整滚到浮层上方。
+        .contentMargins(
+            .bottom,
+            hasCompactTabBar ? bottomChromeClearance : WorkbenchPageLayout.regularPadding,
+            for: .scrollContent
+        )
         .navigationTitle(L10n.text("ui.mac_connection"))
     }
 }


### PR DESCRIPTION
## 变更

- 限制连接诊断展开区域按实际内容高度布局，消除异常空白
- 增加“测试连接”按钮，复用已保存连接信息与现有测试逻辑
- 测试期间显示进度并禁用重复触发
- 为紧凑 Tab Bar 补充底部滚动留白

## 验证

- bash ./scripts/ios-dev.sh build
- 3 项连接诊断定向测试通过
- bash ./scripts/check-source-size.sh
- git diff --check origin/main...HEAD

## 尚未验证

- 尚未在带真实连接诊断数据的 iPhone 状态下完成视觉复核；当前 Simulator 调试数据不生成诊断报告

Linear: MIM-193