### PR TITLE
MIM-195 切换顶部项目时提供触觉反馈

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -284,6 +284,9 @@ struct WorkspaceRootView: View {
     /// 整条胶囊行的容器宽。与 `workspaceStripViewportWidth` 不同，它不受行内控件增减影响，
     /// 因此可以安全地用来决定要不要把 Runtime 筛选器并进这一行。
     @State private var workspaceStripContainerWidth: CGFloat = 0
+    @State private var pagerSelectionIsUserDriven = false
+    @State private var pendingHapticWorkspaceID: String?
+    @State private var suppressedHapticWorkspaceID: String?
     init(
         onStartSession: @escaping (AgentProject, WorkspaceSessionRuntimeChoice) -> Void,
         onOpenSession: @escaping (AgentSession) -> Void = { _ in },
@@ -589,6 +592,20 @@ struct WorkspaceRootView: View {
         } action: { _, pagePosition in
             pagerTransitionState.update(pagePosition: pagePosition)
         }
+        .onScrollPhaseChange { _, phase in
+            switch phase {
+            case .tracking, .interacting, .decelerating:
+                if !pagerSelectionIsUserDriven {
+                    MimiHaptics.prepare(.snap)
+                }
+                pagerSelectionIsUserDriven = true
+            case .idle:
+                pagerSelectionIsUserDriven = false
+            case .animating:
+                // 系统分页可能在手势后进入动画阶段；保留来源直到真正停止。
+                break
+            }
+        }
         .scrollIndicators(.hidden)
     }
 
@@ -709,6 +726,7 @@ struct WorkspaceRootView: View {
                     workspaceStripViewportWidth = width
                 }
                 .onChange(of: selectedWorkspaceID) { previousID, selectedID in
+                    handleWorkspaceSelectionHaptic(previousID: previousID, selectedID: selectedID)
                     guard let selectedID else { return }
                     // 首次恢复选择直接定位，避免页面刚出现就自行滑动；后续切换与正文分页
                     // 共用同一个临界阻尼 token，快速反向点击会从当前画面连续改向。
@@ -882,16 +900,41 @@ struct WorkspaceRootView: View {
         return motion.allowsSpatialMotion ? motion.animation : nil
     }
     private func selectWorkspace(_ project: AgentProject) {
-        selectWorkspace(id: project.id)
+        selectWorkspace(id: project.id, providesHaptic: true)
     }
-    private func selectWorkspace(id: String) {
+    private func selectWorkspace(id: String, providesHaptic: Bool = false) {
         guard selectedWorkspaceID != id else { return }
+        if providesHaptic {
+            pendingHapticWorkspaceID = id
+            suppressedHapticWorkspaceID = nil
+            MimiHaptics.prepare(.snap)
+        } else {
+            pendingHapticWorkspaceID = nil
+            suppressedHapticWorkspaceID = id
+        }
         withAnimation(workspaceSelectionAnimation) {
             selectedWorkspaceID = id
         }
     }
+    private func handleWorkspaceSelectionHaptic(previousID: String?, selectedID: String?) {
+        let shouldFire = WorkspaceSelectionHapticPolicy.shouldFire(
+            previousID: previousID,
+            selectedID: selectedID,
+            isExplicitSelection: pendingHapticWorkspaceID == selectedID,
+            isUserPaging: pagerSelectionIsUserDriven,
+            isSuppressed: suppressedHapticWorkspaceID == selectedID
+        )
+        pendingHapticWorkspaceID = nil
+        suppressedHapticWorkspaceID = nil
+        if shouldFire {
+            MimiHaptics.fire(.snap)
+        }
+    }
     /// 目录恢复和数据同步不代表用户发起了导航；禁止隐式动画，避免首次进入工作区自行滑动。
     private func restoreWorkspaceSelection(_ id: String?) {
+        guard selectedWorkspaceID != id else { return }
+        pendingHapticWorkspaceID = nil
+        suppressedHapticWorkspaceID = id
         var transaction = Transaction(animation: nil)
         transaction.disablesAnimations = true
         withTransaction(transaction) {

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceStripPresentation.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceStripPresentation.swift
@@ -72,6 +72,22 @@ enum WorkspaceStripLayout {
     }
 }
 
+/// 触觉只跟随用户确实完成的项目选中变化；恢复状态和重复选择保持安静。
+enum WorkspaceSelectionHapticPolicy {
+    static func shouldFire(
+        previousID: String?,
+        selectedID: String?,
+        isExplicitSelection: Bool,
+        isUserPaging: Bool,
+        isSuppressed: Bool
+    ) -> Bool {
+        guard let previousID, let selectedID, previousID != selectedID, !isSuppressed else {
+            return false
+        }
+        return isExplicitSelection || isUserPaging
+    }
+}
+
 /// 把分页 ScrollView 的像素偏移转换成项目索引空间。顶部胶囊只消费这个连续值，
 /// 因而 25% 的横滑就是 25% 的收缩/展开，不需要等 selection 在中点切换。
 enum WorkspacePagerTransition {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
@@ -108,4 +108,52 @@ final class WorkspaceStripPresentationTests: XCTestCase {
             )
         )
     }
+
+    func testWorkspaceSelectionHapticOnlyFollowsUserSelectionChanges() {
+        XCTAssertFalse(
+            WorkspaceSelectionHapticPolicy.shouldFire(
+                previousID: nil,
+                selectedID: "project-a",
+                isExplicitSelection: false,
+                isUserPaging: false,
+                isSuppressed: false
+            )
+        )
+        XCTAssertTrue(
+            WorkspaceSelectionHapticPolicy.shouldFire(
+                previousID: "project-a",
+                selectedID: "project-b",
+                isExplicitSelection: true,
+                isUserPaging: false,
+                isSuppressed: false
+            )
+        )
+        XCTAssertTrue(
+            WorkspaceSelectionHapticPolicy.shouldFire(
+                previousID: "project-a",
+                selectedID: "project-b",
+                isExplicitSelection: false,
+                isUserPaging: true,
+                isSuppressed: false
+            )
+        )
+        XCTAssertFalse(
+            WorkspaceSelectionHapticPolicy.shouldFire(
+                previousID: "project-a",
+                selectedID: "project-b",
+                isExplicitSelection: false,
+                isUserPaging: true,
+                isSuppressed: true
+            )
+        )
+        XCTAssertFalse(
+            WorkspaceSelectionHapticPolicy.shouldFire(
+                previousID: "project-a",
+                selectedID: "project-a",
+                isExplicitSelection: true,
+                isUserPaging: true,
+                isSuppressed: false
+            )
+        )
+    }
 }


### PR DESCRIPTION
## 变更

- 点击不同的顶部项目胶囊时，复用系统 selection haptic 反馈
- 横向分页切换到其他项目时，在选中项实际变化后反馈一次
- 首次载入、目录恢复、后台同步和重复选择保持安静
- 不支持触觉反馈的设备继续由系统自动降级为无操作

## 验证

- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/WorkspaceStripPresentationTests`
  - 6 tests passed，0 failures
- `bash ./scripts/check-source-size.sh`
  - 通过
- `git diff --check`
  - 通过

## 限制

- Simulator 已验证编译与触发策略；触觉强度需要在支持 Taptic Engine 的真机上感知

Linear: [MIM-195](https://linear.app/code89757/issue/MIM-195/切换顶部项目时提供触觉反馈)
