### PR TITLE
MIM-97 修复 iPad 返回工作区时的纵向跳动

### DIFF
--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -255,7 +255,12 @@ struct UnifiedWorkbenchShell: View {
                     bottomContentMargin: bottomChromeClearance
                 )
                     .navigationDestination(for: AppDestination.self) { destination in
-                        compactDestination(destination, layout: layout, tokens: tokens)
+                        compactDestination(
+                            destination,
+                            layout: layout,
+                            tokens: tokens,
+                            hasBottomTabBar: hasBottomTabBar
+                        )
                     }
             }
             .tabItem {
@@ -267,7 +272,12 @@ struct UnifiedWorkbenchShell: View {
             NavigationStack(path: compactPathBinding(for: .workspaces, layout: layout)) {
                 workspaces(layout: layout)
                     .navigationDestination(for: AppDestination.self) { destination in
-                        compactDestination(destination, layout: layout, tokens: tokens)
+                        compactDestination(
+                            destination,
+                            layout: layout,
+                            tokens: tokens,
+                            hasBottomTabBar: hasBottomTabBar
+                        )
                     }
             }
             .tabItem {
@@ -1014,7 +1024,8 @@ struct UnifiedWorkbenchShell: View {
     private func compactDestination(
         _ destination: AppDestination,
         layout: WorkbenchLayout,
-        tokens: ThemeTokens
+        tokens: ThemeTokens,
+        hasBottomTabBar: Bool
     ) -> some View {
         switch destination {
         case .sessions:
@@ -1028,7 +1039,13 @@ struct UnifiedWorkbenchShell: View {
                 embedsNavigationStack: false
             )
         case .session:
-            sessionDetail(layout: layout, tokens: tokens)
+            sessionDetail(
+                layout: layout,
+                tokens: tokens,
+                shouldHideTabBar: WorkbenchPageLayout.shouldHideSessionDetailTabBar(
+                    hasBottomTabBar: hasBottomTabBar
+                )
+            )
         case .subagent(let parentID, let childID):
             if let relation = selectedRelatedSubagent,
                relation.id == childID,
@@ -1137,7 +1154,11 @@ struct UnifiedWorkbenchShell: View {
         )
     }
 
-    private func sessionDetail(layout: WorkbenchLayout, tokens: ThemeTokens) -> some View {
+    private func sessionDetail(
+        layout: WorkbenchLayout,
+        tokens: ThemeTokens,
+        shouldHideTabBar: Bool = true
+    ) -> some View {
         let detailSessionID = navigationState.route.detailSessionID
         let canPresentSessionDetail = navigationState.canPresentSessionDetail(
             selectedSessionID: sessionStore.selectedSessionID
@@ -1279,7 +1300,7 @@ struct UnifiedWorkbenchShell: View {
             }
         }
         .background(tokens.conversationCanvasBackground.ignoresSafeArea())
-        .toolbar(.hidden, for: .tabBar)
+        .toolbar(shouldHideTabBar ? .hidden : .visible, for: .tabBar)
         .modifier(
             SessionNavigationMaterialModifier(
                 usesCompactNavigation: layout.usesCompactNavigation,

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -1054,6 +1054,9 @@ struct UnifiedWorkbenchShell: View {
                     relation: relation,
                     parentSessionID: parentID,
                     showsCloseButton: false,
+                    shouldHideTabBar: WorkbenchPageLayout.shouldHideSessionDetailTabBar(
+                        hasBottomTabBar: hasBottomTabBar
+                    ),
                     onClose: {}
                 )
             } else {

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -1146,6 +1146,7 @@ struct RelatedSessionConversationView: View {
     let relation: SessionContextSubagent
     let parentSessionID: SessionID
     let showsCloseButton: Bool
+    var shouldHideTabBar = true
     let onClose: () -> Void
 
     @State private var isLoading = true
@@ -1216,7 +1217,7 @@ struct RelatedSessionConversationView: View {
         }
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .tabBar)
+        .toolbar(shouldHideTabBar ? .hidden : .visible, for: .tabBar)
         .accessibilityIdentifier("subagent.conversation.\(relation.id)")
         .task(id: relation.id) {
             isLoading = true

--- a/ios/MimiRemote/Sources/WorkbenchChrome.swift
+++ b/ios/MimiRemote/Sources/WorkbenchChrome.swift
@@ -1403,6 +1403,12 @@ enum WorkbenchPageLayout {
     ) -> Bool {
         isPhone || (isHorizontallyCompact && !isIOS26OrLater)
     }
+
+    static func shouldHideSessionDetailTabBar(hasBottomTabBar: Bool) -> Bool {
+        // iPadOS 26 的顶部 Tab 栏一旦在详情页隐藏，会改变返回目标的顶部布局基准；
+        // 只隐藏底部 Tab 栏，既保留正文空间，也让顶部 Tab 的返回路径保持同一锚点。
+        hasBottomTabBar
+    }
 }
 
 private struct WorkbenchBottomChromeClearanceKey: EnvironmentKey {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
@@ -47,7 +47,7 @@ final class WorkspaceStripPresentationTests: XCTestCase {
         )
     }
 
-    func testSessionDetailOnlyHidesBottomTabBar() {
+    func testSessionAndSubagentDetailsOnlyHideBottomTabBar() {
         XCTAssertTrue(
             WorkbenchPageLayout.shouldHideSessionDetailTabBar(hasBottomTabBar: true)
         )

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
@@ -47,6 +47,15 @@ final class WorkspaceStripPresentationTests: XCTestCase {
         )
     }
 
+    func testSessionDetailOnlyHidesBottomTabBar() {
+        XCTAssertTrue(
+            WorkbenchPageLayout.shouldHideSessionDetailTabBar(hasBottomTabBar: true)
+        )
+        XCTAssertFalse(
+            WorkbenchPageLayout.shouldHideSessionDetailTabBar(hasBottomTabBar: false)
+        )
+    }
+
     func testBottomTabBarAlwaysKeepsRuntimeMenuAndInlineNewSessionEntry() {
         XCTAssertFalse(
             WorkspaceStripLayout.usesInlineRuntimePicker(


### PR DESCRIPTION
## 目标

修复 iPadOS 26 从会话详情返回工作区时，顶部 Tab 恢复导致工作区内容整体向下跳动的问题。

## 实现

- 仅在存在底部 Tab 栏时隐藏会话详情页 Tab 栏。
- iPadOS 26 顶部 Tab 保持可见，确保详情页和返回目标使用同一纵向布局锚点。
- 增加布局规则单元测试，保留 iPhone 和旧版紧凑布局行为。

## 验证

- bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/WorkspaceStripPresentationTests：5 个测试通过，0 失败。
- git diff --check origin/main...HEAD：通过。
- 本次三个文件行数分别为 1954、1768、111，均在限制内。
- bash ./scripts/check-source-size.sh：未通过；阻断项来自本地 .claude/worktrees 中已有的超限文件，与本次提交无关。

## 运行态边界

固定 M5 模拟器为宽屏侧栏布局，不能覆盖截图中的紧凑顶部 Tab 返回动画。最终视觉效果仍需在对应紧凑 iPad 布局下确认。

Linear: MIM-97