### PR TITLE
MIM-179 Preserve effort fallback for older Claude CLIs

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -227,6 +227,17 @@ impl TurnError {
     }
 }
 
+/// 普通 cold acquire 交给 runtime setter 应用本轮配置；只有旧 generation
+/// 在 setter 阶段发生 transport failure 后，恢复 acquire 才能把配置放进 argv。
+#[derive(Debug, Clone, Copy)]
+enum TurnProcessAcquire {
+    Normal,
+    Recovery {
+        effort_level: Option<&'static str>,
+        permission_mode: &'static str,
+    },
+}
+
 // ============================================================================
 // turn/start
 // ============================================================================
@@ -238,7 +249,7 @@ pub async fn handle_turn_start(
     let envelope = translate_user_input(&params.input)
         .map_err(|e| TurnError::InputTranslation(e.to_string()))?;
 
-    let mut handle = acquire_turn_process(state, &params).await?;
+    let mut handle = acquire_turn_process(state, &params, TurnProcessAcquire::Normal).await?;
 
     // 必须在 runtime overrides 之前拒绝重复 turn/start。否则一次陈旧的客户端
     // 发送会先改掉正在执行轮次的模型/权限，再以内部错误退出。
@@ -282,7 +293,6 @@ pub async fn handle_turn_start(
         };
 
         if err.is_process_transport_failure() {
-            let will_retry = !recovery_attempted;
             let generation = handle.generation().to_string();
             let pid = handle.pid();
             let failure_kind = err.failure_kind();
@@ -292,6 +302,7 @@ pub async fn handle_turn_start(
                 .claude_pool()
                 .release_if_same(&params.thread_id, &handle)
                 .await;
+            let will_retry = !recovery_attempted;
             tracing::warn!(
                 thread_id = %params.thread_id,
                 %generation,
@@ -307,7 +318,15 @@ pub async fn handle_turn_start(
 
             if will_retry {
                 recovery_attempted = true;
-                handle = acquire_turn_process(state, &params).await?;
+                handle = acquire_turn_process(
+                    state,
+                    &params,
+                    TurnProcessAcquire::Recovery {
+                        effort_level: effort_override,
+                        permission_mode,
+                    },
+                )
+                .await?;
                 driver = ensure_event_driver(state, &params.thread_id, &handle);
                 continue;
             }
@@ -431,6 +450,7 @@ pub async fn handle_turn_start(
 async fn acquire_turn_process(
     state: &Arc<ConnectionState>,
     params: &p::TurnStartParams,
+    acquire_mode: TurnProcessAcquire,
 ) -> Result<Arc<ClaudeProcessHandle>, TurnError> {
     if let Some(handle) = state.claude_pool().get(&params.thread_id).await {
         return Ok(handle);
@@ -444,8 +464,16 @@ async fn acquire_turn_process(
     let cwd = resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
     let defaults = state.defaults();
     let model = normalize_claude_model(params.model.clone().or_else(|| defaults.model.clone()));
-    let effort_level = params.effort.map(native_effort_level).map(str::to_string);
-    let permission_mode = claude_permission_mode(params).to_string();
+    let (effort_level, permission_mode) = match acquire_mode {
+        TurnProcessAcquire::Normal => (None, None),
+        TurnProcessAcquire::Recovery {
+            effort_level,
+            permission_mode,
+        } => (
+            effort_level.map(str::to_string),
+            Some(permission_mode.to_string()),
+        ),
+    };
     // 本地可直接以 transcript 是否存在区分新线程和恢复线程。远程线程仍会在
     // thread/start/resume 预启动；这里的 preview 判断只负责进程意外退出后的兜底。
     let resume = if state.trust_persisted_cwd() {
@@ -461,7 +489,7 @@ async fn acquire_turn_process(
             resume,
             model,
             effort_level,
-            Some(permission_mode),
+            permission_mode,
             defaults.system_prompt.clone(),
         )
         .await

--- a/bridges/claude/crates/claude-bridge/tests/runtime_override_recovery.rs
+++ b/bridges/claude/crates/claude-bridge/tests/runtime_override_recovery.rs
@@ -3,7 +3,7 @@
 
 mod support;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use alleycat_bridge_core::framing::write_json_line;
@@ -20,14 +20,127 @@ use support::fake_claude_path;
 
 const STEP_TIMEOUT: Duration = Duration::from_secs(8);
 
+static TEST_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
 #[tokio::test]
-async fn duplicate_resume_control_exit_recovers_with_spawn_time_overrides() {
+async fn cold_start_unsupported_effort_control_uses_runtime_fallback() {
+    let _test_guard = TEST_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
     let fixture = TempDir::new().expect("fixture");
     let cwd = TempDir::new().expect("cwd");
     let turn_log = fixture.path().join("turns.log");
+    let argv_log = fixture.path().join("argv.jsonl");
+    let _restore_reject_arg = EnvRestore::set(
+        "FAKE_CLAUDE_REJECT_EFFORT_ARG",
+        &fixture.path().join("reject-arg"),
+    );
+    let _restore_reject_control = EnvRestore::set(
+        "FAKE_CLAUDE_REJECT_EFFORT_CONTROL",
+        &fixture.path().join("reject-control"),
+    );
+    let _restore_turn_log = EnvRestore::set("FAKE_CLAUDE_TURN_LOG", &turn_log);
+    let _restore_argv_log = EnvRestore::set("FAKE_CLAUDE_ARGV_LOG", &argv_log);
+
+    let claude_pool = Arc::new(ClaudePool::new(fake_claude_path()));
+    let codex_home = TempDir::new().expect("codex home");
+    let thread_index: Arc<dyn ThreadIndexHandle> = ThreadIndex::open_and_hydrate(codex_home.path())
+        .await
+        .expect("thread index");
+    let (client_io, bridge_io) = tokio::io::duplex(64 * 1024);
+    let (bridge_reader, bridge_writer) = tokio::io::split(bridge_io);
+    let bridge_pool = Arc::clone(&claude_pool);
+    let codex_home_path = codex_home.path().to_path_buf();
+    let bridge_task = tokio::spawn(async move {
+        run_connection(
+            bridge_reader,
+            bridge_writer,
+            bridge_pool,
+            thread_index,
+            codex_home_path,
+        )
+        .await
+    });
+
+    let (client_reader, mut client_writer) = tokio::io::split(client_io);
+    let mut client_reader = BufReader::new(client_reader);
+    send(
+        &mut client_writer,
+        1,
+        "initialize",
+        json!({"clientInfo": {"name": "runtime-recovery", "version": "0.0.1"}}),
+    )
+    .await;
+    let _ = await_response(&mut client_reader, 1).await;
+
+    send(
+        &mut client_writer,
+        2,
+        "thread/start",
+        json!({"cwd": cwd.path().to_string_lossy()}),
+    )
+    .await;
+    let started = await_response(&mut client_reader, 2).await;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .expect("thread id")
+        .to_string();
+
+    send(
+        &mut client_writer,
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [{"type": "text", "text": "old cli fallback"}],
+            "effort": "high"
+        }),
+    )
+    .await;
+    let messages = collect_turn(&mut client_reader, 3).await;
+    let response = messages
+        .iter()
+        .find(|message| message["id"].as_u64() == Some(3))
+        .expect("turn/start response");
+    assert!(
+        response.get("error").is_none(),
+        "unexpected error: {response:#?}"
+    );
+    let completed = messages
+        .iter()
+        .find(|message| message["method"] == "turn/completed")
+        .expect("turn/completed");
+    assert_eq!(completed["params"]["turn"]["status"], "completed");
+    assert_eq!(
+        std::fs::read_to_string(&turn_log).expect("turn log"),
+        "old cli fallback\n"
+    );
+
+    let argv = read_argv_log(&argv_log);
+    assert_eq!(argv.len(), 1, "ordinary cold acquire must spawn once");
+    assert!(!argv[0].iter().any(|arg| arg == "--effort"));
+    assert!(!argv[0].iter().any(|arg| arg == "--permission-mode"));
+
+    drop(client_writer);
+    drop(client_reader);
+    let _ = timeout(STEP_TIMEOUT, bridge_task).await;
+}
+
+#[tokio::test]
+async fn duplicate_resume_control_exit_recovers_with_spawn_time_overrides() {
+    let _test_guard = TEST_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let fixture = TempDir::new().expect("fixture");
+    let cwd = TempDir::new().expect("cwd");
+    let turn_log = fixture.path().join("turns.log");
+    let argv_log = fixture.path().join("argv.jsonl");
     let _restore_control_exit =
         EnvRestore::set("FAKE_CLAUDE_EXIT_ON_CONTROL_ALWAYS", fixture.path());
     let _restore_turn_log = EnvRestore::set("FAKE_CLAUDE_TURN_LOG", &turn_log);
+    let _restore_argv_log = EnvRestore::set("FAKE_CLAUDE_ARGV_LOG", &argv_log);
 
     let claude_pool = Arc::new(ClaudePool::new(fake_claude_path()));
     let codex_home = TempDir::new().expect("codex home");
@@ -133,6 +246,16 @@ async fn duplicate_resume_control_exit_recovers_with_spawn_time_overrides() {
         "recover exactly once\n",
         "the user envelope must not be replayed"
     );
+    let argv = read_argv_log(&argv_log);
+    assert_eq!(
+        argv.len(),
+        2,
+        "recovery must create exactly one new generation"
+    );
+    assert!(!argv[0].iter().any(|arg| arg == "--effort"));
+    assert!(!argv[0].iter().any(|arg| arg == "--permission-mode"));
+    assert!(has_arg_pair(&argv[1], "--effort", "high"));
+    assert!(has_arg_pair(&argv[1], "--permission-mode", "default"));
     assert_eq!(claude_pool.len().await, 1);
 
     drop(client_writer);
@@ -187,6 +310,19 @@ async fn next_message<R: AsyncBufRead + Unpin>(reader: &mut R) -> Value {
         .expect("read bridge response");
     assert!(count > 0, "bridge closed before the expected frame");
     serde_json::from_str(line.trim()).expect("valid bridge JSON")
+}
+
+fn read_argv_log(path: &std::path::Path) -> Vec<Vec<String>> {
+    std::fs::read_to_string(path)
+        .expect("argv log")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("argv JSON"))
+        .collect()
+}
+
+fn has_arg_pair(args: &[String], flag: &str, value: &str) -> bool {
+    args.windows(2)
+        .any(|pair| pair[0] == flag && pair[1] == value)
 }
 
 struct EnvRestore {

--- a/bridges/claude/crates/claude-bridge/tests/support/fake_claude.rs
+++ b/bridges/claude/crates/claude-bridge/tests/support/fake_claude.rs
@@ -35,6 +35,13 @@
 //! - `FAKE_CLAUDE_EXIT_ON_CONTROL_ALWAYS`: when non-empty, every generation
 //!   exits after receiving a control request. This verifies that recovery
 //!   changes transport instead of repeating the same failed request.
+//! - `FAKE_CLAUDE_REJECT_EFFORT_CONTROL`: when non-empty, replies to
+//!   `apply_flag_settings` with an unknown-control error while keeping the
+//!   process alive. This models an older Claude CLI.
+//! - `FAKE_CLAUDE_REJECT_EFFORT_ARG`: when non-empty, exits during argument
+//!   parsing if `--effort` is present. This models older CLI argument parsing.
+//! - `FAKE_CLAUDE_ARGV_LOG`: optional JSONL file; records each generation's
+//!   argv so recovery tests can assert which values were passed at spawn time.
 //! - A script line `{"type":"exit_once","marker":"/tmp/path"}` atomically
 //!   creates `marker` and exits the first fake process that reaches it.
 //!   Later processes skip the directive. This models one crashed Claude
@@ -56,6 +63,10 @@ use serde_json::{Value, json};
 
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
+    record_argv(&args);
+    if rejects_effort_argument(&args) {
+        return ExitCode::from(25);
+    }
     let session_id = arg_value(&args, "--session-id").unwrap_or_else(|| "fake-session".to_string());
     let cwd = arg_value(&args, "--add-dir")
         .or_else(|| {
@@ -136,6 +147,20 @@ fn main() -> ExitCode {
                 .get("request_id")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
+            if rejects_effort_control(&inbound) {
+                emit(
+                    &mut out,
+                    &json!({
+                        "type": "control_response",
+                        "response": {
+                            "request_id": request_id,
+                            "subtype": "error",
+                            "error": "unknown control request: apply_flag_settings"
+                        }
+                    }),
+                );
+                continue;
+            }
             emit(
                 &mut out,
                 &json!({
@@ -325,6 +350,39 @@ fn exit_on_control() -> bool {
     env::var_os("FAKE_CLAUDE_EXIT_ON_CONTROL_ONCE")
         .filter(|path| !path.is_empty())
         .is_some_and(|path| create_marker_once(std::path::Path::new(&path)))
+}
+
+fn rejects_effort_argument(args: &[String]) -> bool {
+    env::var_os("FAKE_CLAUDE_REJECT_EFFORT_ARG")
+        .filter(|value| !value.is_empty())
+        .is_some()
+        && args.iter().any(|arg| arg == "--effort")
+}
+
+fn rejects_effort_control(inbound: &Value) -> bool {
+    env::var_os("FAKE_CLAUDE_REJECT_EFFORT_CONTROL")
+        .filter(|value| !value.is_empty())
+        .is_some()
+        && inbound
+            .get("request")
+            .and_then(Value::as_object)
+            .and_then(|request| request.get("subtype"))
+            .and_then(Value::as_str)
+            == Some("apply_flag_settings")
+}
+
+fn record_argv(args: &[String]) {
+    let Ok(path) = env::var("FAKE_CLAUDE_ARGV_LOG") else {
+        return;
+    };
+    if path.is_empty() {
+        return;
+    }
+    let Ok(mut file) = fs::OpenOptions::new().create(true).append(true).open(path) else {
+        return;
+    };
+    let _ = serde_json::to_writer(&mut file, args);
+    let _ = writeln!(file);
 }
 
 fn create_marker_once(path: &std::path::Path) -> bool {


### PR DESCRIPTION
## 目标

修复 #266 合并后的 Claude CLI 兼容回归。旧版本不支持 --effort 时，普通冷启动继续通过运行时设置器降级，不在参数解析阶段退出。

## 实现

- 普通冷启动不再传入 spawn-time effort/permission。
- 继续通过 apply_runtime_overrides 应用设置，并保留全局不支持 effort 时的默认值降级。
- 仅在运行时控制传输失败后的单次恢复重启中传入 spawn-time 设置。
- 增加旧 CLI 拒绝 --effort 的回归测试，并验证恢复代参数及用户输入只发送一次。

## 验证

- cargo test -p alleycat-claude-bridge --test runtime_override_recovery -- --nocapture：2 passed
- cargo test -p alleycat-claude-bridge -- --skip active_thread_is_projected_and_second_turn_is_rejected_before_acceptance：passed
- cargo test -p alleycat-claude-bridge --test active_turn_conflict -- --nocapture：单独复跑 passed（完整套件首次命中已知时序波动）
- cargo fmt --all -- --check：passed
- git diff --check origin/main...HEAD：passed
- bash ./scripts/check-source-size.sh：passed

本 PR 基于已包含 #266 的最新 main，仅新增 1 个修复提交。