### PR TITLE
MIM-179 修复 Claude 历史会话恢复时的 runtime override 重试

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -444,6 +444,8 @@ async fn acquire_turn_process(
     let cwd = resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
     let defaults = state.defaults();
     let model = normalize_claude_model(params.model.clone().or_else(|| defaults.model.clone()));
+    let effort_level = params.effort.map(native_effort_level).map(str::to_string);
+    let permission_mode = claude_permission_mode(params).to_string();
     // 本地可直接以 transcript 是否存在区分新线程和恢复线程。远程线程仍会在
     // thread/start/resume 预启动；这里的 preview 判断只负责进程意外退出后的兜底。
     let resume = if state.trust_persisted_cwd() {
@@ -458,6 +460,8 @@ async fn acquire_turn_process(
             &cwd,
             resume,
             model,
+            effort_level,
+            Some(permission_mode),
             defaults.system_prompt.clone(),
         )
         .await

--- a/bridges/claude/crates/claude-bridge/src/pool/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/mod.rs
@@ -156,6 +156,8 @@ impl ClaudePool {
                 cwd.as_ref(),
                 false,
                 model,
+                None,
+                None,
                 append_system_prompt,
             )
             .await?;
@@ -173,8 +175,16 @@ impl ClaudePool {
         model: Option<String>,
         append_system_prompt: Option<String>,
     ) -> Result<Arc<ClaudeProcessHandle>, PoolError> {
-        self.spawn_with_capacity_check(thread_id, cwd.as_ref(), true, model, append_system_prompt)
-            .await
+        self.spawn_with_capacity_check(
+            thread_id,
+            cwd.as_ref(),
+            true,
+            model,
+            None,
+            None,
+            append_system_prompt,
+        )
+        .await
     }
 
     /// Get or spawn the process needed by a lazily-created thread. `resume`
@@ -186,10 +196,20 @@ impl ClaudePool {
         cwd: impl AsRef<Path>,
         resume: bool,
         model: Option<String>,
+        effort_level: Option<String>,
+        permission_mode: Option<String>,
         append_system_prompt: Option<String>,
     ) -> Result<Arc<ClaudeProcessHandle>, PoolError> {
-        self.spawn_with_capacity_check(thread_id, cwd.as_ref(), resume, model, append_system_prompt)
-            .await
+        self.spawn_with_capacity_check(
+            thread_id,
+            cwd.as_ref(),
+            resume,
+            model,
+            effort_level,
+            permission_mode,
+            append_system_prompt,
+        )
+        .await
     }
 
     /// Borrow a claude process for a one-shot, connection-scoped query
@@ -215,7 +235,7 @@ impl ClaudePool {
             .or_else(|| std::env::current_dir().ok())
             .unwrap_or_else(|| PathBuf::from("."));
         let synthetic_id = format!("utility_{}", Uuid::now_v7());
-        self.spawn_with_capacity_check(synthetic_id, &cwd, false, None, None)
+        self.spawn_with_capacity_check(synthetic_id, &cwd, false, None, None, None, None)
             .await
     }
 
@@ -298,6 +318,8 @@ impl ClaudePool {
         cwd: &Path,
         resume: bool,
         model: Option<String>,
+        effort_level: Option<String>,
+        permission_mode: Option<String>,
         append_system_prompt: Option<String>,
     ) -> Result<Arc<ClaudeProcessHandle>, PoolError> {
         let _spawn_guard = self.spawn_lock.lock().await;
@@ -312,6 +334,8 @@ impl ClaudePool {
             cwd: cwd.to_path_buf(),
             claude_bin: self.claude_bin.clone(),
             model,
+            effort_level,
+            permission_mode,
             append_system_prompt,
             resume,
             bypass_permissions: self.policy.bypass_permissions,

--- a/bridges/claude/crates/claude-bridge/src/pool/process.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/process.rs
@@ -79,6 +79,10 @@ pub struct ClaudeSpawnConfig {
     /// Optional model override (`--model <s>`). Accepts full model ids and the
     /// established `opus` / `sonnet` / `haiku` aliases claude understands directly.
     pub model: Option<String>,
+    /// Optional `--effort <level>` applied before the first user envelope.
+    pub effort_level: Option<String>,
+    /// Optional `--permission-mode <mode>` applied before the first user envelope.
+    pub permission_mode: Option<String>,
     /// Optional `--append-system-prompt <s>`.
     pub append_system_prompt: Option<String>,
     /// True for `thread/resume`: spawn with `--resume <thread_id>` so claude
@@ -314,6 +318,8 @@ impl ClaudeProcessHandle {
             cwd,
             claude_bin,
             model,
+            effort_level,
+            permission_mode,
             append_system_prompt,
             resume,
             bypass_permissions,
@@ -336,6 +342,10 @@ impl ClaudeProcessHandle {
             // outbound control_response{...{behavior:"allow"|"deny"}}.
             args.push("--permission-prompt-tool".into());
             args.push("stdio".into());
+            if let Some(mode) = permission_mode.as_deref() {
+                args.push("--permission-mode".into());
+                args.push(mode.into());
+            }
         }
         args.push("--add-dir".into());
         args.push(cwd.clone().into_os_string());
@@ -355,6 +365,10 @@ impl ClaudeProcessHandle {
         if let Some(m) = model.as_deref() {
             args.push("--model".into());
             args.push(m.into());
+        }
+        if let Some(level) = effort_level.as_deref() {
+            args.push("--effort".into());
+            args.push(level.into());
         }
         if let Some(prompt) = append_system_prompt.as_deref() {
             args.push("--append-system-prompt".into());
@@ -400,15 +414,17 @@ impl ClaudeProcessHandle {
         let init_slot: Arc<InitSlot> = Arc::new(InitSlot::default());
         let pending_controls: Arc<Mutex<HashMap<String, oneshot::Sender<ControlResponseBody>>>> =
             Arc::new(Mutex::new(HashMap::new()));
-        // Seed runtime_state with whatever was passed at spawn — claude reads
-        // `--model <m>` directly so we know that value is live without ever
-        // sending set_model. Effort / permission mode stay None until
-        // the first apply_runtime_overrides call sets them.
+        // Spawn-time flags are already live. Cache them so cold recovery does
+        // not repeat the same runtime control that retired the prior process.
         let runtime_state = Arc::new(Mutex::new(RuntimeState {
             model: model.clone(),
-            effort_level: None,
+            effort_level: effort_level.clone(),
             effort_level_unsupported: false,
-            permission_mode: None,
+            permission_mode: if bypass_permissions {
+                None
+            } else {
+                permission_mode.clone()
+            },
         }));
 
         let writer = tokio::spawn(writer_task(

--- a/bridges/claude/crates/claude-bridge/tests/fake_claude_smoke.rs
+++ b/bridges/claude/crates/claude-bridge/tests/fake_claude_smoke.rs
@@ -66,6 +66,8 @@ async fn fake_claude_emits_system_init_then_replies_to_user_envelope() {
         cwd: cwd.path().to_path_buf(),
         claude_bin: fake_claude_path(),
         model: None,
+        effort_level: None,
+        permission_mode: None,
         append_system_prompt: None,
         resume: false,
         bypass_permissions: true,

--- a/bridges/claude/crates/claude-bridge/tests/runtime_override_recovery.rs
+++ b/bridges/claude/crates/claude-bridge/tests/runtime_override_recovery.rs
@@ -1,5 +1,5 @@
-//! 回归：turn/start 在发送用户输入前遇到 runtime control 进程退出时，
-//! bridge 只冷启动重试一次，并且用户输入只能发送给健康 generation 一次。
+//! 回归：历史会话重复 resume 后，若 runtime control 导致进程退出，
+//! bridge 的冷重试必须改用启动参数，不能再重复同一条失败控制请求。
 
 mod support;
 
@@ -21,19 +21,20 @@ use support::fake_claude_path;
 const STEP_TIMEOUT: Duration = Duration::from_secs(8);
 
 #[tokio::test]
-async fn pre_turn_control_exit_cold_recovers_without_duplicate_user_envelope() {
+async fn duplicate_resume_control_exit_recovers_with_spawn_time_overrides() {
     let fixture = TempDir::new().expect("fixture");
     let cwd = TempDir::new().expect("cwd");
-    let marker = fixture.path().join("first-control-exited");
     let turn_log = fixture.path().join("turns.log");
-    let _restore_marker = EnvRestore::set("FAKE_CLAUDE_EXIT_ON_CONTROL_ONCE", &marker);
+    let _restore_control_exit =
+        EnvRestore::set("FAKE_CLAUDE_EXIT_ON_CONTROL_ALWAYS", fixture.path());
     let _restore_turn_log = EnvRestore::set("FAKE_CLAUDE_TURN_LOG", &turn_log);
 
     let claude_pool = Arc::new(ClaudePool::new(fake_claude_path()));
     let codex_home = TempDir::new().expect("codex home");
-    let thread_index: Arc<dyn ThreadIndexHandle> = ThreadIndex::open_and_hydrate(codex_home.path())
+    let index = ThreadIndex::open_and_hydrate(codex_home.path())
         .await
         .expect("thread index");
+    let thread_index: Arc<dyn ThreadIndexHandle> = index.clone();
     let (client_io, bridge_io) = tokio::io::duplex(64 * 1024);
     let (bridge_reader, bridge_writer) = tokio::io::split(bridge_io);
     let bridge_pool = Arc::clone(&claude_pool);
@@ -72,22 +73,51 @@ async fn pre_turn_control_exit_cold_recovers_without_duplicate_user_envelope() {
         .as_str()
         .expect("thread id")
         .to_string();
+    let transcript = index
+        .lookup(&thread_id)
+        .await
+        .expect("indexed thread")
+        .metadata
+        .claude_session_path;
+    std::fs::create_dir_all(transcript.parent().expect("transcript parent"))
+        .expect("create transcript parent");
+    std::fs::write(&transcript, "").expect("create historical transcript");
+
+    for id in [3, 4] {
+        send(
+            &mut client_writer,
+            id,
+            "thread/resume",
+            json!({
+                "threadId": thread_id,
+                "model": "opus",
+                "excludeTurns": true
+            }),
+        )
+        .await;
+        let resumed = await_response(&mut client_reader, id).await;
+        assert!(
+            resumed.get("error").is_none(),
+            "unexpected resume error: {resumed:#?}"
+        );
+    }
 
     send(
         &mut client_writer,
-        3,
+        5,
         "turn/start",
         json!({
             "threadId": thread_id,
             "input": [{"type": "text", "text": "recover exactly once"}],
+            "model": "opus",
             "effort": "high"
         }),
     )
     .await;
-    let messages = collect_turn(&mut client_reader, 3).await;
+    let messages = collect_turn(&mut client_reader, 5).await;
     let response = messages
         .iter()
-        .find(|message| message["id"].as_u64() == Some(3))
+        .find(|message| message["id"].as_u64() == Some(5))
         .expect("turn/start response");
     assert!(
         response.get("error").is_none(),
@@ -98,10 +128,6 @@ async fn pre_turn_control_exit_cold_recovers_without_duplicate_user_envelope() {
         .find(|message| message["method"] == "turn/completed")
         .expect("turn/completed");
     assert_eq!(completed["params"]["turn"]["status"], "completed");
-    assert!(
-        marker.is_file(),
-        "first generation must fail during control"
-    );
     assert_eq!(
         std::fs::read_to_string(&turn_log).expect("turn log"),
         "recover exactly once\n",

--- a/bridges/claude/crates/claude-bridge/tests/support/fake_claude.rs
+++ b/bridges/claude/crates/claude-bridge/tests/support/fake_claude.rs
@@ -32,6 +32,9 @@
 //! - `FAKE_CLAUDE_EXIT_ON_CONTROL_ONCE`: optional marker path. The first fake
 //!   generation atomically creates the marker and exits after receiving a
 //!   control request but before replying. Later generations reply normally.
+//! - `FAKE_CLAUDE_EXIT_ON_CONTROL_ALWAYS`: when non-empty, every generation
+//!   exits after receiving a control request. This verifies that recovery
+//!   changes transport instead of repeating the same failed request.
 //! - A script line `{"type":"exit_once","marker":"/tmp/path"}` atomically
 //!   creates `marker` and exits the first fake process that reaches it.
 //!   Later processes skip the directive. This models one crashed Claude
@@ -126,7 +129,7 @@ fn main() -> ExitCode {
         };
 
         if inbound.get("type").and_then(Value::as_str) == Some("control_request") {
-            if exit_on_control_once() {
+            if exit_on_control() {
                 return ExitCode::from(24);
             }
             let request_id = inbound
@@ -312,7 +315,13 @@ fn run_script<W: Write>(out: &mut W, steps: &[ScriptStep], session_id: &str, tur
     false
 }
 
-fn exit_on_control_once() -> bool {
+fn exit_on_control() -> bool {
+    if env::var_os("FAKE_CLAUDE_EXIT_ON_CONTROL_ALWAYS")
+        .filter(|value| !value.is_empty())
+        .is_some()
+    {
+        return true;
+    }
     env::var_os("FAKE_CLAUDE_EXIT_ON_CONTROL_ONCE")
         .filter(|path| !path.is_empty())
         .is_some_and(|path| create_marker_once(std::path::Path::new(&path)))


### PR DESCRIPTION
## 目标

修复 Windows 上 Claude 历史会话恢复后，runtime override 连续取消导致 `turn/start` 失败的问题。

## 实现

- 冷重试时将 model、effort 和 permission mode 写入 Claude 启动参数。
- 初始化新 generation 的 runtime cache，避免重复发送已经失败的 control request。
- 增加历史 transcript、重复 `thread/resume` 和进程退出场景的回归测试。

## 验证

- `runtime_override_recovery`：1 passed。
- Claude bridge 其余测试：通过；跳过一个与本改动无关的 Windows GNU 既有时序用例。
- `cargo fmt --all -- --check`：通过。
- `git diff --check`：通过。
- `bash ./scripts/check-source-size.sh`：通过。
- Claude CLI 2.1.241 使用历史会话和 `--model opus --effort high --permission-mode default`：control response 成功，stderr 为空。

## 已知限制

`active_turn_conflict` 在 Windows GNU 环境存在既有时序问题：1.5 秒 fake turn 会在测试读取 ACK 前结束。相关文件未修改，不属于本 PR。

关联 Linear：MIM-179