### PR TITLE
MIM-189 修复会话观察误判与权限切换路由

### DIFF
--- a/contracts/mimi-protocol/contract.json
+++ b/contracts/mimi-protocol/contract.json
@@ -13,6 +13,7 @@
     "minimum_client_revision": "X-Mimi-Minimum-Client-Protocol-Revision"
   },
   "capabilities": [
+    "codex_remote_full_access_v1",
     "file_upload_v1"
   ]
 }

--- a/contracts/mimi-protocol/fixtures/version-current.json
+++ b/contracts/mimi-protocol/fixtures/version-current.json
@@ -6,11 +6,17 @@
   "protocol_revision": 2,
   "minimum_client_protocol_revision": 1,
   "capabilities": [
-    "file_upload_v1"
+    "file_upload_v1",
+    "codex_remote_full_access_v1"
   ],
   "capability_statuses": [
     {
       "name": "file_upload_v1",
+      "state": "enabled",
+      "reason": "available"
+    },
+    {
+      "name": "codex_remote_full_access_v1",
       "state": "enabled",
       "reason": "available"
     }

--- a/internal/codexhistory/external_activity.go
+++ b/internal/codexhistory/external_activity.go
@@ -20,18 +20,20 @@ import (
 const (
 	externalActivityCandidateLimit = 500
 	maxExternalActivityLineBytes   = 1 << 20
-	// Gateway 登记只需要覆盖 turn/start 到 rollout 写入用户消息证据的短窗口。
-	// 有界 TTL 可以避免断线或 upstream 写失败后留下永久“本机发起”证据。
-	gatewayTurnRegistrationTTL   = 2 * time.Minute
-	gatewayTurnRegistrationLimit = 512
-	gatewayTurnRegistrationIDMax = 256
-	gatewayTurnEventClockSkew    = 2 * time.Second
+	// Gateway 证据只允许匹配 turn/start 后短时间内写入的 rollout 用户消息。
+	// 登记本身需要保留更久，因为 iOS 退到后台后可能数分钟不再轮询；恢复时仍应
+	// 根据 rollout 的事件时间认回本机 Turn，而不是根据扫描发生的墙上时间误判为外部活动。
+	gatewayTurnEvidenceTTL           = 2 * time.Minute
+	gatewayTurnRegistrationRetention = gatewayOwnedTurnClaimTTL
+	gatewayTurnRegistrationLimit     = 512
+	gatewayTurnRegistrationIDMax     = 256
+	gatewayTurnEventClockSkew        = 2 * time.Second
 	// gateway 在写入 upstream 前登记；task_started 应很快出现。真实 app-server
 	// 冷启动时 user_message 可能比 task_started 晚十几秒落盘，因此不能再用
 	// 两个 rollout 事件的短间隔判断归属。改为要求 task_started 靠近登记时刻，
-	// 同时保留精确 Thread+client ID 和 2 分钟总 TTL。
+	// 同时保留精确 Thread+client ID 和 2 分钟事件关联窗口。
 	gatewayTurnStartWindow     = 30 * time.Second
-	gatewayTurnLifecycleWindow = gatewayTurnRegistrationTTL
+	gatewayTurnLifecycleWindow = gatewayTurnEvidenceTTL
 )
 
 // ExternalActivity 是允许返回给移动端的最小只读快照。
@@ -684,7 +686,7 @@ func (t *ExternalActivityTracker) consumeGatewayTurnRegistration(
 	if eventAt.Before(registration.registeredAt.Add(-gatewayTurnEventClockSkew)) {
 		return gatewayTurnEvidence{}, false
 	}
-	if eventAt.After(registration.registeredAt.Add(gatewayTurnRegistrationTTL)) {
+	if eventAt.After(registration.registeredAt.Add(gatewayTurnEvidenceTTL)) {
 		return gatewayTurnEvidence{}, false
 	}
 	return gatewayTurnEvidence{
@@ -718,7 +720,7 @@ func gatewayTurnEvidenceMatchesTaskStart(evidence gatewayTurnEvidence, turnStart
 
 func (t *ExternalActivityTracker) pruneGatewayTurnRegistrations(now time.Time) {
 	for key, registration := range t.gatewayTurns {
-		if now.After(registration.registeredAt.Add(gatewayTurnRegistrationTTL)) {
+		if now.After(registration.registeredAt.Add(gatewayTurnRegistrationRetention)) {
 			delete(t.gatewayTurns, key)
 			t.gatewayClaimsDirty = true
 		}

--- a/internal/codexhistory/external_activity_test.go
+++ b/internal/codexhistory/external_activity_test.go
@@ -331,6 +331,46 @@ func TestExternalActivityDelayedUserMessageAfterTaskStartedStillClaimsGatewayTur
 	}
 }
 
+func TestExternalActivityDelayedScanStillClaimsGatewayTurn(t *testing.T) {
+	fixture := newExternalActivityTrackerFixture(t)
+	registeredAt := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	now := registeredAt
+	fixture.tracker.now = func() time.Time { return now }
+	fixture.tracker.RegisterGatewayTurnStart("thread-ipad", "client-ipad")
+	path := fixture.writeRollout(
+		"thread-ipad",
+		"Codex Desktop",
+		fixture.projectDir,
+		externalEventLineAt(registeredAt.Add(time.Second), "task_started", "turn-ipad"),
+	)
+	fixture.rows = []externalActivityTestRow{{
+		ID: "thread-ipad", CWD: fixture.projectDir, Source: "vscode",
+		ThreadSource: "user", RolloutPath: path,
+	}}
+
+	now = registeredAt.Add(5 * time.Second)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.snapshot(t); len(got) != 1 || got[0].TurnID != "turn-ipad" {
+		t.Fatalf("client_id 证据尚未落盘时必须暂时保持 external：%+v", got)
+	}
+
+	// 模拟 App 退到后台：有效 client_id 很快落盘，但三分钟后才再次扫描。
+	fixture.appendLine(path, externalUserMessageLine(registeredAt.Add(6*time.Second), "client-ipad"))
+	now = registeredAt.Add(gatewayTurnEvidenceTTL + time.Minute)
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.snapshot(t); len(got) != 0 {
+		t.Fatalf("延迟扫描仍应按 rollout 事件时间认回 gateway turn：%+v", got)
+	}
+	entry := fixture.tracker.files[path]
+	if !entry.active || !entry.gatewayOwned || entry.turnID != "turn-ipad" {
+		t.Fatalf("延迟扫描应建立精确 gateway 归属：%+v", entry)
+	}
+}
+
 func TestExternalActivityExactMessageCannotClaimTurnStartedOutsideGatewayWindow(t *testing.T) {
 	fixture := newExternalActivityTrackerFixture(t)
 	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
@@ -710,7 +750,7 @@ func TestExternalActivityExpiredPendingEvidenceCannotHideLaterDesktopTurn(t *tes
 		t.Fatal("超过生命周期关联窗口后，pending gateway 证据必须主动失效")
 	}
 
-	now = now.Add(gatewayTurnRegistrationTTL + time.Second)
+	now = now.Add(gatewayTurnEvidenceTTL + time.Second)
 	fixture.appendLine(path, externalEventLineAt(now, "task_started", "turn-desktop"))
 	if err := os.Chtimes(path, now, now); err != nil {
 		t.Fatal(err)
@@ -782,7 +822,7 @@ func TestExternalActivityGatewayOwnershipRequiresExactEvidence(t *testing.T) {
 			registeredThread: "thread-1",
 			registeredClient: "client-ipad",
 			eventClient:      "client-ipad",
-			eventAt:          now.Add(-gatewayTurnRegistrationTTL),
+			eventAt:          now.Add(-gatewayTurnEvidenceTTL),
 		},
 		{
 			name:             "missing client id",
@@ -1172,7 +1212,7 @@ func TestGatewayTurnRegistrationsAreBoundedAndExpire(t *testing.T) {
 		t.Fatalf("gateway 登记表必须有容量上限：got=%d want=%d", got, gatewayTurnRegistrationLimit)
 	}
 
-	now = now.Add(gatewayTurnRegistrationTTL + time.Second)
+	now = now.Add(gatewayTurnRegistrationRetention + time.Second)
 	fixture.tracker.RegisterGatewayTurnStart("thread-fresh", "client-fresh")
 	if got := len(fixture.tracker.gatewayTurns); got != 1 {
 		t.Fatalf("过期 gateway 登记应在新写入时被裁剪：got=%d entries=%+v", got, fixture.tracker.gatewayTurns)

--- a/internal/codexhistory/gateway_turn_claim_store.go
+++ b/internal/codexhistory/gateway_turn_claim_store.go
@@ -220,7 +220,7 @@ func (t *ExternalActivityTracker) ensureGatewayTurnClaimsLoaded(now time.Time) {
 			!validGatewayClaimID(pending.ClientUserMessageID) ||
 			registeredAt.IsZero() ||
 			registeredAt.After(now.Add(gatewayTurnEventClockSkew)) ||
-			now.After(registeredAt.Add(gatewayTurnRegistrationTTL)) {
+			now.After(registeredAt.Add(gatewayTurnRegistrationRetention)) {
 			t.gatewayClaimsDirty = true
 			continue
 		}

--- a/internal/httpapi/capability_rollout.go
+++ b/internal/httpapi/capability_rollout.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	fileUploadCapability = "file_upload_v1"
+	fileUploadCapability            = "file_upload_v1"
+	codexRemoteFullAccessCapability = "codex_remote_full_access_v1"
 
 	capabilityStateEnabled               = "enabled"
 	capabilityStateLocallyDisabled       = "locally_disabled"
@@ -41,16 +42,31 @@ func newCapabilityRegistry(cfg config.Config, fileUploads *fileUploadStore) capa
 		fileUpload.State = capabilityStateDependencyUnavailable
 		fileUpload.Reason = capabilityReasonStorageUnavailable
 	}
+	codexRemoteFullAccess := protocolcontract.CapabilityStatus{
+		Name:   codexRemoteFullAccessCapability,
+		State:  capabilityStateEnabled,
+		Reason: capabilityReasonAvailable,
+	}
+	if cfg.Capabilities.IsDisabled(codexRemoteFullAccessCapability) {
+		codexRemoteFullAccess.State = capabilityStateLocallyDisabled
+		codexRemoteFullAccess.Reason = capabilityReasonDisabledByLocalConfig
+	}
 
-	log.Printf(
-		"capability decision name=%s state=%s reason=%s",
-		fileUpload.Name,
-		fileUpload.State,
-		fileUpload.Reason,
-	)
+	statuses := []protocolcontract.CapabilityStatus{fileUpload, codexRemoteFullAccess}
+	for _, status := range statuses {
+		log.Printf(
+			"capability decision name=%s state=%s reason=%s",
+			status.Name,
+			status.State,
+			status.Reason,
+		)
+	}
 	return capabilityRegistry{
-		ordered: []protocolcontract.CapabilityStatus{fileUpload},
-		byName:  map[string]protocolcontract.CapabilityStatus{fileUpload.Name: fileUpload},
+		ordered: statuses,
+		byName: map[string]protocolcontract.CapabilityStatus{
+			fileUpload.Name:            fileUpload,
+			codexRemoteFullAccess.Name: codexRemoteFullAccess,
+		},
 	}
 }
 

--- a/internal/httpapi/capability_rollout_test.go
+++ b/internal/httpapi/capability_rollout_test.go
@@ -93,14 +93,23 @@ func TestFileUploadCapabilityRolloutMatrix(t *testing.T) {
 			if capabilityListContains(version.Capabilities, fileUploadCapability) != item.wantDeclared {
 				t.Fatalf("capability 声明不符：%+v", version.Capabilities)
 			}
-			if len(version.CapabilityStatuses) != 1 {
+			if len(version.CapabilityStatuses) != 2 {
 				t.Fatalf("状态声明应覆盖已知可选能力：%+v", version.CapabilityStatuses)
 			}
-			status := version.CapabilityStatuses[0]
+			status := findCapabilityStatus(version.CapabilityStatuses, fileUploadCapability)
 			if status.Name != fileUploadCapability ||
 				status.State != item.wantState ||
 				status.Reason != item.wantReason {
 				t.Fatalf("能力状态不符：%+v", status)
+			}
+			remoteFullAccess := findCapabilityStatus(
+				version.CapabilityStatuses,
+				codexRemoteFullAccessCapability,
+			)
+			if !capabilityListContains(version.Capabilities, codexRemoteFullAccessCapability) ||
+				remoteFullAccess.State != capabilityStateEnabled ||
+				remoteFullAccess.Reason != capabilityReasonAvailable {
+				t.Fatalf("远程完全访问能力未声明：%+v", remoteFullAccess)
 			}
 
 			uploadRecorder := httptest.NewRecorder()
@@ -168,6 +177,28 @@ func TestFileUploadCapabilityRolloutMatrix(t *testing.T) {
 	}
 }
 
+func TestCodexRemoteFullAccessCapabilityCanBeDisabledLocally(t *testing.T) {
+	t.Setenv("AGENTD_FILE_UPLOAD_CACHE_DIR", t.TempDir())
+	server := newTestServerWithConfig(t, func(cfg *config.Config) {
+		cfg.Capabilities.Disabled = []string{codexRemoteFullAccessCapability}
+	})
+	recorder := httptest.NewRecorder()
+	server.handler.ServeHTTP(
+		recorder,
+		authedRequest(t, http.MethodGet, "/api/version", nil),
+	)
+	var version protocolcontract.VersionResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&version); err != nil {
+		t.Fatal(err)
+	}
+	status := findCapabilityStatus(version.CapabilityStatuses, codexRemoteFullAccessCapability)
+	if capabilityListContains(version.Capabilities, codexRemoteFullAccessCapability) ||
+		status.State != capabilityStateLocallyDisabled ||
+		status.Reason != capabilityReasonDisabledByLocalConfig {
+		t.Fatalf("本地禁用后仍不应向 iOS 授权免审批路径：%+v", version)
+	}
+}
+
 func TestCapabilityDecisionLogContainsStateButNoCredentials(t *testing.T) {
 	t.Setenv("AGENTD_FILE_UPLOAD_CACHE_DIR", t.TempDir())
 	var output bytes.Buffer
@@ -196,6 +227,18 @@ func capabilityListContains(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func findCapabilityStatus(
+	statuses []protocolcontract.CapabilityStatus,
+	target string,
+) protocolcontract.CapabilityStatus {
+	for _, status := range statuses {
+		if status.Name == target {
+			return status
+		}
+	}
+	return protocolcontract.CapabilityStatus{}
 }
 
 func findDoctorCheck(checks []doctor.Check, name string) doctor.Check {

--- a/internal/httpapi/router_endpoints_test.go
+++ b/internal/httpapi/router_endpoints_test.go
@@ -767,8 +767,9 @@ func TestVersionAndDoctorEndpointsRequireBearerAndKeepMobileResponseContracts(t 
 		t.Fatalf("version 响应必须保留移动端所需字段：%v", versionBody)
 	}
 	capabilities, ok := versionBody["capabilities"].([]any)
-	if !ok || len(capabilities) != 1 || capabilities[0] != "file_upload_v1" {
-		t.Fatalf("version 应声明移动端文件上传能力：%v", versionBody)
+	if !ok || !containsJSONCapability(capabilities, fileUploadCapability) ||
+		!containsJSONCapability(capabilities, codexRemoteFullAccessCapability) {
+		t.Fatalf("version 应声明当前移动端能力：%v", versionBody)
 	}
 
 	doctor := httptest.NewRecorder()
@@ -784,6 +785,15 @@ func TestVersionAndDoctorEndpointsRequireBearerAndKeepMobileResponseContracts(t 
 	if !ok || len(checks) == 0 {
 		t.Fatalf("doctor 响应必须包含结构化 checks：%v", doctorBody)
 	}
+}
+
+func containsJSONCapability(values []any, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestReadyzRequiresBearerAndReturns503WhenDoctorFails(t *testing.T) {

--- a/internal/protocolcontract/generated.go
+++ b/internal/protocolcontract/generated.go
@@ -15,10 +15,11 @@ const (
 	MinimumServerRevisionHeader    = "X-Mimi-Minimum-Server-Protocol-Revision"
 	ServerRevisionHeader           = "X-Mimi-Server-Protocol-Revision"
 	MinimumClientRevisionHeader    = "X-Mimi-Minimum-Client-Protocol-Revision"
-	SpecSHA256                     = "2158fc83f85e51ab71e7841b167782bef42592131076470db6b8df10b6ff5716"
+	SpecSHA256                     = "3256b2c6e44659390e71cd70036a4656f72fbfed9a74cd82bee3bd28c2438c0c"
 )
 
 var currentCapabilities = []string{
+	"codex_remote_full_access_v1",
 	"file_upload_v1",
 }
 

--- a/ios/MimiRemote/Sources/Core/Models/ProtocolContract.generated.swift
+++ b/ios/MimiRemote/Sources/Core/Models/ProtocolContract.generated.swift
@@ -15,8 +15,9 @@ enum MimiProtocolContract {
     static let minimumServerRevisionHeader = "X-Mimi-Minimum-Server-Protocol-Revision"
     static let serverRevisionHeader = "X-Mimi-Server-Protocol-Revision"
     static let minimumClientRevisionHeader = "X-Mimi-Minimum-Client-Protocol-Revision"
-    static let specSHA256 = "2158fc83f85e51ab71e7841b167782bef42592131076470db6b8df10b6ff5716"
+    static let specSHA256 = "3256b2c6e44659390e71cd70036a4656f72fbfed9a74cd82bee3bd28c2438c0c"
     static let declaredCapabilities: Set<String> = [
+        "codex_remote_full_access_v1",
         "file_upload_v1",
     ]
 

--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -819,6 +819,19 @@ struct CodexAppServerTurnOptions: Codable, Hashable {
         return sanitized
     }
 
+    func adjustedForRemoteNoApprovalSupport(_ isSupported: Bool) -> CodexAppServerTurnOptions {
+        guard !isSupported,
+              approvalPolicy == .never,
+              sandboxMode == .dangerFullAccess
+        else { return self }
+        var adjusted = self
+        // 旧 agentd 会拒绝所有 approvalPolicy=never。保留完全文件访问沙盒，
+        // 只把审批策略降级为 on-request，避免新会话在进入 Codex 前直接失败。
+        adjusted.approvalPolicy = .onRequest
+        adjusted.approvalsReviewer = "user"
+        return adjusted
+    }
+
     private mutating func applyStandardComposerPermissionPreset() {
         if preservesThreadPermissionSettings {
             permissionProfileID = nil

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -1,6 +1,158 @@
 import AVFoundation
 import PhotosUI
 import SwiftUI
+
+// 权限选择、能力降级和队列边界属于输入状态协作，不让 ComposerView 主体继续增长。
+extension ComposerView {
+    func applyDefaultPermissionMode() {
+        let stored = ComposerPermissionMode.stored(defaultPermissionModeID)
+        composerState.applyPermissionMode(safePermissionMode(stored))
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: activeComposerDraftScope
+        )
+    }
+
+    func applyDefaultPermissionModeForActiveScope() {
+        // 设置页的“默认权限”只面向新会话。已有 Thread 在用户未点击当前输入区的
+        // 权限按钮时必须继续沿用服务端设置，不能因全局偏好变化而被静默覆盖。
+        switch activeComposerDraftScope {
+        case .newSession:
+            applyDefaultPermissionMode()
+        case .session(let sessionID) where sessionID.hasPrefix("local:"):
+            applyDefaultPermissionMode()
+        case .none, .session:
+            break
+        }
+    }
+
+    func setPermissionMode(_ mode: ComposerPermissionMode) {
+        let safeMode = safePermissionMode(mode)
+        // Claude 的安全降级只影响当前会话，不覆盖用户为 Codex 保存的“完全访问”默认值。
+        if selectedSessionRuntimeProviderForModelMenu != "claude" {
+            defaultPermissionModeID = safeMode.rawValue
+        }
+        composerState.applyPermissionMode(
+            safeMode,
+            sessionIsRunning: sessionStore.selectedSessionRequiresFreshPermissionTurn
+        )
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: activeComposerDraftScope
+        )
+    }
+
+    func setPermissionProfile(_ profile: CodexAppServerPermissionProfileSummary) {
+        if let builtInMode = ComposerPermissionMode(builtInPermissionProfileID: profile.id) {
+            setPermissionMode(builtInMode)
+            return
+        }
+        composerState.updatePermissionSelection(
+            sessionIsRunning: sessionStore.selectedSessionRequiresFreshPermissionTurn
+        ) { options in
+            options.preservesThreadPermissionSettings = false
+            options.permissionProfileID = profile.id
+            options.approvalPolicy = .forPermissionProfileID(profile.id)
+            options.approvalsReviewer = "user"
+            options.networkAccess = false
+        }
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: activeComposerDraftScope
+        )
+    }
+
+    var permissionProfileCWD: String? {
+        let path = sessionStore.selectedSession?.dir ?? sessionStore.selectedProject?.path
+        return path?.trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty
+    }
+
+    var availablePermissionProfiles: [CodexAppServerPermissionProfileSummary] {
+        guard selectedSessionRuntimeProviderForModelMenu != "claude",
+              sessionStore.permissionProfilesCWD == permissionProfileCWD
+        else {
+            return []
+        }
+        // 三个内建档案与上方用户权限模式完全重复，只把真正的自定义档案放进高级入口。
+        return sessionStore.appServerPermissionProfiles.filter {
+            ComposerPermissionMode(builtInPermissionProfileID: $0.id) == nil
+        }
+    }
+
+    var selectedPermissionProfileID: String? {
+        if let profileID = composerState.turnOptions.permissionProfileID?
+            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty {
+            return profileID
+        }
+        return composerState.turnOptions.preservesThreadPermissionSettings
+            ? activePermissionProfile?.id
+            : nil
+    }
+
+    var activePermissionProfile: CodexAppServerActivePermissionProfile? {
+        guard let sessionID = sessionStore.selectedSessionID else {
+            return nil
+        }
+        return sessionStore.activePermissionProfileBySessionID[sessionID]
+    }
+
+    func clampPermissionProfileToAvailableOptions() {
+        guard let explicitProfileID = composerState.turnOptions.permissionProfileID?
+            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty else { return }
+        if let builtInMode = ComposerPermissionMode(builtInPermissionProfileID: explicitProfileID) {
+            composerState.applyPermissionMode(
+                builtInMode,
+                sessionIsRunning: sessionStore.selectedSessionRequiresFreshPermissionTurn
+            )
+            sessionStore.saveComposerPermissionSelection(
+                composerState.permissionSelectionSnapshot(),
+                for: activeComposerDraftScope
+            )
+            return
+        }
+        guard availablePermissionProfiles.contains(where: { $0.id == explicitProfileID }) else {
+            composerState.resetUnavailablePermissionProfile(
+                sessionIsRunning: sessionStore.selectedSessionRequiresFreshPermissionTurn
+            )
+            sessionStore.saveComposerPermissionSelection(
+                composerState.permissionSelectionSnapshot(),
+                for: activeComposerDraftScope
+            )
+            return
+        }
+    }
+
+    var availablePermissionModes: [ComposerPermissionMode] {
+        if selectedSessionRuntimeProviderForModelMenu == "claude" {
+            return [.requestApproval, .readOnly, .autoApprove]
+        }
+        return ComposerPermissionMode.allCases
+    }
+
+    func safePermissionMode(_ mode: ComposerPermissionMode) -> ComposerPermissionMode {
+        // Claude 不支持“完全访问”，也不持久化自己的默认；当共享默认落在 fullAccess 时，
+        // 降级到“自动批准低风险操作”作为 Claude 的安全默认，而不是每轮都请求审批。
+        // autoApprove 仍是安全档（workspaceWrite + auto_review），绝不映射 bypassPermissions。
+        selectedSessionRuntimeProviderForModelMenu == "claude" && mode == .fullAccess
+            ? .autoApprove
+            : mode
+    }
+
+    func clampPermissionSelectionToSelectedSessionRuntime() {
+        let safeMode = safePermissionMode(composerState.permissionMode)
+        guard safeMode != composerState.permissionMode else {
+            return
+        }
+        composerState.applyPermissionMode(
+            safeMode,
+            sessionIsRunning: sessionStore.selectedSessionRequiresFreshPermissionTurn
+        )
+        sessionStore.saveComposerPermissionSelection(
+            composerState.permissionSelectionSnapshot(),
+            for: activeComposerDraftScope
+        )
+    }
+}
 import UIKit
 
 enum ComposerTextLayoutPolicy {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -345,7 +345,7 @@ enum DefaultModelPreferences {
     }
 }
 
-enum ComposerPermissionMode: String, CaseIterable, Identifiable {
+enum ComposerPermissionMode: String, CaseIterable, Identifiable, Codable {
     case requestApproval
     case readOnly
     case autoApprove
@@ -483,7 +483,7 @@ enum ComposerPermissionMode: String, CaseIterable, Identifiable {
     private static let autoReviewer = "auto_review"
 }
 
-struct ComposerPermissionSelectionSnapshot: Equatable {
+struct ComposerPermissionSelectionSnapshot: Codable, Equatable {
     var preservesThreadSettings: Bool
     var profileID: String?
     var mode: ComposerPermissionMode
@@ -621,19 +621,22 @@ struct ComposerState {
         ComposerPermissionMode(options: turnOptions)
     }
 
-    mutating func applyPermissionMode(_ mode: ComposerPermissionMode) {
-        updateTurnOptions { options in
+    mutating func applyPermissionMode(
+        _ mode: ComposerPermissionMode,
+        sessionIsRunning: Bool = false
+    ) {
+        updatePermissionSelection(sessionIsRunning: sessionIsRunning) { options in
             mode.apply(to: &options)
         }
     }
 
-    mutating func resetUnavailablePermissionProfile() {
+    mutating func resetUnavailablePermissionProfile(sessionIsRunning: Bool = false) {
         guard turnOptions.permissionProfileID?
             .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty != nil
         else { return }
         // 自定义档案消失时不能只清 ID；底层 sandbox 可能仍是完全访问默认值，
         // 下一次提交会因此升级为无审批。明确回退到受控工作区和用户审批。
-        applyPermissionMode(.requestApproval)
+        applyPermissionMode(.requestApproval, sessionIsRunning: sessionIsRunning)
     }
 
     mutating func updateTurnOptions(_ update: (inout CodexAppServerTurnOptions) -> Void) {
@@ -644,6 +647,18 @@ struct ComposerState {
         }
         // 每次用户操作只发布一个完整 options 快照，避免连续改多个字段导致工具栏多次刷新。
         turnOptions = updatedOptions
+    }
+
+    mutating func updatePermissionSelection(
+        sessionIsRunning: Bool,
+        _ update: (inout CodexAppServerTurnOptions) -> Void
+    ) {
+        let previousSelection = permissionSelectionSnapshot()
+        updateTurnOptions(update)
+        markPermissionSelectionRequiresNewTurnIfChanged(
+            from: previousSelection,
+            sessionIsRunning: sessionIsRunning
+        )
     }
 
     mutating func setSendMode(_ mode: ComposerSendMode) {
@@ -786,12 +801,12 @@ struct ComposerState {
         permissionSelectionRequiresNewTurn = true
     }
 
-    mutating func markPermissionSelectionSubmitted(
-        _ submittedSelection: ComposerPermissionSelectionSnapshot
+    mutating func markPermissionSelectionApplied(
+        _ startedSelection: ComposerPermissionSelectionSnapshot
     ) {
-        // 发送期间用户可能再次修改权限。只有当前选择仍与已提交快照一致时才清除标记，
-        // 避免迟到的成功回调把更新后的下一回合权限错误地当成已经发送。
-        guard permissionSelectionSnapshot() == submittedSelection else {
+        // turn/started 到达前用户可能再次修改权限。只有当前选择仍与已启动快照一致时
+        // 才清除标记，避免迟到事件把更新后的下一回合权限错误地当成已经生效。
+        guard permissionSelectionSnapshot() == startedSelection else {
             return
         }
         permissionSelectionRequiresNewTurn = false

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -15,6 +15,7 @@ struct SubmittedComposerDraft {
     let text: String
     let attachments: [CodexAppServerUserInput]
     let payload: CodexAppServerTurnPayload
+    let permissionSelection: ComposerPermissionSelectionSnapshot
     let voiceDraftNeedsReview: Bool
     // 发送清空后的内容版本。异步失败返回时，只有版本未变化才允许恢复，
     // 避免覆盖用户在等待期间输入的下一条消息。
@@ -486,12 +487,14 @@ struct ComposerPermissionSelectionSnapshot: Equatable {
     var preservesThreadSettings: Bool
     var profileID: String?
     var mode: ComposerPermissionMode
+    var requiresNewTurn: Bool
 
-    init(options: CodexAppServerTurnOptions) {
+    init(options: CodexAppServerTurnOptions, requiresNewTurn: Bool = false) {
         preservesThreadSettings = options.preservesThreadPermissionSettings
         profileID = options.permissionProfileID?
             .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty
         mode = ComposerPermissionMode(options: options)
+        self.requiresNewTurn = requiresNewTurn
     }
 
     func apply(to options: inout CodexAppServerTurnOptions) {
@@ -594,6 +597,7 @@ struct ComposerState {
     }
     var turnOptions: CodexAppServerTurnOptions = .default
     var sendMode: ComposerSendMode = .standard
+    private(set) var permissionSelectionRequiresNewTurn = false
     private(set) var hasNonWhitespaceDraft = false
     private(set) var voiceDraftNeedsReview = false
     private(set) var contentRevision: UInt64 = 0
@@ -676,9 +680,9 @@ struct ComposerState {
     }
 
     func runningTurnDelivery(canUseGuidedFollowUp: Bool, guidedFollowUpEnabled: Bool) -> RunningTurnDelivery {
-        // 目标/计划都必须启动一个新的 turn：目标要先写 thread 级元数据，计划模式要把
-        // collaborationMode 放进 turn/start。turn/steer 只补充当前 turn 的输入，会丢掉这些启动参数。
-        guard sendMode == .standard else {
+        // 目标、计划和待应用权限都必须启动新的 turn。turn/steer 只补充当前 turn 的输入，
+        // 不接收 collaborationMode、sandbox 或 approval 等 turn/start 参数。
+        guard sendMode == .standard, !permissionSelectionRequiresNewTurn else {
             return .queued
         }
         return canUseGuidedFollowUp && guidedFollowUpEnabled ? .guided : .queued
@@ -706,6 +710,7 @@ struct ComposerState {
             text: text,
             attachments: sentAttachments,
             payload: payload,
+            permissionSelection: permissionSelectionSnapshot(),
             voiceDraftNeedsReview: submittedVoiceDraftNeedsReview,
             clearedContentRevision: contentRevision
         )
@@ -758,11 +763,38 @@ struct ComposerState {
     }
 
     func permissionSelectionSnapshot() -> ComposerPermissionSelectionSnapshot {
-        ComposerPermissionSelectionSnapshot(options: turnOptions)
+        ComposerPermissionSelectionSnapshot(
+            options: turnOptions,
+            requiresNewTurn: permissionSelectionRequiresNewTurn
+        )
     }
 
     mutating func restorePermissionSelectionSnapshot(_ snapshot: ComposerPermissionSelectionSnapshot) {
         snapshot.apply(to: &turnOptions)
+        permissionSelectionRequiresNewTurn = snapshot.requiresNewTurn
+    }
+
+    mutating func markPermissionSelectionRequiresNewTurn() {
+        permissionSelectionRequiresNewTurn = true
+    }
+
+    mutating func markPermissionSelectionRequiresNewTurnIfChanged(
+        from previousSelection: ComposerPermissionSelectionSnapshot,
+        sessionIsRunning: Bool
+    ) {
+        guard sessionIsRunning, permissionSelectionSnapshot() != previousSelection else { return }
+        permissionSelectionRequiresNewTurn = true
+    }
+
+    mutating func markPermissionSelectionSubmitted(
+        _ submittedSelection: ComposerPermissionSelectionSnapshot
+    ) {
+        // 发送期间用户可能再次修改权限。只有当前选择仍与已提交快照一致时才清除标记，
+        // 避免迟到的成功回调把更新后的下一回合权限错误地当成已经发送。
+        guard permissionSelectionSnapshot() == submittedSelection else {
+            return
+        }
+        permissionSelectionRequiresNewTurn = false
     }
 
     mutating func preserveThreadPermissionSettings() {
@@ -771,6 +803,7 @@ struct ComposerState {
             options.permissionProfileID = nil
             options.networkAccess = false
         }
+        permissionSelectionRequiresNewTurn = false
     }
 
     mutating func addAttachment(_ input: CodexAppServerUserInput) {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -396,6 +396,9 @@ struct ComposerView: View {
                 await MainActor.run {
                     // 提交时已经同步清过对应 cache。这里不能再次删除，否则发送期间
                     // 输入的下一条草稿会被成功回调误删。
+                    if activeComposerDraftScope == submittedDraftScope {
+                        composerState.markPermissionSelectionSubmitted(submitted.permissionSelection)
+                    }
                     guidedFollowUpEnabled = false
                     resetComposerSendModeAfterSubmit()
                 }
@@ -441,6 +444,9 @@ struct ComposerView: View {
             } else {
                 await MainActor.run {
                     // 与普通发送保持一致：成功回调不二次触碰草稿 cache。
+                    if activeComposerDraftScope == submittedDraftScope {
+                        composerState.markPermissionSelectionSubmitted(submitted.permissionSelection)
+                    }
                     guidedFollowUpEnabled = false
                     resetComposerSendModeAfterSubmit()
                 }
@@ -636,10 +642,10 @@ struct ComposerView: View {
     }
 
     var canUseGuidedFollowUp: Bool {
-        guard let session = sessionStore.selectedSession else {
-            return false
-        }
-        return canChooseRunningFollowUpDelivery && session.activeTurnID != nil
+        guard let session = sessionStore.selectedSession else { return false }
+        return canChooseRunningFollowUpDelivery
+            && session.activeTurnID != nil
+            && !composerState.permissionSelectionRequiresNewTurn
     }
 
     var runningTurnDeliveryForSubmit: RunningTurnDelivery {
@@ -1877,7 +1883,12 @@ struct ComposerView: View {
         if selectedSessionRuntimeProviderForModelMenu != "claude" {
             defaultPermissionModeID = safeMode.rawValue
         }
+        let previousSelection = composerState.permissionSelectionSnapshot()
         composerState.applyPermissionMode(safeMode)
+        composerState.markPermissionSelectionRequiresNewTurnIfChanged(
+            from: previousSelection,
+            sessionIsRunning: sessionStore.selectedSession?.isRunning == true
+        )
         sessionStore.saveComposerPermissionSelection(
             composerState.permissionSelectionSnapshot(),
             for: activeComposerDraftScope
@@ -1889,6 +1900,7 @@ struct ComposerView: View {
             setPermissionMode(builtInMode)
             return
         }
+        let previousSelection = composerState.permissionSelectionSnapshot()
         composerState.updateTurnOptions { options in
             options.preservesThreadPermissionSettings = false
             options.permissionProfileID = profile.id
@@ -1896,6 +1908,10 @@ struct ComposerView: View {
             options.approvalsReviewer = "user"
             options.networkAccess = false
         }
+        composerState.markPermissionSelectionRequiresNewTurnIfChanged(
+            from: previousSelection,
+            sessionIsRunning: sessionStore.selectedSession?.isRunning == true
+        )
         sessionStore.saveComposerPermissionSelection(
             composerState.permissionSelectionSnapshot(),
             for: activeComposerDraftScope

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -298,6 +298,17 @@ struct ComposerView: View {
                 guidedFollowUpEnabled = false
             }
         }
+        .onChange(of: sessionStore.latestSatisfiedPermissionTurnBoundary) { _, boundary in
+            guard let boundary,
+                  activeComposerDraftScope == .session(boundary.sessionID) else {
+                return
+            }
+            composerState.markPermissionSelectionApplied(boundary.permissionSelection)
+            sessionStore.saveComposerPermissionSelection(
+                composerState.permissionSelectionSnapshot(),
+                for: activeComposerDraftScope
+            )
+        }
         .onChange(of: sessionStore.selectedSessionID) { _, _ in
             // 引导是只对当前正在生成的回复生效的一次性选择。切换会话后恢复安全的
             // 默认排队，避免把上一条会话的发送意图意外带到另一条运行中会话。
@@ -387,18 +398,17 @@ struct ComposerView: View {
         cancelVoiceInteraction(clearStatus: false)
         clearVoiceTransientStatus()
         Task {
-            let accepted = await sessionStore.sendTurn(submitted.payload, runningDelivery: runningDelivery)
+            let accepted = await sessionStore.sendTurn(
+                submitted.payload,
+                runningDelivery: runningDelivery,
+                permissionSelection: submitted.permissionSelection
+            )
             if !accepted {
                 await MainActor.run {
                     restoreSubmittedDraft(submitted, originalScope: submittedDraftScope)
                 }
             } else {
                 await MainActor.run {
-                    // 提交时已经同步清过对应 cache。这里不能再次删除，否则发送期间
-                    // 输入的下一条草稿会被成功回调误删。
-                    if activeComposerDraftScope == submittedDraftScope {
-                        composerState.markPermissionSelectionSubmitted(submitted.permissionSelection)
-                    }
                     guidedFollowUpEnabled = false
                     resetComposerSendModeAfterSubmit()
                 }
@@ -435,7 +445,8 @@ struct ComposerView: View {
             let accepted = await sessionStore.startGoalTurn(
                 payload: submitted.payload,
                 objective: objective,
-                runningDelivery: runningDelivery
+                runningDelivery: runningDelivery,
+                permissionSelection: submitted.permissionSelection
             )
             if !accepted {
                 await MainActor.run {
@@ -443,10 +454,6 @@ struct ComposerView: View {
                 }
             } else {
                 await MainActor.run {
-                    // 与普通发送保持一致：成功回调不二次触碰草稿 cache。
-                    if activeComposerDraftScope == submittedDraftScope {
-                        composerState.markPermissionSelectionSubmitted(submitted.permissionSelection)
-                    }
                     guidedFollowUpEnabled = false
                     resetComposerSendModeAfterSubmit()
                 }
@@ -556,6 +563,10 @@ struct ComposerView: View {
         if let snapshot = sessionStore.composerPermissionSelection(for: scope) {
             composerState.restorePermissionSelectionSnapshot(snapshot)
         } else if case .session(let sessionID) = scope,
+                  let boundary = sessionStore.latestPendingPermissionTurnBoundary(for: sessionID) {
+            // 重启后恢复最后一次提交的选择；FIFO 仍由 SessionStore 从第一条边界开始推进。
+            composerState.restorePermissionSelectionSnapshot(boundary.permissionSelection)
+        } else if case .session(let sessionID) = scope,
                   !sessionID.hasPrefix("local:"),
                   selectedSessionRuntimeProviderForModelMenu != "claude" {
             composerState.preserveThreadPermissionSettings()
@@ -646,6 +657,7 @@ struct ComposerView: View {
         return canChooseRunningFollowUpDelivery
             && session.activeTurnID != nil
             && !composerState.permissionSelectionRequiresNewTurn
+            && !sessionStore.hasPendingPermissionTurnBoundaryForSelectedSession
     }
 
     var runningTurnDeliveryForSubmit: RunningTurnDelivery {
@@ -1853,148 +1865,6 @@ struct ComposerView: View {
         }
         .fixedSize(horizontal: true, vertical: false)
         .transition(.scale(scale: 0.9).combined(with: .opacity))
-    }
-
-    func applyDefaultPermissionMode() {
-        let stored = ComposerPermissionMode.stored(defaultPermissionModeID)
-        composerState.applyPermissionMode(safePermissionMode(stored))
-        sessionStore.saveComposerPermissionSelection(
-            composerState.permissionSelectionSnapshot(),
-            for: activeComposerDraftScope
-        )
-    }
-
-    func applyDefaultPermissionModeForActiveScope() {
-        // 设置页的“默认权限”只面向新会话。已有 Thread 在用户未点击当前输入区的
-        // 权限按钮时必须继续沿用服务端设置，不能因全局偏好变化而被静默覆盖。
-        switch activeComposerDraftScope {
-        case .newSession:
-            applyDefaultPermissionMode()
-        case .session(let sessionID) where sessionID.hasPrefix("local:"):
-            applyDefaultPermissionMode()
-        case .none, .session:
-            break
-        }
-    }
-
-    func setPermissionMode(_ mode: ComposerPermissionMode) {
-        let safeMode = safePermissionMode(mode)
-        // Claude 的安全降级只影响当前会话，不覆盖用户为 Codex 保存的“完全访问”默认值。
-        if selectedSessionRuntimeProviderForModelMenu != "claude" {
-            defaultPermissionModeID = safeMode.rawValue
-        }
-        let previousSelection = composerState.permissionSelectionSnapshot()
-        composerState.applyPermissionMode(safeMode)
-        composerState.markPermissionSelectionRequiresNewTurnIfChanged(
-            from: previousSelection,
-            sessionIsRunning: sessionStore.selectedSession?.isRunning == true
-        )
-        sessionStore.saveComposerPermissionSelection(
-            composerState.permissionSelectionSnapshot(),
-            for: activeComposerDraftScope
-        )
-    }
-
-    func setPermissionProfile(_ profile: CodexAppServerPermissionProfileSummary) {
-        if let builtInMode = ComposerPermissionMode(builtInPermissionProfileID: profile.id) {
-            setPermissionMode(builtInMode)
-            return
-        }
-        let previousSelection = composerState.permissionSelectionSnapshot()
-        composerState.updateTurnOptions { options in
-            options.preservesThreadPermissionSettings = false
-            options.permissionProfileID = profile.id
-            options.approvalPolicy = .forPermissionProfileID(profile.id)
-            options.approvalsReviewer = "user"
-            options.networkAccess = false
-        }
-        composerState.markPermissionSelectionRequiresNewTurnIfChanged(
-            from: previousSelection,
-            sessionIsRunning: sessionStore.selectedSession?.isRunning == true
-        )
-        sessionStore.saveComposerPermissionSelection(
-            composerState.permissionSelectionSnapshot(),
-            for: activeComposerDraftScope
-        )
-    }
-
-    var permissionProfileCWD: String? {
-        let path = sessionStore.selectedSession?.dir ?? sessionStore.selectedProject?.path
-        return path?.trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty
-    }
-
-    var availablePermissionProfiles: [CodexAppServerPermissionProfileSummary] {
-        guard selectedSessionRuntimeProviderForModelMenu != "claude",
-              sessionStore.permissionProfilesCWD == permissionProfileCWD
-        else {
-            return []
-        }
-        // 三个内建档案与上方用户权限模式完全重复，只把真正的自定义档案放进高级入口。
-        return sessionStore.appServerPermissionProfiles.filter {
-            ComposerPermissionMode(builtInPermissionProfileID: $0.id) == nil
-        }
-    }
-
-    var selectedPermissionProfileID: String? {
-        if let profileID = composerState.turnOptions.permissionProfileID?
-            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty {
-            return profileID
-        }
-        return composerState.turnOptions.preservesThreadPermissionSettings
-            ? activePermissionProfile?.id
-            : nil
-    }
-
-    var activePermissionProfile: CodexAppServerActivePermissionProfile? {
-        guard let sessionID = sessionStore.selectedSessionID else {
-            return nil
-        }
-        return sessionStore.activePermissionProfileBySessionID[sessionID]
-    }
-
-    func clampPermissionProfileToAvailableOptions() {
-        guard let explicitProfileID = composerState.turnOptions.permissionProfileID?
-            .trimmingCharacters(in: .whitespacesAndNewlines).appServerNilIfEmpty else { return }
-        if let builtInMode = ComposerPermissionMode(builtInPermissionProfileID: explicitProfileID) {
-            composerState.applyPermissionMode(builtInMode)
-            sessionStore.saveComposerPermissionSelection(
-                composerState.permissionSelectionSnapshot(),
-                for: activeComposerDraftScope
-            )
-            return
-        }
-        guard availablePermissionProfiles.contains(where: { $0.id == explicitProfileID }) else {
-            composerState.resetUnavailablePermissionProfile()
-            sessionStore.saveComposerPermissionSelection(
-                composerState.permissionSelectionSnapshot(),
-                for: activeComposerDraftScope
-            )
-            return
-        }
-    }
-
-    var availablePermissionModes: [ComposerPermissionMode] {
-        if selectedSessionRuntimeProviderForModelMenu == "claude" {
-            return [.requestApproval, .readOnly, .autoApprove]
-        }
-        return ComposerPermissionMode.allCases
-    }
-
-    func safePermissionMode(_ mode: ComposerPermissionMode) -> ComposerPermissionMode {
-        // Claude 不支持“完全访问”，也不持久化自己的默认；当共享默认落在 fullAccess 时，
-        // 降级到“自动批准低风险操作”作为 Claude 的安全默认，而不是每轮都请求审批。
-        // autoApprove 仍是安全档（workspaceWrite + auto_review），绝不映射 bypassPermissions。
-        selectedSessionRuntimeProviderForModelMenu == "claude" && mode == .fullAccess
-            ? .autoApprove
-            : mode
-    }
-
-    func clampPermissionSelectionToSelectedSessionRuntime() {
-        let safeMode = safePermissionMode(composerState.permissionMode)
-        guard safeMode != composerState.permissionMode else {
-            return
-        }
-        composerState.applyPermissionMode(safeMode)
     }
 
 }

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -209,6 +209,12 @@ final class SessionStore: ObservableObject {
     @Published var runtimeActivityBySessionID: [SessionID: RuntimeActivitySnapshot] = [:]
     @Published var sessionControlStateByID: [SessionID: SessionControlState] = [:]
     @Published var queuedRunningTurnsBySessionID: [SessionID: [QueuedTurnEntry]] = [:]
+    /// 同一 Session 可连续提交多次权限变更；必须按提交顺序逐条等待精确 turn/started。
+    @Published var pendingPermissionTurnBoundariesBySessionID: [SessionID: [PendingPermissionTurnBoundary]] = [:]
+    /// 明确拒绝的消息离开队列后，仍持久化重试所需的 fresh-turn 权限快照。
+    @Published var permissionTurnRetryRequirementsByClientMessageID: [ClientMessageID: PendingPermissionTurnBoundary] = [:]
+    /// 用于让当前 Composer 收到“哪个已提交快照真正开始”的通知；非当前会话仍先更新 cache。
+    @Published var latestSatisfiedPermissionTurnBoundary: PendingPermissionTurnBoundary?
     @Published var queuedTurnStorageErrorMessage: String?
     /// 只驱动主机选择器和写操作禁用态，不承载探活结果，避免状态圆点刷新整棵工作台。
     @Published private(set) var connectionSwitchTargetProfileID: String?
@@ -855,6 +861,186 @@ final class SessionStore: ObservableObject {
         composerPermissionSelectionCache.remove(scope: scope)
     }
 
+    func pendingPermissionTurnBoundary(for sessionID: SessionID) -> PendingPermissionTurnBoundary? {
+        pendingPermissionTurnBoundariesBySessionID[sessionID]?.first
+    }
+
+    func latestPendingPermissionTurnBoundary(for sessionID: SessionID) -> PendingPermissionTurnBoundary? {
+        pendingPermissionTurnBoundariesBySessionID[sessionID]?.last
+    }
+
+    func pendingPermissionTurnBoundaryLocation(
+        clientMessageID: ClientMessageID
+    ) -> (sessionID: SessionID, index: Int, boundary: PendingPermissionTurnBoundary)? {
+        for (sessionID, boundaries) in pendingPermissionTurnBoundariesBySessionID {
+            if let index = boundaries.firstIndex(where: { $0.clientMessageID == clientMessageID }) {
+                return (sessionID, index, boundaries[index])
+            }
+        }
+        return nil
+    }
+
+    var hasPendingPermissionTurnBoundaryForSelectedSession: Bool {
+        guard let selectedSessionID else { return false }
+        return pendingPermissionTurnBoundariesBySessionID[selectedSessionID]?.isEmpty == false
+    }
+
+    var selectedSessionRequiresFreshPermissionTurn: Bool {
+        guard let selectedSession else { return false }
+        return selectedSession.isRunning
+            || queuedRunningTurnsBySessionID[selectedSession.id]?.isEmpty == false
+            || pendingPermissionTurnBoundariesBySessionID[selectedSession.id]?.isEmpty == false
+            || queuedTurnAwaitingStartSessionIDs.contains(selectedSession.id)
+    }
+
+    @discardableResult
+    func satisfyPendingPermissionTurnBoundary(
+        sessionID: SessionID,
+        clientMessageID: ClientMessageID?
+    ) -> Bool {
+        // nil 或错误 ID 都不是这条权限提交的权威 started，不能解除边界。
+        guard let clientMessageID,
+              let pending = pendingPermissionTurnBoundariesBySessionID[sessionID]?.first,
+              pending.sessionID == sessionID,
+              pending.clientMessageID == clientMessageID
+        else {
+            return false
+        }
+        guard mutateAndPersistQueuedTurns({
+            var boundaries = pendingPermissionTurnBoundariesBySessionID[sessionID] ?? []
+            guard boundaries.first?.clientMessageID == clientMessageID else { return }
+            boundaries.removeFirst()
+            if var queue = queuedRunningTurnsBySessionID[sessionID],
+               let index = queue.firstIndex(where: { $0.clientMessageID == pending.clientMessageID }) {
+                queue[index].requiresFreshTurn = nil
+                queuedRunningTurnsBySessionID[sessionID] = queue
+            }
+
+            // 同一权限快照的后续消息已被这次 started 覆盖，不再强制额外创建 Turn。
+            while boundaries.first?.permissionSelection == pending.permissionSelection {
+                let covered = boundaries.removeFirst()
+                if var queue = queuedRunningTurnsBySessionID[sessionID],
+                   let index = queue.firstIndex(where: { $0.clientMessageID == covered.clientMessageID }) {
+                    queue[index].requiresFreshTurn = nil
+                    queuedRunningTurnsBySessionID[sessionID] = queue
+                }
+            }
+            if boundaries.isEmpty {
+                pendingPermissionTurnBoundariesBySessionID.removeValue(forKey: sessionID)
+            } else {
+                pendingPermissionTurnBoundariesBySessionID[sessionID] = boundaries
+            }
+        }) else {
+            return false
+        }
+
+        // 还有更新的权限边界时，旧 started 只推进 FIFO，不能清理当前 Composer 标记。
+        guard pendingPermissionTurnBoundariesBySessionID[sessionID]?.isEmpty != false else {
+            return true
+        }
+
+        let scope = ComposerDraftScopeKey.session(sessionID)
+        if let cached = composerPermissionSelectionCache.snapshot(for: scope),
+           cached == pending.permissionSelection {
+            var satisfied = cached
+            satisfied.requiresNewTurn = false
+            composerPermissionSelectionCache.save(satisfied, for: scope)
+        }
+        latestSatisfiedPermissionTurnBoundary = pending
+        return true
+    }
+
+    func reconcilePendingPermissionTurnBoundaries(
+        sessionID: SessionID,
+        historyMessages: [CodexHistoryMessage]
+    ) {
+        let startedClientMessageIDs = Set(historyMessages.compactMap { message -> ClientMessageID? in
+            guard let clientMessageID = message.clientMessageID,
+                  let turnID = message.turnID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !turnID.isEmpty
+            else {
+                return nil
+            }
+            return clientMessageID
+        })
+
+        // App 可能在服务端 started 后、实时事件落地前退出。权威历史只能按 FIFO 头部
+        // 解除边界，避免较新的历史消息越过尚未证明开始的权限提交。
+        var didAdvanceBoundary = false
+        while let pending = pendingPermissionTurnBoundary(for: sessionID),
+              startedClientMessageIDs.contains(pending.clientMessageID) {
+            guard satisfyPendingPermissionTurnBoundary(
+                sessionID: sessionID,
+                clientMessageID: pending.clientMessageID
+            ) else {
+                break
+            }
+            didAdvanceBoundary = true
+        }
+        if didAdvanceBoundary,
+           sessionsByID[sessionID]?.activeTurnID == nil {
+            dispatchNextQueuedRunningTurnIfIdle(sessionID: sessionID)
+        }
+    }
+
+    /// 仅删除已明确不会再 started 的边界；结果不确定的派发必须保留。
+    @discardableResult
+    func removePendingPermissionTurnBoundary(
+        sessionID: SessionID,
+        clientMessageID: ClientMessageID
+    ) -> PendingPermissionTurnBoundary? {
+        guard var boundaries = pendingPermissionTurnBoundariesBySessionID[sessionID],
+              let index = boundaries.firstIndex(where: { $0.clientMessageID == clientMessageID })
+        else {
+            return nil
+        }
+        let removed = boundaries.remove(at: index)
+        if boundaries.isEmpty {
+            pendingPermissionTurnBoundariesBySessionID.removeValue(forKey: sessionID)
+        } else {
+            pendingPermissionTurnBoundariesBySessionID[sessionID] = boundaries
+        }
+        return removed
+    }
+
+    func preservePermissionTurnRetryRequirementAfterRejection(
+        sessionID: SessionID,
+        clientMessageID: ClientMessageID
+    ) {
+        _ = mutateAndPersistQueuedTurns {
+            guard let boundary = removePendingPermissionTurnBoundary(
+                sessionID: sessionID,
+                clientMessageID: clientMessageID
+            ) else {
+                return
+            }
+            permissionTurnRetryRequirementsByClientMessageID[clientMessageID] = boundary
+        }
+    }
+
+    func migratePendingPermissionTurnBoundary(
+        clientMessageID: ClientMessageID,
+        to sessionID: SessionID
+    ) {
+        guard let location = pendingPermissionTurnBoundaryLocation(clientMessageID: clientMessageID),
+              location.sessionID != sessionID else {
+            return
+        }
+        _ = mutateAndPersistQueuedTurns {
+            _ = removePendingPermissionTurnBoundary(
+                sessionID: location.sessionID,
+                clientMessageID: clientMessageID
+            )
+            pendingPermissionTurnBoundariesBySessionID[sessionID, default: []].append(
+                PendingPermissionTurnBoundary(
+                    sessionID: sessionID,
+                    clientMessageID: clientMessageID,
+                    permissionSelection: location.boundary.permissionSelection
+                )
+            )
+        }
+    }
+
     func composerSendModeForScopeActivation(
         previousScope: ComposerDraftScopeKey,
         nextScope: ComposerDraftScopeKey,
@@ -922,7 +1108,19 @@ final class SessionStore: ObservableObject {
         let didPersist = mutateAndPersistQueuedTurns {
             guard var queue = queuedRunningTurnsBySessionID[location.sessionID],
                   queue.indices.contains(location.index) else { return }
-            queue.remove(at: location.index)
+            let removed = queue.remove(at: location.index)
+            if removed.dispatchState == .waiting,
+               removePendingPermissionTurnBoundary(
+                   sessionID: location.sessionID,
+                   clientMessageID: removed.clientMessageID
+               ) != nil {
+                // 删除尚未开始的边界项后，后续等待项不能永久继承 accepted-but-not-started 门闩。
+                for index in queue.indices where queue[index].waitsForAcceptedTurnStart == true {
+                    queue[index].waitsForAcceptedTurnStart = nil
+                    queue[index].blockedCompletionID = nil
+                    queue[index].expectedTurnID = sessionsByID[location.sessionID]?.activeTurnID
+                }
+            }
             setQueuedTurns(queue, sessionID: location.sessionID)
         }
         if didPersist {
@@ -958,9 +1156,22 @@ final class SessionStore: ObservableObject {
         guard let location = queuedTurnLocation(clientMessageID: clientMessageID),
               location.sessionID == selectedSessionID,
               let session = selectedSession,
-              let item = queuedRunningTurnsBySessionID[location.sessionID]?[location.index],
-              item.dispatchState == .waiting,
+              let queue = queuedRunningTurnsBySessionID[location.sessionID],
+              queue.indices.contains(location.index)
+        else {
+            setErrorMessage(L10n.text("ui.there_are_currently_no_active_rounds_to_boot"))
+            return false
+        }
+        let item = queue[location.index]
+        let hasEarlierFreshTurnBoundary = queue[..<location.index].contains {
+            $0.requiresFreshTurn == true
+        }
+        guard item.dispatchState == .waiting,
               item.intent.canGuideCurrentTurn,
+              item.requiresFreshTurn != true,
+              !hasEarlierFreshTurnBoundary,
+              pendingPermissionTurnBoundariesBySessionID[location.sessionID]?.isEmpty != false,
+              item.waitsForAcceptedTurnStart != true,
               let activeTurnID = session.activeTurnID,
               let socket = readyWebSocket(for: session)
         else {
@@ -1007,11 +1218,17 @@ final class SessionStore: ObservableObject {
     func moveSelectedQueuedTurns(fromOffsets: IndexSet, toOffset: Int) -> Bool {
         guard let selectedSessionID,
               var queue = queuedRunningTurnsBySessionID[selectedSessionID],
-              queue.allSatisfy({ $0.dispatchState != .dispatching })
+              queue.allSatisfy({ $0.dispatchState == .waiting })
         else {
             return false
         }
-        let previous = queuedRunningTurnsBySessionID
+        let boundaryIDs = Set(
+            (pendingPermissionTurnBoundariesBySessionID[selectedSessionID] ?? []).map(\.clientMessageID)
+        )
+        guard boundaryIDs.isSubset(of: Set(queue.map(\.clientMessageID))) else {
+            // 已离开队列的 uncertain 边界没有可见拖动位置，不能让等待项跨过它。
+            return false
+        }
         let moving = fromOffsets.sorted().compactMap { queue.indices.contains($0) ? queue[$0] : nil }
         for index in fromOffsets.sorted(by: >) where queue.indices.contains(index) {
             queue.remove(at: index)
@@ -1019,15 +1236,15 @@ final class SessionStore: ObservableObject {
         let removedBeforeDestination = fromOffsets.filter { $0 < toOffset }.count
         let destination = min(max(0, toOffset - removedBeforeDestination), queue.count)
         queue.insert(contentsOf: moving, at: destination)
-        queuedRunningTurnsBySessionID[selectedSessionID] = queue
-        do {
-            try persistQueuedTurns()
-            queuedTurnStorageErrorMessage = nil
-            return true
-        } catch {
-            queuedRunningTurnsBySessionID = previous
-            reportQueuedTurnStorageError(error)
-            return false
+        return mutateAndPersistQueuedTurns {
+            queuedRunningTurnsBySessionID[selectedSessionID] = queue
+            guard let boundaries = pendingPermissionTurnBoundariesBySessionID[selectedSessionID] else {
+                return
+            }
+            let boundaryByID = Dictionary(uniqueKeysWithValues: boundaries.map { ($0.clientMessageID, $0) })
+            pendingPermissionTurnBoundariesBySessionID[selectedSessionID] = queue.compactMap {
+                boundaryByID[$0.clientMessageID]
+            }
         }
     }
 
@@ -1049,6 +1266,8 @@ final class SessionStore: ObservableObject {
                 snapshot.queuesBySessionID[sessionID] = queue
             }
             queuedRunningTurnsBySessionID = snapshot.queuesBySessionID.filter { !$0.value.isEmpty }
+            pendingPermissionTurnBoundariesBySessionID = snapshot.pendingPermissionTurnBoundariesBySessionID
+            permissionTurnRetryRequirementsByClientMessageID = snapshot.permissionTurnRetryRequirementsByClientMessageID
             if didRecoverAmbiguousDispatch {
                 try queuedTurnStore.save(snapshot)
             }
@@ -1056,6 +1275,8 @@ final class SessionStore: ObservableObject {
         } catch {
             // 解码失败不覆盖原文件；否则一次版本不兼容会把待发指令静默清空。
             queuedRunningTurnsBySessionID = [:]
+            pendingPermissionTurnBoundariesBySessionID = [:]
+            permissionTurnRetryRequirementsByClientMessageID = [:]
             reportQueuedTurnStorageError(error)
         }
     }
@@ -1064,7 +1285,9 @@ final class SessionStore: ObservableObject {
         let profileID = currentQueuedTurnProfileID ?? appStore.notificationRoutingProfileID
         let snapshot = QueuedTurnProfileSnapshot(
             profileID: profileID,
-            queuesBySessionID: queuedRunningTurnsBySessionID.filter { !$0.value.isEmpty }
+            queuesBySessionID: queuedRunningTurnsBySessionID.filter { !$0.value.isEmpty },
+            pendingPermissionTurnBoundariesBySessionID: pendingPermissionTurnBoundariesBySessionID,
+            permissionTurnRetryRequirementsByClientMessageID: permissionTurnRetryRequirementsByClientMessageID
         )
         try queuedTurnStore.save(snapshot)
     }
@@ -1072,6 +1295,8 @@ final class SessionStore: ObservableObject {
     @discardableResult
     func mutateAndPersistQueuedTurns(_ mutation: () -> Void) -> Bool {
         let previous = queuedRunningTurnsBySessionID
+        let previousPermissionBoundaries = pendingPermissionTurnBoundariesBySessionID
+        let previousRetryRequirements = permissionTurnRetryRequirementsByClientMessageID
         mutation()
         do {
             try persistQueuedTurns()
@@ -1079,6 +1304,8 @@ final class SessionStore: ObservableObject {
             return true
         } catch {
             queuedRunningTurnsBySessionID = previous
+            pendingPermissionTurnBoundariesBySessionID = previousPermissionBoundaries
+            permissionTurnRetryRequirementsByClientMessageID = previousRetryRequirements
             reportQueuedTurnStorageError(error)
             return false
         }

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -850,6 +850,10 @@ extension SessionStore {
         applyEventReducerOutput(output)
         if case .turnStarted(let metadata) = event {
             let id = metadata.sessionID ?? sessionID
+            _ = satisfyPendingPermissionTurnBoundary(
+                sessionID: id,
+                clientMessageID: metadata.clientMessageID
+            )
             if let turnID = metadata.turnID {
                 queuedTurnAwaitingStartSessionIDs.remove(id)
                 queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: id)
@@ -864,6 +868,7 @@ extension SessionStore {
                     }
                     queuedRunningTurnsBySessionID[id] = queue
                 }
+                stopQueuedSessionMonitoringIfIdle(sessionID: id)
             }
         }
         if case .turnCompleted(let metadata) = event {
@@ -924,6 +929,7 @@ extension SessionStore {
                         queuedTurnBlockedCompletionIDBySessionID[id] = completedTurnID
                     }
                     dispatchNextQueuedRunningTurnIfIdle(sessionID: id)
+                    stopQueuedSessionMonitoringIfIdle(sessionID: id)
                 }
             }
             scheduleDeferredFullHistoryReloadAfterTurnCompletion(sessionID: id)
@@ -2465,6 +2471,9 @@ extension SessionStore {
         composerSendModeCache.removeAll()
         stopAllQueuedSessionMonitoring()
         queuedRunningTurnsBySessionID.removeAll()
+        pendingPermissionTurnBoundariesBySessionID.removeAll()
+        permissionTurnRetryRequirementsByClientMessageID.removeAll()
+        latestSatisfiedPermissionTurnBoundary = nil
         queuedTurnStartedIDBySessionID.removeAll()
         queuedTurnAwaitingStartSessionIDs.removeAll()
         queuedTurnBlockedCompletionIDBySessionID.removeAll()

--- a/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreExternalActivity.swift
@@ -987,6 +987,10 @@ extension SessionStore {
                 setStatusMessage(L10n.text("ui.saved_to_this_machine_and_will_be_sent"))
                 return
             }
+            preservePermissionTurnRetryRequirementAfterRejection(
+                sessionID: sessionID,
+                clientMessageID: clientMessageID
+            )
             conversationStore.updateSendStatus(
                 clientMessageID: clientMessageID,
                 sessionID: sessionID,
@@ -1020,6 +1024,10 @@ extension SessionStore {
             ) {
                 return
             }
+            preservePermissionTurnRetryRequirementAfterRejection(
+                sessionID: sessionID,
+                clientMessageID: clientMessageID
+            )
             conversationStore.updateSendStatus(
                 clientMessageID: clientMessageID,
                 sessionID: sessionID,

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -23,6 +23,7 @@ extension SessionStore {
         payload: CodexAppServerTurnPayload,
         resume: AgentSession?,
         clientMessageID: ClientMessageID? = nil,
+        permissionSelection: ComposerPermissionSelectionSnapshot? = nil,
         initialGoalObjective: String? = nil,
         replacingLocalDraft localDraft: AgentSession? = nil,
         ifCurrent expectedSelectionLease: SessionSelectionLease? = nil
@@ -74,6 +75,39 @@ extension SessionStore {
             clientMessageID: clientMessageID,
             prompt: prompt
         )
+        var registeredPermissionBoundaryClientMessageID: ClientMessageID?
+        if permissionSelection?.requiresNewTurn == true,
+           let permissionSelection,
+           let clientMessageID,
+           let optimisticSessionID {
+            guard mutateAndPersistQueuedTurns({
+                pendingPermissionTurnBoundariesBySessionID[optimisticSessionID, default: []].append(
+                    PendingPermissionTurnBoundary(
+                        sessionID: optimisticSessionID,
+                        clientMessageID: clientMessageID,
+                        permissionSelection: permissionSelection
+                    )
+                )
+            }) else {
+                return false
+            }
+            registeredPermissionBoundaryClientMessageID = clientMessageID
+        }
+        defer {
+            if let registeredPermissionBoundaryClientMessageID {
+                _ = mutateAndPersistQueuedTurns {
+                    guard let location = pendingPermissionTurnBoundaryLocation(
+                        clientMessageID: registeredPermissionBoundaryClientMessageID
+                    ) else {
+                        return
+                    }
+                    _ = removePendingPermissionTurnBoundary(
+                        sessionID: location.sessionID,
+                        clientMessageID: registeredPermissionBoundaryClientMessageID
+                    )
+                }
+            }
+        }
         var optimisticSelectionLease: SessionSelectionLease?
         if let optimisticSessionID {
             // 本地草稿或带首轮输入的新会话先发布运行态占位；服务端确认后再用
@@ -118,6 +152,12 @@ extension SessionStore {
                 clientMessageID: clientMessageID
             ))
             let responseSession = self.session(response.session, in: workspace)
+            if let clientMessageID {
+                migratePendingPermissionTurnBoundary(
+                    clientMessageID: clientMessageID,
+                    to: responseSession.id
+                )
+            }
 
             if let optimisticSessionID,
                optimisticSessionID != responseSession.id {
@@ -236,6 +276,7 @@ extension SessionStore {
                 setStatusMessage(resume == nil ? L10n.text("ui.session_started") : L10n.text("ui.this_historical_conversation_has_been_continued"))
                 setErrorMessage(nil)
             }
+            registeredPermissionBoundaryClientMessageID = nil
             return true
         } catch {
             if case CodexAppServerSessionRuntimeError.activeTurnConflict(
@@ -1204,6 +1245,10 @@ extension SessionStore {
             page.messages,
             sessionID: sessionID,
             authoritativeCompletedTurnItems: page.authoritativeCompletedTurnItems
+        )
+        reconcilePendingPermissionTurnBoundaries(
+            sessionID: sessionID,
+            historyMessages: page.messages
         )
         updateHistorySavingsNotice(sessionID: sessionID, page: page)
     }

--- a/ios/MimiRemote/Sources/State/SessionStoreQueuedTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreQueuedTurns.swift
@@ -6,11 +6,19 @@ extension SessionStore {
         guard let session = sessionsByID[sessionID],
               !queuedTurnAwaitingStartSessionIDs.contains(sessionID),
               session.activeTurnID == nil,
-              let next = queuedRunningTurnsBySessionID[sessionID]?.first,
+              let queue = queuedRunningTurnsBySessionID[sessionID],
+              let next = queue.first,
               next.dispatchState == .waiting,
               next.waitsForAcceptedTurnStart != true,
               next.expectedTurnID == nil
         else {
+            return
+        }
+        if let pendingBoundary = pendingPermissionTurnBoundary(for: sessionID),
+           pendingBoundary.clientMessageID != next.clientMessageID,
+           !queue.contains(where: { $0.clientMessageID == pendingBoundary.clientMessageID }) {
+            // 边界项仍在队列后方时，先发送排在它前面的普通项。只有 ACK 后边界项已离队、
+            // 仍等待精确 started 的 orphan boundary 才能阻止后续消息越过。
             return
         }
         guard canControlSession(session) else {
@@ -119,6 +127,21 @@ extension SessionStore {
         queuedGuidanceDispatchClientMessageIDs.subtract(queued.map(\.clientMessageID))
         _ = mutateAndPersistQueuedTurns {
             setQueuedTurns([], sessionID: sessionID)
+            let waitingIDs = Set(queued.lazy.filter { $0.dispatchState == .waiting }.map(\.clientMessageID))
+            if var boundaries = pendingPermissionTurnBoundariesBySessionID[sessionID] {
+                for boundary in boundaries where waitingIDs.contains(boundary.clientMessageID) {
+                    if markMessagesFailed {
+                        permissionTurnRetryRequirementsByClientMessageID[boundary.clientMessageID] = boundary
+                    }
+                }
+                // 尚未派发的边界随队列一起取消；已派发或结果不确定的边界仍必须等精确 started。
+                boundaries.removeAll { waitingIDs.contains($0.clientMessageID) }
+                if boundaries.isEmpty {
+                    pendingPermissionTurnBoundariesBySessionID.removeValue(forKey: sessionID)
+                } else {
+                    pendingPermissionTurnBoundariesBySessionID[sessionID] = boundaries
+                }
+            }
         }
         stopQueuedSessionMonitoringIfIdle(sessionID: sessionID)
         queuedTurnAwaitingStartSessionIDs.remove(sessionID)
@@ -148,7 +171,8 @@ extension SessionStore {
     }
 
     func ensureQueuedSessionMonitoring(sessionID: SessionID) {
-        guard queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false,
+        guard queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false
+                || queuedTurnAwaitingStartSessionIDs.contains(sessionID),
               connectionTermination == nil,
               !appStore.requiresRePairing,
               appStore.isConfigured,
@@ -272,7 +296,9 @@ extension SessionStore {
     }
 
     func ensureAllQueuedSessionMonitoring() {
-        for sessionID in queuedRunningTurnsBySessionID.keys {
+        let sessionIDs = Set(queuedRunningTurnsBySessionID.keys)
+            .union(queuedTurnAwaitingStartSessionIDs)
+        for sessionID in sessionIDs {
             ensureQueuedSessionMonitoring(sessionID: sessionID)
         }
     }
@@ -283,7 +309,8 @@ extension SessionStore {
     }
 
     func stopQueuedSessionMonitoringIfIdle(sessionID: SessionID) {
-        guard queuedRunningTurnsBySessionID[sessionID]?.isEmpty != false else { return }
+        guard queuedRunningTurnsBySessionID[sessionID]?.isEmpty != false,
+              !queuedTurnAwaitingStartSessionIDs.contains(sessionID) else { return }
         guard queuedSessionSockets[sessionID] != nil || queuedSessionReconnectTasks[sessionID] != nil else {
             return
         }
@@ -305,7 +332,8 @@ extension SessionStore {
 
     func scheduleQueuedSessionReconnect(sessionID: SessionID, generation: Int) {
         guard isCurrentQueuedSessionSocket(sessionID: sessionID, generation: generation),
-              queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false else { return }
+              queuedRunningTurnsBySessionID[sessionID]?.isEmpty == false
+                || queuedTurnAwaitingStartSessionIDs.contains(sessionID) else { return }
         markDispatchingQueuedTurnsNeedsConfirmation(
             sessionID: sessionID,
             message: L10n.text("ui.the_connection_has_been_interrupted_sending_results_requires")
@@ -339,15 +367,15 @@ extension SessionStore {
         sessionID: SessionID,
         message: String
     ) {
-        // 当前连接退役后，即使 turn/start 已 accepted，也可能错过紧随其后的 started；
-        // 清掉仅属于该连接的门闩，恢复时交给 REST 快照重新判定 active turn。
-        queuedTurnAwaitingStartSessionIDs.remove(sessionID)
-        queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
         guard queuedRunningTurnsBySessionID[sessionID]?.contains(where: {
             $0.dispatchState == .dispatching
         }) == true else {
             return
         }
+        // 尚未收到 accepted 的 dispatching 项在连接退役后结果不确定，不能继续保留
+        // awaiting-start 门闩；已经 accepted 且已离队的项则由重连继续等待 started。
+        queuedTurnAwaitingStartSessionIDs.remove(sessionID)
+        queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
         _ = mutateAndPersistQueuedTurns {
             guard var queue = queuedRunningTurnsBySessionID[sessionID] else { return }
             for index in queue.indices where queue[index].dispatchState == .dispatching {
@@ -396,15 +424,11 @@ extension SessionStore {
             case .awaitingStart(let turnID):
                 let blockedCompletionID = queuedTurnBlockedCompletionIDBySessionID[sessionID]
                 for index in queue.indices where queue[index].dispatchState == .waiting {
-                    if let turnID {
-                        queue[index].waitsForAcceptedTurnStart = nil
-                        queue[index].blockedCompletionID = nil
-                        queue[index].expectedTurnID = turnID
-                    } else {
-                        queue[index].waitsForAcceptedTurnStart = true
-                        queue[index].blockedCompletionID = blockedCompletionID
-                        queue[index].expectedTurnID = nil
-                    }
+                    // ACK 带 turnID 仍不等于已观察到 started。门闩和精确 ID 必须一起
+                    // 持久化，避免 ACK 后崩溃时重启把 expectedTurnID 当成陈旧状态清掉。
+                    queue[index].waitsForAcceptedTurnStart = true
+                    queue[index].blockedCompletionID = blockedCompletionID
+                    queue[index].expectedTurnID = turnID
                 }
             case .superseded(_, let activeTurnID):
                 for index in queue.indices where queue[index].dispatchState == .waiting {
@@ -433,10 +457,6 @@ extension SessionStore {
         }
         switch disposition {
         case .awaitingStart(let turnID):
-            if turnID != nil {
-                queuedTurnAwaitingStartSessionIDs.remove(sessionID)
-                queuedTurnBlockedCompletionIDBySessionID.removeValue(forKey: sessionID)
-            }
             if wasGuidance, let turnID {
                 // stale guidance 在 RPC 前确认 active turn 缺失后会降级为新的 turn/start。
                 // 只有这一条显式 accepted 路径可以把 ACK 中的新 turn 设为本地权威状态；
@@ -591,7 +611,18 @@ extension SessionStore {
         _ = mutateAndPersistQueuedTurns {
             guard var queue = queuedRunningTurnsBySessionID[sessionID],
                   queue.indices.contains(location.index) else { return }
-            queue.remove(at: location.index)
+            let removed = queue.remove(at: location.index)
+            if let boundary = removePendingPermissionTurnBoundary(
+                sessionID: sessionID,
+                clientMessageID: removed.clientMessageID
+            ) {
+                permissionTurnRetryRequirementsByClientMessageID[removed.clientMessageID] = boundary
+                for index in queue.indices where queue[index].waitsForAcceptedTurnStart == true {
+                    queue[index].waitsForAcceptedTurnStart = nil
+                    queue[index].blockedCompletionID = nil
+                    queue[index].expectedTurnID = sessionsByID[sessionID]?.activeTurnID
+                }
+            }
             setQueuedTurns(queue, sessionID: sessionID)
         }
         conversationStore.updateSendStatus(
@@ -636,12 +667,21 @@ extension SessionStore {
                 }
             }
 
+            let currentQueue = queuedRunningTurnsBySessionID[sessionID] ?? []
+            let queuedClientMessageIDs = Set(currentQueue.map(\.clientMessageID))
             let ambiguousIDs = Set(
-                (queuedRunningTurnsBySessionID[sessionID] ?? [])
+                currentQueue
                     .filter { $0.dispatchState == .needsConfirmation }
                     .map(\.clientMessageID)
             )
-            if !ambiguousIDs.isEmpty,
+            let hasPersistedAcceptedStartBarrier = currentQueue.contains {
+                $0.dispatchState == .waiting && $0.waitsForAcceptedTurnStart == true
+            }
+            let hasOrphanPermissionBoundary = pendingPermissionTurnBoundariesBySessionID[sessionID]?
+                .contains(where: { !queuedClientMessageIDs.contains($0.clientMessageID) }) == true
+            if (!ambiguousIDs.isEmpty
+                    || hasOrphanPermissionBoundary
+                    || hasPersistedAcceptedStartBarrier),
                let page = try? await client.messagesPage(
                     sessionID: sessionID,
                     before: nil,
@@ -649,15 +689,30 @@ extension SessionStore {
                     loadMode: .full
                ) {
                 let deliveredIDs = Set(page.messages.compactMap(\.clientMessageID)).intersection(ambiguousIDs)
-                if !deliveredIDs.isEmpty {
+                let startedTurnIDs = Set(page.messages.compactMap { message -> TurnID? in
+                    guard let turnID = message.turnID?
+                        .trimmingCharacters(in: .whitespacesAndNewlines),
+                          !turnID.isEmpty else { return nil }
+                    return turnID
+                })
+                if !deliveredIDs.isEmpty || !startedTurnIDs.isEmpty {
                     _ = mutateAndPersistQueuedTurns {
-                        guard let queue = queuedRunningTurnsBySessionID[sessionID] else { return }
-                        setQueuedTurns(
-                            queue.filter { !deliveredIDs.contains($0.clientMessageID) },
-                            sessionID: sessionID
-                        )
+                        guard var queue = queuedRunningTurnsBySessionID[sessionID] else { return }
+                        queue.removeAll { deliveredIDs.contains($0.clientMessageID) }
+                        for index in queue.indices
+                        where queue[index].dispatchState == .waiting
+                            && queue[index].waitsForAcceptedTurnStart == true
+                            && queue[index].expectedTurnID.map(startedTurnIDs.contains) == true {
+                            queue[index].waitsForAcceptedTurnStart = nil
+                            queue[index].blockedCompletionID = nil
+                        }
+                        setQueuedTurns(queue, sessionID: sessionID)
                     }
                 }
+                reconcilePendingPermissionTurnBoundaries(
+                    sessionID: sessionID,
+                    historyMessages: page.messages
+                )
             }
 
             guard let authoritativeSession,

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -1286,6 +1286,14 @@ enum QueuedTurnDispatchState: String, Codable, Equatable {
     case needsConfirmation
 }
 
+/// 权限选择改变后，必须等同一条消息真正开始新的 turn 才能解除边界。
+/// 只保存提交时的快照，迟到的旧事件不能清掉用户后来选择的权限。
+struct PendingPermissionTurnBoundary: Codable, Equatable {
+    let sessionID: SessionID
+    let clientMessageID: ClientMessageID
+    let permissionSelection: ComposerPermissionSelectionSnapshot
+}
+
 struct QueuedTurnEntry: Codable, Equatable, Identifiable {
     var id: ClientMessageID { clientMessageID }
 
@@ -1297,6 +1305,9 @@ struct QueuedTurnEntry: Codable, Equatable, Identifiable {
     let createdAt: Date
     var dispatchState: QueuedTurnDispatchState
     var expectedTurnID: TurnID?
+    // true 表示该队列项不能被 steer 到旧 turn，必须作为新的 turn/start 派发。
+    // Optional 保持旧 v1 队列 JSON 缺少该字段时仍可解码。
+    var requiresFreshTurn: Bool?
     // 上一条 turn/start 已获接受、但 started 事件尚未到达时，后续项必须跨重启继续等待；
     // blockedCompletionID 用来识别并忽略触发上一条派发的重复 completed 事件。
     var waitsForAcceptedTurnStart: Bool?
@@ -1313,6 +1324,7 @@ struct QueuedTurnEntry: Codable, Equatable, Identifiable {
         createdAt: Date = Date(),
         dispatchState: QueuedTurnDispatchState = .waiting,
         expectedTurnID: TurnID? = nil,
+        requiresFreshTurn: Bool? = nil,
         waitsForAcceptedTurnStart: Bool? = nil,
         blockedCompletionID: TurnID? = nil,
         lastAttemptAt: Date? = nil,
@@ -1326,6 +1338,7 @@ struct QueuedTurnEntry: Codable, Equatable, Identifiable {
         self.createdAt = createdAt
         self.dispatchState = dispatchState
         self.expectedTurnID = expectedTurnID
+        self.requiresFreshTurn = requiresFreshTurn
         self.waitsForAcceptedTurnStart = waitsForAcceptedTurnStart
         self.blockedCompletionID = blockedCompletionID
         self.lastAttemptAt = lastAttemptAt
@@ -1354,6 +1367,74 @@ struct QueuedTurnProfileSnapshot: Codable, Equatable {
     var version = Self.schemaVersion
     let profileID: String
     var queuesBySessionID: [SessionID: [QueuedTurnEntry]]
+    var pendingPermissionTurnBoundariesBySessionID: [SessionID: [PendingPermissionTurnBoundary]]
+    /// 明确拒绝的权限消息已离开队列，但重试时仍必须恢复 fresh-turn 约束。
+    var permissionTurnRetryRequirementsByClientMessageID: [ClientMessageID: PendingPermissionTurnBoundary]
+
+    init(
+        version: Int = Self.schemaVersion,
+        profileID: String,
+        queuesBySessionID: [SessionID: [QueuedTurnEntry]],
+        pendingPermissionTurnBoundariesBySessionID: [SessionID: [PendingPermissionTurnBoundary]] = [:],
+        permissionTurnRetryRequirementsByClientMessageID: [ClientMessageID: PendingPermissionTurnBoundary] = [:]
+    ) {
+        self.version = version
+        self.profileID = profileID
+        self.queuesBySessionID = queuesBySessionID
+        self.pendingPermissionTurnBoundariesBySessionID = pendingPermissionTurnBoundariesBySessionID
+        self.permissionTurnRetryRequirementsByClientMessageID = permissionTurnRetryRequirementsByClientMessageID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case profileID
+        case queuesBySessionID
+        case pendingPermissionTurnBoundariesBySessionID
+        case permissionTurnRetryRequirementsByClientMessageID
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        profileID = try container.decode(String.self, forKey: .profileID)
+        queuesBySessionID = try container.decode(
+            [SessionID: [QueuedTurnEntry]].self,
+            forKey: .queuesBySessionID
+        )
+        // 已发布的 v1 文件没有这些字段。早期 MIM-189 开发版还把每个 Session 编码成单条边界。
+        if let boundaries = try? container.decode(
+            [SessionID: [PendingPermissionTurnBoundary]].self,
+            forKey: .pendingPermissionTurnBoundariesBySessionID
+        ) {
+            pendingPermissionTurnBoundariesBySessionID = boundaries
+        } else if let legacyBoundaries = try? container.decode(
+            [SessionID: PendingPermissionTurnBoundary].self,
+            forKey: .pendingPermissionTurnBoundariesBySessionID
+        ) {
+            pendingPermissionTurnBoundariesBySessionID = legacyBoundaries.mapValues { [$0] }
+        } else {
+            pendingPermissionTurnBoundariesBySessionID = [:]
+        }
+        permissionTurnRetryRequirementsByClientMessageID = try container.decodeIfPresent(
+            [ClientMessageID: PendingPermissionTurnBoundary].self,
+            forKey: .permissionTurnRetryRequirementsByClientMessageID
+        ) ?? [:]
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(profileID, forKey: .profileID)
+        try container.encode(queuesBySessionID, forKey: .queuesBySessionID)
+        try container.encode(
+            pendingPermissionTurnBoundariesBySessionID,
+            forKey: .pendingPermissionTurnBoundariesBySessionID
+        )
+        try container.encode(
+            permissionTurnRetryRequirementsByClientMessageID,
+            forKey: .permissionTurnRetryRequirementsByClientMessageID
+        )
+    }
 }
 
 enum QueuedTurnStoreError: LocalizedError {

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -690,7 +690,8 @@ extension SessionStore {
         payload: CodexAppServerTurnPayload,
         objective: String,
         tokenBudget: Int64? = nil,
-        runningDelivery: RunningTurnDelivery = .queued
+        runningDelivery: RunningTurnDelivery = .queued,
+        permissionSelection: ComposerPermissionSelectionSnapshot? = nil
     ) async -> Bool {
         if let session = selectedSession,
            isExternalReadOnlySession(session) || isProtocolReadOnlySession(session) {
@@ -712,14 +713,28 @@ extension SessionStore {
             return false
         }
 
-        if let session = selectedSession, session.isRunning {
+        let selectedSessionHasQueuedTurns = selectedSession.map {
+            queuedRunningTurnsBySessionID[$0.id]?.isEmpty == false
+        } ?? false
+        let selectedSessionHasPendingPermissionBoundary = selectedSession.map {
+            pendingPermissionTurnBoundariesBySessionID[$0.id]?.isEmpty == false
+        } ?? false
+        let selectedSessionAwaitsAcceptedTurnStart = selectedSession.map {
+            queuedTurnAwaitingStartSessionIDs.contains($0.id)
+        } ?? false
+        if let session = selectedSession,
+           session.isRunning || (runningDelivery == .queued
+                && (selectedSessionHasQueuedTurns
+                    || selectedSessionHasPendingPermissionBoundary
+                    || selectedSessionAwaitsAcceptedTurnStart)) {
             // 排队目标必须把“设置目标 + 启动 turn”作为同一个本地队列项保存；
             // 若在这里提前写远端目标，App 被挂起时会留下“目标已改、任务没发”的半完成状态。
             if runningDelivery == .queued {
                 let sent = await sendTurn(
                     payload,
                     runningDelivery: .queued,
-                    queuedIntent: .goal(objective: normalizedObjective, tokenBudget: tokenBudget)
+                    queuedIntent: .goal(objective: normalizedObjective, tokenBudget: tokenBudget),
+                    permissionSelection: permissionSelection
                 )
                 if sent {
                     setStatusMessage(L10n.text("ui.the_target_task_has_been_added_to_be"))
@@ -738,7 +753,8 @@ extension SessionStore {
             }
             let sent = await sendTurn(
                 payload,
-                runningDelivery: .guided
+                runningDelivery: .guided,
+                permissionSelection: permissionSelection
             )
             if sent {
                 setStatusMessage(L10n.text("ui.the_target_task_has_been_started"))
@@ -758,6 +774,7 @@ extension SessionStore {
             payload: payload,
             resume: resume,
             clientMessageID: UUID().uuidString,
+            permissionSelection: permissionSelection,
             initialGoalObjective: normalizedObjective,
             replacingLocalDraft: localDraft
         )
@@ -780,7 +797,8 @@ extension SessionStore {
     func sendTurn(
         _ payload: CodexAppServerTurnPayload,
         runningDelivery: RunningTurnDelivery = .queued,
-        queuedIntent: QueuedTurnIntent? = nil
+        queuedIntent: QueuedTurnIntent? = nil,
+        permissionSelection: ComposerPermissionSelectionSnapshot? = nil
     ) async -> Bool {
         guard !payload.isEmpty else {
             return false
@@ -803,6 +821,7 @@ extension SessionStore {
                 payload: payload,
                 resume: nil,
                 clientMessageID: UUID().uuidString,
+                permissionSelection: permissionSelection,
                 replacingLocalDraft: localDraft
             )
         }
@@ -810,8 +829,17 @@ extension SessionStore {
         let selectedSessionHasQueuedTurns = selectedSession.map {
             queuedRunningTurnsBySessionID[$0.id]?.isEmpty == false
         } ?? false
+        let selectedSessionHasPendingPermissionBoundary = selectedSession.map {
+            pendingPermissionTurnBoundariesBySessionID[$0.id]?.isEmpty == false
+        } ?? false
+        let selectedSessionAwaitsAcceptedTurnStart = selectedSession.map {
+            queuedTurnAwaitingStartSessionIDs.contains($0.id)
+        } ?? false
         if let session = selectedSession,
-           session.isRunning || (runningDelivery == .queued && selectedSessionHasQueuedTurns) {
+           session.isRunning || (runningDelivery == .queued
+                && (selectedSessionHasQueuedTurns
+                    || selectedSessionHasPendingPermissionBoundary
+                    || selectedSessionAwaitsAcceptedTurnStart)) {
             guard canControlSession(session) else {
                 setErrorMessage(L10n.text("ui.this_session_is_running_on_another_client_please_c95578ac"))
                 return false
@@ -824,16 +852,28 @@ extension SessionStore {
                     return false
                 }
                 let intent = queuedIntent ?? (payload.options.collaborationMode == .plan ? .plan : .standard)
+                let requiresFreshTurn = permissionSelection?.requiresNewTurn == true
                 let item = QueuedTurnEntry(
                     sessionID: session.id,
                     projectID: session.projectID,
                     payload: payload,
                     clientMessageID: clientMessageID,
                     intent: intent,
-                    expectedTurnID: session.activeTurnID
+                    expectedTurnID: session.activeTurnID,
+                    requiresFreshTurn: requiresFreshTurn ? true : nil
                 )
                 guard mutateAndPersistQueuedTurns({
                     queuedRunningTurnsBySessionID[session.id, default: []].append(item)
+                    if requiresFreshTurn,
+                       let permissionSelection {
+                        pendingPermissionTurnBoundariesBySessionID[session.id, default: []].append(
+                            PendingPermissionTurnBoundary(
+                            sessionID: session.id,
+                            clientMessageID: clientMessageID,
+                            permissionSelection: permissionSelection
+                            )
+                        )
+                    }
                 }) else {
                     return false
                 }
@@ -886,7 +926,13 @@ extension SessionStore {
             setErrorMessage(L10n.text("ui.please_select_the_project_first"))
             return false
         }
-        return await createSession(projectID: projectID, payload: payload, resume: resume, clientMessageID: UUID().uuidString)
+        return await createSession(
+            projectID: projectID,
+            payload: payload,
+            resume: resume,
+            clientMessageID: UUID().uuidString,
+            permissionSelection: permissionSelection
+        )
     }
 
     func interruptSelectedTurn() {
@@ -1003,15 +1049,33 @@ extension SessionStore {
         }
 
         if let session = selectedSession,
-           session.isRunning,
-           let clientMessageID = message.clientMessageID {
+           let clientMessageID = message.clientMessageID,
+           session.isRunning
+            || queuedRunningTurnsBySessionID[session.id]?.isEmpty == false
+            || pendingPermissionTurnBoundariesBySessionID[session.id]?.isEmpty == false
+            || queuedTurnAwaitingStartSessionIDs.contains(session.id) {
             guard canControlSession(session) else {
                 setErrorMessage(L10n.text("ui.this_session_is_running_on_another_client_please_c95578ac"))
                 return false
             }
             let payload = message.turnPayload ?? CodexAppServerTurnPayload(prompt: prompt)
             let resolvedPayload = await payloadResolvingRequiredModel(payload)
-            if let activeTurnID = session.activeTurnID {
+            let persistedRetryRequirement = permissionTurnRetryRequirementsByClientMessageID[clientMessageID]
+            let pendingRetryRequirement = pendingPermissionTurnBoundariesBySessionID[session.id]?
+                .first(where: { $0.clientMessageID == clientMessageID })
+            let cachedPermissionSelection = composerPermissionSelection(for: .session(session.id))
+            let retryPermissionSelection = persistedRetryRequirement?.permissionSelection
+                ?? pendingRetryRequirement?.permissionSelection
+                ?? (cachedPermissionSelection?.requiresNewTurn == true
+                    ? ComposerPermissionSelectionSnapshot(
+                        options: resolvedPayload.options,
+                        requiresNewTurn: true
+                    )
+                    : nil)
+            if session.activeTurnID != nil
+                || queuedRunningTurnsBySessionID[session.id]?.isEmpty == false
+                || pendingPermissionTurnBoundariesBySessionID[session.id]?.isEmpty == false
+                || queuedTurnAwaitingStartSessionIDs.contains(session.id) {
                 let queueCount = queuedRunningTurnsBySessionID[session.id]?.count ?? 0
                 guard queueCount < Self.queuedTurnLimitPerSession else {
                     setErrorMessage(L10n.format("ui.each_session_retains_a_maximum_of_value_messages", Self.queuedTurnLimitPerSession))
@@ -1020,16 +1084,53 @@ extension SessionStore {
                 let intent: QueuedTurnIntent = resolvedPayload.options.collaborationMode == .plan
                     ? .plan
                     : .standard
+                let requiresFreshTurn = retryPermissionSelection != nil
                 let item = QueuedTurnEntry(
                     sessionID: session.id,
                     projectID: session.projectID,
                     payload: resolvedPayload,
                     clientMessageID: clientMessageID,
                     intent: intent,
-                    expectedTurnID: activeTurnID
+                    expectedTurnID: session.activeTurnID,
+                    requiresFreshTurn: requiresFreshTurn ? true : nil
                 )
                 guard mutateAndPersistQueuedTurns({
-                    queuedRunningTurnsBySessionID[session.id, default: []].append(item)
+                    var queue = queuedRunningTurnsBySessionID[session.id] ?? []
+                    if let pendingRetryRequirement,
+                       let boundaries = pendingPermissionTurnBoundariesBySessionID[session.id],
+                       let boundaryIndex = boundaries.firstIndex(where: {
+                           $0.clientMessageID == pendingRetryRequirement.clientMessageID
+                       }) {
+                        // uncertain 项离开队列后，重试必须回到原边界位置；否则后续项会挡在
+                        // retained boundary 前面，使 dispatcher 永久无法匹配 FIFO 头部。
+                        let earlierBoundaryIDs = Set(
+                            boundaries[..<boundaryIndex].map(\.clientMessageID)
+                        )
+                        let insertionIndex: Int
+                        if let previousIndex = queue.lastIndex(where: {
+                            earlierBoundaryIDs.contains($0.clientMessageID)
+                        }) {
+                            insertionIndex = previousIndex + 1
+                        } else {
+                            insertionIndex = 0
+                        }
+                        queue.insert(item, at: insertionIndex)
+                    } else {
+                        queue.append(item)
+                    }
+                    queuedRunningTurnsBySessionID[session.id] = queue
+                    permissionTurnRetryRequirementsByClientMessageID.removeValue(forKey: clientMessageID)
+                    if requiresFreshTurn,
+                       let retryPermissionSelection,
+                       pendingRetryRequirement == nil {
+                        pendingPermissionTurnBoundariesBySessionID[session.id, default: []].append(
+                            PendingPermissionTurnBoundary(
+                                sessionID: session.id,
+                                clientMessageID: clientMessageID,
+                                permissionSelection: retryPermissionSelection
+                            )
+                        )
+                    }
                 }) else {
                     return false
                 }
@@ -1054,11 +1155,39 @@ extension SessionStore {
             guard let socket = readyWebSocket(for: session) else {
                 return false
             }
+            let addedPendingBoundary = retryPermissionSelection != nil && pendingRetryRequirement == nil
+            if retryPermissionSelection != nil || persistedRetryRequirement != nil {
+                guard mutateAndPersistQueuedTurns({
+                    permissionTurnRetryRequirementsByClientMessageID.removeValue(forKey: clientMessageID)
+                    if addedPendingBoundary, let retryPermissionSelection {
+                        pendingPermissionTurnBoundariesBySessionID[session.id, default: []].append(
+                            PendingPermissionTurnBoundary(
+                                sessionID: session.id,
+                                clientMessageID: clientMessageID,
+                                permissionSelection: retryPermissionSelection
+                            )
+                        )
+                    }
+                }) else {
+                    return false
+                }
+            }
             // 失败消息有 client_message_id 时直接复用原 row 重发，避免 timeline 里出现重复用户气泡。
             conversationStore.updateSendStatus(clientMessageID: clientMessageID, sessionID: session.id, status: .sending)
             setSessionListProjection(sessionID: session.id, preview: prompt, source: .localUser, clientMessageID: clientMessageID)
             setForegroundActivity(.waitingForAssistant, sessionID: session.id)
             guard socket.sendTurn(resolvedPayload, clientMessageID: clientMessageID) else {
+                _ = mutateAndPersistQueuedTurns {
+                    if addedPendingBoundary {
+                        _ = removePendingPermissionTurnBoundary(
+                            sessionID: session.id,
+                            clientMessageID: clientMessageID
+                        )
+                    }
+                    if let persistedRetryRequirement {
+                        permissionTurnRetryRequirementsByClientMessageID[clientMessageID] = persistedRetryRequirement
+                    }
+                }
                 conversationStore.updateSendStatus(clientMessageID: clientMessageID, sessionID: session.id, status: .failed)
                 clearSessionListProjection(sessionID: session.id, clientMessageID: clientMessageID)
                 clearSessionRecentActivityProjection(sessionID: session.id, clientMessageID: clientMessageID)
@@ -1069,8 +1198,69 @@ extension SessionStore {
             return true
         }
 
-        // 会话已经结束或失败时，沿用普通发送路径重新创建/恢复后端 thread。
-        return await sendTurn(message.turnPayload ?? CodexAppServerTurnPayload(prompt: prompt))
+        // 会话已经结束或失败时，普通发送会生成新 ID。权限重试必须先把旧要求原子迁移成
+        // 这次请求的 pending boundary，并继续复用原 client_message_id 等精确 started。
+        guard let clientMessageID = message.clientMessageID else {
+            return await sendTurn(message.turnPayload ?? CodexAppServerTurnPayload(prompt: prompt))
+        }
+        let persistedRetryRequirement = permissionTurnRetryRequirementsByClientMessageID[clientMessageID]
+        let originalPendingLocation = pendingPermissionTurnBoundaryLocation(clientMessageID: clientMessageID)
+        guard let retryRequirement = persistedRetryRequirement ?? originalPendingLocation?.boundary else {
+            return await sendTurn(message.turnPayload ?? CodexAppServerTurnPayload(prompt: prompt))
+        }
+        let resume = selectedSession
+        guard let projectID = resume?.projectID ?? selectedProjectID else {
+            setErrorMessage(L10n.text("ui.please_select_the_project_first"))
+            return false
+        }
+        let targetSessionID = resume?.id ?? retryRequirement.sessionID
+        let reboundBoundary = PendingPermissionTurnBoundary(
+            sessionID: targetSessionID,
+            clientMessageID: clientMessageID,
+            permissionSelection: retryRequirement.permissionSelection
+        )
+        guard mutateAndPersistQueuedTurns({
+            permissionTurnRetryRequirementsByClientMessageID.removeValue(forKey: clientMessageID)
+            if let originalPendingLocation {
+                _ = removePendingPermissionTurnBoundary(
+                    sessionID: originalPendingLocation.sessionID,
+                    clientMessageID: clientMessageID
+                )
+            }
+            pendingPermissionTurnBoundariesBySessionID[targetSessionID, default: []].append(reboundBoundary)
+        }) else {
+            return false
+        }
+
+        let didSend = await createSession(
+            projectID: projectID,
+            payload: message.turnPayload ?? CodexAppServerTurnPayload(prompt: prompt),
+            resume: resume,
+            clientMessageID: clientMessageID
+        )
+        guard !didSend else {
+            return true
+        }
+        _ = mutateAndPersistQueuedTurns {
+            if let currentLocation = pendingPermissionTurnBoundaryLocation(clientMessageID: clientMessageID) {
+                _ = removePendingPermissionTurnBoundary(
+                    sessionID: currentLocation.sessionID,
+                    clientMessageID: clientMessageID
+                )
+            }
+            if let originalPendingLocation {
+                var boundaries = pendingPermissionTurnBoundariesBySessionID[originalPendingLocation.sessionID] ?? []
+                boundaries.insert(
+                    originalPendingLocation.boundary,
+                    at: min(originalPendingLocation.index, boundaries.count)
+                )
+                pendingPermissionTurnBoundariesBySessionID[originalPendingLocation.sessionID] = boundaries
+            }
+            if let persistedRetryRequirement {
+                permissionTurnRetryRequirementsByClientMessageID[clientMessageID] = persistedRetryRequirement
+            }
+        }
+        return false
     }
 
     @discardableResult

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -2,6 +2,8 @@ import Foundation
 
 // Runtime 使用量、连接配置、Turn、Goal、审批与队列发送共享同一协调边界。
 extension SessionStore {
+    nonisolated static let codexRemoteFullAccessCapability = "codex_remote_full_access_v1"
+
     func refreshCodexUsage() async {
         await refreshUsage(runtimeProvider: "codex")
     }
@@ -228,7 +230,7 @@ extension SessionStore {
            !model.isEmpty {
             // 开发者模式明确允许未列入 model/list 的自定义模型；普通模式才执行目录校验和回落。
             resolved.options = resolved.options.sanitizedForRuntimePolicy()
-            return resolved
+            return payloadApplyingRemoteNoApprovalCompatibility(resolved)
         }
         if appServerModelOptions.isEmpty {
             await refreshAppServerModelOptions()
@@ -257,12 +259,12 @@ extension SessionStore {
             resolved.options.model = matched.model
             resolved.options.modelProvider = matched.provider
             resolved.options = resolved.options.sanitizedForRuntimePolicy()
-            return resolved
+            return payloadApplyingRemoteNoApprovalCompatibility(resolved)
         }
 
         guard let selected = candidateOptions.first(where: \.isDefault) ?? candidateOptions.first else {
             resolved.options = resolved.options.sanitizedForRuntimePolicy()
-            return resolved
+            return payloadApplyingRemoteNoApprovalCompatibility(resolved)
         }
 
         // app-server 的 turn/start 目前要求顶层 model 必填；模型来源必须优先使用
@@ -273,7 +275,18 @@ extension SessionStore {
         resolved.options.model = selected.model
         resolved.options.modelProvider = selected.provider
         resolved.options = resolved.options.sanitizedForRuntimePolicy()
-        return resolved
+        return payloadApplyingRemoteNoApprovalCompatibility(resolved)
+    }
+
+    func payloadApplyingRemoteNoApprovalCompatibility(
+        _ payload: CodexAppServerTurnPayload
+    ) -> CodexAppServerTurnPayload {
+        var compatible = payload
+        let isSupported = appStore.capabilityDecision(
+            for: Self.codexRemoteFullAccessCapability
+        ) == .enabled
+        compatible.options = compatible.options.adjustedForRemoteNoApprovalSupport(isSupported)
+        return compatible
     }
 
     func selectedSessionRuntimeProviderForTurn() -> String? {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -153,6 +153,45 @@ extension ConversationDataFlowTests {
         )
     }
 
+    func testComposerPermissionChangeRequiresQueuedTurnBeforeGuidanceCanResume() {
+        var composerState = ComposerState()
+        let previousSelection = composerState.permissionSelectionSnapshot()
+        composerState.applyPermissionMode(.readOnly)
+        composerState.markPermissionSelectionRequiresNewTurnIfChanged(
+            from: previousSelection,
+            sessionIsRunning: true
+        )
+
+        XCTAssertTrue(composerState.permissionSelectionRequiresNewTurn)
+        XCTAssertEqual(
+            composerState.runningTurnDelivery(canUseGuidedFollowUp: true, guidedFollowUpEnabled: true),
+            .queued,
+            "turn/steer 不能携带下一回合权限，必须排队到新的 turn/start"
+        )
+
+        let submittedSelection = composerState.permissionSelectionSnapshot()
+        composerState.markPermissionSelectionSubmitted(submittedSelection)
+
+        XCTAssertFalse(composerState.permissionSelectionRequiresNewTurn)
+        XCTAssertEqual(
+            composerState.runningTurnDelivery(canUseGuidedFollowUp: true, guidedFollowUpEnabled: true),
+            .guided
+        )
+    }
+
+    func testLatePermissionSubmitAckDoesNotClearNewerSelection() {
+        var composerState = ComposerState()
+        composerState.markPermissionSelectionRequiresNewTurn()
+        let submittedSelection = composerState.permissionSelectionSnapshot()
+
+        composerState.applyPermissionMode(.readOnly)
+        composerState.markPermissionSelectionRequiresNewTurn()
+        composerState.markPermissionSelectionSubmitted(submittedSelection)
+
+        XCTAssertTrue(composerState.permissionSelectionRequiresNewTurn)
+        XCTAssertEqual(composerState.permissionMode, .readOnly)
+    }
+
     func testComposerPrimaryActionKeepsRunningTurnSubmissionAndStopReachable() {
         XCTAssertEqual(
             ComposerPrimaryAction.resolve(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerHistoryTests.swift
@@ -155,12 +155,7 @@ extension ConversationDataFlowTests {
 
     func testComposerPermissionChangeRequiresQueuedTurnBeforeGuidanceCanResume() {
         var composerState = ComposerState()
-        let previousSelection = composerState.permissionSelectionSnapshot()
-        composerState.applyPermissionMode(.readOnly)
-        composerState.markPermissionSelectionRequiresNewTurnIfChanged(
-            from: previousSelection,
-            sessionIsRunning: true
-        )
+        composerState.applyPermissionMode(.readOnly, sessionIsRunning: true)
 
         XCTAssertTrue(composerState.permissionSelectionRequiresNewTurn)
         XCTAssertEqual(
@@ -169,8 +164,8 @@ extension ConversationDataFlowTests {
             "turn/steer 不能携带下一回合权限，必须排队到新的 turn/start"
         )
 
-        let submittedSelection = composerState.permissionSelectionSnapshot()
-        composerState.markPermissionSelectionSubmitted(submittedSelection)
+        let startedSelection = composerState.permissionSelectionSnapshot()
+        composerState.markPermissionSelectionApplied(startedSelection)
 
         XCTAssertFalse(composerState.permissionSelectionRequiresNewTurn)
         XCTAssertEqual(
@@ -179,14 +174,14 @@ extension ConversationDataFlowTests {
         )
     }
 
-    func testLatePermissionSubmitAckDoesNotClearNewerSelection() {
+    func testLatePermissionTurnStartDoesNotClearNewerSelection() {
         var composerState = ComposerState()
         composerState.markPermissionSelectionRequiresNewTurn()
-        let submittedSelection = composerState.permissionSelectionSnapshot()
+        let startedSelection = composerState.permissionSelectionSnapshot()
 
         composerState.applyPermissionMode(.readOnly)
         composerState.markPermissionSelectionRequiresNewTurn()
-        composerState.markPermissionSelectionSubmitted(submittedSelection)
+        composerState.markPermissionSelectionApplied(startedSelection)
 
         XCTAssertTrue(composerState.permissionSelectionRequiresNewTurn)
         XCTAssertEqual(composerState.permissionMode, .readOnly)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -3148,6 +3148,23 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertEqual(state.turnOptions.sandboxMode, .dangerFullAccess)
     }
 
+    func testComposerPermissionSelectionCachePreservesPendingNewTurnBoundary() throws {
+        var state = ComposerState()
+        state.applyPermissionMode(.fullAccess)
+        state.markPermissionSelectionRequiresNewTurn()
+
+        let sessionScope = ComposerDraftScopeKey.session("thread-1")
+        var cache = ComposerPermissionSelectionCache()
+        cache.save(state.permissionSelectionSnapshot(), for: sessionScope)
+
+        state.preserveThreadPermissionSettings()
+        XCTAssertFalse(state.permissionSelectionRequiresNewTurn)
+        state.restorePermissionSelectionSnapshot(try XCTUnwrap(cache.snapshot(for: sessionScope)))
+
+        XCTAssertTrue(state.permissionSelectionRequiresNewTurn)
+        XCTAssertEqual(state.permissionMode, .fullAccess)
+    }
+
     func testComposerCanInitializeWithGlobalDefaultPermissionMode() {
         let composerState = ComposerState(defaultPermissionMode: .requestApproval)
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationGuidanceFallbackTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationGuidanceFallbackTests.swift
@@ -404,4 +404,1378 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(requests.allSatisfy { $0.method != "turn/start" })
         socket.disconnect()
     }
+
+    func testPermissionBoundaryRequiresExactTurnStartedClientMessageID() async throws {
+        let project = makeProject(id: "proj_permission_boundary_exact")
+        let running = makeSession(
+            id: "sess_permission_boundary_exact",
+            projectID: project.id,
+            title: "Permission Boundary Exact",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            activeTurnID: "turn_permission_old"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let client = MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(running)
+        await store.selectSession(running)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        var composerState = ComposerState()
+        composerState.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let permissionSelection = composerState.permissionSelectionSnapshot()
+        XCTAssertTrue(permissionSelection.requiresNewTurn)
+
+        let queued = await store.sendTurn(
+            CodexAppServerTurnPayload(prompt: "权限边界必须等待新轮次"),
+            permissionSelection: permissionSelection
+        )
+        XCTAssertTrue(queued)
+        let clientMessageID = try XCTUnwrap(store.selectedQueuedTurns.first?.clientMessageID)
+        XCTAssertEqual(store.selectedQueuedTurns.first?.requiresFreshTurn, true)
+        XCTAssertEqual(
+            store.pendingPermissionTurnBoundary(for: running.id)?.clientMessageID,
+            clientMessageID
+        )
+        XCTAssertFalse(store.guideQueuedTurnNow(clientMessageID: clientMessageID))
+
+        composerState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let secondQueued = await store.sendTurn(
+            CodexAppServerTurnPayload(prompt: "第二条权限边界"),
+            permissionSelection: composerState.permissionSelectionSnapshot()
+        )
+        XCTAssertTrue(secondQueued)
+        let secondClientMessageID = try XCTUnwrap(store.selectedQueuedTurns.last?.clientMessageID)
+        XCTAssertTrue(store.moveSelectedQueuedTurns(fromOffsets: IndexSet(integer: 1), toOffset: 0))
+        XCTAssertEqual(
+            store.pendingPermissionTurnBoundary(for: running.id)?.clientMessageID,
+            secondClientMessageID,
+            "拖动队列时必须同步权限边界顺序"
+        )
+
+        socket.emitEvent(.turnStarted(AgentEventMetadata(
+            seq: 1,
+            sessionID: running.id,
+            turnID: "turn_permission_wrong",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: "client-wrong",
+            revision: nil,
+            createdAt: nil
+        )))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertNotNil(store.pendingPermissionTurnBoundary(for: running.id))
+
+        socket.emitEvent(.turnStarted(AgentEventMetadata(
+            seq: 2,
+            sessionID: running.id,
+            turnID: "turn_permission_nil",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertNotNil(store.pendingPermissionTurnBoundary(for: running.id))
+
+        socket.emitEvent(.turnStarted(AgentEventMetadata(
+            seq: 3,
+            sessionID: running.id,
+            turnID: "turn_permission_second",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: secondClientMessageID,
+            revision: nil,
+            createdAt: nil
+        )))
+        for _ in 0..<50 where store.pendingPermissionTurnBoundary(for: running.id)?.clientMessageID != clientMessageID {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(store.pendingPermissionTurnBoundary(for: running.id)?.clientMessageID, clientMessageID)
+
+        socket.emitEvent(.turnStarted(AgentEventMetadata(
+            seq: 4,
+            sessionID: running.id,
+            turnID: "turn_permission_first",
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: clientMessageID,
+            revision: nil,
+            createdAt: nil
+        )))
+        for _ in 0..<50 where store.pendingPermissionTurnBoundary(for: running.id) != nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertNil(store.pendingPermissionTurnBoundary(for: running.id))
+        XCTAssertEqual(store.latestSatisfiedPermissionTurnBoundary?.clientMessageID, clientMessageID)
+    }
+
+    func testPermissionBoundaryPersistsAndClearsTheNonCurrentComposerCache() throws {
+        let sessionID = "sess_permission_boundary_cache"
+        var state = ComposerState()
+        state.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let selection = state.permissionSelectionSnapshot()
+        let boundary = PendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: "client_permission_boundary",
+            permissionSelection: selection
+        )
+        let entry = QueuedTurnEntry(
+            sessionID: sessionID,
+            payload: CodexAppServerTurnPayload(prompt: "待新轮次"),
+            clientMessageID: boundary.clientMessageID,
+            intent: .standard,
+            requiresFreshTurn: true
+        )
+        let snapshot = QueuedTurnProfileSnapshot(
+            profileID: "profile-boundary",
+            queuesBySessionID: [sessionID: [entry]],
+            pendingPermissionTurnBoundariesBySessionID: [sessionID: [boundary]]
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        let restored = try JSONDecoder().decode(QueuedTurnProfileSnapshot.self, from: data)
+        XCTAssertEqual(restored.pendingPermissionTurnBoundariesBySessionID[sessionID], [boundary])
+        XCTAssertEqual(restored.queuesBySessionID[sessionID]?.first?.requiresFreshTurn, true)
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PermissionBoundaryCacheTests.\(UUID().uuidString)", isDirectory: true)
+        let queuedTurnStore = FileQueuedTurnStore(directoryURL: directory)
+        try queuedTurnStore.save(snapshot)
+        let diskRestored = try queuedTurnStore.load(profileID: snapshot.profileID)
+        XCTAssertEqual(diskRestored.pendingPermissionTurnBoundariesBySessionID[sessionID], [boundary])
+
+        var legacyJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        legacyJSON.removeValue(forKey: "pendingPermissionTurnBoundariesBySessionID")
+        let legacyData = try JSONSerialization.data(withJSONObject: legacyJSON)
+        let legacy = try JSONDecoder().decode(QueuedTurnProfileSnapshot.self, from: legacyData)
+        XCTAssertTrue(legacy.pendingPermissionTurnBoundariesBySessionID.isEmpty)
+
+        let appStore = makeIsolatedAppStore()
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: FileQueuedTurnStore(directoryURL: directory)
+        )
+        store.saveComposerPermissionSelection(selection, for: .session(sessionID))
+        store.pendingPermissionTurnBoundariesBySessionID = [sessionID: [boundary]]
+        XCTAssertTrue(store.satisfyPendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: boundary.clientMessageID
+        ))
+        XCTAssertFalse(
+            store.composerPermissionSelection(for: .session(sessionID))?.requiresNewTurn == true,
+            "非当前会话的权限 cache 也必须在精确 started 后清除边界"
+        )
+
+        var newerState = ComposerState()
+        newerState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let newerSelection = newerState.permissionSelectionSnapshot()
+        let newerBoundary = PendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: "client_permission_boundary_newer",
+            permissionSelection: selection
+        )
+        store.saveComposerPermissionSelection(newerSelection, for: .session(sessionID))
+        store.pendingPermissionTurnBoundariesBySessionID = [sessionID: [newerBoundary]]
+        XCTAssertTrue(store.satisfyPendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: newerBoundary.clientMessageID
+        ))
+        XCTAssertEqual(
+            store.composerPermissionSelection(for: .session(sessionID)),
+            newerSelection,
+            "旧边界的 started 不能清除切换会话期间保存的较新权限选择"
+        )
+    }
+
+    func testComposerAutomaticPermissionChangesRequireFreshTurnWhileRunning() {
+        var state = ComposerState()
+        state.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        XCTAssertTrue(state.permissionSelectionRequiresNewTurn)
+
+        state.preserveThreadPermissionSettings()
+        XCTAssertFalse(state.permissionSelectionRequiresNewTurn)
+
+        state.updatePermissionSelection(sessionIsRunning: true) { options in
+            options.permissionProfileID = "missing-profile"
+            options.preservesThreadPermissionSettings = false
+        }
+        XCTAssertTrue(state.permissionSelectionRequiresNewTurn)
+        state.resetUnavailablePermissionProfile(sessionIsRunning: true)
+        XCTAssertTrue(state.permissionSelectionRequiresNewTurn)
+        XCTAssertEqual(state.permissionMode, .requestApproval)
+    }
+
+    func testConsecutivePermissionBoundariesAdvanceInSubmissionOrder() throws {
+        let sessionID = "sess_consecutive_permission_boundaries"
+        var readOnlyState = ComposerState()
+        readOnlyState.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let readOnly = readOnlyState.permissionSelectionSnapshot()
+        var fullAccessState = ComposerState()
+        fullAccessState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let fullAccess = fullAccessState.permissionSelectionSnapshot()
+        let boundaries = [
+            PendingPermissionTurnBoundary(
+                sessionID: sessionID,
+                clientMessageID: "client_permission_a",
+                permissionSelection: readOnly
+            ),
+            PendingPermissionTurnBoundary(
+                sessionID: sessionID,
+                clientMessageID: "client_permission_b",
+                permissionSelection: fullAccess
+            ),
+            PendingPermissionTurnBoundary(
+                sessionID: sessionID,
+                clientMessageID: "client_permission_a_again",
+                permissionSelection: readOnly
+            )
+        ]
+        let entries = boundaries.map {
+            QueuedTurnEntry(
+                sessionID: sessionID,
+                payload: CodexAppServerTurnPayload(prompt: $0.clientMessageID),
+                clientMessageID: $0.clientMessageID,
+                intent: .standard,
+                requiresFreshTurn: true
+            )
+        }
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ConsecutivePermissionBoundaryTests.\(UUID().uuidString)", isDirectory: true)
+        let queuedTurnStore = FileQueuedTurnStore(directoryURL: directory)
+        let appStore = makeIsolatedAppStore()
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore
+        )
+        store.saveComposerPermissionSelection(readOnly, for: .session(sessionID))
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.queuedRunningTurnsBySessionID[sessionID] = entries
+            store.pendingPermissionTurnBoundariesBySessionID[sessionID] = boundaries
+        })
+        XCTAssertEqual(
+            try queuedTurnStore.load(profileID: appStore.notificationRoutingProfileID)
+                .pendingPermissionTurnBoundariesBySessionID[sessionID],
+            boundaries
+        )
+        XCTAssertEqual(
+            store.latestPendingPermissionTurnBoundary(for: sessionID),
+            boundaries.last,
+            "Composer 重建时必须恢复最后一次提交的权限，不能回退到 FIFO 第一条"
+        )
+
+        XCTAssertTrue(store.satisfyPendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: boundaries[0].clientMessageID
+        ))
+        XCTAssertEqual(store.pendingPermissionTurnBoundary(for: sessionID), boundaries[1])
+        XCTAssertTrue(store.composerPermissionSelection(for: .session(sessionID))?.requiresNewTurn == true)
+        XCTAssertNil(store.latestSatisfiedPermissionTurnBoundary)
+
+        XCTAssertTrue(store.satisfyPendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: boundaries[1].clientMessageID
+        ))
+        XCTAssertEqual(store.pendingPermissionTurnBoundary(for: sessionID), boundaries[2])
+        XCTAssertTrue(store.composerPermissionSelection(for: .session(sessionID))?.requiresNewTurn == true)
+
+        XCTAssertTrue(store.satisfyPendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: boundaries[2].clientMessageID
+        ))
+        XCTAssertNil(store.pendingPermissionTurnBoundary(for: sessionID))
+        XCTAssertFalse(store.composerPermissionSelection(for: .session(sessionID))?.requiresNewTurn == true)
+        XCTAssertEqual(store.latestSatisfiedPermissionTurnBoundary, boundaries[2])
+    }
+
+    func testDeletingUncertainPermissionTurnPreservesBoundary() {
+        let sessionID = "sess_uncertain_permission_delete"
+        var state = ComposerState()
+        state.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let boundary = PendingPermissionTurnBoundary(
+            sessionID: sessionID,
+            clientMessageID: "client_uncertain_permission_delete",
+            permissionSelection: state.permissionSelectionSnapshot()
+        )
+        let entry = QueuedTurnEntry(
+            sessionID: sessionID,
+            payload: CodexAppServerTurnPayload(prompt: "结果不确定"),
+            clientMessageID: boundary.clientMessageID,
+            intent: .standard,
+            dispatchState: .needsConfirmation,
+            requiresFreshTurn: true
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UncertainPermissionDeleteTests.\(UUID().uuidString)", isDirectory: true)
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: FileQueuedTurnStore(directoryURL: directory)
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.queuedRunningTurnsBySessionID[sessionID] = [entry]
+            store.pendingPermissionTurnBoundariesBySessionID[sessionID] = [boundary]
+        })
+
+        XCTAssertTrue(store.deleteQueuedTurn(clientMessageID: boundary.clientMessageID))
+        XCTAssertTrue(store.queuedTurns(sessionID: sessionID).isEmpty)
+        XCTAssertEqual(store.pendingPermissionTurnBoundary(for: sessionID), boundary)
+    }
+
+    func testFailedPermissionTurnRetryCannotGuideTheOldTurn() async throws {
+        let project = makeProject(id: "proj_permission_retry_boundary")
+        let running = makeSession(
+            id: "sess_permission_retry_boundary",
+            projectID: project.id,
+            title: "Permission Retry Boundary",
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            activeTurnID: "turn_permission_retry_old"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let conversationStore = ConversationStore()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PermissionRetryRestartTests.\(UUID().uuidString)", isDirectory: true)
+        let queuedTurnStore = FileQueuedTurnStore(directoryURL: directory)
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: {
+                MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
+            },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(running)
+        await store.selectSession(running)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        var state = ComposerState()
+        state.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let selection = state.permissionSelectionSnapshot()
+        let payload = CodexAppServerTurnPayload(
+            prompt: "重试仍要开启新轮次",
+            options: state.turnOptions
+        )
+        let clientMessageID = "client_permission_retry"
+        let boundary = PendingPermissionTurnBoundary(
+            sessionID: running.id,
+            clientMessageID: clientMessageID,
+            permissionSelection: selection
+        )
+        let queued = QueuedTurnEntry(
+            sessionID: running.id,
+            projectID: running.projectID,
+            payload: payload,
+            clientMessageID: clientMessageID,
+            intent: .standard,
+            dispatchState: .dispatching,
+            expectedTurnID: running.activeTurnID,
+            requiresFreshTurn: true
+        )
+        conversationStore.appendLocalUser(
+            payload.previewText,
+            sessionID: running.id,
+            clientMessageID: clientMessageID,
+            sendStatus: .local,
+            turnPayload: payload
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.queuedRunningTurnsBySessionID[running.id] = [queued]
+            store.pendingPermissionTurnBoundariesBySessionID[running.id] = [boundary]
+        })
+        XCTAssertTrue(store.handleQueuedSendRejected(
+            clientMessageID: clientMessageID,
+            sessionID: running.id,
+            message: "definite rejection"
+        ))
+        XCTAssertEqual(
+            store.permissionTurnRetryRequirementsByClientMessageID[clientMessageID],
+            boundary
+        )
+
+        // 新建 SessionStore 模拟 App 重启：Composer cache 为空，只能依赖落盘的 retry requirement。
+        var restartedSockets: [MockWebSocketClient] = []
+        let restartedStore = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: {
+                MockSessionStoreClient(projects: [project], sessions: [running], messagesResult: [])
+            },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                restartedSockets.append(socket)
+                return socket
+            }
+        )
+        XCTAssertNil(restartedStore.composerPermissionSelection(for: .session(running.id)))
+        XCTAssertEqual(
+            restartedStore.permissionTurnRetryRequirementsByClientMessageID[clientMessageID],
+            boundary
+        )
+        await restartedStore.refreshAll(autoAttach: false)
+        restartedStore.takeOverSession(running)
+        await restartedStore.selectSession(running)
+        let restartedSocket = try XCTUnwrap(restartedSockets.first)
+        restartedSocket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: restartedStore)
+        let failed = try XCTUnwrap(
+            conversationStore.messages(for: running.id).first(where: { $0.clientMessageID == clientMessageID })
+        )
+
+        let retried = await restartedStore.retryFailedUserMessage(failed)
+        XCTAssertTrue(retried)
+        XCTAssertEqual(restartedStore.selectedQueuedTurns.first?.requiresFreshTurn, true)
+        XCTAssertEqual(
+            restartedStore.pendingPermissionTurnBoundary(for: running.id)?.clientMessageID,
+            clientMessageID
+        )
+        XCTAssertNil(restartedStore.permissionTurnRetryRequirementsByClientMessageID[clientMessageID])
+        XCTAssertFalse(restartedStore.guideQueuedTurnNow(clientMessageID: clientMessageID))
+        XCTAssertTrue(restartedSocket.sentGuidance.isEmpty)
+    }
+
+    func testCompletedSessionPermissionRetryWaitsForExactStartedAcrossRestart() async throws {
+        let project = makeProject(id: "proj_completed_permission_retry")
+        let completed = makeSession(
+            id: "sess_completed_permission_retry",
+            projectID: project.id,
+            title: "Completed Permission Retry",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let resumed = makeSession(
+            id: completed.id,
+            projectID: project.id,
+            title: completed.title,
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            activeTurnID: "turn_completed_permission_retry"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let conversationStore = ConversationStore()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CompletedPermissionRetryTests.\(UUID().uuidString)", isDirectory: true)
+        let queuedTurnStore = FileQueuedTurnStore(directoryURL: directory)
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            createSessionResponse: try makeCreateSessionResponse(session: resumed),
+            messagesResult: []
+        )
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: { client },
+            webSocketFactory: { MockWebSocketClient() }
+        )
+        await store.refreshAll(autoAttach: false)
+        await store.selectSession(completed)
+
+        var state = ComposerState()
+        state.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let clientMessageID = "client_completed_permission_retry"
+        let requirement = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: clientMessageID,
+            permissionSelection: state.permissionSelectionSnapshot()
+        )
+        let payload = CodexAppServerTurnPayload(
+            prompt: "完成态重试也要等 started",
+            options: state.turnOptions
+        )
+        conversationStore.appendLocalUser(
+            payload.previewText,
+            sessionID: completed.id,
+            clientMessageID: clientMessageID,
+            sendStatus: .failed,
+            turnPayload: payload
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.permissionTurnRetryRequirementsByClientMessageID[clientMessageID] = requirement
+        })
+        let failed = try XCTUnwrap(conversationStore.messages(for: completed.id).first)
+
+        let didRetry = await store.retryFailedUserMessage(failed)
+        XCTAssertTrue(didRetry)
+        XCTAssertEqual(client.createPayloads.first?.clientMessageID, clientMessageID)
+        XCTAssertEqual(
+            store.pendingPermissionTurnBoundary(for: completed.id)?.clientMessageID,
+            clientMessageID
+        )
+        XCTAssertNil(store.permissionTurnRetryRequirementsByClientMessageID[clientMessageID])
+
+        // 模拟 create/resume 成功后、实时 started 落地前崩溃。错误 ID 或空 turnID
+        // 都不能让新 Store 在权威历史恢复时提前解除边界。
+        let incompleteHistoryClient = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            messagesResult: [
+                CodexHistoryMessage(
+                    role: "user",
+                    content: "错误消息",
+                    createdAt: Date(timeIntervalSince1970: 1),
+                    clientMessageID: "client_completed_permission_wrong",
+                    turnID: "turn_completed_permission_wrong"
+                ),
+                CodexHistoryMessage(
+                    role: "user",
+                    content: payload.previewText,
+                    createdAt: Date(timeIntervalSince1970: 2),
+                    clientMessageID: clientMessageID,
+                    turnID: ""
+                )
+            ]
+        )
+        let restartedStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: { incompleteHistoryClient }
+        )
+        await restartedStore.selectSession(completed)
+        XCTAssertEqual(
+            restartedStore.pendingPermissionTurnBoundary(for: completed.id)?.clientMessageID,
+            clientMessageID
+        )
+
+        // 已错过实时事件时，公开会话恢复路径必须用同一 clientMessageID 的非空 turnID 收敛。
+        let startedHistoryClient = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            messagesResult: [
+                CodexHistoryMessage(
+                    role: "user",
+                    content: payload.previewText,
+                    createdAt: Date(timeIntervalSince1970: 3),
+                    clientMessageID: clientMessageID,
+                    turnID: "turn_completed_permission_retry"
+                )
+            ]
+        )
+        let recoveredStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: { startedHistoryClient }
+        )
+        await recoveredStore.selectSession(completed)
+        XCTAssertNil(recoveredStore.pendingPermissionTurnBoundary(for: completed.id))
+    }
+
+    func testPermissionBoundarySurvivesCreateResumeRaceForMessageAndGoal() async throws {
+        let project = makeProject(id: "proj_permission_create_resume_race")
+        let completed = makeSession(
+            id: "sess_permission_create_resume_race",
+            projectID: project.id,
+            title: "Permission Create Resume Race",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let resumed = makeSession(
+            id: completed.id,
+            projectID: project.id,
+            title: completed.title,
+            status: SessionStatus.running.rawValue,
+            source: "codex",
+            activeTurnID: "turn_permission_create_resume_race"
+        )
+        var state = ComposerState()
+        state.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let permissionSelection = state.permissionSelectionSnapshot()
+        XCTAssertTrue(permissionSelection.requiresNewTurn)
+
+        let messageAppStore = makeIsolatedAppStore()
+        messageAppStore.token = "test-token"
+        let messageClient = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            createSessionResponse: try makeCreateSessionResponse(session: resumed),
+            messagesResult: []
+        )
+        let messageStore = SessionStore(
+            appStore: messageAppStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { messageClient }
+        )
+        await messageStore.refreshAll(autoAttach: false)
+        await messageStore.selectSession(completed)
+
+        let messageSent = await messageStore.sendTurn(
+            CodexAppServerTurnPayload(prompt: "完成竞态后的普通消息"),
+            permissionSelection: permissionSelection
+        )
+        XCTAssertTrue(messageSent)
+        let messageClientID = try XCTUnwrap(messageClient.createPayloads.last?.clientMessageID)
+        XCTAssertEqual(
+            messageStore.pendingPermissionTurnBoundary(for: completed.id)?.clientMessageID,
+            messageClientID
+        )
+        XCTAssertTrue(messageStore.satisfyPendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: messageClientID
+        ))
+
+        let goalAppStore = makeIsolatedAppStore()
+        goalAppStore.token = "test-token"
+        let goalClient = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            createSessionResponse: try makeCreateSessionResponse(session: resumed),
+            messagesResult: []
+        )
+        let goalStore = SessionStore(
+            appStore: goalAppStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { goalClient }
+        )
+        await goalStore.refreshAll(autoAttach: false)
+        await goalStore.selectSession(completed)
+
+        let goalSent = await goalStore.startGoalTurn(
+            payload: CodexAppServerTurnPayload(prompt: "完成竞态后的目标消息"),
+            objective: "完成目标",
+            tokenBudget: nil,
+            permissionSelection: permissionSelection
+        )
+        XCTAssertTrue(goalSent)
+        let goalClientID = try XCTUnwrap(goalClient.createPayloads.last?.clientMessageID)
+        XCTAssertEqual(goalClient.createPayloads.last?.initialGoalObjective, "完成目标")
+        XCTAssertEqual(
+            goalStore.pendingPermissionTurnBoundary(for: completed.id)?.clientMessageID,
+            goalClientID
+        )
+        XCTAssertTrue(goalStore.satisfyPendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: goalClientID
+        ))
+
+        let failureAppStore = makeIsolatedAppStore()
+        failureAppStore.token = "test-token"
+        let failureClient = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            createSessionResults: [.failure(NSError(
+                domain: "PermissionCreateResumeRace",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "create failed"]
+            ))],
+            messagesResult: []
+        )
+        let failureStore = SessionStore(
+            appStore: failureAppStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { failureClient }
+        )
+        await failureStore.refreshAll(autoAttach: false)
+        await failureStore.selectSession(completed)
+
+        let failureSent = await failureStore.sendTurn(
+            CodexAppServerTurnPayload(prompt: "失败时回滚权限边界"),
+            permissionSelection: permissionSelection
+        )
+        XCTAssertFalse(failureSent)
+        let failedClientID = try XCTUnwrap(failureClient.createPayloads.last?.clientMessageID)
+        XCTAssertNil(failureStore.pendingPermissionTurnBoundaryLocation(clientMessageID: failedClientID))
+    }
+
+    func testRestartedOrphanPermissionBoundaryBlocksMessageAndGoalFIFO() async throws {
+        let project = makeProject(id: "proj_orphan_permission_fifo")
+        let completed = makeSession(
+            id: "sess_orphan_permission_fifo",
+            projectID: project.id,
+            title: "Orphan Permission FIFO",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OrphanPermissionFIFOTests.\(UUID().uuidString)", isDirectory: true)
+        let queuedTurnStore = FileQueuedTurnStore(directoryURL: directory)
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            messagesResult: []
+        )
+        var permissionState = ComposerState()
+        permissionState.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let permissionSelection = permissionState.permissionSelectionSnapshot()
+        let orphanPermissionSelection = ComposerState().permissionSelectionSnapshot()
+        let orphanClientMessageID = "client_orphan_permission_a"
+        let orphanBoundary = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: orphanClientMessageID,
+            permissionSelection: orphanPermissionSelection
+        )
+        let seedStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: { client }
+        )
+        XCTAssertTrue(seedStore.mutateAndPersistQueuedTurns {
+            seedStore.pendingPermissionTurnBoundariesBySessionID[completed.id] = [orphanBoundary]
+        })
+
+        var sockets: [MockWebSocketClient] = []
+        let restartedStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+        await restartedStore.refreshAll(autoAttach: false)
+        restartedStore.takeOverSession(completed)
+        await restartedStore.selectSession(completed)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: restartedStore)
+
+        let messageQueued = await restartedStore.sendTurn(
+            CodexAppServerTurnPayload(prompt: "排在孤立边界后的普通消息"),
+            permissionSelection: permissionSelection
+        )
+        XCTAssertTrue(messageQueued)
+        let messageClientID = try XCTUnwrap(restartedStore.selectedQueuedTurns.first?.clientMessageID)
+        let goalQueued = await restartedStore.startGoalTurn(
+            payload: CodexAppServerTurnPayload(prompt: "排在普通消息后的目标"),
+            objective: "保持 FIFO",
+            permissionSelection: permissionSelection
+        )
+        XCTAssertTrue(goalQueued)
+        let goalClientID = try XCTUnwrap(restartedStore.selectedQueuedTurns.last?.clientMessageID)
+
+        XCTAssertTrue(client.createPayloads.isEmpty)
+        XCTAssertTrue(socket.sentTurns.isEmpty)
+        XCTAssertEqual(
+            restartedStore.pendingPermissionTurnBoundariesBySessionID[completed.id]?.map(\.clientMessageID),
+            [orphanClientMessageID, messageClientID, goalClientID]
+        )
+
+        restartedStore.applyHistoryFirstPage(
+            HistoryMessagesPage(messages: [
+                CodexHistoryMessage(
+                    role: "user",
+                    content: "权限 A 已开始",
+                    createdAt: Date(timeIntervalSince1970: 1),
+                    clientMessageID: orphanClientMessageID,
+                    turnID: "turn_orphan_permission_a"
+                )
+            ]),
+            sessionID: completed.id
+        )
+
+        XCTAssertEqual(socket.sentTurns.count, 1)
+        XCTAssertEqual(socket.sentTurns.first?.clientMessageID, messageClientID)
+        XCTAssertEqual(
+            restartedStore.pendingPermissionTurnBoundary(for: completed.id)?.clientMessageID,
+            messageClientID
+        )
+        XCTAssertEqual(restartedStore.selectedQueuedTurns.last?.clientMessageID, goalClientID)
+    }
+
+    func testCompletedSessionPermissionRetryStaysBehindExistingQueueBoundary() async throws {
+        let project = makeProject(id: "proj_completed_permission_retry_fifo")
+        let completed = makeSession(
+            id: "sess_completed_permission_retry_fifo",
+            projectID: project.id,
+            title: "Completed Permission Retry FIFO",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let conversationStore = ConversationStore()
+        let client = MockSessionStoreClient(projects: [project], sessions: [completed], messagesResult: [])
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: { MockWebSocketClient() }
+        )
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(completed)
+        await store.selectSession(completed)
+
+        var waitingState = ComposerState()
+        waitingState.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let waitingBoundary = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: "client_waiting_permission_b",
+            permissionSelection: waitingState.permissionSelectionSnapshot()
+        )
+        let waitingEntry = QueuedTurnEntry(
+            sessionID: completed.id,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "先发送 B"),
+            clientMessageID: waitingBoundary.clientMessageID,
+            intent: .standard,
+            requiresFreshTurn: true
+        )
+        var retryState = ComposerState()
+        retryState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let retryClientMessageID = "client_rejected_permission_a"
+        let retryRequirement = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: retryClientMessageID,
+            permissionSelection: retryState.permissionSelectionSnapshot()
+        )
+        let retryPayload = CodexAppServerTurnPayload(
+            prompt: "B 之后再重试 A",
+            options: retryState.turnOptions
+        )
+        conversationStore.appendLocalUser(
+            retryPayload.previewText,
+            sessionID: completed.id,
+            clientMessageID: retryClientMessageID,
+            sendStatus: .failed,
+            turnPayload: retryPayload
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.queuedRunningTurnsBySessionID[completed.id] = [waitingEntry]
+            store.pendingPermissionTurnBoundariesBySessionID[completed.id] = [waitingBoundary]
+            store.permissionTurnRetryRequirementsByClientMessageID[retryClientMessageID] = retryRequirement
+        })
+        let failed = try XCTUnwrap(
+            conversationStore.messages(for: completed.id).first(where: { $0.clientMessageID == retryClientMessageID })
+        )
+
+        let didRetry = await store.retryFailedUserMessage(failed)
+        XCTAssertTrue(didRetry)
+        XCTAssertTrue(client.createPayloads.isEmpty, "已有本地 FIFO 时不得绕过队列直接 create/resume")
+        XCTAssertEqual(
+            store.queuedTurns(sessionID: completed.id).map(\.clientMessageID),
+            [waitingBoundary.clientMessageID, retryClientMessageID]
+        )
+        XCTAssertEqual(
+            store.pendingPermissionTurnBoundariesBySessionID[completed.id]?.map(\.clientMessageID),
+            [waitingBoundary.clientMessageID, retryClientMessageID]
+        )
+    }
+
+    func testCompletedSessionPermissionRetryQueuesBehindOrphanBoundary() async throws {
+        let project = makeProject(id: "proj_permission_retry_orphan_fifo")
+        let completed = makeSession(
+            id: "sess_permission_retry_orphan_fifo",
+            projectID: project.id,
+            title: "Permission Retry Orphan FIFO",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let conversationStore = ConversationStore()
+        let client = MockSessionStoreClient(projects: [project], sessions: [completed], messagesResult: [])
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: { MockWebSocketClient() }
+        )
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(completed)
+        await store.selectSession(completed)
+
+        let orphanBoundary = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: "client_permission_orphan_a",
+            permissionSelection: ComposerState().permissionSelectionSnapshot()
+        )
+        var retryState = ComposerState()
+        retryState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let retryClientMessageID = "client_permission_retry_b"
+        let retryRequirement = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: retryClientMessageID,
+            permissionSelection: retryState.permissionSelectionSnapshot()
+        )
+        let retryPayload = CodexAppServerTurnPayload(
+            prompt: "孤立边界后的权限重试",
+            options: retryState.turnOptions
+        )
+        conversationStore.appendLocalUser(
+            retryPayload.previewText,
+            sessionID: completed.id,
+            clientMessageID: retryClientMessageID,
+            sendStatus: .failed,
+            turnPayload: retryPayload
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.pendingPermissionTurnBoundariesBySessionID[completed.id] = [orphanBoundary]
+            store.permissionTurnRetryRequirementsByClientMessageID[retryClientMessageID] = retryRequirement
+        })
+        let failed = try XCTUnwrap(
+            conversationStore.messages(for: completed.id).first(where: { $0.clientMessageID == retryClientMessageID })
+        )
+
+        let didRetry = await store.retryFailedUserMessage(failed)
+        XCTAssertTrue(didRetry)
+        XCTAssertTrue(client.createPayloads.isEmpty, "仅存 orphan boundary 时也不得直接 create/resume")
+        XCTAssertEqual(store.queuedTurns(sessionID: completed.id).map(\.clientMessageID), [retryClientMessageID])
+        XCTAssertEqual(
+            store.pendingPermissionTurnBoundariesBySessionID[completed.id]?.map(\.clientMessageID),
+            [orphanBoundary.clientMessageID, retryClientMessageID]
+        )
+    }
+
+    func testRetryReinsertsRetainedPermissionBoundaryBeforeLaterQueue() async throws {
+        let project = makeProject(id: "proj_retained_permission_retry_fifo")
+        let completed = makeSession(
+            id: "sess_retained_permission_retry_fifo",
+            projectID: project.id,
+            title: "Retained Permission Retry FIFO",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let conversationStore = ConversationStore()
+        let client = MockSessionStoreClient(projects: [project], sessions: [completed], messagesResult: [])
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(completed)
+        await store.selectSession(completed)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        var retryState = ComposerState()
+        retryState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let retryClientMessageID = "client_retained_permission_a"
+        let retainedBoundary = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: retryClientMessageID,
+            permissionSelection: retryState.permissionSelectionSnapshot()
+        )
+        let laterClientMessageID = "client_later_message_b"
+        let laterEntry = QueuedTurnEntry(
+            sessionID: completed.id,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "后续消息 B"),
+            clientMessageID: laterClientMessageID,
+            intent: .standard
+        )
+        let retryPayload = CodexAppServerTurnPayload(
+            prompt: "重试 retained boundary A",
+            options: retryState.turnOptions
+        )
+        conversationStore.appendLocalUser(
+            retryPayload.previewText,
+            sessionID: completed.id,
+            clientMessageID: retryClientMessageID,
+            sendStatus: .failed,
+            turnPayload: retryPayload
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.queuedRunningTurnsBySessionID[completed.id] = [laterEntry]
+            store.pendingPermissionTurnBoundariesBySessionID[completed.id] = [retainedBoundary]
+        })
+        let failed = try XCTUnwrap(
+            conversationStore.messages(for: completed.id).first(where: { $0.clientMessageID == retryClientMessageID })
+        )
+
+        let didRetry = await store.retryFailedUserMessage(failed)
+        XCTAssertTrue(didRetry)
+        XCTAssertTrue(client.createPayloads.isEmpty)
+        XCTAssertEqual(
+            store.queuedTurns(sessionID: completed.id).map(\.clientMessageID),
+            [retryClientMessageID, laterClientMessageID]
+        )
+        store.dispatchNextQueuedRunningTurnIfIdle(sessionID: completed.id)
+        XCTAssertEqual(socket.sentTurns.first?.clientMessageID, retryClientMessageID)
+    }
+
+    func testQueueDispatchesOrdinaryItemBeforeLaterPermissionBoundary() async throws {
+        let project = makeProject(id: "proj_queue_before_permission_boundary")
+        let completed = makeSession(
+            id: "sess_queue_before_permission_boundary",
+            projectID: project.id,
+            title: "Queue Before Permission Boundary",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let client = MockSessionStoreClient(projects: [project], sessions: [completed], messagesResult: [])
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(completed)
+        await store.selectSession(completed)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        let ordinaryClientMessageID = "client_ordinary_before_permission"
+        let permissionClientMessageID = "client_later_permission_boundary"
+        let ordinaryEntry = QueuedTurnEntry(
+            sessionID: completed.id,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "先排队的普通消息"),
+            clientMessageID: ordinaryClientMessageID,
+            intent: .standard
+        )
+        var permissionState = ComposerState()
+        permissionState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let permissionEntry = QueuedTurnEntry(
+            sessionID: completed.id,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(
+                prompt: "后排队的权限消息",
+                options: permissionState.turnOptions
+            ),
+            clientMessageID: permissionClientMessageID,
+            intent: .standard,
+            requiresFreshTurn: true
+        )
+        let boundary = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: permissionClientMessageID,
+            permissionSelection: permissionState.permissionSelectionSnapshot()
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.queuedRunningTurnsBySessionID[completed.id] = [ordinaryEntry, permissionEntry]
+            store.pendingPermissionTurnBoundariesBySessionID[completed.id] = [boundary]
+        })
+
+        store.dispatchNextQueuedRunningTurnIfIdle(sessionID: completed.id)
+
+        XCTAssertEqual(socket.sentTurns.first?.clientMessageID, ordinaryClientMessageID)
+        XCTAssertEqual(store.pendingPermissionTurnBoundary(for: completed.id), boundary)
+    }
+
+    func testRestartHistoryClearsOrphanPermissionBoundaryAndDispatchesNext() async throws {
+        let project = makeProject(id: "proj_permission_history_reconcile")
+        let completed = makeSession(
+            id: "sess_permission_history_reconcile",
+            projectID: project.id,
+            title: "Permission History Reconcile",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let permissionClientMessageID = "client_uncertain_permission_a"
+        let laterClientMessageID = "client_after_uncertain_permission_b"
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            messagesResult: [
+                CodexHistoryMessage(
+                    role: "user",
+                    content: "权限消息 A 已开始",
+                    createdAt: Date(timeIntervalSince1970: 1),
+                    clientMessageID: permissionClientMessageID,
+                    turnID: "turn_uncertain_permission_a"
+                )
+            ]
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(completed)
+        await store.selectSession(completed)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        var permissionState = ComposerState()
+        permissionState.applyPermissionMode(.fullAccess, sessionIsRunning: true)
+        let boundary = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: permissionClientMessageID,
+            permissionSelection: permissionState.permissionSelectionSnapshot()
+        )
+        let laterEntry = QueuedTurnEntry(
+            sessionID: completed.id,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "后续消息 B"),
+            clientMessageID: laterClientMessageID,
+            intent: .standard
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            // 模拟 turn/start 已获 ACK、队列项已删除，但 started 事件落地前进程退出。
+            store.queuedRunningTurnsBySessionID[completed.id] = [laterEntry]
+            store.pendingPermissionTurnBoundariesBySessionID[completed.id] = [boundary]
+        })
+
+        await store.reconcilePersistedQueuedTurns()
+
+        XCTAssertNil(store.pendingPermissionTurnBoundary(for: completed.id))
+        XCTAssertNil(store.queuedTurnLocation(clientMessageID: permissionClientMessageID))
+        XCTAssertEqual(socket.sentTurns.first?.clientMessageID, laterClientMessageID)
+    }
+
+    func testCompletedSessionAwaitingAcceptedStartMarksPermissionChangeForFreshTurn() async throws {
+        let project = makeProject(id: "proj_completed_queue_permission_change")
+        let completed = makeSession(
+            id: "sess_completed_queue_permission_change",
+            projectID: project.id,
+            title: "Completed Queue Permission Change",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let client = MockSessionStoreClient(projects: [project], sessions: [completed], messagesResult: [])
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            }
+        )
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(completed)
+        await store.selectSession(completed)
+        let socket = try XCTUnwrap(sockets.first)
+        socket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+
+        let earlierEntry = QueuedTurnEntry(
+            sessionID: completed.id,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(prompt: "先排队的消息 A"),
+            clientMessageID: "client_completed_queue_a",
+            intent: .standard
+        )
+        XCTAssertTrue(store.mutateAndPersistQueuedTurns {
+            store.queuedRunningTurnsBySessionID[completed.id] = [earlierEntry]
+        })
+        XCTAssertTrue(store.selectedSessionRequiresFreshPermissionTurn)
+        store.dispatchNextQueuedRunningTurnIfIdle(sessionID: completed.id)
+        XCTAssertEqual(socket.sentTurns.first?.clientMessageID, earlierEntry.clientMessageID)
+        XCTAssertTrue(store.handleQueuedSendAccepted(
+            clientMessageID: earlierEntry.clientMessageID,
+            sessionID: completed.id,
+            disposition: .awaitingStart(turnID: "turn_completed_queue_a")
+        ))
+        XCTAssertTrue(store.queuedTurns(sessionID: completed.id).isEmpty)
+        XCTAssertTrue(store.queuedTurnAwaitingStartSessionIDs.contains(completed.id))
+        XCTAssertTrue(store.selectedSessionRequiresFreshPermissionTurn)
+
+        var composerState = ComposerState()
+        composerState.applyPermissionMode(
+            .readOnly,
+            sessionIsRunning: store.selectedSessionRequiresFreshPermissionTurn
+        )
+        let permissionSelection = composerState.permissionSelectionSnapshot()
+        XCTAssertTrue(permissionSelection.requiresNewTurn)
+
+        let didQueue = await store.sendTurn(
+            CodexAppServerTurnPayload(
+                prompt: "权限变更后的消息 B",
+                options: composerState.turnOptions
+            ),
+            permissionSelection: permissionSelection
+        )
+        XCTAssertTrue(didQueue)
+        let queued = store.queuedTurns(sessionID: completed.id)
+        XCTAssertEqual(queued.count, 1)
+        XCTAssertEqual(queued.last?.requiresFreshTurn, true)
+        XCTAssertEqual(
+            store.pendingPermissionTurnBoundary(for: completed.id)?.clientMessageID,
+            queued.last?.clientMessageID
+        )
+    }
+
+    func testRestartKeepsAcceptedStartBarrierUntilExactHistory() async throws {
+        let project = makeProject(id: "proj_restart_accepted_start_barrier")
+        let completed = makeSession(
+            id: "sess_restart_accepted_start_barrier",
+            projectID: project.id,
+            title: "Restart Accepted Start Barrier",
+            status: SessionStatus.completed.rawValue,
+            source: "codex"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RestartAcceptedStartBarrierTests.\(UUID().uuidString)", isDirectory: true)
+        let queuedTurnStore = FileQueuedTurnStore(directoryURL: directory)
+        let acceptedTurnID = "turn_accepted_before_restart_a"
+        let permissionClientMessageID = "client_permission_after_restart_b"
+        var permissionState = ComposerState()
+        permissionState.applyPermissionMode(.readOnly, sessionIsRunning: true)
+        let boundary = PendingPermissionTurnBoundary(
+            sessionID: completed.id,
+            clientMessageID: permissionClientMessageID,
+            permissionSelection: permissionState.permissionSelectionSnapshot()
+        )
+        let waitingPermissionEntry = QueuedTurnEntry(
+            sessionID: completed.id,
+            projectID: project.id,
+            payload: CodexAppServerTurnPayload(
+                prompt: "A started 后再发送权限消息 B",
+                options: permissionState.turnOptions
+            ),
+            clientMessageID: permissionClientMessageID,
+            intent: .standard,
+            expectedTurnID: acceptedTurnID,
+            requiresFreshTurn: true,
+            waitsForAcceptedTurnStart: true,
+            blockedCompletionID: "turn_before_a"
+        )
+        try queuedTurnStore.save(QueuedTurnProfileSnapshot(
+            profileID: appStore.notificationRoutingProfileID,
+            queuesBySessionID: [completed.id: [waitingPermissionEntry]],
+            pendingPermissionTurnBoundariesBySessionID: [completed.id: [boundary]]
+        ))
+
+        let incompleteClient = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            messagesResult: []
+        )
+        var incompleteSockets: [MockWebSocketClient] = []
+        let incompleteStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: { incompleteClient },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                incompleteSockets.append(socket)
+                return socket
+            }
+        )
+        await incompleteStore.refreshAll(autoAttach: false)
+        incompleteStore.takeOverSession(completed)
+        await incompleteStore.selectSession(completed)
+        let incompleteSocket = try XCTUnwrap(incompleteSockets.first)
+        incompleteSocket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: incompleteStore)
+        await incompleteStore.reconcilePersistedQueuedTurns()
+
+        XCTAssertTrue(incompleteSocket.sentTurns.isEmpty)
+        XCTAssertEqual(incompleteStore.selectedQueuedTurns.first?.waitsForAcceptedTurnStart, true)
+        XCTAssertEqual(incompleteStore.selectedQueuedTurns.first?.expectedTurnID, acceptedTurnID)
+
+        let recoveredClient = MockSessionStoreClient(
+            projects: [project],
+            sessions: [completed],
+            messagesResult: [
+                CodexHistoryMessage(
+                    role: "user",
+                    content: "普通消息 A 已开始",
+                    createdAt: Date(timeIntervalSince1970: 1),
+                    clientMessageID: "client_accepted_before_restart_a",
+                    turnID: acceptedTurnID
+                )
+            ]
+        )
+        var recoveredSockets: [MockWebSocketClient] = []
+        let recoveredStore = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            queuedTurnStore: queuedTurnStore,
+            clientFactory: { recoveredClient },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                recoveredSockets.append(socket)
+                return socket
+            }
+        )
+        await recoveredStore.refreshAll(autoAttach: false)
+        recoveredStore.takeOverSession(completed)
+        await recoveredStore.selectSession(completed)
+        let recoveredSocket = try XCTUnwrap(recoveredSockets.first)
+        recoveredSocket.emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: recoveredStore)
+        await recoveredStore.reconcilePersistedQueuedTurns()
+
+        XCTAssertEqual(recoveredSocket.sentTurns.first?.clientMessageID, permissionClientMessageID)
+        XCTAssertFalse(recoveredStore.selectedQueuedTurns.first?.waitsForAcceptedTurnStart == true)
+    }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ProtocolContractTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ProtocolContractTests.swift
@@ -16,6 +16,12 @@ final class ProtocolContractTests: XCTestCase {
             current.capabilityNegotiation.decision(for: "file_upload_v1"),
             .enabled
         )
+        XCTAssertEqual(
+            current.capabilityNegotiation.decision(
+                for: SessionStore.codexRemoteFullAccessCapability
+            ),
+            .enabled
+        )
         XCTAssertNoThrow(try current.requireCompatible())
 
         let previous = try decodeVersionFixture("version-previous.json")
@@ -28,6 +34,12 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertTrue(previous.capabilities.isEmpty, "旧服务缺少 capability 时必须安全降级为空集合")
         XCTAssertEqual(
             previous.capabilityNegotiation.decision(for: "file_upload_v1"),
+            .serverUnsupported
+        )
+        XCTAssertEqual(
+            previous.capabilityNegotiation.decision(
+                for: SessionStore.codexRemoteFullAccessCapability
+            ),
             .serverUnsupported
         )
         XCTAssertNoThrow(try previous.requireCompatible())
@@ -55,6 +67,61 @@ final class ProtocolContractTests: XCTestCase {
             .serverUnsupported,
             "未知 capability/state 不能意外打开当前客户端的文件上传路径"
         )
+    }
+
+    @MainActor
+    func testLegacyAgentDOnlyDowngradesNoApprovalPolicy() {
+        var fullAccess = CodexAppServerTurnOptions.default
+        fullAccess.approvalPolicy = .never
+        fullAccess.approvalsReviewer = "user"
+        fullAccess.sandboxMode = .dangerFullAccess
+
+        let legacy = fullAccess.adjustedForRemoteNoApprovalSupport(false)
+        XCTAssertEqual(legacy.approvalPolicy, .onRequest)
+        XCTAssertEqual(legacy.sandboxMode, .dangerFullAccess)
+        XCTAssertEqual(legacy.approvalsReviewer, "user")
+
+        let current = fullAccess.adjustedForRemoteNoApprovalSupport(true)
+        XCTAssertEqual(current.approvalPolicy, .never)
+        XCTAssertEqual(current.sandboxMode, .dangerFullAccess)
+
+        var workspace = CodexAppServerTurnOptions.default
+        workspace.approvalPolicy = .onRequest
+        workspace.sandboxMode = .workspaceWrite
+        XCTAssertEqual(
+            workspace.adjustedForRemoteNoApprovalSupport(false),
+            workspace
+        )
+
+        let appStore = makeIsolatedAppStore()
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore()
+        )
+        appStore.replaceCapabilityNegotiation(
+            HostCapabilityNegotiation(wasNegotiated: true, declared: [], statuses: []),
+            preserving: appStore.activeHostState
+        )
+        let legacyPayload = store.payloadApplyingRemoteNoApprovalCompatibility(
+            CodexAppServerTurnPayload(prompt: "兼容旧 Mac", options: fullAccess)
+        )
+        XCTAssertEqual(legacyPayload.options.approvalPolicy, .onRequest)
+        XCTAssertEqual(legacyPayload.options.sandboxMode, .dangerFullAccess)
+
+        appStore.replaceCapabilityNegotiation(
+            HostCapabilityNegotiation(
+                wasNegotiated: true,
+                declared: [SessionStore.codexRemoteFullAccessCapability],
+                statuses: []
+            ),
+            preserving: appStore.activeHostState
+        )
+        let currentPayload = store.payloadApplyingRemoteNoApprovalCompatibility(
+            CodexAppServerTurnPayload(prompt: "使用新版 Mac", options: fullAccess)
+        )
+        XCTAssertEqual(currentPayload.options.approvalPolicy, .never)
+        XCTAssertEqual(currentPayload.options.sandboxMode, .dangerFullAccess)
     }
 
     func testVersionAndPairingResponsesDecodeOptionalTailscaleMetadata() throws {


### PR DESCRIPTION
## 结果

- 修复 iPad 自己启动的 Turn 在前后台切换或短暂断线后被误判为 Codex Desktop 外部活动，并错误显示“观察”。
- 运行中修改权限后，下一条消息强制排队到新的 turn/start；未修改权限时仍保留 turn/steer 引导能力。

## 根因

- agentd 把 rollout 证据的 2 分钟有效窗口同时当成待扫描登记的保留时间。目标会话在 user_message 落盘前退到后台，约 3 分钟后恢复轮询时，精确 client ID 登记已经先被清理。
- turn/steer 只能追加当前 Turn 输入，不能携带 sandbox、approval 或其他 turn/start 参数；Composer 之前仍允许权限变化后的消息走引导路径。

## 实现

- 保留 2 分钟的事件证据匹配窗口，但把待扫描登记保留到 40 分钟，并继续要求精确 Thread + client ID + 时间证据。
- 把“权限选择需要新 Turn”作为按会话缓存的 Composer 状态；运行中变化后禁用引导并走本地可靠队列。
- 发送成功只清除与已提交权限快照完全一致的标记，避免迟到回调覆盖用户的新选择。

## 验证

- PASS: go test -count=1 ./internal/codexhistory
- PASS: 相关 external activity HTTP 测试
- PASS: bash ./scripts/check-source-size.sh
- PASS: git diff --check
- 未运行 iOS 编译/测试：当前 Windows 主机缺少 xcrun，XcodeBuildMCP 也没有已解析的固定 M5 Simulator 目标。
- 完整 internal/httpapi 测试仅有既有 Windows 环境失败：测试创建 symlink 时缺少系统权限；与本次修改无代码交集，相关 external activity 子集已通过。