### PR TITLE
MIM-125 统一侧边栏相邻项目头像展示

### DIFF
--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListPresentation.swift
@@ -418,15 +418,13 @@ enum SessionListPresentation {
         directoryTail(for: session)
     }
 
-    /// 仅在运行中和刚完成分区将相邻的同项目视为一组；返回 true 代表当前行是组头。
+    /// 侧边栏各分区都将相邻的同项目视为一组；返回 true 代表当前行是组头。
     /// 缺少项目 ID 时不合并，避免把不同的未知项目误当成一组。
     static func startsSidebarProjectGroup(
         for session: AgentSession,
-        previousSession: AgentSession?,
-        in kind: SessionSidebarSectionKind
+        previousSession: AgentSession?
     ) -> Bool {
-        guard kind == .running || kind == .justCompleted,
-              let previousSession,
+        guard let previousSession,
               !session.projectID.isEmpty else {
             return true
         }

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -858,8 +858,7 @@ struct UnifiedWorkbenchShell: View {
                             kind: section.kind,
                             startsProjectGroup: SessionListPresentation.startsSidebarProjectGroup(
                                 for: session,
-                                previousSession: index > 0 ? section.sessions[index - 1] : nil,
-                                in: section.kind
+                                previousSession: index > 0 ? section.sessions[index - 1] : nil
                             ),
                             layout: layout
                         )
@@ -986,7 +985,7 @@ struct UnifiedWorkbenchShell: View {
             isSelected: navigationState.selection == .session(session.id),
             isRecentlyCompleted: sidebarHighlightCoordinator.highlightedSessionID == session.id,
             completionObservedAt: sessionStore.historyCompletionObservedAtBySessionID[session.id],
-            // 运行组头承担状态和项目身份；后续同项目行隐藏标记，Row 固定占位保持标题对齐。
+            // 各分区只在组头显示项目头像；运行分区同时隐藏后续同项目的重复状态菊花。
             showsStateMarker: kind != .running || startsProjectGroup,
             projectIcon: startsProjectGroup
                 ? sidebarProjectIcons[session.projectID]

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
@@ -506,7 +506,7 @@ final class SessionListPresentationTests: XCTestCase {
         XCTAssertEqual(sections[0].overflowCount, 0)
     }
 
-    func testSidebarUsesOneGroupHeaderForAdjacentProjectsInRunningAndJustCompleted() {
+    func testSidebarUsesOneProjectAvatarForAdjacentSessions() {
         let first = makeSession(id: "project-a-first", projectID: "project-a")
         let adjacentSameProject = makeSession(id: "project-a-second", projectID: "project-a")
         let differentProject = makeSession(id: "project-b", projectID: "project-b")
@@ -516,60 +516,33 @@ final class SessionListPresentationTests: XCTestCase {
         XCTAssertTrue(
             SessionListPresentation.startsSidebarProjectGroup(
                 for: first,
-                previousSession: nil,
-                in: .running
+                previousSession: nil
             )
         )
         XCTAssertFalse(
             SessionListPresentation.startsSidebarProjectGroup(
                 for: adjacentSameProject,
-                previousSession: first,
-                in: .running
+                previousSession: first
             ),
-            "运行中的相邻同项目只在第一行展示菊花和头像"
-        )
-        XCTAssertFalse(
-            SessionListPresentation.startsSidebarProjectGroup(
-                for: adjacentSameProject,
-                previousSession: first,
-                in: .justCompleted
-            ),
-            "刚完成的相邻同项目也应合并头像"
+            "各分区的相邻同项目会话都只在第一行展示头像"
         )
         XCTAssertTrue(
             SessionListPresentation.startsSidebarProjectGroup(
                 for: differentProject,
-                previousSession: adjacentSameProject,
-                in: .running
+                previousSession: adjacentSameProject
             )
         )
         XCTAssertTrue(
             SessionListPresentation.startsSidebarProjectGroup(
                 for: separatedSameProject,
-                previousSession: differentProject,
-                in: .running
+                previousSession: differentProject
             ),
             "同项目被其他项目隔开后要重新展示头像"
         )
-        for kind in [
-            SessionSidebarSectionKind.needYou,
-            .pinned,
-            .recent,
-        ] {
-            XCTAssertTrue(
-                SessionListPresentation.startsSidebarProjectGroup(
-                    for: adjacentSameProject,
-                    previousSession: first,
-                    in: kind
-                ),
-                "\(kind.rawValue) 不在本次合并范围，仍应逐行展示项目身份"
-            )
-        }
         XCTAssertTrue(
             SessionListPresentation.startsSidebarProjectGroup(
                 for: missingProject,
-                previousSession: missingProject,
-                in: .running
+                previousSession: missingProject
             ),
             "缺少项目 ID 时不能把未知会话误合并"
         )


### PR DESCRIPTION
## 变更

- 侧边栏各分区统一按相邻 projectID 判断头像分组
- 同项目连续会话仅首行显示头像；项目切换、间隔后再次出现或缺少 projectID 时显示头像
- 增加相邻、切换、间隔和缺失项目标识的回归测试

## 验证

- iPad mini 真机构建、安装、启动成功，用户目视验收通过
- 变基到 origin/main 后运行 SessionListPresentationTests：25/25 通过
- bash ./scripts/check-source-size.sh：通过
- git diff --check origin/main...HEAD：通过

Linear: MIM-125