### PR TITLE
MIM-179 修复 Claude runtime override 故障恢复

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -238,39 +238,7 @@ pub async fn handle_turn_start(
     let envelope = translate_user_input(&params.input)
         .map_err(|e| TurnError::InputTranslation(e.to_string()))?;
 
-    let handle = match state.claude_pool().get(&params.thread_id).await {
-        Some(handle) => handle,
-        None => {
-            let entry = state
-                .thread_index()
-                .lookup(&params.thread_id)
-                .await
-                .ok_or_else(|| TurnError::ThreadNotLoaded(params.thread_id.clone()))?;
-            let cwd =
-                resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
-            let defaults = state.defaults();
-            let model =
-                normalize_claude_model(params.model.clone().or_else(|| defaults.model.clone()));
-            // 本地可直接以 transcript 是否存在区分新线程和恢复线程。远程线程仍会在
-            // thread/start/resume 预启动；这里的 preview 判断只负责进程意外退出后的兜底。
-            let resume = if state.trust_persisted_cwd() {
-                !entry.preview.trim().is_empty() || !state.thread_log(&params.thread_id).is_empty()
-            } else {
-                entry.metadata.claude_session_path.is_file()
-            };
-            state
-                .claude_pool()
-                .acquire_for_thread(
-                    params.thread_id.clone(),
-                    &cwd,
-                    resume,
-                    model,
-                    defaults.system_prompt.clone(),
-                )
-                .await
-                .map_err(|err| TurnError::ClaudeRpc(format!("starting claude process: {err:#}")))?
-        }
-    };
+    let mut handle = acquire_turn_process(state, &params).await?;
 
     // 必须在 runtime overrides 之前拒绝重复 turn/start。否则一次陈旧的客户端
     // 发送会先改掉正在执行轮次的模型/权限，再以内部错误退出。
@@ -296,15 +264,55 @@ pub async fn handle_turn_start(
     let model_override = normalized_model_override.as_deref();
     let effort_override = params.effort.map(native_effort_level);
     let permission_mode = claude_permission_mode(&params);
-    if let Err(err) = handle
-        .apply_runtime_overrides(
-            model_override,
-            effort_override,
-            Some(permission_mode),
-            CONTROL_SET_TIMEOUT,
-        )
-        .await
-    {
+    // Start lifecycle observation before the first control write. A process
+    // can lose stdin during runtime overrides, before a turn exists.
+    let mut driver = ensure_event_driver(state, &params.thread_id, &handle);
+    let mut recovery_attempted = false;
+    loop {
+        let result = handle
+            .apply_runtime_overrides(
+                model_override,
+                effort_override,
+                Some(permission_mode),
+                CONTROL_SET_TIMEOUT,
+            )
+            .await;
+        let Err(err) = result else {
+            break;
+        };
+
+        if err.is_process_transport_failure() {
+            let will_retry = !recovery_attempted;
+            let generation = handle.generation().to_string();
+            let pid = handle.pid();
+            let failure_kind = err.failure_kind();
+            let runtime_field = err.runtime_field().unwrap_or("unknown");
+            let terminal = handle.has_exited();
+            let released = state
+                .claude_pool()
+                .release_if_same(&params.thread_id, &handle)
+                .await;
+            tracing::warn!(
+                thread_id = %params.thread_id,
+                %generation,
+                ?pid,
+                failure_kind,
+                runtime_field,
+                terminal,
+                released,
+                will_retry,
+                error = %err,
+                "claude runtime override transport failure"
+            );
+
+            if will_retry {
+                recovery_attempted = true;
+                handle = acquire_turn_process(state, &params).await?;
+                driver = ensure_event_driver(state, &params.thread_id, &handle);
+                continue;
+            }
+        }
+
         if let Some((model, message)) = explicit_model_rejection(&err) {
             tracing::warn!(
                 thread_id = %params.thread_id,
@@ -321,7 +329,6 @@ pub async fn handle_turn_start(
     }
 
     let turn_id = Uuid::now_v7().to_string();
-    let driver = ensure_event_driver(state, &params.thread_id, &handle);
     state.claude_pool().mark_active(&params.thread_id).await;
 
     let started_at = now_unix_secs();
@@ -419,6 +426,42 @@ pub async fn handle_turn_start(
     spawn_preview_backfill(state, &params.thread_id, &params.input);
 
     Ok(p::TurnStartResponse { turn })
+}
+
+async fn acquire_turn_process(
+    state: &Arc<ConnectionState>,
+    params: &p::TurnStartParams,
+) -> Result<Arc<ClaudeProcessHandle>, TurnError> {
+    if let Some(handle) = state.claude_pool().get(&params.thread_id).await {
+        return Ok(handle);
+    }
+
+    let entry = state
+        .thread_index()
+        .lookup(&params.thread_id)
+        .await
+        .ok_or_else(|| TurnError::ThreadNotLoaded(params.thread_id.clone()))?;
+    let cwd = resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
+    let defaults = state.defaults();
+    let model = normalize_claude_model(params.model.clone().or_else(|| defaults.model.clone()));
+    // 本地可直接以 transcript 是否存在区分新线程和恢复线程。远程线程仍会在
+    // thread/start/resume 预启动；这里的 preview 判断只负责进程意外退出后的兜底。
+    let resume = if state.trust_persisted_cwd() {
+        !entry.preview.trim().is_empty() || !state.thread_log(&params.thread_id).is_empty()
+    } else {
+        entry.metadata.claude_session_path.is_file()
+    };
+    state
+        .claude_pool()
+        .acquire_for_thread(
+            params.thread_id.clone(),
+            &cwd,
+            resume,
+            model,
+            defaults.system_prompt.clone(),
+        )
+        .await
+        .map_err(|err| TurnError::ClaudeRpc(format!("starting claude process: {err:#}")))
 }
 
 fn explicit_model_rejection(err: &ClaudeProcessError) -> Option<(String, String)> {

--- a/bridges/claude/crates/claude-bridge/src/pool/process.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/process.rs
@@ -131,6 +131,42 @@ pub enum ClaudeProcessError {
     Io(#[from] std::io::Error),
 }
 
+impl ClaudeProcessError {
+    /// Transport failures leave the child lifecycle or runtime state
+    /// uncertain. A turn that has not sent its user envelope yet may safely
+    /// replace the process and retry these failures once.
+    pub(crate) fn is_process_transport_failure(&self) -> bool {
+        match self {
+            Self::WriterClosed(_)
+            | Self::ControlTimeout { .. }
+            | Self::ControlCancelled { .. }
+            | Self::Io(_) => true,
+            Self::RuntimeOverride { source, .. } => source.is_process_transport_failure(),
+            Self::InitTimeout | Self::ControlError { .. } | Self::Json(_) => false,
+        }
+    }
+
+    pub(crate) fn failure_kind(&self) -> &'static str {
+        match self {
+            Self::InitTimeout => "init_timeout",
+            Self::WriterClosed(_) => "writer_closed",
+            Self::ControlTimeout { .. } => "control_timeout",
+            Self::ControlCancelled { .. } => "control_cancelled",
+            Self::ControlError { .. } => "control_error",
+            Self::RuntimeOverride { source, .. } => source.failure_kind(),
+            Self::Json(_) => "json",
+            Self::Io(_) => "io",
+        }
+    }
+
+    pub(crate) fn runtime_field(&self) -> Option<&'static str> {
+        match self {
+            Self::RuntimeOverride { field, .. } => Some(*field),
+            _ => None,
+        }
+    }
+}
+
 // Claude Code versions have used both `subtype:"error"` and a nominally
 // successful control response carrying `{accepted:false}` for rejected
 // setters. Normalize the latter so callers never treat a refused model as
@@ -161,6 +197,9 @@ pub struct ClaudeProcessHandle {
     cwd: PathBuf,
     claude_bin: PathBuf,
     thread_id: String,
+    /// Stable identity for this process instance. A thread can own several
+    /// generations over its lifetime after crash recovery.
+    generation: String,
     pid: Option<u32>,
     /// Sender end of the writer mpsc — closing this is the signal to the
     /// writer task to drop claude's stdin (which makes claude exit cleanly).
@@ -354,6 +393,7 @@ impl ClaudeProcessHandle {
             .take_stderr()
             .ok_or_else(|| anyhow!("claude child has no stderr pipe"))?;
 
+        let generation = Uuid::now_v7().to_string();
         let (writer_tx, writer_rx) = mpsc::unbounded_channel::<String>();
         let (events_tx, _events_rx) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         let (exit_tx, _exit_rx) = watch::channel(false);
@@ -371,7 +411,15 @@ impl ClaudeProcessHandle {
             permission_mode: None,
         }));
 
-        let writer = tokio::spawn(writer_task(stdin, writer_rx));
+        let writer = tokio::spawn(writer_task(
+            stdin,
+            writer_rx,
+            pending_controls.clone(),
+            exit_tx.clone(),
+            thread_id.clone(),
+            generation.clone(),
+            pid,
+        ));
         let reader = tokio::spawn(reader_task(
             stdout,
             init_slot.clone(),
@@ -392,6 +440,7 @@ impl ClaudeProcessHandle {
             cwd,
             claude_bin,
             thread_id,
+            generation,
             pid,
             writer_tx,
             events_tx,
@@ -419,6 +468,11 @@ impl ClaudeProcessHandle {
         &self.thread_id
     }
 
+    /// Stable identity for this child-process generation.
+    pub fn generation(&self) -> &str {
+        &self.generation
+    }
+
     /// OS process id (when the spawn surfaced one).
     pub fn pid(&self) -> Option<u32> {
         self.pid
@@ -438,7 +492,7 @@ impl ClaudeProcessHandle {
         self.exit_tx.subscribe()
     }
 
-    /// Whether stdout has closed and the child can no longer serve requests.
+    /// Whether this child generation can no longer serve requests.
     ///
     /// `watch` keeps the terminal value, so callers can reject a dead pooled
     /// handle even when the event driver has not finished its cleanup yet.
@@ -485,6 +539,11 @@ impl ClaudeProcessHandle {
     /// by `turn::handle_turn_start` / `turn/steer` to push a user envelope.
     /// Lines do not include the trailing newline — the writer task adds it.
     pub fn send_line(&self, line: String) -> Result<(), ClaudeProcessError> {
+        if self.has_exited() {
+            return Err(ClaudeProcessError::WriterClosed(
+                "claude process generation is terminal".to_string(),
+            ));
+        }
         self.writer_tx
             .send(line)
             .map_err(|e| ClaudeProcessError::WriterClosed(e.to_string()))
@@ -524,6 +583,14 @@ impl ClaudeProcessHandle {
         let (tx, rx) = oneshot::channel();
         {
             let mut pending = self.pending_controls.lock().await;
+            // Serialize registration with terminal cleanup. Otherwise a
+            // waiter can be inserted just after cleanup and hang until its
+            // full deadline on a generation that is already dead.
+            if *self.exit_tx.borrow() {
+                return Err(ClaudeProcessError::WriterClosed(
+                    "claude process generation is terminal".to_string(),
+                ));
+            }
             pending.insert(request_id.clone(), tx);
         }
         let envelope = ClaudeInbound::ControlRequest(ControlRequestEnvelope {
@@ -534,6 +601,8 @@ impl ClaudeProcessHandle {
             // Pull the slot back so we don't leak a sender.
             let mut pending = self.pending_controls.lock().await;
             pending.remove(&request_id);
+            drop(pending);
+            mark_process_terminal(&self.pending_controls, &self.exit_tx).await;
             return Err(err);
         }
         match timeout(deadline, rx).await {
@@ -552,11 +621,15 @@ impl ClaudeProcessHandle {
                     message: error,
                 }),
             },
-            Ok(Err(_)) => Err(ClaudeProcessError::ControlCancelled { request_id }),
+            Ok(Err(_)) => {
+                mark_process_terminal(&self.pending_controls, &self.exit_tx).await;
+                Err(ClaudeProcessError::ControlCancelled { request_id })
+            }
             Err(_) => {
-                // Reclaim the slot so a late response doesn't sit in the map.
-                let mut pending = self.pending_controls.lock().await;
-                pending.remove(&request_id);
+                // A timed-out setter leaves both the child lifecycle and its
+                // runtime state uncertain. Retire the whole generation so a
+                // late response cannot make later turns reuse poisoned state.
+                mark_process_terminal(&self.pending_controls, &self.exit_tx).await;
                 Err(ClaudeProcessError::ControlTimeout {
                     request_id,
                     elapsed: deadline,
@@ -687,9 +760,13 @@ impl ClaudeProcessHandle {
     /// Close stdin to signal a clean shutdown, then wait for claude to exit
     /// and reap the child. Idempotent.
     pub async fn shutdown(&self) {
+        // A generation already marked terminal reached shutdown through a
+        // failure path. Keep its eventual exit status visible at the default
+        // production log level; routine eviction remains debug-only.
+        let was_terminal = self.has_exited();
         // 先通知 driver，保证显式 interrupt/release 即使随后 abort reader，
         // 也会把当前 turn 收敛为 Failed，而不是永久停在 InProgress。
-        let _ = self.exit_tx.send(true);
+        mark_process_terminal(&self.pending_controls, &self.exit_tx).await;
         // Aborting the writer task drops its `ChildStdin`, which closes
         // claude's stdin pipe and causes a clean exit.
         if let Some(handle) = self._tasks.writer.lock().await.take() {
@@ -701,8 +778,35 @@ impl ClaudeProcessHandle {
         if let Some(mut child) = self._tasks.child.lock().await.take() {
             // kill is a no-op if the child has already exited via stdin EOF.
             // We still call it as a safety net for stuck children.
-            let _ = child.kill().await;
-            let _ = child.wait().await;
+            let kill_error = child.kill().await.err();
+            match child.wait().await {
+                Ok(status) if was_terminal => tracing::warn!(
+                    thread_id = %self.thread_id,
+                    generation = %self.generation,
+                    pid = ?self.pid,
+                    exit_code = ?status.code(),
+                    exit_status = %status,
+                    ?kill_error,
+                    "reaped terminal claude process generation"
+                ),
+                Ok(status) => tracing::debug!(
+                    thread_id = %self.thread_id,
+                    generation = %self.generation,
+                    pid = ?self.pid,
+                    exit_code = ?status.code(),
+                    exit_status = %status,
+                    ?kill_error,
+                    "reaped claude process generation"
+                ),
+                Err(wait_error) => tracing::warn!(
+                    thread_id = %self.thread_id,
+                    generation = %self.generation,
+                    pid = ?self.pid,
+                    ?kill_error,
+                    ?wait_error,
+                    "failed to reap claude process generation"
+                ),
+            }
         }
         if let Some(handle) = self._tasks.reader.lock().await.take() {
             handle.abort();
@@ -799,18 +903,64 @@ impl alleycat_bridge_core::pool::PoolMember for ClaudeProcessHandle {
     }
 }
 
-async fn writer_task(mut stdin: ChildStdin, mut rx: mpsc::UnboundedReceiver<String>) {
+async fn mark_process_terminal(
+    pending_controls: &Arc<Mutex<HashMap<String, oneshot::Sender<ControlResponseBody>>>>,
+    exit_tx: &watch::Sender<bool>,
+) -> usize {
+    // Keep the terminal transition and waiter cleanup in one critical
+    // section. request_control checks the watch value while holding this same
+    // lock, so it cannot insert a waiter after cleanup.
+    let mut pending = pending_controls.lock().await;
+    exit_tx.send_replace(true);
+    let cancelled = pending.len();
+    pending.clear();
+    cancelled
+}
+
+async fn writer_task(
+    mut stdin: ChildStdin,
+    mut rx: mpsc::UnboundedReceiver<String>,
+    pending_controls: Arc<Mutex<HashMap<String, oneshot::Sender<ControlResponseBody>>>>,
+    exit_tx: watch::Sender<bool>,
+    thread_id: String,
+    generation: String,
+    pid: Option<u32>,
+) {
+    let mut terminal_reason = "writer_channel_closed";
     while let Some(mut line) = rx.recv().await {
         line.push('\n');
         if let Err(err) = stdin.write_all(line.as_bytes()).await {
-            tracing::warn!(?err, "claude writer task: stdin write failed; exiting");
+            terminal_reason = "stdin_write_failed";
+            tracing::warn!(
+                %thread_id,
+                %generation,
+                ?pid,
+                ?err,
+                "claude writer task: stdin write failed; retiring generation"
+            );
             break;
         }
         if let Err(err) = stdin.flush().await {
-            tracing::warn!(?err, "claude writer task: stdin flush failed; exiting");
+            terminal_reason = "stdin_flush_failed";
+            tracing::warn!(
+                %thread_id,
+                %generation,
+                ?pid,
+                ?err,
+                "claude writer task: stdin flush failed; retiring generation"
+            );
             break;
         }
     }
+    let cancelled_controls = mark_process_terminal(&pending_controls, &exit_tx).await;
+    tracing::debug!(
+        %thread_id,
+        %generation,
+        ?pid,
+        terminal_reason,
+        cancelled_controls,
+        "claude writer task entered terminal state"
+    );
     // Dropping `stdin` here closes claude's input pipe, prompting it to exit.
 }
 
@@ -885,10 +1035,7 @@ async fn reader_task(
     }
     // Process exit drains every waiter so they error with ControlCancelled
     // instead of hanging on the deadline.
-    let mut pending = pending_controls.lock().await;
-    pending.clear();
-    drop(pending);
-    let _ = exit_tx.send(true);
+    mark_process_terminal(&pending_controls, &exit_tx).await;
 }
 
 async fn stderr_task(stderr: ChildStderr, pid: Option<u32>) {
@@ -919,6 +1066,7 @@ impl ClaudeProcessHandle {
             cwd,
             claude_bin: PathBuf::from("/dev/null"),
             thread_id: "test-thread".into(),
+            generation: "test-generation".into(),
             pid: None,
             writer_tx,
             events_tx,
@@ -1023,6 +1171,9 @@ mod tests {
         let handle =
             ClaudeProcessHandle::__test_dangling(writer_tx, events_tx, PathBuf::from("/tmp"));
         let mut exit_rx = handle.subscribe_exit();
+        let pending = handle.pending_controls_handle();
+        let (waiter_tx, waiter_rx) = oneshot::channel();
+        pending.lock().await.insert("pending".into(), waiter_tx);
 
         handle.shutdown().await;
         exit_rx
@@ -1030,6 +1181,42 @@ mod tests {
             .await
             .expect("exit signal sender remains live");
         assert!(*exit_rx.borrow());
+        assert!(pending.lock().await.is_empty());
+        assert!(waiter_rx.await.is_err(), "shutdown must cancel waiters");
+    }
+
+    #[tokio::test]
+    async fn writer_pipe_failure_marks_generation_terminal_and_cancels_waiters() {
+        let (stdin, peer) = tokio::io::duplex(64);
+        drop(peer);
+        let (writer_tx, writer_rx) = mpsc::unbounded_channel::<String>();
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let (waiter_tx, waiter_rx) = oneshot::channel();
+        pending.lock().await.insert("pending".into(), waiter_tx);
+        let (exit_tx, mut exit_rx) = watch::channel(false);
+
+        let writer = tokio::spawn(writer_task(
+            Box::new(stdin),
+            writer_rx,
+            pending.clone(),
+            exit_tx,
+            "thread-broken-pipe".into(),
+            "generation-1".into(),
+            Some(42),
+        ));
+        writer_tx.send("queued-control".into()).unwrap();
+
+        timeout(Duration::from_secs(1), exit_rx.changed())
+            .await
+            .expect("writer must signal terminal without waiting for control deadline")
+            .expect("exit sender remains live");
+        assert!(*exit_rx.borrow());
+        assert!(pending.lock().await.is_empty());
+        assert!(
+            waiter_rx.await.is_err(),
+            "writer failure must cancel waiters"
+        );
+        writer.await.expect("writer task");
     }
 
     #[tokio::test]
@@ -1186,9 +1373,15 @@ mod tests {
         let _ = writer_rx.recv().await.unwrap();
         let err = task.await.expect("join").expect_err("timeout expected");
         assert!(matches!(err, ClaudeProcessError::ControlTimeout { .. }));
-        // Slot must be reclaimed so a stray late response doesn't sit in the
-        // map.
+        // A timed-out generation must not accept another control request.
+        assert!(handle.has_exited());
         assert!(pending.lock().await.is_empty());
+        let retry = handle
+            .request_control(ControlRequestBody::Interrupt, Duration::from_secs(1))
+            .await
+            .expect_err("terminal generation must reject a new request");
+        assert!(matches!(retry, ClaudeProcessError::WriterClosed(_)));
+        assert!(writer_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/bridges/claude/crates/claude-bridge/tests/runtime_override_recovery.rs
+++ b/bridges/claude/crates/claude-bridge/tests/runtime_override_recovery.rs
@@ -1,0 +1,190 @@
+//! 回归：turn/start 在发送用户输入前遇到 runtime control 进程退出时，
+//! bridge 只冷启动重试一次，并且用户输入只能发送给健康 generation 一次。
+
+mod support;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alleycat_bridge_core::framing::write_json_line;
+use alleycat_claude_bridge::index::ThreadIndex;
+use alleycat_claude_bridge::pool::ClaudePool;
+use alleycat_claude_bridge::run_connection;
+use alleycat_claude_bridge::state::ThreadIndexHandle;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
+use tokio::time::timeout;
+
+use support::fake_claude_path;
+
+const STEP_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[tokio::test]
+async fn pre_turn_control_exit_cold_recovers_without_duplicate_user_envelope() {
+    let fixture = TempDir::new().expect("fixture");
+    let cwd = TempDir::new().expect("cwd");
+    let marker = fixture.path().join("first-control-exited");
+    let turn_log = fixture.path().join("turns.log");
+    let _restore_marker = EnvRestore::set("FAKE_CLAUDE_EXIT_ON_CONTROL_ONCE", &marker);
+    let _restore_turn_log = EnvRestore::set("FAKE_CLAUDE_TURN_LOG", &turn_log);
+
+    let claude_pool = Arc::new(ClaudePool::new(fake_claude_path()));
+    let codex_home = TempDir::new().expect("codex home");
+    let thread_index: Arc<dyn ThreadIndexHandle> = ThreadIndex::open_and_hydrate(codex_home.path())
+        .await
+        .expect("thread index");
+    let (client_io, bridge_io) = tokio::io::duplex(64 * 1024);
+    let (bridge_reader, bridge_writer) = tokio::io::split(bridge_io);
+    let bridge_pool = Arc::clone(&claude_pool);
+    let codex_home_path = codex_home.path().to_path_buf();
+    let bridge_task = tokio::spawn(async move {
+        run_connection(
+            bridge_reader,
+            bridge_writer,
+            bridge_pool,
+            thread_index,
+            codex_home_path,
+        )
+        .await
+    });
+
+    let (client_reader, mut client_writer) = tokio::io::split(client_io);
+    let mut client_reader = BufReader::new(client_reader);
+    send(
+        &mut client_writer,
+        1,
+        "initialize",
+        json!({"clientInfo": {"name": "runtime-recovery", "version": "0.0.1"}}),
+    )
+    .await;
+    let _ = await_response(&mut client_reader, 1).await;
+
+    send(
+        &mut client_writer,
+        2,
+        "thread/start",
+        json!({"cwd": cwd.path().to_string_lossy()}),
+    )
+    .await;
+    let started = await_response(&mut client_reader, 2).await;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .expect("thread id")
+        .to_string();
+
+    send(
+        &mut client_writer,
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [{"type": "text", "text": "recover exactly once"}],
+            "effort": "high"
+        }),
+    )
+    .await;
+    let messages = collect_turn(&mut client_reader, 3).await;
+    let response = messages
+        .iter()
+        .find(|message| message["id"].as_u64() == Some(3))
+        .expect("turn/start response");
+    assert!(
+        response.get("error").is_none(),
+        "unexpected error: {response:#?}"
+    );
+    let completed = messages
+        .iter()
+        .find(|message| message["method"] == "turn/completed")
+        .expect("turn/completed");
+    assert_eq!(completed["params"]["turn"]["status"], "completed");
+    assert!(
+        marker.is_file(),
+        "first generation must fail during control"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&turn_log).expect("turn log"),
+        "recover exactly once\n",
+        "the user envelope must not be replayed"
+    );
+    assert_eq!(claude_pool.len().await, 1);
+
+    drop(client_writer);
+    drop(client_reader);
+    let _ = timeout(STEP_TIMEOUT, bridge_task).await;
+}
+
+async fn send<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    id: u64,
+    method: &str,
+    params: Value,
+) {
+    write_json_line(
+        writer,
+        &json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}),
+    )
+    .await
+    .expect("write request");
+}
+
+async fn collect_turn<R: AsyncBufRead + Unpin>(reader: &mut R, response_id: u64) -> Vec<Value> {
+    let mut messages = Vec::new();
+    let mut saw_response = false;
+    let mut saw_completed = false;
+    for _ in 0..200 {
+        let message = next_message(reader).await;
+        saw_response |= message["id"].as_u64() == Some(response_id);
+        saw_completed |= message["method"] == "turn/completed";
+        messages.push(message);
+        if saw_response && saw_completed {
+            return messages;
+        }
+    }
+    panic!("turn {response_id} did not complete: {messages:#?}");
+}
+
+async fn await_response<R: AsyncBufRead + Unpin>(reader: &mut R, response_id: u64) -> Value {
+    loop {
+        let message = next_message(reader).await;
+        if message["id"].as_u64() == Some(response_id) {
+            return message;
+        }
+    }
+}
+
+async fn next_message<R: AsyncBufRead + Unpin>(reader: &mut R) -> Value {
+    let mut line = String::new();
+    let count = timeout(STEP_TIMEOUT, reader.read_line(&mut line))
+        .await
+        .expect("bridge response timeout")
+        .expect("read bridge response");
+    assert!(count > 0, "bridge closed before the expected frame");
+    serde_json::from_str(line.trim()).expect("valid bridge JSON")
+}
+
+struct EnvRestore {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvRestore {
+    fn set(key: &'static str, value: &std::path::Path) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}

--- a/bridges/claude/crates/claude-bridge/tests/support/fake_claude.rs
+++ b/bridges/claude/crates/claude-bridge/tests/support/fake_claude.rs
@@ -29,6 +29,9 @@
 //! - `FAKE_CLAUDE_INIT_DELAY_MS`: optional delay before emitting the
 //!   `system/init`. Defaults to 0. Used by tests that need to exercise
 //!   `wait_for_init` slow paths.
+//! - `FAKE_CLAUDE_EXIT_ON_CONTROL_ONCE`: optional marker path. The first fake
+//!   generation atomically creates the marker and exits after receiving a
+//!   control request but before replying. Later generations reply normally.
 //! - A script line `{"type":"exit_once","marker":"/tmp/path"}` atomically
 //!   creates `marker` and exits the first fake process that reaches it.
 //!   Later processes skip the directive. This models one crashed Claude
@@ -123,6 +126,9 @@ fn main() -> ExitCode {
         };
 
         if inbound.get("type").and_then(Value::as_str) == Some("control_request") {
+            if exit_on_control_once() {
+                return ExitCode::from(24);
+            }
             let request_id = inbound
                 .get("request_id")
                 .and_then(Value::as_str)
@@ -297,18 +303,27 @@ fn run_script<W: Write>(out: &mut W, steps: &[ScriptStep], session_id: &str, tur
             }
             ScriptStep::Sleep(d) => thread::sleep(*d),
             ScriptStep::ExitOnce(marker) => {
-                if fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(marker)
-                    .is_ok()
-                {
+                if create_marker_once(marker) {
                     return true;
                 }
             }
         }
     }
     false
+}
+
+fn exit_on_control_once() -> bool {
+    env::var_os("FAKE_CLAUDE_EXIT_ON_CONTROL_ONCE")
+        .filter(|path| !path.is_empty())
+        .is_some_and(|path| create_marker_once(std::path::Path::new(&path)))
+}
+
+fn create_marker_once(path: &std::path::Path) -> bool {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .is_ok()
 }
 
 fn substitute_session(value: &mut Value, session_id: &str) {


### PR DESCRIPTION
## 修复内容

- Windows 下 Claude 子进程 stdin 出现 BrokenPipe、控制请求超时或取消后，立即把该 generation 标记为终态并清理所有等待中的控制请求，防止进程池继续复用失效句柄。
- runtime override 在用户消息写入前遇到传输故障时，按 generation 精确释放旧进程、冷启动并只重试一次；不会重复发送用户消息，也不会重试 Claude 明确返回的配置拒绝。
- 增加 generation、PID、失败类型、runtime 字段和退出码诊断。
- 增加 BrokenPipe、控制超时和首代进程退出后自动恢复的回归测试。

## 验证

- `cargo fmt --all -- --check`：通过。
- `cargo +stable-x86_64-pc-windows-gnullvm test --target-dir C:\Users\gaixg\code\codex-ipad-agent\target\mim179-gnullvm -p alleycat-claude-bridge`：完整套件首次通过；日志级别调整后的第二次全量运行仅命中既有 `active_turn_conflict` 时序波动，隔离重跑通过。
- `cargo +stable-x86_64-pc-windows-gnullvm test --target-dir C:\Users\gaixg\code\codex-ipad-agent\target\mim179-gnullvm -p alleycat-claude-bridge --test runtime_override_recovery`：通过。
- `bash ./scripts/check-source-size.sh`：通过。
- Windows 真实会话：Claude Code 2.1.240，Sonnet + `high`，会话完成并返回 `MIM179_OK`。

## 未验证范围

- 当前 Windows 环境没有 Go 工具链，未运行 `go test ./internal/claudebridge ./internal/httpapi ./cmd/agentd`；本 PR 未修改 Go 文件。

Linear: MIM-179
