### PR TITLE
MIM-194 修复 Windows 运行时刷新复审问题

### DIFF
--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -449,10 +449,6 @@ func runStatus(args []string) error {
 	}
 	result := agentsetup.ResultFromConfig(context.Background(), *configPath, cfg)
 	loopbackEndpoint := loopbackServiceEndpoint(result.Endpoint)
-	type runtimeStatusResult struct {
-		payload map[string]any
-		err     error
-	}
 	networkStatus := configuredAgentNetworkStatus(cfg)
 	var networkStatusCh chan agentNetworkStatus
 	if *inspectNetworkPolicy {
@@ -467,19 +463,11 @@ func runStatus(args []string) error {
 	if *includeRuntime {
 		runtimeStatusCh = make(chan runtimeStatusResult, 1)
 		go func() {
-			timeout := 2 * time.Second
-			if *refreshRuntime {
-				// 服务端探测窗口为 9 秒；手动刷新必须给它留出完整完成时间。
-				timeout = 10 * time.Second
-			}
-			payload, fetchErr := fetchServiceRuntimeStatus(
-				context.Background(),
+			runtimeStatusCh <- fetchRuntimeStatusForCommand(
 				loopbackEndpoint,
 				result.Token,
-				timeout,
 				*refreshRuntime,
 			)
-			runtimeStatusCh <- runtimeStatusResult{payload: payload, err: fetchErr}
 		}()
 	}
 	serviceStatus := probeAgentServiceStatus(
@@ -534,10 +522,10 @@ func runStatus(args []string) error {
 	status["doctor"] = doctorResults
 	status["network_status"] = networkStatus
 	status["pair_expires"] = result.PairExpiresAt
-	// 旧版本 agentd 没有 runtime status endpoint。升级/接管过程中保持 status
-	// 兼容，只在成功拿到脱敏快照时附加字段，不让展示增强阻断服务状态。
-	if runtimeStatusCh != nil && runtimeStatus.err == nil {
-		status["runtime_status"] = runtimeStatus.payload
+	if runtimeStatusCh != nil {
+		if err := attachRuntimeStatus(status, runtimeStatus, *refreshRuntime); err != nil {
+			return err
+		}
 	}
 	if *asJSON {
 		return printJSON(status)

--- a/cmd/agentd/main_test.go
+++ b/cmd/agentd/main_test.go
@@ -1102,6 +1102,29 @@ func TestStatusRuntimeRefreshRequiresRuntimeJSON(t *testing.T) {
 	}
 }
 
+func TestAttachRuntimeStatusPropagatesOnlyForcedRefreshFailure(t *testing.T) {
+	status := map[string]any{"version": "1.2.3"}
+	fetchErr := errors.New("runtime status HTTP 500")
+	if err := attachRuntimeStatus(status, runtimeStatusResult{err: fetchErr}, false); err != nil {
+		t.Fatalf("cached runtime enrichment must remain compatible with an old service: %v", err)
+	}
+	if _, exists := status["runtime_status"]; exists {
+		t.Fatalf("failed cached enrichment must not attach an empty runtime status: %v", status)
+	}
+	if err := attachRuntimeStatus(status, runtimeStatusResult{err: fetchErr}, true); err == nil ||
+		!strings.Contains(err.Error(), "强制刷新运行时状态失败") {
+		t.Fatalf("forced refresh failure must reach the tray as a non-zero error: %v", err)
+	}
+
+	payload := map[string]any{"runtimes": []any{}}
+	if err := attachRuntimeStatus(status, runtimeStatusResult{payload: payload}, true); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(status["runtime_status"], payload) {
+		t.Fatalf("successful runtime status was not attached: %v", status)
+	}
+}
+
 func TestStatusNetworkPolicyInspectionRequiresJSON(t *testing.T) {
 	err := runStatus([]string{"status", "--network-policy"})
 	if err == nil || !strings.Contains(err.Error(), "--json") {
@@ -1117,6 +1140,7 @@ func TestStatusOnlyRequestsRuntimeWhenExplicitlyEnabled(t *testing.T) {
 	const token = "status-runtime-opt-in-token-0123456789"
 	var runtimeRequests atomic.Int32
 	var runtimeRefreshRequests atomic.Int32
+	var runtimeFailure atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case "/healthz":
@@ -1136,6 +1160,17 @@ func TestStatusOnlyRequestsRuntimeWhenExplicitlyEnabled(t *testing.T) {
 			}
 			if req.Header.Get("Authorization") != "Bearer "+token {
 				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			switch runtimeFailure.Load() {
+			case 1:
+				w.WriteHeader(http.StatusNotFound)
+				return
+			case 2:
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			case 3:
+				_, _ = w.Write([]byte(`{"runtimes":`))
 				return
 			}
 			_, _ = w.Write([]byte(`{"refreshing":false,"stale":false,"runtimes":[]}`))
@@ -1224,6 +1259,14 @@ func TestStatusOnlyRequestsRuntimeWhenExplicitlyEnabled(t *testing.T) {
 	if runtimeRequests.Load() != 2 || runtimeRefreshRequests.Load() != 1 {
 		t.Fatalf("--runtime-refresh 必须只请求一次强制刷新接口：requests=%d refresh=%d", runtimeRequests.Load(), runtimeRefreshRequests.Load())
 	}
+	for mode, want := range map[int32]string{1: "HTTP 404", 2: "HTTP 500", 3: "不是有效 JSON"} {
+		runtimeFailure.Store(mode)
+		if _, _, err := captureMainCommandOutput(t, func() error {
+			return runStatus([]string{"status", "--config", configPath, "--json", "--runtime", "--runtime-refresh"})
+		}); err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("forced runtime failure mode %d = %v, want substring %q", mode, err, want)
+		}
+	}
 }
 
 func TestFetchServiceRuntimeStatusUsesBearerAndStrictJSON(t *testing.T) {
@@ -1266,6 +1309,38 @@ func TestFetchServiceRuntimeStatusUsesBearerAndStrictJSON(t *testing.T) {
 	if _, err := fetchServiceRuntimeStatus(context.Background(), server.URL, "wrong-token", time.Second, false); err == nil ||
 		!strings.Contains(err.Error(), "HTTP 401") {
 		t.Fatalf("runtime status 必须使用 Bearer Token：%v", err)
+	}
+}
+
+func TestFetchServiceRuntimeStatusReportsRefreshFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    string
+		timeout time.Duration
+	}{
+		{name: "old endpoint", handler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}, want: "HTTP 404", timeout: time.Second},
+		{name: "server error", handler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}, want: "HTTP 500", timeout: time.Second},
+		{name: "malformed JSON", handler: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"runtimes":`))
+		}, want: "不是有效 JSON", timeout: time.Second},
+		{name: "timeout", handler: func(w http.ResponseWriter, req *http.Request) {
+			<-req.Context().Done()
+		}, want: "deadline exceeded", timeout: 20 * time.Millisecond},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.handler)
+			defer server.Close()
+			_, err := fetchServiceRuntimeStatus(context.Background(), server.URL, "", test.timeout, true)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("refresh failure = %v, want substring %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/cmd/agentd/managed_service_console_windows.go
+++ b/cmd/agentd/managed_service_console_windows.go
@@ -6,13 +6,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf8"
 	"unsafe"
 )
 
-const swHide = 0
+const (
+	swHide                           = 0
+	managedServiceDiagnosticMaxBytes = 16 * 1024
+)
 
 var (
 	managedConsoleKernel32            = syscall.NewLazyDLL("kernel32.dll")
@@ -63,11 +68,7 @@ func appendManagedServiceFailure(args []string, serviceErr error) {
 	if logPath == "" {
 		return
 	}
-	line := fmt.Sprintf(
-		"%s managed_service_error=%q\n",
-		time.Now().UTC().Format(time.RFC3339),
-		sanitizeManagedServiceDiagnostic(serviceErr.Error()),
-	)
+	line := formatManagedServiceFailureLine(time.Now(), serviceErr.Error())
 	if appendManagedServiceDiagnostic(logPath, line, false) == nil {
 		return
 	}
@@ -81,20 +82,64 @@ func appendManagedServiceFailure(args []string, serviceErr error) {
 }
 
 func appendManagedServiceDiagnostic(path, line string, replace bool) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	if replace {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return err
+		}
+		logFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			return err
+		}
+		defer logFile.Close()
+		_, err = logFile.WriteString(line)
 		return err
 	}
-	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND
-	if replace {
-		flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
-	}
-	logFile, err := os.OpenFile(path, flags, 0o600)
+	// configureServeFileLogging 尚未建立时也复用同一 5 MiB 轮转规则，
+	// 避免错误配置被计划任务反复重试后无界追加主日志。
+	logFile, err := newRotatingLogWriter(path, defaultManagedLogMaxBytes)
 	if err != nil {
 		return err
 	}
-	defer logFile.Close()
-	_, err = logFile.WriteString(line)
-	return err
+	_, writeErr := logFile.Write([]byte(line))
+	closeErr := logFile.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
+}
+
+func formatManagedServiceFailureLine(now time.Time, value string) string {
+	prefix := fmt.Sprintf("%s managed_service_error=", now.UTC().Format(time.RFC3339))
+	value = strings.ToValidUTF8(sanitizeManagedServiceDiagnostic(value), "�")
+	line := prefix + strconv.Quote(value) + "\n"
+	if len(line) <= managedServiceDiagnosticMaxBytes {
+		return line
+	}
+
+	const marker = "[truncated] "
+	tail := managedServiceDiagnosticTail(value, managedServiceDiagnosticMaxBytes-len(prefix)-len(marker)-3)
+	for {
+		line = prefix + strconv.Quote(marker+tail) + "\n"
+		if len(line) <= managedServiceDiagnosticMaxBytes || tail == "" {
+			return line
+		}
+		_, size := utf8.DecodeRuneInString(tail)
+		tail = tail[size:]
+	}
+}
+
+func managedServiceDiagnosticTail(value string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+	start := len(value) - maxBytes
+	for start < len(value) && !utf8.RuneStart(value[start]) {
+		start++
+	}
+	return value[start:]
 }
 
 func sanitizeManagedServiceDiagnostic(value string) string {

--- a/cmd/agentd/managed_service_console_windows_test.go
+++ b/cmd/agentd/managed_service_console_windows_test.go
@@ -3,11 +3,13 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestManagedServiceRequested(t *testing.T) {
@@ -88,6 +90,55 @@ func TestAppendManagedServiceFailureUsesBoundedFallback(t *testing.T) {
 	text := string(raw)
 	if strings.Contains(text, "first failure") || !strings.Contains(text, "second failure") {
 		t.Fatalf("fallback should retain only the latest failure: %q", text)
+	}
+}
+
+func TestAppendManagedServiceFailureBoundsFallbackBytes(t *testing.T) {
+	root := t.TempDir()
+	primaryPath := filepath.Join(root, "primary-as-directory")
+	if err := os.MkdirAll(primaryPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fallbackPath := filepath.Join(root, "fallback", "agentd.last-error.log")
+	previous := managedServiceFailureFallbackPath
+	managedServiceFailureFallbackPath = func() (string, error) { return fallbackPath, nil }
+	t.Cleanup(func() { managedServiceFailureFallbackPath = previous })
+
+	message := strings.Repeat("\n路径故障\\", managedServiceDiagnosticMaxBytes) + "final-cause"
+	appendManagedServiceFailure(
+		[]string{"agentd.exe", "serve", "--managed-service", "--log-file", primaryPath},
+		errors.New(message),
+	)
+	raw, err := os.ReadFile(fallbackPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) > managedServiceDiagnosticMaxBytes {
+		t.Fatalf("fallback exceeded byte limit: got=%d limit=%d", len(raw), managedServiceDiagnosticMaxBytes)
+	}
+	if !utf8.Valid(raw) || !bytes.Contains(raw, []byte("final-cause")) {
+		t.Fatalf("fallback must keep a valid UTF-8 diagnostic tail: %q", raw)
+	}
+}
+
+func TestAppendManagedServiceFailureRotatesEarlyPrimaryLog(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "agentd.log")
+	if err := os.WriteFile(logPath, bytes.Repeat([]byte("x"), int(defaultManagedLogMaxBytes)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	appendManagedServiceFailure(
+		[]string{"agentd.exe", "serve", "--managed-service", "--log-file", logPath},
+		errors.New("startup failure after full log"),
+	)
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(raw)) > defaultManagedLogMaxBytes || !bytes.Contains(raw, []byte("startup failure after full log")) {
+		t.Fatalf("primary log was not rotated before the early failure: size=%d text=%q", len(raw), raw)
+	}
+	if info, err := os.Stat(logPath + ".previous"); err != nil || info.Size() != defaultManagedLogMaxBytes {
+		t.Fatalf("previous log was not retained at the configured limit: info=%v err=%v", info, err)
 	}
 }
 

--- a/cmd/agentd/runtime_status_client.go
+++ b/cmd/agentd/runtime_status_client.go
@@ -9,7 +9,14 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	runtimebudget "github.com/gaixianggeng/mimi-remote/internal/runtimestatus"
 )
+
+type runtimeStatusResult struct {
+	payload map[string]any
+	err     error
+}
 
 // runtime status 探测单独放在客户端文件，避免主入口继续膨胀，同时保持 setup/status 共用同一校验逻辑。
 func runtimeStatusURL(endpoint string) (string, error) {
@@ -65,6 +72,38 @@ func fetchServiceRuntimeStatus(
 		return nil, err
 	}
 	return payload, nil
+}
+
+func fetchRuntimeStatusForCommand(endpoint string, token string, refresh bool) runtimeStatusResult {
+	timeout := runtimebudget.CachedHTTPTimeout
+	if refresh {
+		timeout = runtimebudget.ForcedRefreshHTTPTimeout
+	}
+	payload, err := fetchServiceRuntimeStatus(
+		context.Background(),
+		endpoint,
+		token,
+		timeout,
+		refresh,
+	)
+	return runtimeStatusResult{payload: payload, err: err}
+}
+
+func attachRuntimeStatus(
+	status map[string]any,
+	result runtimeStatusResult,
+	refresh bool,
+) error {
+	if result.err != nil {
+		// 普通后台状态继续兼容旧服务；用户显式刷新必须暴露失败，
+		// 让托盘保留 last-good 状态并显示刷新错误。
+		if refresh {
+			return fmt.Errorf("强制刷新运行时状态失败：%w", result.err)
+		}
+		return nil
+	}
+	status["runtime_status"] = result.payload
+	return nil
 }
 
 func validateRuntimeStatusPayload(payload map[string]any) error {

--- a/cmd/mimi-remote-tray/controller_windows.go
+++ b/cmd/mimi-remote-tray/controller_windows.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	runtimebudget "github.com/gaixianggeng/mimi-remote/internal/runtimestatus"
 )
 
 const (
@@ -349,7 +351,7 @@ func trayLogf(format string, args ...any) {
 const (
 	statusQueueTimeout             = 25 * time.Second
 	backgroundStatusCommandTimeout = 12 * time.Second
-	manualStatusCommandTimeout     = 20 * time.Second
+	manualStatusCommandTimeout     = runtimebudget.ManualCommandTimeout
 )
 
 func statusContext() (context.Context, context.CancelFunc) {

--- a/internal/httpapi/runtime_status.go
+++ b/internal/httpapi/runtime_status.go
@@ -16,10 +16,11 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/gaixianggeng/mimi-remote/internal/appserver"
+	runtimebudget "github.com/gaixianggeng/mimi-remote/internal/runtimestatus"
 )
 
 const (
-	runtimeStatusRefreshTimeout = 9 * time.Second
+	runtimeStatusRefreshTimeout = runtimebudget.ProbeGenerationTimeout
 	runtimeStatusSuccessTTL     = 5 * time.Minute
 	runtimeStatusFailureTTL     = 15 * time.Second
 	runtimeQuotaFallbackTTL     = 15 * time.Minute

--- a/internal/runtimestatus/budget.go
+++ b/internal/runtimestatus/budget.go
@@ -1,0 +1,14 @@
+package runtimestatus
+
+import "time"
+
+const (
+	// 单次探测同时等待 Codex 与 Claude，服务端会在这个窗口后结束该 generation。
+	ProbeGenerationTimeout = 9 * time.Second
+	CachedHTTPTimeout      = 2 * time.Second
+
+	// 点击刷新时可能要先等点击前的后台 generation，再等待一次点击后的 follow-up。
+	// 额外两秒用于 HTTP 响应、JSON 解码和本机调度抖动。
+	ForcedRefreshHTTPTimeout = 2*ProbeGenerationTimeout + 2*time.Second
+	ManualCommandTimeout     = ForcedRefreshHTTPTimeout + 5*time.Second
+)

--- a/internal/runtimestatus/budget_test.go
+++ b/internal/runtimestatus/budget_test.go
@@ -1,0 +1,12 @@
+package runtimestatus
+
+import "testing"
+
+func TestForcedRefreshBudgetsCoverFollowUpGeneration(t *testing.T) {
+	if ForcedRefreshHTTPTimeout < 2*ProbeGenerationTimeout {
+		t.Fatalf("forced HTTP budget %s does not cover two %s generations", ForcedRefreshHTTPTimeout, ProbeGenerationTimeout)
+	}
+	if ManualCommandTimeout <= ForcedRefreshHTTPTimeout {
+		t.Fatalf("manual command budget %s must include overhead beyond HTTP budget %s", ManualCommandTimeout, ForcedRefreshHTTPTimeout)
+	}
+}


### PR DESCRIPTION
## 变更

- 统一运行时状态预算：单代探测 9 秒、强制刷新 HTTP 20 秒、托盘手动命令 25 秒，完整覆盖后台 generation 与点击后 follow-up。
- 显式 `--runtime-refresh` 失败时返回非零错误，让托盘保留 last-good 状态并显示刷新失败；普通后台读取继续兼容旧服务。
- managed-service 最后错误行限制为 16 KiB，并让启动早期主日志复用 5 MiB 轮转规则。
- 增加 404、500、畸形 JSON、超时、日志单条上限和启动早期轮转回归测试。

## 验证

- `go vet ./...`
- `go test ./internal/runtimestatus ./cmd/agentd ./cmd/mimi-remote-tray`
- `go test ./internal/httpapi -run 'TestRuntimeStatus' -count=1`
- 干净临时 worktree：`bash ./scripts/check-source-size.sh`
- Windows `agentd.exe` 与 `mimi-remote-tray.exe` release 参数构建
- `./scripts/test-windows-install.ps1`
- `./scripts/check-windows-installer.ps1`：unsigned snapshot 通过

安装包：`Mimi-Remote-Setup-0.3.8-mim194.20260826.bfdb229a.exe`
SHA-256：`A9EC0DD0F2637AD8760185618268947271ECBBDCA2E2087E7F5576789CCB891A`

## 本机完整回归限制

本机未启用 Windows symlink privilege，因此 `internal/httpapi` 的全局发现 symlink 用例和 `internal/config` 的等价目录 symlink 用例无法执行。`internal/claudeenv` 在清除宿主继承的代理变量后通过。GitHub CI 将继续执行干净环境的全量测试。

关联 MIM-194。