### PR TITLE
MIM-207 通过 SSH 接入同一 Codex App Server

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -455,6 +455,7 @@ Mimi Remote 支持 iOS / iPadOS 18 及以上版本。iOS 26+ 继续使用 Liquid
 - [安装、升级与回滚](docs/install-upgrade-rollback.md)
 - [Tailscale 与 Peer Relay 运维](docs/tailscale-peer-relay-ops.md)
 - [Codex 协议支持边界](docs/codex-protocol-support.md)
+- [通过 SSH 接入同一个 Codex App Server](docs/ssh-codex-cli.md)
 - [Capability 声明与本地降级](docs/capability-rollout.md)
 - [Claude bridge 架构](docs/claude-bridge-architecture.md)
 - [与 Litter 的能力对照](docs/litter-comparison.md)

--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -88,12 +88,14 @@ func run(args []string) error {
 		return runNetwork(args)
 	case "runtime":
 		return runRuntime(args)
+	case "remote-token":
+		return runRemoteToken(args)
 	case "doctor":
 		return runDoctor(args)
 	case "serve":
 		return runServe(args)
 	default:
-		return fmt.Errorf("未知命令 %q，可用命令：up、setup、start、restart、stop、status、logs、pair、network、runtime、serve、doctor、version", cmd)
+		return fmt.Errorf("未知命令 %q，可用命令：up、setup、start、restart、stop、status、logs、pair、network、runtime、remote-token、serve、doctor、version", cmd)
 	}
 }
 
@@ -968,6 +970,24 @@ func runDoctorFix(
 			}
 		}
 	}
+	if hasFailedCheck(current, "remote-gateway-token-file") && !needsSetup {
+		tokenPath, repaired, repairErr := agentsetup.RepairRemoteGatewayTokenFile(configPath)
+		if repairErr != nil {
+			return nil, false, nil, current, fmt.Errorf("修复 remote gateway token file 失败：%w", repairErr)
+		}
+		if repaired {
+			fixes = append(fixes, "已生成独立 remote gateway token file 并原子更新配置")
+			restartRequired = true
+		} else if strings.TrimSpace(tokenPath) != "" {
+			fixed, fixErr := tightenSensitiveFilePermissions(tokenPath)
+			if fixErr != nil {
+				return nil, false, nil, current, fmt.Errorf("修复 remote gateway token file 权限失败：%w", fixErr)
+			}
+			if fixed {
+				fixes = append(fixes, "已将 remote gateway token file 权限收紧为 0600")
+			}
+		}
+	}
 	if (hasFailedCheck(current, "codex") || hasFailedCheck(current, "codex-app-server")) && !needsSetup {
 		// 旧的绝对路径失效或 Windows CLI 缺少 single-writer 基线时只修复
 		// codex.bin；无法发现安全替代项则保留原 Doctor 结果继续给出升级指引。
@@ -1108,16 +1128,30 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 		}
 		listeners = append(listeners, listener)
 	}
+	remoteGateway, err := startRemoteGatewayServer(cfg, apiRouter)
+	if err != nil {
+		for _, opened := range listeners {
+			_ = opened.Close()
+		}
+		_ = shutdownServeResources(manager, appServerWSProcess, apiRouter)
+		return err
+	}
 	maybePrintServeConnection(os.Stdout, agentsetup.ResultFromConfig(context.Background(), "", cfg))
 
 	// 每个 HTTP listener 与 managed upstream 各自最多发送一次退出事件；容量必须覆盖全部来源，
 	// 确保 shutdown 同时触发多个 goroutine 退出时不会因主 goroutine 已选中另一事件而阻塞。
-	errCh := make(chan error, len(listeners)+1)
+	errCh := make(chan error, len(listeners)+2)
 	for _, listener := range listeners {
 		listener := listener
 		go func() {
 			log.Printf("agentd listening on http://%s", listener.Addr())
 			errCh <- server.Serve(listener)
+		}()
+	}
+	if remoteGateway != nil {
+		go func() {
+			log.Printf("remote gateway listening on ws://%s/", remoteGateway.listener.Addr())
+			errCh <- remoteGateway.server.Serve(remoteGateway.listener)
 		}()
 	}
 	if appServerWSProcess != nil {
@@ -1131,9 +1165,11 @@ func serve(cfg config.Config, registry *projects.Registry, checker *doctor.Check
 	stopSignals := notifyServeSignals(stopCh)
 	defer stopSignals()
 	return waitForServeExit(stopCh, errCh, func() error {
-		return shutdownServe(server, serveHTTPDrainTimeout, func() error {
+		remoteErr := remoteGateway.shutdown(serveHTTPDrainTimeout)
+		primaryErr := shutdownServe(server, serveHTTPDrainTimeout, func() error {
 			return shutdownServeResources(manager, appServerWSProcess, apiRouter)
 		})
+		return errors.Join(remoteErr, primaryErr)
 	})
 }
 

--- a/cmd/agentd/remote_gateway_server.go
+++ b/cmd/agentd/remote_gateway_server.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+	"github.com/gaixianggeng/mimi-remote/internal/httpapi"
+)
+
+type remoteGatewayServer struct {
+	server   *http.Server
+	listener net.Listener
+}
+
+func startRemoteGatewayServer(cfg config.Config, router *httpapi.Router) (*remoteGatewayServer, error) {
+	if !cfg.AppServer.RemoteGateway.Enabled {
+		return nil, nil
+	}
+	if router == nil {
+		return nil, fmt.Errorf("remote gateway 缺少 Router")
+	}
+	address := strings.TrimSpace(cfg.AppServer.RemoteGateway.Listen)
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("监听 remote gateway %s 失败：%w", address, err)
+	}
+	return &remoteGatewayServer{
+		server: &http.Server{
+			Addr:              address,
+			Handler:           router.RemoteGatewayHandler(),
+			ReadHeaderTimeout: 10 * time.Second,
+		},
+		listener: listener,
+	}, nil
+}
+
+func (s *remoteGatewayServer) shutdown(timeout time.Duration) error {
+	if s == nil || s.server == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := s.server.Shutdown(ctx); err != nil {
+		_ = s.server.Close()
+		return err
+	}
+	return nil
+}

--- a/cmd/agentd/remote_token.go
+++ b/cmd/agentd/remote_token.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+	agentsetup "github.com/gaixianggeng/mimi-remote/internal/setup"
+)
+
+func runRemoteToken(args []string) error {
+	fs := flag.NewFlagSet("remote-token", flag.ContinueOnError)
+	configPath := fs.String("config", config.DefaultPath(), "配置文件路径")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 || fs.Arg(0) != "rotate" {
+		return fmt.Errorf("用法：agentd remote-token [--config PATH] rotate")
+	}
+	path, err := agentsetup.RotateRemoteGatewayTokenFile(*configPath)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("已原子轮换 remote gateway token：%s\n", path)
+	return nil
+}

--- a/cmd/agentd/runtime_environment.go
+++ b/cmd/agentd/runtime_environment.go
@@ -58,5 +58,8 @@ func ensureManagedWSTokenAvailable(configPath string) error {
 	if _, _, err := agentsetup.RepairManagedWSTokenFile(configPath); err != nil {
 		return fmt.Errorf("准备 managed app-server token 失败：%w", err)
 	}
+	if _, _, err := agentsetup.RepairRemoteGatewayTokenFile(configPath); err != nil {
+		return fmt.Errorf("准备 remote gateway token 失败：%w", err)
+	}
 	return nil
 }

--- a/docs/ssh-codex-cli.md
+++ b/docs/ssh-codex-cli.md
@@ -1,0 +1,117 @@
+# 通过 SSH 接入同一个 Codex App Server
+
+## 目标
+
+Mimi 和远程 Codex CLI 连接 agentd 管理的同一个 Codex App Server 进程。远程链路使用 SSH 本地端口转发，不把 App Server 或 agentd HTTP 接口暴露到局域网。
+
+这条链路不支持官方 Codex Desktop。Desktop 通过 SSH 打开项目时会启动自己的 App Server，不能接管 agentd 的进程。
+
+## 主机配置
+
+先在主机的 `config.json` 中启用独立入口：
+
+```json
+{
+  "app_server": {
+    "transport": "ws",
+    "managed": true,
+    "listen": "ws://127.0.0.1:4222",
+    "remote_gateway": {
+      "enabled": true,
+      "listen": "127.0.0.1:8788"
+    }
+  }
+}
+```
+
+生成只供远程 CLI 使用的 token，并重启 agentd：
+
+```bash
+agentd doctor --fix
+agentd restart
+```
+
+`doctor --fix` 会创建权限为 `0600` 的 `remote_gateway.token_file`。该 token 与 Mimi 访问 token、App Server upstream token 相互独立。
+
+首次远程打开项目前，必须先在主机信任该项目。远程入口不会接受 `config/batchWrite`：
+
+```bash
+agentd stop
+codex -C /absolute/host/project
+# 在 Codex 中确认信任，然后退出。
+agentd start
+```
+
+## 远程连接
+
+在远程设备建立 SSH 隧道。以下命令把远程设备的 `4500` 端口转发到主机的 remote gateway：
+
+```bash
+ssh -N \
+  -L 4500:127.0.0.1:8788 \
+  -o ExitOnForwardFailure=yes \
+  devbox
+```
+
+通过受保护的渠道把主机 `remote_gateway.token_file` 的内容保存到远程设备。例如：
+
+```bash
+mkdir -p "$HOME/.config/mimi-remote"
+chmod 700 "$HOME/.config/mimi-remote"
+install -m 600 /dev/null "$HOME/.config/mimi-remote/remote-token"
+scp devbox:/absolute/path/from/remote_gateway.token_file \
+  "$HOME/.config/mimi-remote/remote-token"
+```
+
+启动 Codex CLI：
+
+```bash
+export MIMI_CODEX_REMOTE_TOKEN="$(tr -d '\r\n' < "$HOME/.config/mimi-remote/remote-token")"
+
+codex \
+  --remote ws://127.0.0.1:4500 \
+  --remote-auth-token-env MIMI_CODEX_REMOTE_TOKEN \
+  -C /absolute/host/project
+```
+
+`-C` 必须对应主机已经授权的项目路径。Codex CLI 也需要能够接受这个路径；跨操作系统或目录结构不一致时，先建立相同路径或改用 SSH 登录主机后运行 CLI。
+
+## 使用边界
+
+- remote gateway 默认关闭，只允许绑定 loopback。
+- 同时只允许一个远程 CLI 连接。
+- Mimi 和远程 CLI 可以先后接手同一线程，但同一线程同时只能启动一个 turn。
+- 启用 remote gateway 时，Mimi 的 inline review 与普通 turn 共用同一门禁；`thread/compact/start` 暂时禁用，因为当前响应不提供可安全关联的 turn ID。
+- 连接在 `turn/start` 后异常断开时，agentd 不会假定请求失败，也不会自动重放。若终态通知没有被任何连接观察到，需要重启 agentd 后再接手。
+- 远程 CLI 可以读取经过过滤的当前项目配置和账号类型。它不能读取配置层、环境变量或 MCP 配置。
+- v1 远程 CLI 不能写 Codex 配置，也不能调用 hooks、plugin、app、`review/start`、`thread/compact/start` 或未知协议方法。
+- agentd 不提供重试或消息重放。客户端必须根据原始请求结果决定下一步。
+
+## 轮换 token
+
+以下命令原子替换 token。新 WebSocket 握手会立即拒绝旧 token，不需要重启 agentd：
+
+```bash
+agentd remote-token rotate
+```
+
+轮换后重新复制 token 文件，并重启远程 Codex CLI。已经建立的连接不会被强制中断。
+
+## 验证
+
+在主机确认监听器仍只绑定 loopback：
+
+```bash
+lsof -nP -iTCP:8788 -sTCP:LISTEN
+```
+
+在远程设备确认隧道和鉴权可用：
+
+```bash
+codex \
+  --remote ws://127.0.0.1:4500 \
+  --remote-auth-token-env MIMI_CODEX_REMOTE_TOKEN \
+  -C /absolute/host/project
+```
+
+如果 TUI 要求重新信任项目，请退出，不要从远程写配置。回到主机完成信任步骤后重试。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,8 +91,17 @@ type AppServerConfig struct {
 	Managed     bool   `json:"managed"`
 	Listen      string `json:"listen,omitempty"`
 	WSTokenFile string `json:"ws_token_file,omitempty"`
+	// RemoteGateway 是给 SSH 本地端口转发使用的独立入口。它默认关闭，
+	// 只监听 loopback，并使用与 agentd、upstream 都不同的 token file。
+	RemoteGateway RemoteGatewayConfig `json:"remote_gateway"`
 	// AutoTitle 只在 Mac 端通过本机 app-server 生成标题，移动端不接触 provider 凭据。
 	AutoTitle bool `json:"auto_title"`
+}
+
+type RemoteGatewayConfig struct {
+	Enabled   bool   `json:"enabled"`
+	Listen    string `json:"listen,omitempty"`
+	TokenFile string `json:"token_file,omitempty"`
 }
 
 type VoiceConfig struct {
@@ -276,6 +285,9 @@ func loadRawWithoutProjectDiscovery(raw []byte) (Config, error) {
 		// 早期独立 App Server 配置可能没有 listen；补默认 loopback 地址。
 		cfg.AppServer.Listen = defaultAppServerWebSocketListen
 	}
+	if strings.TrimSpace(cfg.AppServer.RemoteGateway.Listen) == "" {
+		cfg.AppServer.RemoteGateway.Listen = defaultRemoteGatewayListen
+	}
 	return cfg, nil
 }
 
@@ -329,6 +341,7 @@ func expandPath(path string) string {
 const (
 	// defaultAppServerWebSocketListen 是独立 App Server 的 loopback 默认地址。
 	defaultAppServerWebSocketListen = "ws://127.0.0.1:4222"
+	defaultRemoteGatewayListen      = "127.0.0.1:8788"
 )
 
 func DefaultAppServerTransport() string {
@@ -341,6 +354,10 @@ func DefaultAppServerListen() string {
 
 func DefaultAppServerWebSocketListen() string {
 	return defaultAppServerWebSocketListen
+}
+
+func DefaultRemoteGatewayListen() string {
+	return defaultRemoteGatewayListen
 }
 
 func DefaultClaudeConfig() ClaudeConfig {
@@ -364,6 +381,10 @@ func defaults() Config {
 			Transport: DefaultAppServerTransport(),
 			Managed:   true,
 			Listen:    DefaultAppServerListen(),
+			RemoteGateway: RemoteGatewayConfig{
+				Enabled: false,
+				Listen:  DefaultRemoteGatewayListen(),
+			},
 			AutoTitle: true,
 		},
 		Voice: VoiceConfig{
@@ -672,6 +693,21 @@ func (c Config) Validate() error {
 	}
 	if strings.EqualFold(c.AppServer.Transport, "ws") && c.AppServer.Listen != "" && !isLoopbackListen(c.AppServer.Listen) {
 		return fmt.Errorf("app_server.listen 只允许 loopback；iPad 应连接 agentd，不应直连 Codex app-server")
+	}
+	if c.AppServer.RemoteGateway.Enabled {
+		if err := validateAgentListen(c.AppServer.RemoteGateway.Listen, false); err != nil {
+			return fmt.Errorf("app_server.remote_gateway.listen 无效：%w", err)
+		}
+		if !isLoopbackListen(c.AppServer.RemoteGateway.Listen) {
+			return fmt.Errorf("app_server.remote_gateway.listen 只允许 loopback；远端必须通过 SSH 本地端口转发接入")
+		}
+		remoteTokenFile := strings.TrimSpace(c.AppServer.RemoteGateway.TokenFile)
+		if remoteTokenFile == "" {
+			return fmt.Errorf("app_server.remote_gateway.token_file 不能为空；请运行 agentd doctor --fix")
+		}
+		if SameConfigPath(remoteTokenFile, c.AppServer.WSTokenFile) {
+			return fmt.Errorf("app_server.remote_gateway.token_file 不能复用 app_server.ws_token_file")
+		}
 	}
 	if c.Session.OutputBufferBytes <= 0 {
 		return fmt.Errorf("session.output_buffer_bytes 必须大于 0")

--- a/internal/config/remote_gateway_test.go
+++ b/internal/config/remote_gateway_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRemoteGatewayDefaultsDisabledOnLoopback(t *testing.T) {
+	cfg, err := loadRawWithoutProjectDiscovery(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AppServer.RemoteGateway.Enabled {
+		t.Fatal("remote gateway 必须默认关闭")
+	}
+	if cfg.AppServer.RemoteGateway.Listen != DefaultRemoteGatewayListen() {
+		t.Fatalf("unexpected listen: %q", cfg.AppServer.RemoteGateway.Listen)
+	}
+}
+
+func TestRemoteGatewayValidationRequiresDedicatedLoopbackTokenFile(t *testing.T) {
+	base := defaults()
+	base.Auth.Token = strings.Repeat("a", 32)
+	base.Projects = []ProjectConfig{{ID: "p", Name: "p", Path: t.TempDir()}}
+	base.Session.OutputBufferBytes = 1
+	base.AppServer.WSTokenFile = filepath.Join(t.TempDir(), "upstream-token")
+	base.AppServer.RemoteGateway.Enabled = true
+
+	if err := base.Validate(); err == nil || !strings.Contains(err.Error(), "token_file 不能为空") {
+		t.Fatalf("missing token file should fail: %v", err)
+	}
+	base.AppServer.RemoteGateway.TokenFile = base.AppServer.WSTokenFile
+	if err := base.Validate(); err == nil || !strings.Contains(err.Error(), "不能复用") {
+		t.Fatalf("shared token file should fail: %v", err)
+	}
+	base.AppServer.RemoteGateway.TokenFile = filepath.Join(t.TempDir(), "remote-token")
+	base.AppServer.RemoteGateway.Listen = "0.0.0.0:8788"
+	if err := base.Validate(); err == nil || !strings.Contains(err.Error(), "remote_gateway.listen") {
+		t.Fatalf("non-loopback listen should fail: %v", err)
+	}
+	base.AppServer.RemoteGateway.Listen = "127.0.0.1:8788"
+	if err := base.Validate(); err != nil {
+		t.Fatalf("valid remote gateway config rejected: %v", err)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -107,6 +107,9 @@ func (c *Checker) Run(ctx context.Context, checkPort bool) Results {
 	if check := c.appServerTokenFileCheck(); check.Name != "" {
 		checks = append(checks, check)
 	}
+	if check := c.remoteGatewayTokenFileCheck(); check.Name != "" {
+		checks = append(checks, check)
+	}
 	if c.needsCodexAppServerCheck() {
 		checks = append(checks, c.codexAppServerCheck(ctx))
 	}
@@ -155,6 +158,9 @@ func (c *Checker) RunReadiness(ctx context.Context) Results {
 		checks = append(checks, check)
 	}
 	if check := c.appServerTokenFileCheck(); check.Name != "" {
+		checks = append(checks, check)
+	}
+	if check := c.remoteGatewayTokenFileCheck(); check.Name != "" {
 		checks = append(checks, check)
 	}
 	if check := c.appServerGatewayCheck(ctx); check.Name != "" {
@@ -267,6 +273,43 @@ func (c *Checker) appServerTokenFileCheck() Check {
 		return Check{}
 	}
 	return sensitiveFileCheck("app-server-token-file", "app-server token file", path)
+}
+
+func (c *Checker) remoteGatewayTokenFileCheck() Check {
+	if !c.cfg.AppServer.RemoteGateway.Enabled {
+		return Check{}
+	}
+	path := strings.TrimSpace(c.cfg.AppServer.RemoteGateway.TokenFile)
+	if path == "" {
+		return Check{
+			Name:    "remote-gateway-token-file",
+			OK:      false,
+			Message: "SSH/CLI remote gateway 未配置独立 token file",
+			Fix:     "运行 agentd doctor --fix 生成独立 token file",
+		}
+	}
+	check := sensitiveFileCheck("remote-gateway-token-file", "remote gateway token file", path)
+	if !check.OK {
+		return check
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Check{Name: check.Name, OK: false, Message: "remote gateway token file 不可读取", Fix: "检查文件所有者和当前用户读取权限"}
+	}
+	token := strings.TrimSpace(string(raw))
+	if len(token) < 32 {
+		return Check{Name: check.Name, OK: false, Message: "remote gateway token 长度不足 32 字节", Fix: "运行 agentd remote-token rotate 生成新 token"}
+	}
+	if token == strings.TrimSpace(c.cfg.Auth.Token) {
+		return Check{Name: check.Name, OK: false, Message: "remote gateway token 复用了 agentd 访问 token", Fix: "运行 agentd remote-token rotate 生成独立 token"}
+	}
+	upstreamPath := strings.TrimSpace(c.cfg.AppServer.WSTokenFile)
+	if upstreamPath != "" {
+		if upstreamRaw, readErr := os.ReadFile(upstreamPath); readErr == nil && token == strings.TrimSpace(string(upstreamRaw)) {
+			return Check{Name: check.Name, OK: false, Message: "remote gateway token 复用了 app-server upstream token", Fix: "运行 agentd remote-token rotate 生成独立 token"}
+		}
+	}
+	return check
 }
 
 func sensitiveFileCheck(name string, label string, path string) Check {
@@ -438,6 +481,9 @@ func (c *Checker) portChecks(ctx context.Context) []Check {
 	}
 	if strings.EqualFold(c.cfg.AppServer.Transport, "ws") && c.cfg.AppServer.Managed && strings.TrimSpace(c.cfg.AppServer.Listen) != "" {
 		checks = append(checks, c.portCheck(ctx, "app-server-port", c.cfg.AppServer.Listen, "app-server upstream"))
+	}
+	if c.cfg.AppServer.RemoteGateway.Enabled {
+		checks = append(checks, c.portCheck(ctx, "remote-gateway-port", c.cfg.AppServer.RemoteGateway.Listen, "SSH/CLI remote gateway"))
 	}
 	return checks
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -560,6 +560,53 @@ func hasCheck(results Results, name string) bool {
 	return false
 }
 
+func TestRemoteGatewayTokenCheckMatchesHandshakeRequirements(t *testing.T) {
+	dir := t.TempDir()
+	remotePath := filepath.Join(dir, "remote-token")
+	upstreamPath := filepath.Join(dir, "upstream-token")
+	writeToken := func(path, token string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	upstreamToken := "upstream-token-00000000000000000001"
+	writeToken(upstreamPath, upstreamToken)
+	cfg := config.Config{
+		Auth: config.AuthConfig{Token: "agentd-token-0000000000000000000001"},
+		AppServer: config.AppServerConfig{
+			WSTokenFile: upstreamPath,
+			RemoteGateway: config.RemoteGatewayConfig{
+				Enabled: true, TokenFile: remotePath,
+			},
+		},
+	}
+
+	for _, testCase := range []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{name: "too short", token: "short", want: "长度不足"},
+		{name: "agentd token reuse", token: cfg.Auth.Token, want: "agentd"},
+		{name: "upstream token reuse", token: upstreamToken, want: "upstream"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			writeToken(remotePath, testCase.token)
+			check := NewChecker("test", cfg, &projects.Registry{}).remoteGatewayTokenFileCheck()
+			if check.OK || !strings.Contains(check.Message, testCase.want) {
+				t.Fatalf("invalid remote token should fail doctor: %+v", check)
+			}
+		})
+	}
+
+	writeToken(remotePath, "remote-token-0000000000000000000001")
+	check := NewChecker("test", cfg, &projects.Registry{}).remoteGatewayTokenFileCheck()
+	if !check.OK {
+		t.Fatalf("dedicated remote token should pass doctor: %+v", check)
+	}
+}
+
 func hasCheckMessage(results Results, name, want string) bool {
 	for _, check := range results.Checks {
 		if check.Name == name && strings.Contains(check.Message, want) {

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -106,6 +106,45 @@ var appServerAllowedMethods = map[string]struct{}{
 	"account/usage/read":      {},
 }
 
+// remote CLI 使用逐项维护的独立 allowlist。移动端以后新增能力时不能自动扩大
+// SSH token 的权限；会启动额外工作的 review/compact 与 plugin 方法也不在 v1 边界内。
+var appServerRemoteCLIAllowedMethods = map[string]struct{}{
+	"initialize":              {},
+	"initialized":             {},
+	"thread/list":             {},
+	"thread/search":           {},
+	"thread/start":            {},
+	"thread/resume":           {},
+	"thread/fork":             {},
+	"thread/read":             {},
+	"thread/turns/list":       {},
+	"thread/name/set":         {},
+	"thread/unsubscribe":      {},
+	"thread/archive":          {},
+	"thread/unarchive":        {},
+	"thread/goal/get":         {},
+	"thread/goal/set":         {},
+	"thread/goal/clear":       {},
+	"turn/start":              {},
+	"turn/steer":              {},
+	"turn/interrupt":          {},
+	"model/list":              {},
+	"permissionProfile/list":  {},
+	"skills/list":             {},
+	"account/rateLimits/read": {},
+	"account/usage/read":      {},
+	"config/read":             {},
+	"configRequirements/read": {},
+	"account/read":            {},
+}
+
+type appServerGatewayClientKind string
+
+const (
+	appServerGatewayClientMobile    appServerGatewayClientKind = "mobile"
+	appServerGatewayClientRemoteCLI appServerGatewayClientKind = "remote_cli"
+)
+
 // appServerAllowedServerRequestMethods 是反向 RPC 的显式能力边界。
 // app-server 新增 Server Request 时不能直接落到移动端；只有 iOS 已实现响应协议的方法才能加入这里，
 // 未知方法会由 gateway 立即回错，避免上游一直等待一个移动端永远不会发出的响应。
@@ -231,20 +270,24 @@ type appServerGatewayPolicyError struct {
 }
 
 type appServerGatewayPolicy struct {
-	router    *Router
-	runtimeID string
-	mu        sync.Mutex
-	closed    bool
+	router       *Router
+	runtimeID    string
+	clientKind   appServerGatewayClientKind
+	connectionID uint64
+	mu           sync.Mutex
+	closed       bool
 
-	pendingThreads        map[string]appServerGatewayPendingThreadRequest
-	pendingClientRequests map[string]appServerGatewayPendingClientRequest
-	pendingServerRequests map[string]appServerGatewayPendingServerRequest
-	pendingHistory        map[string]appServerGatewayPendingHistoryRequest
-	historyBudgets        map[string]appServerGatewayHistoryBudget
-	allowedThreads        map[string]appServerGatewayAllowedThread
-	globalListCursors     map[string]string
-	beforePendingRemember func()
-	beforeManagedComplete func()
+	pendingThreads         map[string]appServerGatewayPendingThreadRequest
+	pendingClientRequests  map[string]appServerGatewayPendingClientRequest
+	inflightClientRequests map[string]string
+	pendingTurnStarts      map[string]string
+	pendingServerRequests  map[string]appServerGatewayPendingServerRequest
+	pendingHistory         map[string]appServerGatewayPendingHistoryRequest
+	historyBudgets         map[string]appServerGatewayHistoryBudget
+	allowedThreads         map[string]appServerGatewayAllowedThread
+	globalListCursors      map[string]string
+	beforePendingRemember  func()
+	beforeManagedComplete  func()
 }
 
 type appServerGatewayPendingThreadRequest struct {
@@ -261,6 +304,7 @@ type appServerGatewayPendingThreadRequest struct {
 
 type appServerGatewayPendingClientRequest struct {
 	method    string
+	cwd       string
 	createdAt time.Time
 }
 
@@ -411,6 +455,13 @@ func appServerAllowedMethodsForRuntime(runtimeID string) map[string]struct{} {
 		return appServerClaudeAllowedMethods
 	}
 	return appServerAllowedMethods
+}
+
+func appServerAllowedMethodsForClient(runtimeID string, clientKind appServerGatewayClientKind) map[string]struct{} {
+	if normalizeAppServerRuntimeID(runtimeID) == "codex" && clientKind == appServerGatewayClientRemoteCLI {
+		return appServerRemoteCLIAllowedMethods
+	}
+	return appServerAllowedMethodsForRuntime(runtimeID)
 }
 
 func (r *Router) appServerGatewayURL(req *http.Request) string {
@@ -610,7 +661,7 @@ func (r *Router) appServerCodexGatewayWS(w http.ResponseWriter, req *http.Reques
 
 	log.Printf("app-server gateway connected upstream=%s", sanitizeGatewayURL(upstreamURL))
 	monitor := r.monitor.startGatewayConnection(requestRemoteHost(req), req.Host, sanitizeGatewayURL(upstreamURL), dialDuration)
-	r.proxyAppServerGateway(req.Context(), client, upstream, monitor)
+	r.proxyAppServerGateway(req.Context(), client, upstream, monitor, appServerGatewayClientMobile)
 }
 
 func (r *Router) acquireCodexGatewaySlot() bool {

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -46,19 +46,49 @@ func (p *appServerGatewayPolicy) validateClientFrameContext(ctx context.Context,
 		}
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "JSON-RPC frame 缺少 method"}
 	}
+	if method == "initialized" && gatewayJSONRPCFrameHasID(payload) {
+		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "initialized 必须是不带 id 的 JSON-RPC notification"}
+	}
 	if method != "initialized" && frame.ID == nil {
 		return nil, &appServerGatewayPolicyError{message: "app-server request 必须包含 id"}
 	}
 	if !p.methodAllowed(method) {
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "app-server method 不允许：" + method}
 	}
+	if normalizeAppServerRuntimeID(p.runtimeID) == "codex" && p.router.cfg.AppServer.RemoteGateway.Enabled && method == "thread/compact/start" {
+		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "启用 remote gateway 时暂不允许 thread/compact/start；该协议响应没有可关联的 turn ID"}
+	}
+	inflightReserved := false
+	if frame.ID != nil {
+		if err := p.reserveInflightClientRequest(frame.ID, method); err != nil {
+			return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
+		}
+		inflightReserved = true
+	}
+	keepInflight := false
+	defer func() {
+		if inflightReserved && !keepInflight {
+			p.cancelInflightClientRequest(frame.ID)
+		}
+	}()
 	params, err := decodeGatewayParams(frame.Params)
 	if err != nil {
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
 	}
+	if p.clientKind == appServerGatewayClientRemoteCLI {
+		normalizeRemoteCLIClientParams(method, params)
+	}
 	validated, err := p.router.validateGatewayPolicyParams(normalizeAppServerRuntimeID(p.runtimeID), method, params)
 	if err != nil {
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
+	}
+	if p.clientKind == appServerGatewayClientRemoteCLI && validated.hasCWD &&
+		(!validated.cwdScopeOK || validated.cwdScope.browse) {
+		p.router.releaseManagedWorktreePendingUse(validated.pendingManagedWorktreePath)
+		return nil, &appServerGatewayPolicyError{id: frame.ID, message: method + ".cwd 必须来自 projects allowlist"}
+	}
+	if p.clientKind == appServerGatewayClientRemoteCLI && method == "config/read" && !validated.hasCWD {
+		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "config/read.cwd 必须来自 projects allowlist"}
 	}
 	if err := p.validateThreadCapability(&frame, method, params, validated); err != nil {
 		p.router.releaseManagedWorktreePendingUse(validated.pendingManagedWorktreePath)
@@ -76,23 +106,78 @@ func (p *appServerGatewayPolicy) validateClientFrameContext(ctx context.Context,
 	}
 	runtimeID := normalizeAppServerRuntimeID(p.runtimeID)
 	tracksClientResponse := (runtimeID == "claude" && method == "model/list") ||
-		(runtimeID == "codex" && method == "account/usage/read")
+		(runtimeID == "codex" && method == "account/usage/read") ||
+		(p.clientKind == appServerGatewayClientRemoteCLI &&
+			(method == "config/read" || method == "configRequirements/read" || method == "account/read"))
 	if frame.ID != nil && tracksClientResponse {
-		if err := p.rememberPendingClientRequest(frame.ID, method); err != nil {
+		if err := p.rememberPendingClientRequestWithCWD(frame.ID, method, validated.cwd); err != nil {
+			return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
+		}
+	}
+	if gatewayMethodStartsTurnWork(method) {
+		threadID, _ := gatewayStringParam(params, "threadId")
+		if err := p.reservePendingTurnStart(frame.ID, threadID); err != nil {
 			return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
 		}
 	}
 	if p.isClosed() {
+		if gatewayMethodStartsTurnWork(method) {
+			threadID, _ := gatewayStringParam(params, "threadId")
+			p.router.cancelGatewayTurnReservation(threadID, p.connectionID)
+		}
 		p.cancelPendingHistoryRequest(frame.ID)
 		p.forgetPending(frame.ID)
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: "app-server gateway 连接已关闭"}
 	}
 	logGatewayForwardedClientTurnSummary(method, rewritten)
+	keepInflight = inflightReserved
 	return rewritten, nil
 }
 
+func gatewayJSONRPCFrameHasID(payload []byte) bool {
+	var envelope map[string]json.RawMessage
+	if json.Unmarshal(payload, &envelope) != nil {
+		return false
+	}
+	_, ok := envelope["id"]
+	return ok
+}
+
+func gatewayMethodStartsTurnWork(method string) bool {
+	switch method {
+	case "turn/start", "review/start":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeRemoteCLIClientParams(method string, params map[string]any) {
+	if method != "turn/start" {
+		return
+	}
+	// CLI 会把主机 config/read 的 approval_policy=never 当作缺省值带回。
+	// 远程请求本身没有显式完全访问沙盒时，这会在通用策略校验前被拒绝。
+	// 先降为可审批值；后续安全改写仍会把显式 danger-full-access 归一化为 never。
+	if policy, ok := gatewayStringParam(params, "approvalPolicy"); ok && normalizePolicyValue(policy) == "never" {
+		params["approvalPolicy"] = "on-request"
+		params["approvalsReviewer"] = "user"
+	}
+	collaboration, ok := params["collaborationMode"].(map[string]any)
+	if !ok {
+		return
+	}
+	settings, ok := collaboration["settings"].(map[string]any)
+	if !ok {
+		return
+	}
+	// TUI 会附带自己的本地协作说明。远端不能把任意 developer instructions
+	// 当成受信策略透传；清空后由既有 gateway 安全常量重建 Default Mode。
+	settings["developer_instructions"] = nil
+}
+
 func (p *appServerGatewayPolicy) methodAllowed(method string) bool {
-	_, ok := appServerAllowedMethodsForRuntime(p.runtimeID)[method]
+	_, ok := appServerAllowedMethodsForClient(p.runtimeID, p.clientKind)[method]
 	return ok
 }
 
@@ -310,7 +395,7 @@ func (p *appServerGatewayPolicy) validateThreadInputPaths(method string, params 
 	var scope gatewayScope
 	var scopeOK bool
 	if strings.TrimSpace(thread.cwd) != "" {
-		scope, scopeOK = p.router.gatewayScopeForPath(thread.cwd)
+		scope, scopeOK = p.gatewayScopeForPath(thread.cwd)
 	}
 	for _, path := range inputPaths {
 		if _, ok := p.router.projectForGatewayPath(path); ok {
@@ -622,6 +707,12 @@ func rewriteGatewaySafeDefaults(payload []byte, runtimeID string, method string,
 		sanitized = sanitizedGatewayInitializeParams(params)
 	case "initialized", "model/list", "account/rateLimits/read", "account/usage/read":
 		sanitized = map[string]any{}
+	case "config/read":
+		sanitized = map[string]any{"cwd": validated.cwd, "includeLayers": false}
+	case "configRequirements/read":
+		sanitized = map[string]any{}
+	case "account/read":
+		sanitized = map[string]any{"refreshToken": false}
 	case "skills/list":
 		sanitized = sanitizedGatewaySkillsListParams(params, validated.cwd)
 	case "permissionProfile/list":
@@ -671,7 +762,7 @@ func rewriteGatewaySafeDefaults(payload []byte, runtimeID string, method string,
 	if err := decoder.Decode(&frame); err != nil {
 		return nil, fmt.Errorf("JSON-RPC frame 无效")
 	}
-	if method == "account/usage/read" {
+	if method == "account/usage/read" || method == "configRequirements/read" {
 		// mimiForceRefresh 是移动端与 agentd 的私有提示；上游 schema 没有 params，必须完整剥离。
 		delete(frame, "params")
 	} else {

--- a/internal/httpapi/appserver_gateway_remote_policy.go
+++ b/internal/httpapi/appserver_gateway_remote_policy.go
@@ -1,0 +1,111 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func (p *appServerGatewayPolicy) rewriteRemoteCLIResponse(payload []byte, frame *appServerGatewayFrame) ([]byte, bool, error) {
+	if p == nil || p.clientKind != appServerGatewayClientRemoteCLI || frame == nil || !gatewayFrameIsResponse(frame) {
+		return payload, false, nil
+	}
+	pending, ok := p.consumePendingClientRequest(frame.ID)
+	if !ok || (pending.method != "config/read" && pending.method != "configRequirements/read" && pending.method != "account/read") {
+		return payload, false, nil
+	}
+	if len(frame.Error) > 0 {
+		return rewriteRemoteCLIResponseError(payload, pending.method+" failed")
+	}
+	var result map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(frame.Result))
+	decoder.UseNumber()
+	if decoder.Decode(&result) != nil {
+		return nil, true, fmt.Errorf("%s 响应不是 JSON object", pending.method)
+	}
+	safe := map[string]any{}
+	switch pending.method {
+	case "config/read":
+		safe = sanitizeRemoteCLIConfigReadResult(result, pending.cwd)
+	case "configRequirements/read":
+		// 0.149.1 在无集中策略时返回 {requirements:null}。不把未来新增的
+		// 未知字段跨 SSH 透传，升级协议基线后再显式评审。
+		safe = map[string]any{"requirements": nil}
+	case "account/read":
+		safe = sanitizeRemoteCLIAccountReadResult(result)
+	}
+	return rewriteGatewayResponseResult(payload, safe)
+}
+
+func rewriteRemoteCLIResponseError(payload []byte, message string) ([]byte, bool, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, true, err
+	}
+	errorValue, err := json.Marshal(map[string]any{
+		"code":    appServerPolicyErrorCode,
+		"message": message,
+	})
+	if err != nil {
+		return nil, true, err
+	}
+	delete(envelope, "result")
+	envelope["error"] = errorValue
+	rewritten, err := json.Marshal(envelope)
+	return rewritten, true, err
+}
+
+func sanitizeRemoteCLIConfigReadResult(result map[string]any, cwd string) map[string]any {
+	configValue, _ := result["config"].(map[string]any)
+	safeConfig := copyGatewayParams(configValue,
+		"model", "model_provider", "sandbox_mode", "personality", "web_search", "service_tier")
+	// remote gateway 始终从可审批策略开始。客户端若显式选择完全访问，后续
+	// turn/start 安全改写仍会在明确沙盒/permission profile 下归一化为 never。
+	safeConfig["approval_policy"] = "on-request"
+	if projectsValue, ok := configValue["projects"].(map[string]any); ok {
+		for configuredPath, rawProject := range projectsValue {
+			if strings.TrimSpace(configuredPath) != strings.TrimSpace(cwd) {
+				continue
+			}
+			project, ok := rawProject.(map[string]any)
+			if !ok {
+				continue
+			}
+			trustLevel, ok := project["trust_level"].(string)
+			if ok && (trustLevel == "trusted" || trustLevel == "untrusted") {
+				safeConfig["projects"] = map[string]any{configuredPath: map[string]any{"trust_level": trustLevel}}
+			}
+		}
+	}
+	// Codex CLI 0.149.1 的响应模型包含这三个字段。空 origins/layers 保留协议形状，
+	// 但不会把主机配置层、环境变量或 MCP 配置送过 SSH。
+	return map[string]any{"config": safeConfig, "origins": map[string]any{}, "layers": []any{}}
+}
+
+func sanitizeRemoteCLIAccountReadResult(result map[string]any) map[string]any {
+	safe := map[string]any{}
+	if value, ok := result["requiresOpenaiAuth"].(bool); ok {
+		safe["requiresOpenaiAuth"] = value
+	}
+	if account, ok := result["account"].(map[string]any); ok {
+		safeAccount := copyGatewayParams(account, "type", "planType")
+		if len(safeAccount) > 0 {
+			safe["account"] = safeAccount
+		}
+	}
+	return safe
+}
+
+func rewriteGatewayResponseResult(payload []byte, result any) ([]byte, bool, error) {
+	var envelope map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&envelope); err != nil {
+		return nil, true, err
+	}
+	envelope["result"] = result
+	delete(envelope, "error")
+	rewritten, err := json.Marshal(envelope)
+	return rewritten, true, err
+}

--- a/internal/httpapi/appserver_gateway_request_ids.go
+++ b/internal/httpapi/appserver_gateway_request_ids.go
@@ -1,0 +1,58 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const appServerGatewayInflightClientRequestMax = 512
+
+// reserveInflightClientRequest 对所有发往上游的 JSON-RPC 请求实施连接级 ID 唯一性。
+// 这不仅符合 JSON-RPC 的响应关联语义，也防止普通请求的同 ID 响应误释放 turn admission。
+func (p *appServerGatewayPolicy) reserveInflightClientRequest(id *json.RawMessage, method string) error {
+	if p == nil || p.router == nil || normalizeAppServerRuntimeID(p.runtimeID) != "codex" || !p.router.cfg.AppServer.RemoteGateway.Enabled {
+		return nil
+	}
+	key := gatewayRequestIDKey(id)
+	if key == "" {
+		return fmt.Errorf("%s 请求缺少 id", method)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.inflightClientRequests == nil {
+		p.inflightClientRequests = map[string]string{}
+	}
+	if previous, exists := p.inflightClientRequests[key]; exists {
+		return fmt.Errorf("JSON-RPC request id 已被在途 %s 请求占用", previous)
+	}
+	if len(p.inflightClientRequests) >= appServerGatewayInflightClientRequestMax {
+		return fmt.Errorf("gateway 在途 client request 过多")
+	}
+	p.inflightClientRequests[key] = method
+	return nil
+}
+
+func (p *appServerGatewayPolicy) consumeInflightClientRequest(id *json.RawMessage) (string, bool) {
+	key := gatewayRequestIDKey(id)
+	if key == "" {
+		return "", false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	method, ok := p.inflightClientRequests[key]
+	if ok {
+		delete(p.inflightClientRequests, key)
+	}
+	return method, ok
+}
+
+func (p *appServerGatewayPolicy) cancelInflightClientRequest(id *json.RawMessage) {
+	_, _ = p.consumeInflightClientRequest(id)
+}
+
+func (p *appServerGatewayPolicy) cancelInflightClientRequestFromPayload(payload []byte) {
+	var frame appServerGatewayFrame
+	if json.Unmarshal(payload, &frame) == nil {
+		p.cancelInflightClientRequest(frame.ID)
+	}
+}

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,13 +86,36 @@ func (p *appServerGatewayPolicy) allowedThread(threadID string) (appServerGatewa
 	p.mu.Lock()
 	thread, ok := p.allowedThreads[threadID]
 	p.mu.Unlock()
-	if ok {
+	if ok && p.threadScopeAllowed(thread) {
 		return thread, true
 	}
 	if p.router == nil {
 		return appServerGatewayAllowedThread{}, false
 	}
-	return p.router.gatewayThread(p.runtimeID, threadID)
+	thread, ok = p.router.gatewayThread(p.runtimeID, threadID)
+	if !ok || !p.threadScopeAllowed(thread) {
+		return appServerGatewayAllowedThread{}, false
+	}
+	return thread, true
+}
+
+func (p *appServerGatewayPolicy) gatewayScopeForPath(raw string) (gatewayScope, bool) {
+	if p == nil || p.router == nil {
+		return gatewayScope{}, false
+	}
+	scope, ok := p.router.gatewayScopeForPath(raw)
+	if !ok || (p.clientKind == appServerGatewayClientRemoteCLI && scope.browse) {
+		return gatewayScope{}, false
+	}
+	return scope, true
+}
+
+func (p *appServerGatewayPolicy) threadScopeAllowed(thread appServerGatewayAllowedThread) bool {
+	if p == nil || p.clientKind != appServerGatewayClientRemoteCLI {
+		return true
+	}
+	_, ok := p.gatewayScopeForPath(thread.cwd)
+	return ok
 }
 
 func (r *Router) gatewayThread(runtimeID string, threadID string) (appServerGatewayAllowedThread, bool) {
@@ -150,6 +174,7 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 			return payload, false, nil
 		}
 		p.clearPendingServerRequestsForNotification(&frame)
+		p.observeTurnCompletion(&frame)
 		p.rememberReplayedServerRequests(&frame)
 		if appServerRuntimeRedactsInlineImages(p.runtimeID) && appServerMediaRedactNotificationsEnabled() {
 			if redacted, changed := p.router.redactInlineHistoryImagesInGatewayResponse(payload); changed {
@@ -160,6 +185,19 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 		return payload, true, nil
 	}
 	if gatewayFrameIsResponse(&frame) {
+		requestMethod, requestKnown := p.consumeInflightClientRequest(frame.ID)
+		if requestKnown {
+			p.observePendingTurnStartResponse(&frame, requestMethod)
+		}
+		if rewritten, handled, err := p.rewriteRemoteCLIResponse(payload, &frame); handled {
+			if err != nil {
+				return payload, false, &appServerGatewayPolicyError{id: frame.ID, message: err.Error(), target: "client"}
+			}
+			payload = rewritten
+			if json.Unmarshal(payload, &frame) != nil {
+				return payload, false, &appServerGatewayPolicyError{id: frame.ID, message: "remote CLI 响应改写失败", target: "client"}
+			}
+		}
 		p.rememberAccountTokenUsageResponse(&frame, time.Now())
 		if pending, ok := p.consumePendingHistoryRequest(frame.ID); ok {
 			if len(frame.Error) == 0 && len(frame.Result) > 0 {
@@ -358,7 +396,7 @@ func (p *appServerGatewayPolicy) sanitizeGlobalThreadListResponse(
 		if threadID == "" || threadID != threadIDRaw || cwd == "" || cwd != cwdRaw || !filepath.IsAbs(cwd) {
 			continue
 		}
-		scope, ok := p.router.gatewayScopeForPath(cwd)
+		scope, ok := p.gatewayScopeForPath(cwd)
 		if !ok {
 			continue
 		}
@@ -501,7 +539,7 @@ func (p *appServerGatewayPolicy) validateReadOnlyThreadResponse(
 	if cwd == "" || cwd != cwdRaw || !filepath.IsAbs(cwd) || p.router == nil {
 		return fmt.Errorf("thread/read 返回的只读子会话缺少可验证的 cwd")
 	}
-	scope, ok := p.router.gatewayScopeForPath(cwd)
+	scope, ok := p.gatewayScopeForPath(cwd)
 	if !ok || scope.id != allowed.scopeID {
 		return fmt.Errorf("thread/read 返回的只读子会话不在授权作用域")
 	}
@@ -639,7 +677,7 @@ func (p *appServerGatewayPolicy) sanitizeThreadSearchResponse(payload []byte, pe
 		if threadID == "" || threadID != thread.ID || cwd == "" || cwd != thread.CWD || !filepath.IsAbs(cwd) {
 			continue
 		}
-		scope, ok := p.router.gatewayScopeForPath(cwd)
+		scope, ok := p.gatewayScopeForPath(cwd)
 		if !ok {
 			continue
 		}
@@ -725,6 +763,10 @@ func gatewayFrameIsResponse(frame *appServerGatewayFrame) bool {
 }
 
 func (p *appServerGatewayPolicy) rememberPendingClientRequest(id *json.RawMessage, method string) error {
+	return p.rememberPendingClientRequestWithCWD(id, method, "")
+}
+
+func (p *appServerGatewayPolicy) rememberPendingClientRequestWithCWD(id *json.RawMessage, method string, cwd string) error {
 	key := gatewayRequestIDKey(id)
 	if key == "" {
 		return fmt.Errorf("%s 请求缺少 id", method)
@@ -739,7 +781,7 @@ func (p *appServerGatewayPolicy) rememberPendingClientRequest(id *json.RawMessag
 	if _, exists := p.pendingClientRequests[key]; !exists && len(p.pendingClientRequests) >= appServerGatewayPendingClientRequestMax {
 		return fmt.Errorf("gateway pending client request 过多")
 	}
-	p.pendingClientRequests[key] = appServerGatewayPendingClientRequest{method: method, createdAt: now}
+	p.pendingClientRequests[key] = appServerGatewayPendingClientRequest{method: method, cwd: cwd, createdAt: now}
 	return nil
 }
 
@@ -1059,7 +1101,7 @@ func (p *appServerGatewayPolicy) threadsFromResult(raw json.RawMessage, pending 
 			continue
 		}
 		cwd := firstNonEmpty(item.CWD, item.Path, pending.cwd)
-		scope, ok := p.router.gatewayScopeForPath(cwd)
+		scope, ok := p.gatewayScopeForPath(cwd)
 		if !ok {
 			continue
 		}
@@ -1372,7 +1414,28 @@ func gatewayRequestIDKey(id *json.RawMessage) string {
 	if id == nil || len(bytes.TrimSpace(*id)) == 0 {
 		return ""
 	}
-	return string(bytes.TrimSpace(*id))
+	decoder := json.NewDecoder(bytes.NewReader(*id))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return "s:" + typed
+	case json.Number:
+		literal := typed.String()
+		if strings.ContainsAny(literal, ".eE") {
+			return ""
+		}
+		var integer big.Int
+		if _, ok := integer.SetString(literal, 10); !ok {
+			return ""
+		}
+		return "n:" + integer.String()
+	default:
+		return ""
+	}
 }
 
 func decodeGatewayParams(raw json.RawMessage) (map[string]any, error) {

--- a/internal/httpapi/appserver_gateway_turn_admission.go
+++ b/internal/httpapi/appserver_gateway_turn_admission.go
@@ -1,0 +1,187 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type appServerGatewayTurnAdmission struct {
+	ownerConnectionID uint64
+	turnID            string
+	completedTurnIDs  map[string]struct{}
+	startedAt         time.Time
+}
+
+func (r *Router) nextGatewayConnectionID() uint64 {
+	r.gatewayTurnMu.Lock()
+	defer r.gatewayTurnMu.Unlock()
+	r.gatewayTurnSequence++
+	return r.gatewayTurnSequence
+}
+
+func (r *Router) reserveGatewayTurn(threadID string, owner uint64) error {
+	if r == nil || !r.cfg.AppServer.RemoteGateway.Enabled {
+		return nil
+	}
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" || owner == 0 {
+		return fmt.Errorf("turn work 缺少有效 thread admission identity")
+	}
+	r.gatewayTurnMu.Lock()
+	defer r.gatewayTurnMu.Unlock()
+	if _, exists := r.gatewayActiveTurns[threadID]; exists {
+		return fmt.Errorf("thread 已有运行中的 turn；请等待完成后再从另一个客户端接手")
+	}
+	r.gatewayActiveTurns[threadID] = appServerGatewayTurnAdmission{
+		ownerConnectionID: owner,
+		startedAt:         time.Now(),
+	}
+	return nil
+}
+
+func (r *Router) confirmGatewayTurn(threadID string, owner uint64, turnID string) {
+	if r == nil || !r.cfg.AppServer.RemoteGateway.Enabled {
+		return
+	}
+	r.gatewayTurnMu.Lock()
+	defer r.gatewayTurnMu.Unlock()
+	current, ok := r.gatewayActiveTurns[strings.TrimSpace(threadID)]
+	if !ok || current.ownerConnectionID != owner {
+		return
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return
+	}
+	if _, completed := current.completedTurnIDs[turnID]; completed {
+		delete(r.gatewayActiveTurns, strings.TrimSpace(threadID))
+		return
+	}
+	current.turnID = turnID
+	r.gatewayActiveTurns[strings.TrimSpace(threadID)] = current
+}
+
+func (r *Router) cancelGatewayTurnReservation(threadID string, owner uint64) {
+	if r == nil || !r.cfg.AppServer.RemoteGateway.Enabled {
+		return
+	}
+	r.gatewayTurnMu.Lock()
+	defer r.gatewayTurnMu.Unlock()
+	current, ok := r.gatewayActiveTurns[strings.TrimSpace(threadID)]
+	if ok && current.ownerConnectionID == owner && current.turnID == "" {
+		delete(r.gatewayActiveTurns, strings.TrimSpace(threadID))
+	}
+}
+
+func (r *Router) completeGatewayTurn(threadID string, turnID string) {
+	if r == nil || !r.cfg.AppServer.RemoteGateway.Enabled {
+		return
+	}
+	threadID = strings.TrimSpace(threadID)
+	turnID = strings.TrimSpace(turnID)
+	r.gatewayTurnMu.Lock()
+	defer r.gatewayTurnMu.Unlock()
+	current, ok := r.gatewayActiveTurns[threadID]
+	if !ok {
+		return
+	}
+	// 只有带明确 turn ID 的完成通知能释放 reservation。thread/closed 或旧版
+	// 空 ID 通知无法与本次 start 可靠关联，宁可保持锁定等待人工重启，也不能误放并发 turn。
+	if turnID == "" {
+		return
+	}
+	if current.turnID == "" {
+		if current.completedTurnIDs == nil {
+			current.completedTurnIDs = map[string]struct{}{}
+		}
+		current.completedTurnIDs[turnID] = struct{}{}
+		r.gatewayActiveTurns[threadID] = current
+		return
+	}
+	if current.turnID != turnID {
+		return
+	}
+	delete(r.gatewayActiveTurns, threadID)
+}
+
+func (p *appServerGatewayPolicy) reservePendingTurnStart(id *json.RawMessage, threadID string) error {
+	if p == nil || p.router == nil || normalizeAppServerRuntimeID(p.runtimeID) != "codex" || !p.router.cfg.AppServer.RemoteGateway.Enabled {
+		return nil
+	}
+	key := gatewayRequestIDKey(id)
+	if key == "" {
+		return fmt.Errorf("turn work 请求缺少 id")
+	}
+	if err := p.router.reserveGatewayTurn(threadID, p.connectionID); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	if p.pendingTurnStarts == nil {
+		p.pendingTurnStarts = map[string]string{}
+	}
+	if _, exists := p.pendingTurnStarts[key]; exists {
+		p.mu.Unlock()
+		p.router.cancelGatewayTurnReservation(threadID, p.connectionID)
+		return fmt.Errorf("turn work request id 重复")
+	}
+	p.pendingTurnStarts[key] = threadID
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *appServerGatewayPolicy) observePendingTurnStartResponse(frame *appServerGatewayFrame, requestMethod string) {
+	if p == nil || p.router == nil || normalizeAppServerRuntimeID(p.runtimeID) != "codex" || !p.router.cfg.AppServer.RemoteGateway.Enabled || frame == nil || !gatewayFrameIsResponse(frame) {
+		return
+	}
+	if !gatewayMethodStartsTurnWork(requestMethod) {
+		return
+	}
+	key := gatewayRequestIDKey(frame.ID)
+	if key == "" {
+		return
+	}
+	p.mu.Lock()
+	threadID, ok := p.pendingTurnStarts[key]
+	if ok {
+		delete(p.pendingTurnStarts, key)
+	}
+	p.mu.Unlock()
+	if !ok {
+		return
+	}
+	if len(frame.Error) > 0 || len(frame.Result) == 0 {
+		p.router.cancelGatewayTurnReservation(threadID, p.connectionID)
+		return
+	}
+	turnID := turnIDFromGatewayResult(frame.Result)
+	p.router.confirmGatewayTurn(threadID, p.connectionID, turnID)
+}
+
+func turnIDFromGatewayResult(raw json.RawMessage) string {
+	var result map[string]any
+	if json.Unmarshal(raw, &result) != nil {
+		return ""
+	}
+	if turn, ok := result["turn"].(map[string]any); ok {
+		turnID, _ := gatewayStringParam(turn, "id")
+		return turnID
+	}
+	turnID, _ := gatewayStringParam(result, "turnId")
+	return turnID
+}
+
+func (p *appServerGatewayPolicy) observeTurnCompletion(frame *appServerGatewayFrame) {
+	if p == nil || p.router == nil || normalizeAppServerRuntimeID(p.runtimeID) != "codex" || !p.router.cfg.AppServer.RemoteGateway.Enabled || frame == nil {
+		return
+	}
+	method := strings.TrimSpace(frame.Method)
+	if method != "turn/completed" {
+		return
+	}
+	threadID, turnID, _ := appServerGatewayServerRequestScope(frame.Params)
+	if threadID != "" {
+		p.router.completeGatewayTurn(threadID, turnID)
+	}
+}

--- a/internal/httpapi/appserver_gateway_turn_admission_test.go
+++ b/internal/httpapi/appserver_gateway_turn_admission_test.go
@@ -1,0 +1,237 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+func TestGatewayTurnAdmissionIsAtomicAcrossMobileAndRemoteCLI(t *testing.T) {
+	router := &Router{
+		cfg:                config.Config{AppServer: config.AppServerConfig{RemoteGateway: config.RemoteGatewayConfig{Enabled: true}}},
+		gatewayActiveTurns: map[string]appServerGatewayTurnAdmission{},
+	}
+	mobile := &appServerGatewayPolicy{
+		router:            router,
+		clientKind:        appServerGatewayClientMobile,
+		connectionID:      1,
+		pendingTurnStarts: map[string]string{},
+	}
+	remote := &appServerGatewayPolicy{
+		router:            router,
+		clientKind:        appServerGatewayClientRemoteCLI,
+		connectionID:      2,
+		pendingTurnStarts: map[string]string{},
+	}
+	id1 := json.RawMessage(`1`)
+	id2 := json.RawMessage(`2`)
+	if err := mobile.reservePendingTurnStart(&id1, "thread-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.reservePendingTurnStart(&id2, "thread-1"); err == nil {
+		t.Fatal("second surface must not start a concurrent turn")
+	}
+
+	// 连接结束不能证明上游没有接受请求，因此 close 不释放 admission。
+	mobile.close()
+	if err := remote.reservePendingTurnStart(&id2, "thread-1"); err == nil {
+		t.Fatal("disconnect must not release uncertain turn admission")
+	}
+	mobile.observePendingTurnStartResponse(&appServerGatewayFrame{
+		ID:     &id1,
+		Result: json.RawMessage(`{"turn":{"id":"turn-1"}}`),
+	}, "turn/start")
+	remote.observeTurnCompletion(&appServerGatewayFrame{
+		Method: "turn/completed",
+		Params: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1"}}`),
+	})
+	if err := remote.reservePendingTurnStart(&id2, "thread-1"); err != nil {
+		t.Fatalf("terminal notification should release admission: %v", err)
+	}
+}
+
+func TestGatewayTurnAdmissionReleasesDefiniteStartError(t *testing.T) {
+	router := &Router{
+		cfg:                config.Config{AppServer: config.AppServerConfig{RemoteGateway: config.RemoteGatewayConfig{Enabled: true}}},
+		gatewayActiveTurns: map[string]appServerGatewayTurnAdmission{},
+	}
+	first := &appServerGatewayPolicy{router: router, connectionID: 1, pendingTurnStarts: map[string]string{}}
+	second := &appServerGatewayPolicy{router: router, connectionID: 2, pendingTurnStarts: map[string]string{}}
+	id1 := json.RawMessage(`1`)
+	id2 := json.RawMessage(`2`)
+	if err := first.reservePendingTurnStart(&id1, "thread-1"); err != nil {
+		t.Fatal(err)
+	}
+	first.observePendingTurnStartResponse(&appServerGatewayFrame{
+		ID:    &id1,
+		Error: json.RawMessage(`{"code":-32000,"message":"rejected"}`),
+	}, "turn/start")
+	if err := second.reservePendingTurnStart(&id2, "thread-1"); err != nil {
+		t.Fatalf("definite upstream rejection should release admission: %v", err)
+	}
+}
+
+func TestGatewayTurnAdmissionIgnoresOldAndUnidentifiedTerminalNotifications(t *testing.T) {
+	router := &Router{
+		cfg:                config.Config{AppServer: config.AppServerConfig{RemoteGateway: config.RemoteGatewayConfig{Enabled: true}}},
+		gatewayActiveTurns: map[string]appServerGatewayTurnAdmission{},
+	}
+	first := &appServerGatewayPolicy{router: router, connectionID: 1, pendingTurnStarts: map[string]string{}}
+	second := &appServerGatewayPolicy{router: router, connectionID: 2, pendingTurnStarts: map[string]string{}}
+	id1 := json.RawMessage(`1`)
+	id2 := json.RawMessage(`2`)
+	if err := first.reservePendingTurnStart(&id1, "thread-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// 上一个 turn 的重复终态和无 turn ID 的 thread 终态都不能释放新 reservation。
+	router.completeGatewayTurn("thread-1", "turn-old")
+	router.completeGatewayTurn("thread-1", "")
+	if err := second.reservePendingTurnStart(&id2, "thread-1"); err == nil {
+		t.Fatal("old terminal notification must not release pending reservation")
+	}
+	first.observePendingTurnStartResponse(&appServerGatewayFrame{
+		ID:     &id1,
+		Result: json.RawMessage(`{"turn":{"id":"turn-new"}}`),
+	}, "turn/start")
+	router.completeGatewayTurn("thread-1", "turn-old")
+	if err := second.reservePendingTurnStart(&id2, "thread-1"); err == nil {
+		t.Fatal("old terminal notification must not release confirmed reservation")
+	}
+	router.completeGatewayTurn("thread-1", "turn-new")
+	if err := second.reservePendingTurnStart(&id2, "thread-1"); err != nil {
+		t.Fatalf("matching terminal notification should release reservation: %v", err)
+	}
+}
+
+func TestGatewayTurnAdmissionMatchesCompletionThatPrecedesStartResponse(t *testing.T) {
+	router := &Router{
+		cfg:                config.Config{AppServer: config.AppServerConfig{RemoteGateway: config.RemoteGatewayConfig{Enabled: true}}},
+		gatewayActiveTurns: map[string]appServerGatewayTurnAdmission{},
+	}
+	first := &appServerGatewayPolicy{router: router, connectionID: 1, pendingTurnStarts: map[string]string{}}
+	second := &appServerGatewayPolicy{router: router, connectionID: 2, pendingTurnStarts: map[string]string{}}
+	id1 := json.RawMessage(`1`)
+	id2 := json.RawMessage(`2`)
+	if err := first.reservePendingTurnStart(&id1, "thread-1"); err != nil {
+		t.Fatal(err)
+	}
+	router.completeGatewayTurn("thread-1", "turn-fast")
+	first.observePendingTurnStartResponse(&appServerGatewayFrame{
+		ID:     &id1,
+		Result: json.RawMessage(`{"turn":{"id":"turn-fast"}}`),
+	}, "turn/start")
+	if err := second.reservePendingTurnStart(&id2, "thread-1"); err != nil {
+		t.Fatalf("matching completion observed before response should release reservation: %v", err)
+	}
+}
+
+func TestGatewayTurnAdmissionDoesNotApplyToClaudeBridge(t *testing.T) {
+	router := &Router{
+		cfg:                config.Config{AppServer: config.AppServerConfig{RemoteGateway: config.RemoteGatewayConfig{Enabled: true}}},
+		gatewayActiveTurns: map[string]appServerGatewayTurnAdmission{},
+	}
+	claude := &appServerGatewayPolicy{router: router, runtimeID: "claude", pendingTurnStarts: map[string]string{}}
+	id := json.RawMessage(`1`)
+	if err := claude.reservePendingTurnStart(&id, "thread-1"); err != nil {
+		t.Fatalf("remote Codex admission must not change Claude bridge: %v", err)
+	}
+	if len(router.gatewayActiveTurns) != 0 {
+		t.Fatalf("Claude bridge must not reserve Codex turns: %+v", router.gatewayActiveTurns)
+	}
+}
+
+func TestGatewayTurnAdmissionCoversReviewAndRejectsUncorrelatableCompact(t *testing.T) {
+	if !gatewayMethodStartsTurnWork("turn/start") || !gatewayMethodStartsTurnWork("review/start") {
+		t.Fatal("turn/start and inline review/start must share the same admission")
+	}
+	if gatewayMethodStartsTurnWork("thread/compact/start") {
+		t.Fatal("compact response has no turn ID and cannot use turn admission")
+	}
+	router := &Router{
+		cfg:                config.Config{AppServer: config.AppServerConfig{RemoteGateway: config.RemoteGatewayConfig{Enabled: true}}},
+		gatewayActiveTurns: map[string]appServerGatewayTurnAdmission{},
+	}
+	policy := &appServerGatewayPolicy{router: router, runtimeID: "codex", clientKind: appServerGatewayClientMobile}
+	id := json.RawMessage(`1`)
+	payload := []byte(`{"id":1,"method":"thread/compact/start","params":{"threadId":"thread-1"}}`)
+	if _, policyErr := policy.validateClientFrame(websocket.TextMessage, payload); policyErr == nil || policyErr.id == nil || string(*policyErr.id) != string(id) {
+		t.Fatalf("compact must fail closed while remote gateway is enabled: %+v", policyErr)
+	}
+}
+
+func TestGatewayTurnAdmissionRejectsCrossMethodRequestIDReuse(t *testing.T) {
+	router := &Router{
+		cfg:                config.Config{AppServer: config.AppServerConfig{RemoteGateway: config.RemoteGatewayConfig{Enabled: true}}},
+		gatewayActiveTurns: map[string]appServerGatewayTurnAdmission{},
+	}
+	policy := &appServerGatewayPolicy{
+		router:                 router,
+		runtimeID:              "codex",
+		connectionID:           1,
+		pendingTurnStarts:      map[string]string{},
+		inflightClientRequests: map[string]string{},
+	}
+	other := &appServerGatewayPolicy{router: router, runtimeID: "codex", connectionID: 2, pendingTurnStarts: map[string]string{}}
+	id := json.RawMessage(`7`)
+	escapedID := json.RawMessage(`"\u0078"`)
+	plainID := json.RawMessage(`"x"`)
+	otherID := json.RawMessage(`8`)
+	if err := policy.reserveInflightClientRequest(&id, "turn/start"); err != nil {
+		t.Fatal(err)
+	}
+	if err := policy.reservePendingTurnStart(&id, "thread-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := policy.reserveInflightClientRequest(&id, "turn/interrupt"); err == nil {
+		t.Fatal("non-turn request must not reuse an inflight turn request ID")
+	}
+	policy.cancelInflightClientRequest(&id)
+	if err := policy.reserveInflightClientRequest(&plainID, "turn/start"); err != nil {
+		t.Fatal(err)
+	}
+	if err := policy.reserveInflightClientRequest(&escapedID, "turn/interrupt"); err == nil {
+		t.Fatal("semantically equal escaped string ID must be treated as duplicate")
+	}
+	// 即使伪造一个同 ID 的普通错误响应，方法关联也不能释放 turn reservation。
+	policy.observePendingTurnStartResponse(&appServerGatewayFrame{
+		ID:    &id,
+		Error: json.RawMessage(`{"code":-1,"message":"interrupt failed"}`),
+	}, "turn/interrupt")
+	if err := other.reservePendingTurnStart(&otherID, "thread-1"); err == nil {
+		t.Fatal("ordinary response with reused ID must not release turn admission")
+	}
+}
+
+func TestGatewayRequestIDKeyCanonicalizesAndRejectsUnsafeTypes(t *testing.T) {
+	key := func(raw string) string {
+		id := json.RawMessage(raw)
+		return gatewayRequestIDKey(&id)
+	}
+	if key(`"x"`) != key(`"\u0078"`) || key(`"1"`) == key(`1`) {
+		t.Fatal("request ID key must canonicalize strings while preserving string/number types")
+	}
+	if key(`-0`) != key(`0`) || key(`123456789012345678901234567890`) == "" {
+		t.Fatal("integer request IDs must have an exact canonical representation")
+	}
+	for _, raw := range []string{"null", "true", "1.0", "1e0", `[]`, `{}`} {
+		if got := key(raw); got != "" {
+			t.Fatalf("unsafe request ID %s must be rejected, got %q", raw, got)
+		}
+	}
+}
+
+func TestInitializedRejectsAnyID(t *testing.T) {
+	policy := &appServerGatewayPolicy{}
+	for _, payload := range []string{
+		`{"id":1,"method":"initialized","params":{}}`,
+		`{"id":null,"method":"initialized","params":{}}`,
+	} {
+		if _, policyErr := policy.validateClientFrame(websocket.TextMessage, []byte(payload)); policyErr == nil {
+			t.Fatalf("initialized with id must be rejected: %s", payload)
+		}
+	}
+}

--- a/internal/httpapi/appserver_gateway_websocket.go
+++ b/internal/httpapi/appserver_gateway_websocket.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func (r *Router) proxyAppServerGateway(ctx context.Context, client *websocket.Conn, upstream *websocket.Conn, monitor *relayGatewayConnMonitor) {
+func (r *Router) proxyAppServerGateway(ctx context.Context, client *websocket.Conn, upstream *websocket.Conn, monitor *relayGatewayConnMonitor, clientKind appServerGatewayClientKind) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	done := make(chan string, 5)
@@ -18,14 +18,18 @@ func (r *Router) proxyAppServerGateway(ctx context.Context, client *websocket.Co
 	configureGatewayReadConn(client)
 	configureGatewayReadConn(upstream)
 	policy := &appServerGatewayPolicy{
-		router:                r,
-		runtimeID:             "codex",
-		pendingThreads:        map[string]appServerGatewayPendingThreadRequest{},
-		pendingClientRequests: map[string]appServerGatewayPendingClientRequest{},
-		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
-		pendingHistory:        map[string]appServerGatewayPendingHistoryRequest{},
-		historyBudgets:        map[string]appServerGatewayHistoryBudget{},
-		allowedThreads:        map[string]appServerGatewayAllowedThread{},
+		router:                 r,
+		runtimeID:              "codex",
+		clientKind:             clientKind,
+		connectionID:           r.nextGatewayConnectionID(),
+		pendingThreads:         map[string]appServerGatewayPendingThreadRequest{},
+		pendingClientRequests:  map[string]appServerGatewayPendingClientRequest{},
+		inflightClientRequests: map[string]string{},
+		pendingTurnStarts:      map[string]string{},
+		pendingServerRequests:  map[string]appServerGatewayPendingServerRequest{},
+		pendingHistory:         map[string]appServerGatewayPendingHistoryRequest{},
+		historyBudgets:         map[string]appServerGatewayHistoryBudget{},
+		allowedThreads:         map[string]appServerGatewayAllowedThread{},
 	}
 	defer policy.releaseAllHistoryInflight()
 	defer policy.close()
@@ -94,6 +98,7 @@ func (r *Router) copyClientFramesToAppServer(ctx context.Context, client *websoc
 			continue
 		}
 		if cachedPayload, ok := policy.cachedAccountTokenUsageResponse(payload, time.Now()); ok {
+			policy.cancelInflightClientRequestFromPayload(forwardPayload)
 			writeStart := time.Now()
 			if err := writeWebSocketFrame(client, clientWriteMu, websocket.TextMessage, cachedPayload); err != nil {
 				return gatewayCloseReason("client_cache_write", err)

--- a/internal/httpapi/remote_gateway.go
+++ b/internal/httpapi/remote_gateway.go
@@ -1,0 +1,163 @@
+package httpapi
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const remoteGatewayMaxConnections = 1
+
+// RemoteGatewayHandler 是给 `codex --remote` 使用的独立根路径 WebSocket。
+// 监听器由 agentd 单独绑定 loopback；这里再次验证 peer 和 token，避免配置漂移扩大边界。
+func (r *Router) RemoteGatewayHandler() http.Handler {
+	return http.HandlerFunc(r.remoteGatewayWS)
+}
+
+func (r *Router) remoteGatewayWS(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path != "/" {
+		http.NotFound(w, req)
+		return
+	}
+	if req.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	if !remoteGatewayPeerIsLoopback(req.RemoteAddr) {
+		writeError(w, http.StatusForbidden, "remote gateway 只接受 loopback peer")
+		return
+	}
+	if !sameOriginOrNoOrigin(req) {
+		writeError(w, http.StatusForbidden, "Origin 不允许访问 remote gateway")
+		return
+	}
+	if !websocket.IsWebSocketUpgrade(req) {
+		writeError(w, http.StatusBadRequest, "remote gateway 需要 WebSocket Upgrade")
+		return
+	}
+	token, err := r.readRemoteGatewayToken()
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "remote gateway 鉴权配置不可用，请运行 agentd doctor")
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(remoteGatewayBearerToken(req.Header.Get("Authorization"))), []byte(token)) != 1 {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if !r.acquireRemoteGatewaySlot() {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "remote gateway 已有客户端连接")
+		return
+	}
+	defer r.releaseRemoteGatewaySlot()
+
+	upstreamURL, err := r.appServerUpstreamWebSocketURL()
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "Codex app-server 上游配置不可用，请运行 agentd doctor")
+		return
+	}
+	upstreamHeaders, err := r.appServerUpstreamHeaders()
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "Codex app-server 上游鉴权不可用，请运行 agentd doctor")
+		return
+	}
+	dialer, err := r.appServerUpstreamDialer(4 * time.Second)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "Codex app-server 上游配置不可用，请运行 agentd doctor")
+		return
+	}
+	client, err := r.upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		log.Printf("remote gateway ws upgrade failed err=%v", err)
+		return
+	}
+	defer client.Close()
+	dialStart := time.Now()
+	upstream, _, err := dialer.DialContext(req.Context(), upstreamURL, upstreamHeaders)
+	dialDuration := time.Since(dialStart)
+	if err != nil {
+		r.monitor.recordGatewayDialFailure(dialDuration, err)
+		writeCodexGatewayRuntimeError(client, "CODEX_UPSTREAM_UNAVAILABLE", "Codex app-server 暂时不可用，请稍后重试")
+		return
+	}
+	defer upstream.Close()
+	monitor := r.monitor.startGatewayConnection(requestRemoteHost(req), req.Host, sanitizeGatewayURL(upstreamURL), dialDuration)
+	r.proxyAppServerGateway(req.Context(), client, upstream, monitor, appServerGatewayClientRemoteCLI)
+}
+
+func (r *Router) readRemoteGatewayToken() (string, error) {
+	path := strings.TrimSpace(r.cfg.AppServer.RemoteGateway.TokenFile)
+	if path == "" {
+		return "", fmt.Errorf("remote gateway token file 未配置")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("remote gateway token file 不是 regular file")
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return "", fmt.Errorf("remote gateway token file 权限必须是 0600")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(string(raw))
+	if len(token) < 32 {
+		return "", fmt.Errorf("remote gateway token 太短")
+	}
+	if token == strings.TrimSpace(r.cfg.Auth.Token) {
+		return "", fmt.Errorf("remote gateway token 不能复用 agentd token")
+	}
+	if upstreamHeaders, err := r.appServerUpstreamHeaders(); err == nil &&
+		remoteGatewayBearerToken(upstreamHeaders.Get("Authorization")) == token {
+		return "", fmt.Errorf("remote gateway token 不能复用 app-server upstream token")
+	}
+	return token, nil
+}
+
+func remoteGatewayBearerToken(raw string) string {
+	parts := strings.SplitN(raw, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func remoteGatewayPeerIsLoopback(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(remoteAddr))
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	return ip != nil && ip.IsLoopback()
+}
+
+func (r *Router) acquireRemoteGatewaySlot() bool {
+	r.remoteGatewayMu.Lock()
+	defer r.remoteGatewayMu.Unlock()
+	if r.activeRemoteGateway >= remoteGatewayMaxConnections {
+		return false
+	}
+	r.activeRemoteGateway++
+	return true
+}
+
+func (r *Router) releaseRemoteGatewaySlot() {
+	r.remoteGatewayMu.Lock()
+	if r.activeRemoteGateway > 0 {
+		r.activeRemoteGateway--
+	}
+	r.remoteGatewayMu.Unlock()
+}

--- a/internal/httpapi/remote_gateway_test.go
+++ b/internal/httpapi/remote_gateway_test.go
@@ -1,0 +1,280 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+)
+
+func TestRemoteGatewayUsesRootAuthIndependentLimitAndFilteredConfig(t *testing.T) {
+	const oldToken = "remote-cli-token-0000000000000001"
+	const newToken = "remote-cli-token-0000000000000002"
+	var projectDir string
+	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var frame appServerGatewayFrame
+		if json.Unmarshal(payload, &frame) != nil || frame.Method != "config/read" {
+			return
+		}
+		var semanticID any
+		if json.Unmarshal(*frame.ID, &semanticID) != nil {
+			return
+		}
+		response, err := json.Marshal(map[string]any{
+			"id": semanticID,
+			"result": map[string]any{
+				"config": map[string]any{
+					"model":       "gpt-test",
+					"mcp_servers": map[string]any{"secret": map[string]any{"env": map[string]any{"TOKEN": "leak"}}},
+					"projects": map[string]any{
+						projectDir:   map[string]any{"trust_level": "trusted"},
+						"/tmp/other": map[string]any{"trust_level": "trusted"},
+					},
+				},
+				"origins": map[string]any{"secret": "leak"},
+				"layers":  []any{map[string]any{"name": "user", "config": map[string]any{"env": map[string]any{"TOKEN": "leak"}}}},
+			},
+		})
+		if err == nil {
+			_ = conn.WriteMessage(messageType, response)
+		}
+	})
+	tokenFile := filepath.Join(t.TempDir(), "remote-token")
+	if err := os.WriteFile(tokenFile, []byte(oldToken+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, router, dir := buildAppServerGatewayFixture(t, upstreamURL, func(cfg *config.Config) {
+		cfg.AppServer.RemoteGateway = config.RemoteGatewayConfig{
+			Enabled:   true,
+			Listen:    "127.0.0.1:8788",
+			TokenFile: tokenFile,
+		}
+	})
+	projectDir = dir
+	server := httptest.NewServer(router.RemoteGatewayHandler())
+	defer server.Close()
+
+	conn := dialRemoteGateway(t, server.URL, oldToken)
+	// upstream 会把转义字符串 ID 解码后重新编码；关联键必须按 JSON 值规范化。
+	request := []byte(fmt.Sprintf(`{"id":"\u0078","method":"config/read","params":{"cwd":%q,"includeLayers":true}}`, projectDir))
+	if err := conn.WriteMessage(websocket.TextMessage, request); err != nil {
+		t.Fatal(err)
+	}
+	forwarded := readUpstreamFrame(t, received)
+	params := decodeGatewayParamsForTest(t, forwarded)
+	if params["cwd"] != projectDir || params["includeLayers"] != false {
+		t.Fatalf("config/read must force safe params: %v", params)
+	}
+	_, response, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope map[string]any
+	if json.Unmarshal(response, &envelope) != nil {
+		t.Fatalf("invalid response: %s", response)
+	}
+	result := envelope["result"].(map[string]any)
+	if len(result["origins"].(map[string]any)) != 0 || len(result["layers"].([]any)) != 0 {
+		t.Fatalf("config origins/layers leaked: %v", result)
+	}
+	safeConfig := result["config"].(map[string]any)
+	if _, exists := safeConfig["mcp_servers"]; exists {
+		t.Fatalf("MCP config leaked: %v", safeConfig)
+	}
+	if safeConfig["approval_policy"] != "on-request" {
+		t.Fatalf("remote config must start from an approval-capable policy: %v", safeConfig)
+	}
+	projects := safeConfig["projects"].(map[string]any)
+	if len(projects) != 1 || projects[projectDir] == nil {
+		t.Fatalf("only requested project trust may pass: %v", projects)
+	}
+
+	if _, response, err := websocket.DefaultDialer.Dial(wsURL(server.URL, "/"), http.Header{
+		"Authorization": []string{"Bearer " + oldToken},
+	}); err == nil || response == nil || response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("second remote connection should be limited: response=%v err=%v", response, err)
+	}
+	_ = conn.Close()
+	time.Sleep(20 * time.Millisecond)
+
+	tempToken := tokenFile + ".new"
+	if err := os.WriteFile(tempToken, []byte(newToken+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tempToken, tokenFile); err != nil {
+		t.Fatal(err)
+	}
+	if _, response, err := websocket.DefaultDialer.Dial(wsURL(server.URL, "/"), http.Header{
+		"Authorization": []string{"Bearer " + oldToken},
+	}); err == nil || response == nil || response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("old token must fail immediately: response=%v err=%v", response, err)
+	}
+	rotated := dialRemoteGateway(t, server.URL, newToken)
+	_ = rotated.Close()
+}
+
+func TestRemoteGatewayRejectsConfigWritesBeforeUpstream(t *testing.T) {
+	const token = "remote-cli-token-0000000000000003"
+	upstreamURL, received, _ := fakeAppServerUpstream(t, nil)
+	tokenFile := testAppServerTokenFile(t, token)
+	_, router, _ := buildAppServerGatewayFixture(t, upstreamURL, func(cfg *config.Config) {
+		cfg.AppServer.RemoteGateway = config.RemoteGatewayConfig{Enabled: true, Listen: "127.0.0.1:8788", TokenFile: tokenFile}
+	})
+	server := httptest.NewServer(router.RemoteGatewayHandler())
+	defer server.Close()
+	conn := dialRemoteGateway(t, server.URL, token)
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"id":9,"method":"config/batchWrite","params":{"edits":[]}}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, response, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(response) || !containsGatewayPolicyError(response, "config/batchWrite") {
+		t.Fatalf("config write should be rejected: %s", response)
+	}
+	select {
+	case payload := <-received:
+		t.Fatalf("rejected config write reached upstream: %s", payload)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestRemoteGatewayUsesExplicitMethodListAndRejectsBrowseRootCWD(t *testing.T) {
+	for _, method := range []string{"review/start", "thread/compact/start", "plugin/installed"} {
+		if _, ok := appServerRemoteCLIAllowedMethods[method]; ok {
+			t.Fatalf("remote v1 must not inherit work-producing or plugin method %q", method)
+		}
+	}
+	for _, method := range []string{"turn/start", "config/read", "configRequirements/read", "account/read"} {
+		if _, ok := appServerRemoteCLIAllowedMethods[method]; !ok {
+			t.Fatalf("remote CLI startup/turn method missing: %q", method)
+		}
+	}
+
+	const token = "remote-cli-token-0000000000000004"
+	upstreamURL, received, _ := fakeAppServerUpstream(t, nil)
+	tokenFile := testAppServerTokenFile(t, token)
+	browseRoot := t.TempDir()
+	browseCWD := filepath.Join(browseRoot, "not-a-project")
+	if err := os.Mkdir(browseCWD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, router, _ := buildAppServerGatewayFixture(t, upstreamURL, func(cfg *config.Config) {
+		cfg.BrowseRoots = []string{browseRoot}
+		cfg.AppServer.RemoteGateway = config.RemoteGatewayConfig{Enabled: true, Listen: "127.0.0.1:8788", TokenFile: tokenFile}
+	})
+	server := httptest.NewServer(router.RemoteGatewayHandler())
+	defer server.Close()
+	conn := dialRemoteGateway(t, server.URL, token)
+	defer conn.Close()
+	request := []byte(fmt.Sprintf(`{"id":10,"method":"config/read","params":{"cwd":%q,"includeLayers":false}}`, browseCWD))
+	if err := conn.WriteMessage(websocket.TextMessage, request); err != nil {
+		t.Fatal(err)
+	}
+	_, response, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsGatewayPolicyError(response, "config/read") || !containsText(response, "projects allowlist") {
+		t.Fatalf("browse-root cwd must be rejected for SSH token: %s", response)
+	}
+	select {
+	case payload := <-received:
+		t.Fatalf("browse-root request reached upstream: %s", payload)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestRemoteGatewayFiltersConfigRequirementsAndReadErrors(t *testing.T) {
+	policy := &appServerGatewayPolicy{
+		clientKind:            appServerGatewayClientRemoteCLI,
+		pendingClientRequests: map[string]appServerGatewayPendingClientRequest{},
+	}
+	id := json.RawMessage(`1`)
+	if err := policy.rememberPendingClientRequest(&id, "configRequirements/read"); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"id":1,"result":{"requirements":{"futureSecret":"must-not-pass"}}}`)
+	var frame appServerGatewayFrame
+	if json.Unmarshal(payload, &frame) != nil {
+		t.Fatal("invalid test payload")
+	}
+	rewritten, handled, err := policy.rewriteRemoteCLIResponse(payload, &frame)
+	if err != nil || !handled || string(rewritten) != `{"id":1,"result":{"requirements":null}}` {
+		t.Fatalf("config requirements not filtered: handled=%t err=%v payload=%s", handled, err, rewritten)
+	}
+
+	id = json.RawMessage(`2`)
+	if err := policy.rememberPendingClientRequest(&id, "account/read"); err != nil {
+		t.Fatal(err)
+	}
+	payload = []byte(`{"id":2,"error":{"code":-1,"message":"/secret/path","data":{"token":"leak"}}}`)
+	frame = appServerGatewayFrame{}
+	if json.Unmarshal(payload, &frame) != nil {
+		t.Fatal("invalid test error payload")
+	}
+	rewritten, handled, err = policy.rewriteRemoteCLIResponse(payload, &frame)
+	if err != nil || !handled || string(rewritten) == "" || json.Valid(rewritten) == false {
+		t.Fatalf("account error rewrite failed: handled=%t err=%v payload=%s", handled, err, rewritten)
+	}
+	if string(rewritten) == string(payload) || containsText(rewritten, "secret") || containsText(rewritten, "token") {
+		t.Fatalf("upstream error details leaked: %s", rewritten)
+	}
+}
+
+func TestRemoteCLINormalizesInheritedNeverBeforePolicyValidation(t *testing.T) {
+	params := map[string]any{
+		"approvalPolicy":    "never",
+		"approvalsReviewer": "auto_review",
+		"collaborationMode": map[string]any{
+			"mode": "default",
+			"settings": map[string]any{
+				"developer_instructions": "untrusted local instructions",
+			},
+		},
+	}
+	normalizeRemoteCLIClientParams("turn/start", params)
+	if params["approvalPolicy"] != "on-request" || params["approvalsReviewer"] != "user" {
+		t.Fatalf("inherited never must be downgraded before validation: %v", params)
+	}
+	settings := params["collaborationMode"].(map[string]any)["settings"].(map[string]any)
+	if settings["developer_instructions"] != nil {
+		t.Fatalf("remote developer instructions must be cleared: %v", settings)
+	}
+}
+
+func dialRemoteGateway(t *testing.T, serverURL string, token string) *websocket.Conn {
+	t.Helper()
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(serverURL, "/"), http.Header{
+		"Authorization": []string{"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
+}
+
+func containsGatewayPolicyError(payload []byte, method string) bool {
+	var frame struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	return json.Unmarshal(payload, &frame) == nil && frame.Error.Code == appServerPolicyErrorCode && frame.Error.Message != "" && len(method) > 0
+}
+
+func containsText(payload []byte, text string) bool {
+	return bytes.Contains(payload, []byte(text))
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -85,6 +85,11 @@ type Router struct {
 	gatewayThreads                map[string]appServerGatewayAllowedThread
 	codexGatewayMu                sync.Mutex
 	activeCodexGateway            int
+	remoteGatewayMu               sync.Mutex
+	activeRemoteGateway           int
+	gatewayTurnMu                 sync.Mutex
+	gatewayTurnSequence           uint64
+	gatewayActiveTurns            map[string]appServerGatewayTurnAdmission
 	gatewayHistoryBudgetMu        sync.Mutex
 	gatewayHistoryGlobalBudget    appServerGatewayHistoryBudget
 	claudeMu                      sync.Mutex
@@ -179,6 +184,7 @@ func NewRouterWithRuntimeInstallationIDAndOptions(
 		capabilities:                newCapabilityRegistry(cfg, fileUploads),
 		tailscalePathLookup:         defaultTailscaleNetworkPathLookup,
 		gatewayThreads:              map[string]appServerGatewayAllowedThread{},
+		gatewayActiveTurns:          map[string]appServerGatewayTurnAdmission{},
 		managedWorktrees:            map[string]managedWorktree{},
 		managedWorktreeCleanupPlans: map[string]worktreeCleanupPlan{},
 		managedWorktreePendingUses:  map[string]int{},

--- a/internal/setup/remote_gateway_token_test.go
+++ b/internal/setup/remote_gateway_token_test.go
@@ -1,0 +1,67 @@
+package setup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRepairAndRotateRemoteGatewayTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	raw := []byte(`{
+  "auth": {"token": "keep-agent-token"},
+  "future": {"keep": true},
+  "app_server": {
+    "transport": "ws",
+    "managed": true,
+    "listen": "ws://127.0.0.1:4222",
+    "ws_token_file": "/tmp/upstream-token",
+    "remote_gateway": {"enabled": true, "listen": "127.0.0.1:8788", "future": "keep"}
+  }
+}`)
+	if err := os.WriteFile(configPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tokenPath, repaired, err := RepairRemoteGatewayTokenFile(configPath)
+	if err != nil || !repaired || tokenPath == "" {
+		t.Fatalf("repair failed: path=%q repaired=%t err=%v", tokenPath, repaired, err)
+	}
+	info, err := os.Lstat(tokenPath)
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("token file invalid: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("token mode=%04o", info.Mode().Perm())
+	}
+	before, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotatedPath, err := RotateRemoteGatewayTokenFile(configPath)
+	if err != nil || rotatedPath != tokenPath {
+		t.Fatalf("rotate failed: path=%q err=%v", rotatedPath, err)
+	}
+	after, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) == string(after) {
+		t.Fatal("rotation must replace token")
+	}
+	updated, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if json.Unmarshal(updated, &document) != nil || document["future"] == nil {
+		t.Fatal("repair must preserve unknown top-level fields")
+	}
+	appServer := document["app_server"].(map[string]any)
+	remote := appServer["remote_gateway"].(map[string]any)
+	if remote["future"] != "keep" || remote["token_file"] != tokenPath {
+		t.Fatalf("remote config not preserved: %+v", remote)
+	}
+}

--- a/internal/setup/repair.go
+++ b/internal/setup/repair.go
@@ -29,6 +29,155 @@ func RepairManagedWSTokenFile(configPath string) (string, bool, error) {
 	return repairManagedWSTokenFile(configPath, nil)
 }
 
+// RepairRemoteGatewayTokenFile 只在 remote_gateway 已显式启用时补齐独立 token。
+// 它保留未知配置字段，并且不会让 SSH/CLI 入口复用外侧或 upstream 凭据。
+func RepairRemoteGatewayTokenFile(configPath string) (string, bool, error) {
+	cfgPath, err := resolveConfigPath(configPath)
+	if err != nil {
+		return "", false, err
+	}
+	info, err := os.Lstat(cfgPath)
+	if err != nil {
+		return "", false, fmt.Errorf("读取配置文件状态失败：%w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", false, fmt.Errorf("配置文件必须是 regular file，不能是目录或符号链接")
+	}
+	original, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return "", false, fmt.Errorf("读取配置文件失败：%w", err)
+	}
+	if err := config.RejectLegacyAppServerConfiguration(original); err != nil {
+		return "", false, err
+	}
+	document, appServer, remote, enabled, tokenPath, err := decodeRemoteGatewayForTokenRepair(original)
+	if err != nil || !enabled {
+		return "", false, err
+	}
+	if tokenPath != "" {
+		tokenInfo, statErr := os.Lstat(tokenPath)
+		switch {
+		case statErr == nil && !tokenInfo.Mode().IsRegular():
+			return "", false, fmt.Errorf("remote gateway token file 必须是 regular file，不能是目录或符号链接：%s", tokenPath)
+		case statErr == nil:
+			return tokenPath, false, nil
+		case !os.IsNotExist(statErr):
+			return "", false, fmt.Errorf("读取 remote gateway token file 状态失败：%w", statErr)
+		}
+	}
+
+	token, err := randomHex(32)
+	if err != nil {
+		return "", false, err
+	}
+	tokenPath, err = createPrivateNamedTokenFile(filepath.Dir(cfgPath), "remote-gateway-token-", token)
+	if err != nil {
+		return "", false, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tokenPath)
+		}
+	}()
+	encodedPath, err := json.Marshal(tokenPath)
+	if err != nil {
+		return "", false, fmt.Errorf("编码 remote gateway token file 路径失败：%w", err)
+	}
+	remote["token_file"] = encodedPath
+	encodedRemote, err := json.Marshal(remote)
+	if err != nil {
+		return "", false, fmt.Errorf("编码 app_server.remote_gateway 配置失败：%w", err)
+	}
+	appServer["remote_gateway"] = encodedRemote
+	encodedAppServer, err := json.Marshal(appServer)
+	if err != nil {
+		return "", false, fmt.Errorf("编码 app_server 配置失败：%w", err)
+	}
+	document["app_server"] = encodedAppServer
+	updated, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return "", false, fmt.Errorf("编码配置文件失败：%w", err)
+	}
+	if err := writePrivateFileAtomicallyCAS(cfgPath, original, append(updated, '\n')); err != nil {
+		return "", false, fmt.Errorf("原子更新配置文件失败：%w", err)
+	}
+	committed = true
+	return tokenPath, true, nil
+}
+
+// RotateRemoteGatewayTokenFile 原子替换 SSH/CLI token。handler 每次握手重新读文件，
+// 因此 rename 成功后旧 token 立即失效，不需要重启 agentd。
+func RotateRemoteGatewayTokenFile(configPath string) (string, error) {
+	cfgPath, err := resolveConfigPath(configPath)
+	if err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return "", fmt.Errorf("读取配置文件失败：%w", err)
+	}
+	_, _, _, enabled, tokenPath, err := decodeRemoteGatewayForTokenRepair(raw)
+	if err != nil {
+		return "", err
+	}
+	if !enabled {
+		return "", fmt.Errorf("app_server.remote_gateway 尚未启用")
+	}
+	if tokenPath == "" {
+		return "", fmt.Errorf("app_server.remote_gateway.token_file 为空；请先运行 agentd doctor --fix")
+	}
+	info, err := os.Lstat(tokenPath)
+	if err != nil {
+		return "", fmt.Errorf("读取 remote gateway token file 状态失败：%w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("remote gateway token file 必须是 regular file，不能是目录或符号链接")
+	}
+	token, err := randomHex(32)
+	if err != nil {
+		return "", err
+	}
+	if err := writePrivateFileAtomically(tokenPath, []byte(token+"\n")); err != nil {
+		return "", fmt.Errorf("原子轮换 remote gateway token 失败：%w", err)
+	}
+	return tokenPath, nil
+}
+
+func decodeRemoteGatewayForTokenRepair(raw []byte) (
+	map[string]json.RawMessage,
+	map[string]json.RawMessage,
+	map[string]json.RawMessage,
+	bool,
+	string,
+	error,
+) {
+	document, appServer, _, err := decodeConfigForTokenRepair(raw)
+	if err != nil {
+		return nil, nil, nil, false, "", err
+	}
+	remote := map[string]json.RawMessage{}
+	if encoded, ok := appServer["remote_gateway"]; ok && string(encoded) != "null" {
+		if err := json.Unmarshal(encoded, &remote); err != nil {
+			return nil, nil, nil, false, "", fmt.Errorf("解析 app_server.remote_gateway 失败：%w", err)
+		}
+	}
+	enabled := false
+	if encoded, ok := remote["enabled"]; ok {
+		if err := json.Unmarshal(encoded, &enabled); err != nil {
+			return nil, nil, nil, false, "", fmt.Errorf("解析 app_server.remote_gateway.enabled 失败：%w", err)
+		}
+	}
+	tokenPath := ""
+	if encoded, ok := remote["token_file"]; ok {
+		if err := json.Unmarshal(encoded, &tokenPath); err != nil {
+			return nil, nil, nil, false, "", fmt.Errorf("解析 app_server.remote_gateway.token_file 失败：%w", err)
+		}
+		tokenPath = strings.TrimSpace(tokenPath)
+	}
+	return document, appServer, remote, enabled, tokenPath, nil
+}
+
 func repairManagedWSTokenFile(configPath string, writeConfig configWriter) (string, bool, error) {
 	cfgPath, err := resolveConfigPath(configPath)
 	if err != nil {
@@ -141,7 +290,11 @@ func decodeConfigForTokenRepair(raw []byte) (map[string]json.RawMessage, map[str
 }
 
 func createPrivateTokenFile(dir string, token string) (string, error) {
-	path, err := stagePrivateFile(dir, "app-server-ws-token-", []byte(token+"\n"))
+	return createPrivateNamedTokenFile(dir, "app-server-ws-token-", token)
+}
+
+func createPrivateNamedTokenFile(dir string, pattern string, token string) (string, error) {
+	path, err := stagePrivateFile(dir, pattern, []byte(token+"\n"))
 	if err != nil {
 		return "", fmt.Errorf("创建 app-server token file 失败：%w", err)
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -153,6 +153,10 @@ func runWithFileOps(ctx context.Context, options Options, fileOps setupFileTrans
 			Managed:     true,
 			Listen:      appServerListen,
 			WSTokenFile: tokenFile,
+			RemoteGateway: config.RemoteGatewayConfig{
+				Enabled: false,
+				Listen:  config.DefaultRemoteGatewayListen(),
+			},
 		},
 		Codex: config.CodexConfig{
 			Bin:         defaultCodexBin(),


### PR DESCRIPTION
## 目标

在 MIM-206 的单一 managed Codex App Server 基础上，增加默认关闭、只监听 loopback 的 SSH/CLI WebSocket 入口。Codex CLI 通过 SSH 本地转发接入，与 Mimi 共享同一 App Server 进程。

Depends on #277

## 实现

- 增加独立 remote gateway listener、独立 token 文件、轮换命令和 Doctor 检查。
- remote CLI 使用显式最小白名单；拒绝配置写入、hooks、plugin、app、review、compact 和未知方法。
- 只允许 projects allowlist 或受管 worktree；不继承 browse_roots。
- config/account 响应按字段重建，阻止 MCP、环境变量、配置层和上游错误细节泄漏。
- Mimi 与 remote CLI 对同一线程共用原子 turn admission；不做超时猜测、重试或消息重放。
- 统一规范化 JSON-RPC request ID，防止跨方法响应错配和脱敏绕过。
- 增加中文 SSH 配置、连接、轮换和恢复文档。

## 验证

- go test ./internal/httpapi ./internal/config ./internal/doctor ./cmd/agentd -count=1
- go test -race ./internal/httpapi -run RemoteGateway\|RemoteCLI\|TurnAdmission\|RequestID -count=1
- go vet ./cmd/agentd ./internal/config ./internal/doctor ./internal/httpapi ./internal/setup
- Linux amd64 与 Windows amd64 agentd 编译通过
- bash ./scripts/check-source-size.sh
- git diff --check
- Codex CLI 0.149.1 经 localhost SSH -L 接入，发送“只回复 OK”并收到 OK

全量 go test ./... 仅命中 origin/main 可复现的既有 Claude 50ms timeout：TestProbeClaudeAuthStatusDoesNotTurnTimeoutIntoSignedOut。

## 已知边界

断线后若没有任何连接观察到明确 turn/completed，admission 保持 fail-closed，需重启 agentd 后接手。当前不使用 TTL 猜测，也不自动重放写请求。