### PR TITLE
MIM-158 Fix shared App Server resource lifecycle

### DIFF
--- a/docs/shared-ssh-app-server.md
+++ b/docs/shared-ssh-app-server.md
@@ -54,9 +54,17 @@ agentd status
 agentd 先通过 SSH 打开 `codex app-server proxy` 并执行真实 WebSocket 初始化。若默认 Unix Socket 尚未提供服务，agentd 才通过同一个 SSH 目标后台启动：
 
 ```bash
+open_file_limit=$(ulimit -Sn)
+if test "$open_file_limit" != unlimited && test "$open_file_limit" -lt 8192; then
+  ulimit -Sn 8192
+fi
 CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1 \
   codex -c features.code_mode_host=true app-server --listen unix://
 ```
+
+SSH 登录在 macOS 上的 open-file soft limit 通常只有 256。agentd 启动新 resident 前会读取当前值；低于 8192 时先提高到 8192，无法提高时拒绝启动。它不会降低已经更高的限制。
+
+这个容量余量不能替代订阅释放。App Server 会为每个已加载 Thread 保留 session 和 MCP 资源；取消最后一个订阅后，官方实现仍有 30 分钟无活动宽限期，之后才卸载 Thread。
 
 这个 App Server 只接受 Unix Socket 上的 SSH proxy 连接。启动命令会关闭它的 Remote Control 注册，防止它继承 Desktop 已保存的同一套服务端身份。ChatGPT 移动端和 Desktop 普通 “This Mac” 模式继续连接官方 App Server，不会被 SSH resident 接管。
 
@@ -69,6 +77,7 @@ agentd 或单条 Mimi WebSocket 退出时只关闭对应 SSH proxy，不停止�
 ## 会话和消息规则
 
 - `thread/start` 创建 Thread，`thread/resume` 订阅和接续现有 Thread。
+- Mimi 在同一个 Thread 的最后一个本地事件观察者离开时发送 `thread/unsubscribe`。同一 Thread 有多个观察者时，只由最后一个离开的观察者退订。物理连接异常结束时不为退订重新建立连接；App Server 会清理断开连接上的订阅。
 - Mimi 的普通消息只使用 `thread/queue/add`。运行中的 Thread 会在 App Server 内排队，空闲后自动开始，不会被误解释成 `turn/steer`。
 - 同一个 Thread 同时最多有一条由 Mimi 提交、尚未开始的服务端队列消息。下一条继续保留在 Mimi 本地，避免后一次线程设置覆盖前一条尚未开始的消息。
 - 发送结果不确定时，Mimi 使用相同的 `clientUserMessageId` 完整分页查询 `thread/queue/list` 和 `thread/items/list`，并在两者切换的竞态窗口再次查询队列。找不到记录时保留待发送状态，由用户确认是否重试。
@@ -92,6 +101,16 @@ agentd status --json
 ps -axo pid,ppid,command | grep '[c]odex.*app-server'
 lsof -U | grep app-server-control.sock
 ```
+
+升级到包含 open-file 修复的版本后，已经运行的 resident 不会自动获得新限制。先结束所有共享 Thread 的活动 Turn，并关闭对应的 Mimi 和 SSH Desktop 页面。然后核对并重启唯一的 Unix resident：
+
+```bash
+ps -axo pid=,ppid=,command= | grep '[c]odex.*app-server --listen unix://'
+kill -TERM <上一步确认的-resident-pid>
+agentd doctor
+```
+
+不要对模糊的 `pgrep codex` 结果批量执行 `kill`。普通 “This Mac”、OpenClaw 和共享 SSH resident 可能同时存在。
 
 验收至少覆盖：Mimi-first、远程 Desktop-first、本机 Desktop-first、并发排队、审批首响应、agentd 重启和分页历史。验收前后分别记录 OpenClaw 的 App Server PID；二者必须保持不变。
 

--- a/internal/appserver/ssh.go
+++ b/internal/appserver/ssh.go
@@ -1,7 +1,6 @@
 package appserver
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -27,9 +26,13 @@ const (
 	MinimumCodexVersion        = "0.149.1"
 
 	sshProxyRemoteCommand = "codex app-server proxy"
+	// App Server 会为仍处于加载宽限期的 Thread 保留 session 和 MCP 文件描述符。
+	// SSH 登录在 macOS 上默认只有 256，无法承载 Desktop 与 Mimi 的正常并发恢复。
+	// 这里保证新 resident 至少有 8192；客户端仍必须按生命周期取消 Thread 订阅。
+	sshAppServerOpenFileSoftLimit = 8192
 	// SSH resident 只服务 Unix proxy。禁止它继承 Desktop 保存的 Remote Control
 	// 身份，否则移动端请求可能进入第二个 App Server，并与官方进程争用 Thread writer。
-	sshBootstrapRemoteCommand = "nohup env CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1 codex -c features.code_mode_host=true app-server --listen unix:// >/dev/null 2>&1 </dev/null &"
+	sshBootstrapRemoteCommand = `/bin/sh -c 'open_file_limit=$(ulimit -Sn); if test "$open_file_limit" != unlimited && test "$open_file_limit" -lt 8192; then ulimit -Sn 8192 || { printf "远端 open-file soft limit 无法提高到 8192\n" >&2; exit 72; }; fi; nohup env CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1 codex -c features.code_mode_host=true app-server --listen unix:// >/dev/null 2>&1 </dev/null &'`
 	sshSocketStateCommand     = `if test -S "$HOME/.codex/app-server-control/app-server-control.sock"; then printf socket-present; else printf socket-missing; fi`
 
 	defaultSSHReadyTimeout     = 12 * time.Second
@@ -246,8 +249,8 @@ func (t *SSHTransport) bootstrap(ctx context.Context) error {
 	cmd.Env = buildManagedEnv(nil)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		if len(bytes.TrimSpace(output)) > 0 {
-			return fmt.Errorf("SSH bootstrap 失败：%w", err)
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return fmt.Errorf("SSH bootstrap 失败：%s：%w", detail, err)
 		}
 		return err
 	}

--- a/internal/appserver/ssh_test.go
+++ b/internal/appserver/ssh_test.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -92,6 +94,77 @@ func TestSSHBootstrapAloneDisablesPersistedRemoteControl(t *testing.T) {
 	}
 	if strings.Contains(sshProxyRemoteCommand, remoteControlEnv) {
 		t.Fatalf("SSH proxy 不应覆盖官方 environment identity：%s", sshProxyRemoteCommand)
+	}
+}
+
+func TestSSHBootstrapGuaranteesOpenFileCapacityBeforeStartingResident(t *testing.T) {
+	limitCheck := "ulimit -Sn"
+	limitRaise := fmt.Sprintf("ulimit -Sn %d", sshAppServerOpenFileSoftLimit)
+	residentStart := "nohup env"
+	for _, required := range []string{limitCheck, limitRaise, residentStart} {
+		if !strings.Contains(sshBootstrapRemoteCommand, required) {
+			t.Fatalf("bootstrap 缺少 %q：%s", required, sshBootstrapRemoteCommand)
+		}
+	}
+	if strings.Index(sshBootstrapRemoteCommand, limitCheck) > strings.Index(sshBootstrapRemoteCommand, residentStart) ||
+		strings.Index(sshBootstrapRemoteCommand, limitRaise) > strings.Index(sshBootstrapRemoteCommand, residentStart) {
+		t.Fatalf("必须在启动 resident 前确认 open-file soft limit：%s", sshBootstrapRemoteCommand)
+	}
+	if strings.Contains(sshBootstrapRemoteCommand, limitRaise+" || true") {
+		t.Fatalf("无法提高 open-file soft limit 时必须阻止低上限 resident 启动：%s", sshBootstrapRemoteCommand)
+	}
+}
+
+func TestSSHBootstrapResidentInheritsRaisedOpenFileLimit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SSH Unix resident 只在 Unix 主机启动")
+	}
+	hardOutput, err := exec.Command("/bin/sh", "-c", "ulimit -Hn").Output()
+	if err != nil {
+		t.Fatalf("读取测试 shell hard limit：%v", err)
+	}
+	hardLimit := strings.TrimSpace(string(hardOutput))
+	if hardLimit != "unlimited" {
+		value, parseErr := strconv.Atoi(hardLimit)
+		if parseErr != nil {
+			t.Fatalf("解析测试 shell hard limit %q：%v", hardLimit, parseErr)
+		}
+		if value < sshAppServerOpenFileSoftLimit {
+			t.Skipf("测试环境 hard limit %d 低于 resident 要求 %d", value, sshAppServerOpenFileSoftLimit)
+		}
+	}
+
+	directory := t.TempDir()
+	marker := filepath.Join(directory, "resident-limit")
+	fakeCodex := filepath.Join(directory, "codex")
+	if err := os.WriteFile(fakeCodex, []byte("#!/bin/sh\nulimit -Sn > \"$MIMI_BOOTSTRAP_LIMIT_MARKER\"\n"), 0o755); err != nil {
+		t.Fatalf("创建 fake codex：%v", err)
+	}
+	t.Setenv("MIMI_BOOTSTRAP_LIMIT_MARKER", marker)
+	t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+	command := exec.Command("/bin/sh", "-c", "ulimit -Sn 256; "+sshBootstrapRemoteCommand)
+	command.Env = os.Environ()
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("执行 bootstrap shell：%v，output=%s", err, strings.TrimSpace(string(output)))
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		output, readErr := os.ReadFile(marker)
+		if readErr == nil {
+			limit, parseErr := strconv.Atoi(strings.TrimSpace(string(output)))
+			if parseErr != nil || limit < sshAppServerOpenFileSoftLimit {
+				t.Fatalf("resident 继承的 open-file soft limit=%q，至少应为 %d", strings.TrimSpace(string(output)), sshAppServerOpenFileSoftLimit)
+			}
+			break
+		}
+		if !errors.Is(readErr, os.ErrNotExist) {
+			t.Fatalf("读取 resident limit marker：%v", readErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fake resident 未写入 open-file soft limit")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -833,6 +833,9 @@ actor CodexAppServerSessionRuntime {
             contextsBySessionID.removeValue(forKey: id)
             pendingTurnStartObservationsBySessionID.removeValue(forKey: id)
             threadSubscriptionLeaseBySessionID.removeValue(forKey: id)
+            cancelThreadResumeTask(sessionID: id)
+            threadsResumedOnConnection.remove(id)
+            finishAttachedEventStreams(sessionID: id)
         }
     }
 
@@ -851,9 +854,13 @@ actor CodexAppServerSessionRuntime {
     }
 
     @discardableResult
-    func unsubscribeThread(threadID: SessionID) async throws -> CodexAppServerThreadUnsubscribeStatus? {
+    func unsubscribeThread(
+        threadID: SessionID,
+        usingExistingConnectionOnly: Bool = false
+    ) async throws -> CodexAppServerThreadUnsubscribeStatus? {
         let hadResumeBinding = threadsResumedOnConnection.contains(threadID)
             || threadResumeTasksBySessionID[threadID] != nil
+        let existingConnection = connection
         let lease = replaceThreadSubscriptionLease(sessionID: threadID, wantsEvents: false)
         cancelThreadResumeTask(sessionID: threadID)
         // 在 RPC 发出前先清本地标记。若用户随即重新打开，新的 connectForEvents 必须真的
@@ -870,9 +877,21 @@ actor CodexAppServerSessionRuntime {
         }
         let result: CodexAppServerJSONValue?
         do {
-            result = try await sendRecoveringFromStaleInitialization(
-                builder.threadUnsubscribe(threadID: threadID)
-            )
+            let request = builder.threadUnsubscribe(threadID: threadID)
+            if usingExistingConnectionOnly {
+                // 页面离开时的自动退订不能为了清理 listener 复活已经断开的物理连接。
+                // notification pump 可能尚未来得及执行 producer finish，因此这里同时核对
+                // 连接代次与 readiness；失败就保留本地 false lease，等待正常业务连接恢复。
+                guard let existingConnection,
+                      connection === existingConnection,
+                      await existingConnection.isReadyForRequests()
+                else {
+                    return nil
+                }
+                result = try await existingConnection.send(request)
+            } else {
+                result = try await sendRecoveringFromStaleInitialization(request)
+            }
         } catch {
             // timeout 可能表示服务端已经执行退订、只是 ACK 丢失；若这时已经有更新一代
             // 订阅，仍需 best-effort 恢复，不能把不确定结果留成静默断流。
@@ -2714,11 +2733,27 @@ actor CodexAppServerSessionRuntime {
         defaults.set(String(sequence), forKey: key)
     }
 
-    func detachEvents(sessionID: SessionID, token: UUID) {
-        eventMailboxesBySessionID[sessionID]?.removeValue(forKey: token)
-        if eventMailboxesBySessionID[sessionID]?.isEmpty == true {
-            eventMailboxesBySessionID.removeValue(forKey: sessionID)
+    func detachEvents(sessionID: SessionID, token: UUID) async {
+        guard eventMailboxesBySessionID[sessionID]?.removeValue(forKey: token) != nil else {
+            // producer 结束会先整体移除邮箱。随后消费者 defer 中的 cancel 不能再发起 RPC，
+            // 否则一次物理断线会被误判成用户离开，并在重连窗口创建新连接只为退订。
+            return
         }
+        guard eventMailboxesBySessionID[sessionID]?.isEmpty == true else {
+            return
+        }
+        eventMailboxesBySessionID.removeValue(forKey: sessionID)
+        // Claude bridge 没有 thread/unsubscribe 协议。保持它原有的连接生命周期，
+        // 避免页面离开时向 gateway 发送必然被策略拒绝的 Codex 专用请求。
+        guard runtimeProvider == "codex" else {
+            return
+        }
+        // 页面和后台队列可能同时观察同一 thread。只有最后一个主动观察者离开时才释放
+        // app-server listener；RPC 失败不影响本地 stream 收尾，连接恢复后仍以新 lease 为准。
+        _ = try? await unsubscribeThread(
+            threadID: sessionID,
+            usingExistingConnectionOnly: true
+        )
     }
 
     func ensureConfig(forceRefresh: Bool = false) async throws -> CodexAppServerConfigResponse {
@@ -2882,6 +2917,13 @@ actor CodexAppServerSessionRuntime {
     func finishAttachedEventStreams() {
         let mailboxes = eventMailboxesBySessionID.values.flatMap { $0.values }
         eventMailboxesBySessionID.removeAll(keepingCapacity: true)
+        for mailbox in mailboxes {
+            mailbox.finishFromProducer()
+        }
+    }
+
+    func finishAttachedEventStreams(sessionID: SessionID) {
+        let mailboxes = eventMailboxesBySessionID.removeValue(forKey: sessionID)?.values ?? [:].values
         for mailbox in mailboxes {
             mailbox.finishFromProducer()
         }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -91,6 +91,11 @@ struct CodexAppServerThreadSubscriptionLease: Equatable {
     let wantsEvents: Bool
 }
 
+struct CodexAppServerThreadUnsubscribeRetryTask {
+    let token: UUID
+    let task: Task<Void, Never>
+}
+
 struct CodexAppServerTurnInterruptRecoveryTask {
     let turnID: TurnID
     let token: UUID
@@ -154,6 +159,9 @@ actor CodexAppServerSessionRuntime {
     // unsubscribe 是后台 best-effort RPC，响应可能晚于同一 thread 的新 connectForEvents。
     // 每次订阅意图都换代；迟到退订只能作用于自己的 lease，不能覆盖更新一代的监听。
     var threadSubscriptionLeaseBySessionID: [SessionID: CodexAppServerThreadSubscriptionLease] = [:]
+    // 最后一个观察者离开时，unsubscribe 可能超时或暂时失败。失败状态必须绑定原连接保留并重试；
+    // 新观察者、归档或连接退役会取消任务，且清理任务绝不为退订单独建立新连接。
+    var threadUnsubscribeRetryTasksBySessionID: [SessionID: CodexAppServerThreadUnsubscribeRetryTask] = [:]
     var bufferedEventsBySessionID: [SessionID: [AgentEvent]] = [:]
     var eventMailboxesBySessionID: [
         SessionID: [UUID: CodexAppServerEventMailbox]
@@ -242,6 +250,7 @@ actor CodexAppServerSessionRuntime {
         rateLimitRefreshTask?.cancel()
         accountTokenUsageRefreshTask?.cancel()
         threadResumeTasksBySessionID.values.forEach { $0.task.cancel() }
+        threadUnsubscribeRetryTasksBySessionID.values.forEach { $0.task.cancel() }
         turnInterruptRecoveryTasksBySessionID.values.forEach { $0.task.cancel() }
     }
 
@@ -833,6 +842,7 @@ actor CodexAppServerSessionRuntime {
             contextsBySessionID.removeValue(forKey: id)
             pendingTurnStartObservationsBySessionID.removeValue(forKey: id)
             threadSubscriptionLeaseBySessionID.removeValue(forKey: id)
+            cancelThreadUnsubscribeRetryTask(sessionID: id)
             cancelThreadResumeTask(sessionID: id)
             threadsResumedOnConnection.remove(id)
             finishAttachedEventStreams(sessionID: id)
@@ -899,6 +909,14 @@ actor CodexAppServerSessionRuntime {
                 try? await reassertThreadSubscriptionIfNeeded(
                     sessionID: threadID,
                     supersededLease: lease
+                )
+            } else if usingExistingConnectionOnly,
+                      let existingConnection,
+                      connection === existingConnection {
+                scheduleThreadUnsubscribeRetry(
+                    sessionID: threadID,
+                    lease: lease,
+                    connection: existingConnection
                 )
             }
             throw error
@@ -1877,6 +1895,9 @@ actor CodexAppServerSessionRuntime {
         sessionID: SessionID,
         wantsEvents: Bool
     ) -> CodexAppServerThreadSubscriptionLease {
+        if wantsEvents {
+            cancelThreadUnsubscribeRetryTask(sessionID: sessionID)
+        }
         let generation = (threadSubscriptionLeaseBySessionID[sessionID]?.generation ?? 0) &+ 1
         let lease = CodexAppServerThreadSubscriptionLease(
             generation: generation,
@@ -1884,6 +1905,96 @@ actor CodexAppServerSessionRuntime {
         )
         threadSubscriptionLeaseBySessionID[sessionID] = lease
         return lease
+    }
+
+    func cancelThreadUnsubscribeRetryTask(sessionID: SessionID) {
+        threadUnsubscribeRetryTasksBySessionID.removeValue(forKey: sessionID)?.task.cancel()
+    }
+
+    func scheduleThreadUnsubscribeRetry(
+        sessionID: SessionID,
+        lease: CodexAppServerThreadSubscriptionLease,
+        connection retryConnection: CodexAppServerConnection
+    ) {
+        guard threadUnsubscribeRetryTasksBySessionID[sessionID] == nil else {
+            return
+        }
+        let token = UUID()
+        let task = Task { [weak self] in
+            var delayNanoseconds: UInt64 = 250_000_000
+            while !Task.isCancelled {
+                await Task.yield()
+                let completed = await self?.retryThreadUnsubscribe(
+                    sessionID: sessionID,
+                    lease: lease,
+                    connection: retryConnection,
+                    token: token
+                ) ?? true
+                if completed {
+                    await self?.clearThreadUnsubscribeRetryTask(sessionID: sessionID, token: token)
+                    return
+                }
+                do {
+                    try await Task.sleep(nanoseconds: delayNanoseconds)
+                } catch {
+                    return
+                }
+                delayNanoseconds = min(delayNanoseconds * 2, 5_000_000_000)
+            }
+        }
+        threadUnsubscribeRetryTasksBySessionID[sessionID] = .init(token: token, task: task)
+    }
+
+    // 返回 true 表示不再需要重试。false 只用于同一连接仍可用但 RPC 暂时失败的情况。
+    func retryThreadUnsubscribe(
+        sessionID: SessionID,
+        lease: CodexAppServerThreadSubscriptionLease,
+        connection retryConnection: CodexAppServerConnection,
+        token: UUID
+    ) async -> Bool {
+        guard threadSubscriptionLeaseBySessionID[sessionID] == lease,
+              eventMailboxesBySessionID[sessionID]?.isEmpty != false,
+              connection === retryConnection,
+              await retryConnection.isReadyForRequests()
+        else {
+            clearThreadUnsubscribeRetryTask(sessionID: sessionID, token: token)
+            return true
+        }
+        do {
+            let builder = CodexAppServerRequestBuilder(allowlistedProjects: try await projects())
+            guard threadSubscriptionLeaseBySessionID[sessionID] == lease else {
+                return true
+            }
+            _ = try await retryConnection.send(builder.threadUnsubscribe(threadID: sessionID))
+            if threadSubscriptionLeaseBySessionID[sessionID] == lease {
+                threadsResumedOnConnection.remove(sessionID)
+            } else {
+                try await reassertThreadSubscriptionIfNeeded(
+                    sessionID: sessionID,
+                    supersededLease: lease
+                )
+            }
+            clearThreadUnsubscribeRetryTask(sessionID: sessionID, token: token)
+            return true
+        } catch {
+            guard threadSubscriptionLeaseBySessionID[sessionID] == lease,
+                  connection === retryConnection else {
+                clearThreadUnsubscribeRetryTask(sessionID: sessionID, token: token)
+                return true
+            }
+            let connectionEnded = !(await retryConnection.isReadyForRequests())
+            if connectionEnded {
+                clearThreadUnsubscribeRetryTask(sessionID: sessionID, token: token)
+            }
+            return connectionEnded
+        }
+    }
+
+    func clearThreadUnsubscribeRetryTask(sessionID: SessionID, token: UUID) {
+        guard threadUnsubscribeRetryTasksBySessionID[sessionID]?.token == token else {
+            return
+        }
+        threadUnsubscribeRetryTasksBySessionID.removeValue(forKey: sessionID)
     }
 
     func reassertThreadSubscriptionIfNeeded(
@@ -2903,6 +3014,8 @@ actor CodexAppServerSessionRuntime {
         cancelThreadResumeTasks(for: endedConnection)
         connection = nil
         threadsResumedOnConnection.removeAll(keepingCapacity: true)
+        threadUnsubscribeRetryTasksBySessionID.values.forEach { $0.task.cancel() }
+        threadUnsubscribeRetryTasksBySessionID.removeAll(keepingCapacity: true)
         let affected = clearAllPendingServerRequests()
         for sessionID in affected.approvalSessionIDs {
             emitApprovalResolved(sessionID: sessionID)

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -870,6 +870,7 @@ actor CodexAppServerSessionRuntime {
     ) async throws -> CodexAppServerThreadUnsubscribeStatus? {
         let hadResumeBinding = threadsResumedOnConnection.contains(threadID)
             || threadResumeTasksBySessionID[threadID] != nil
+            || threadUnsubscribeRetryTasksBySessionID[threadID] != nil
         let existingConnection = connection
         let lease = replaceThreadSubscriptionLease(sessionID: threadID, wantsEvents: false)
         cancelThreadResumeTask(sessionID: threadID)
@@ -1895,9 +1896,9 @@ actor CodexAppServerSessionRuntime {
         sessionID: SessionID,
         wantsEvents: Bool
     ) -> CodexAppServerThreadSubscriptionLease {
-        if wantsEvents {
-            cancelThreadUnsubscribeRetryTask(sessionID: sessionID)
-        }
+        // false→false 也代表更新一代清理意图。先移除旧任务占位，避免旧任务因 lease
+        // 不匹配退出后，新一代失败退订无法安装自己的重试任务。
+        cancelThreadUnsubscribeRetryTask(sessionID: sessionID)
         let generation = (threadSubscriptionLeaseBySessionID[sessionID]?.generation ?? 0) &+ 1
         let lease = CodexAppServerThreadSubscriptionLease(
             generation: generation,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -971,7 +971,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(secondRequests.filter { $0.method == "turn/start" }.count, 1)
     }
 
-    func testDirectRuntimeRecoversPendingUserInputAfterForegroundReconnectWithoutColdStart() async throws {
+    func testDirectRuntimeReplaysPendingUserInputToAdditionalObserverWithoutColdStart() async throws {
         let project = AgentProject(id: "proj_pending_input_recovery", name: "Pending Input Recovery", path: "/tmp/pending-input-recovery")
         let transport = FakeCodexAppServerTransport()
         let runtime = CodexAppServerSessionRuntime(
@@ -1022,21 +1022,8 @@ extension ConversationDataFlowTests {
         }
         XCTAssertEqual(statuses.filter { $0 == .connected }.count, 1)
 
-        // 模拟 App 进后台后页面订阅被取消，底层 runtime/gateway 连接仍在。
-        // 此时重连必须再发 thread/resume，不能被“已 resume”的本地标记短路。
-        socket.disconnect()
-        let beforeRecoveryConnect = await transport.sentMessages().count
-        socket.connect(sessionID: "thr_pending_input_recovery", replayBufferedEvents: false)
-        let recoveryResume = try await waitForFakeAppServerRequest(
-            transport,
-            method: "thread/resume",
-            after: beforeRecoveryConnect
-        )
-        transportResponse(
-            transport,
-            id: recoveryResume.id,
-            result: #"{"thread":{"id":"thr_pending_input_recovery","sessionId":"thr_pending_input_recovery","preview":"等待补充信息","ephemeral":false,"modelProvider":"openai","createdAt":1780491200,"updatedAt":1780491203,"status":{"type":"active","activeFlags":["waitingOnUserInput"]},"path":null,"cwd":"/tmp/pending-input-recovery","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"等待补充信息","turns":[{"id":"turn_pending_input_recovery","status":"inProgress","items":[]}]}}"#
-        )
+        // runtime 已收到 server request 后，新页面观察者应直接补放完整问题，
+        // 无需冷启动或重复 thread/resume。
         transport.enqueue(#"{"id":701,"method":"item/tool/requestUserInput","params":{"threadId":"thr_pending_input_recovery","turnId":"turn_pending_input_recovery","itemId":"input_pending_recovery","questions":[{"id":"strategy","header":"策略","question":"期望怎么处理？","isOther":true,"isSecret":false,"options":[{"label":"确认并发送","description":"保留当前文本"}]}]}}"#)
         for _ in 0..<200 where !events.contains(where: {
             if case .userInputRequest(let request, _) = $0 {
@@ -1054,41 +1041,50 @@ extension ConversationDataFlowTests {
             return false
         })
 
-        // 再次切换会话时，runtime 已保有未处理请求；新页面应直接补放该请求，
-        // 无需冷启动，也无需第三次 thread/resume。
-        let userInputEventCount = events.filter {
-            if case .userInputRequest(let request, _) = $0 {
-                return request.id == "input_pending_recovery"
-            }
-            return false
-        }.count
-        socket.disconnect()
-        let beforeKnownRequestReconnect = await transport.sentMessages().count
-        socket.connect(sessionID: "thr_pending_input_recovery", replayBufferedEvents: false)
-        for _ in 0..<200 where events.filter({
-            if case .userInputRequest(let request, _) = $0 {
-                return request.id == "input_pending_recovery"
-            }
-            return false
-        }).count <= userInputEventCount {
-            try await Task.sleep(nanoseconds: 10_000_000)
-        }
-        XCTAssertGreaterThan(
-            events.filter {
-                if case .userInputRequest(let request, _) = $0 {
-                    return request.id == "input_pending_recovery"
-                }
-                return false
-            }.count,
-            userInputEventCount
+        // runtime 已保有未处理请求时，新前台页面可与后台观察者并存，并直接补放请求。
+        // 第二个观察者不能重复 resume，也不能触发冷启动。
+        let replayEvents = await runtime.attachEvents(
+            sessionID: "thr_pending_input_recovery",
+            replayPolicy: .stateOnly
         )
+        let beforeKnownRequestReconnect = await transport.sentMessages().count
+        try await runtime.connectForEvents(sessionID: "thr_pending_input_recovery")
+        var replayIterator = replayEvents.makeAsyncIterator()
+        let replayedEvent = await replayIterator.next()
+        guard case .some(.userInputRequest(let replayedRequest, let replayedMetadata)) = replayedEvent else {
+            return XCTFail("第二 observer 应直接重放 pending user input")
+        }
+        XCTAssertEqual(replayedRequest.id, "input_pending_recovery")
+        XCTAssertEqual(replayedMetadata.sessionID, "thr_pending_input_recovery")
         let messagesAfterKnownRequestReconnect = await transport.sentMessages()
         let reconnectRequests = messagesAfterKnownRequestReconnect
             .dropFirst(beforeKnownRequestReconnect)
             .compactMap { try? decodeAppServerRequest($0) }
-        XCTAssertFalse(reconnectRequests.contains { $0.method == "thread/resume" })
+        XCTAssertEqual(reconnectRequests.filter { $0.method == "thread/resume" }.count, 0)
+        XCTAssertEqual(reconnectRequests.filter { $0.method == "initialize" }.count, 0)
 
+        let beforeReplayDisconnect = await transport.sentMessages().count
+        replayEvents.cancel()
+        for _ in 0..<200 {
+            if await runtime.eventMailboxesBySessionID["thr_pending_input_recovery"]?.count == 1 {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let messagesAfterReplayDisconnect = await transport.sentMessages()
+        let replayDisconnectRequests = messagesAfterReplayDisconnect
+            .dropFirst(beforeReplayDisconnect)
+            .compactMap { try? decodeAppServerRequest($0) }
+        XCTAssertEqual(replayDisconnectRequests.filter { $0.method == "thread/unsubscribe" }.count, 0)
+
+        let beforeFinalDisconnect = await transport.sentMessages().count
         socket.disconnect()
+        let finalUnsubscribe = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/unsubscribe",
+            after: beforeFinalDisconnect
+        )
+        transportResponse(transport, id: finalUnsubscribe.id, result: #"{"status":"unsubscribed"}"#)
     }
 
     func testCodexAppServerSessionWebSocketReportsDisconnectedAfterTransportReceiveFailure() async throws {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
@@ -457,6 +457,82 @@ extension ConversationDataFlowTests {
         reopenedEvents.cancel()
     }
 
+    func testNewFalseLeaseReplacesOlderUnsubscribeRetry() async throws {
+        let project = AgentProject(id: "proj_replace_retry", name: "Replace Retry", path: "/tmp/replace-retry")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "thread/list", "thread/resume", "thread/unsubscribe"]
+                )
+            }
+        )
+        let threadID = "thr_replace_retry"
+        let thread = #"{"id":"thr_replace_retry","sessionId":"thr_replace_retry","preview":"替换重试","ephemeral":false,"modelProvider":"openai","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/replace-retry","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"替换重试","turns":[]}"#
+        let pageTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let list = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: list.id, result: #"{"data":[\#(thread)],"nextCursor":null}"#)
+        _ = try await pageTask.value
+        let connect = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let resume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 2)
+        transportResponse(transport, id: resume.id, result: #"{"thread":\#(thread)}"#)
+        try await connect.value
+
+        let firstCleanup = Task {
+            try await runtime.unsubscribeThread(threadID: threadID, usingExistingConnectionOnly: true)
+        }
+        let first = try await waitForFakeAppServerRequest(transport, method: "thread/unsubscribe", after: 3)
+        let messagesAfterFirst = await transport.sentMessages().count
+        transportErrorResponse(transport, id: first.id, code: -32603, message: "first failure")
+        do {
+            _ = try await firstCleanup.value
+            XCTFail("首次退订应失败")
+        } catch {}
+        let oldRetry = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/unsubscribe",
+            after: messagesAfterFirst
+        )
+        transportErrorResponse(transport, id: oldRetry.id, code: -32603, message: "old retry failure")
+
+        let messagesBeforeNewLease = await transport.sentMessages().count
+        let secondCleanup = Task {
+            try await runtime.unsubscribeThread(threadID: threadID, usingExistingConnectionOnly: true)
+        }
+        let second = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/unsubscribe",
+            after: messagesBeforeNewLease
+        )
+        let messagesAfterSecond = await transport.sentMessages().count
+        transportErrorResponse(transport, id: second.id, code: -32603, message: "second failure")
+        do {
+            _ = try await secondCleanup.value
+            XCTFail("第二代退订应失败")
+        } catch {}
+        let newRetry = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/unsubscribe",
+            after: messagesAfterSecond
+        )
+        transportResponse(transport, id: newRetry.id, result: #"{"status":"unsubscribed"}"#)
+
+        for _ in 0..<20 {
+            if await runtime.threadUnsubscribeRetryTasksBySessionID[threadID] == nil { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        let retryTask = await runtime.threadUnsubscribeRetryTasksBySessionID[threadID]
+        XCTAssertEqual(requests.filter { $0.method == "thread/unsubscribe" }.count, 4)
+        XCTAssertNil(retryTask)
+    }
+
     func testProducerFinishDoesNotCreateConnectionToUnsubscribe() async {
         let project = AgentProject(id: "proj_producer_finish", name: "Producer Finish", path: "/tmp/producer-finish")
         let transport = FakeCodexAppServerTransport()

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
@@ -352,6 +352,111 @@ extension ConversationDataFlowTests {
         XCTAssertFalse(remainsResumed)
     }
 
+    func testLastObserverRetriesFailedUnsubscribeOnExistingConnection() async throws {
+        let project = AgentProject(id: "proj_retry_unsubscribe", name: "Retry Unsubscribe", path: "/tmp/retry-unsubscribe")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "thread/list", "thread/resume", "thread/unsubscribe"]
+                )
+            }
+        )
+        let threadID = "thr_retry_unsubscribe"
+        let thread = #"{"id":"thr_retry_unsubscribe","sessionId":"thr_retry_unsubscribe","preview":"重试退订","ephemeral":false,"modelProvider":"openai","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/retry-unsubscribe","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"重试退订","turns":[]}"#
+        let pageTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let list = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: list.id, result: #"{"data":[\#(thread)],"nextCursor":null}"#)
+        _ = try await pageTask.value
+        let events = await runtime.attachEvents(sessionID: threadID)
+        let connect = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let resume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 2)
+        transportResponse(transport, id: resume.id, result: #"{"thread":\#(thread)}"#)
+        try await connect.value
+
+        events.cancel()
+        let first = try await waitForFakeAppServerRequest(transport, method: "thread/unsubscribe", after: 3)
+        let messagesAfterFirst = await transport.sentMessages().count
+        transportErrorResponse(transport, id: first.id, code: -32603, message: "temporary failure")
+        let retry = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/unsubscribe",
+            after: messagesAfterFirst
+        )
+        transportResponse(transport, id: retry.id, result: #"{"status":"unsubscribed"}"#)
+
+        for _ in 0..<20 {
+            if await runtime.threadUnsubscribeRetryTasksBySessionID[threadID] == nil { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        let retryTask = await runtime.threadUnsubscribeRetryTasksBySessionID[threadID]
+        XCTAssertEqual(requests.filter { $0.method == "thread/unsubscribe" }.count, 2)
+        XCTAssertEqual(requests.filter { $0.method == "initialize" }.count, 1)
+        XCTAssertNil(retryTask)
+    }
+
+    func testObserverReentryCancelsAndDeduplicatesUnsubscribeRetry() async throws {
+        let project = AgentProject(id: "proj_cancel_retry", name: "Cancel Retry", path: "/tmp/cancel-retry")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "thread/list", "thread/resume", "thread/unsubscribe"]
+                )
+            }
+        )
+        let threadID = "thr_cancel_retry"
+        let thread = #"{"id":"thr_cancel_retry","sessionId":"thr_cancel_retry","preview":"取消重试","ephemeral":false,"modelProvider":"openai","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/cancel-retry","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"取消重试","turns":[]}"#
+        let pageTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let list = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: list.id, result: #"{"data":[\#(thread)],"nextCursor":null}"#)
+        _ = try await pageTask.value
+        let firstEvents = await runtime.attachEvents(sessionID: threadID)
+        let initialConnect = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let initialResume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 2)
+        transportResponse(transport, id: initialResume.id, result: #"{"thread":\#(thread)}"#)
+        try await initialConnect.value
+
+        firstEvents.cancel()
+        let first = try await waitForFakeAppServerRequest(transport, method: "thread/unsubscribe", after: 3)
+        let messagesAfterFirst = await transport.sentMessages().count
+        transportErrorResponse(transport, id: first.id, code: -32603, message: "temporary failure")
+        let retry = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/unsubscribe",
+            after: messagesAfterFirst
+        )
+        transportErrorResponse(transport, id: retry.id, code: -32603, message: "temporary failure")
+
+        let reopenedEvents = await runtime.attachEvents(sessionID: threadID)
+        let reopen = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let reopenResume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 5)
+        transportResponse(transport, id: reopenResume.id, result: #"{"thread":\#(thread)}"#)
+        try await reopen.value
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        let retryTask = await runtime.threadUnsubscribeRetryTasksBySessionID[threadID]
+        XCTAssertEqual(requests.filter { $0.method == "thread/unsubscribe" }.count, 2)
+        XCTAssertEqual(requests.filter { $0.method == "initialize" }.count, 1)
+        XCTAssertNil(retryTask)
+        await runtime.finishAttachedEventStreams()
+        reopenedEvents.cancel()
+    }
+
     func testProducerFinishDoesNotCreateConnectionToUnsubscribe() async {
         let project = AgentProject(id: "proj_producer_finish", name: "Producer Finish", path: "/tmp/producer-finish")
         let transport = FakeCodexAppServerTransport()

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
@@ -296,4 +296,202 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(requests.filter { $0.method == "thread/unsubscribe" }.count, 1)
         XCTAssertEqual(requests.filter { $0.method == "thread/resume" }.count, 3)
     }
+
+    func testLastEventObserverUnsubscribesThreadOnlyOnce() async throws {
+        let project = AgentProject(id: "proj_last_observer", name: "Last Observer", path: "/tmp/last-observer")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: [
+                        "initialize", "initialized", "thread/list", "thread/resume", "thread/unsubscribe"
+                    ]
+                )
+            }
+        )
+        let threadID = "thr_last_observer"
+        let thread = #"{"id":"thr_last_observer","sessionId":"thr_last_observer","preview":"最后观察者","ephemeral":false,"modelProvider":"openai","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/last-observer","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"最后观察者","turns":[]}"#
+        let pageTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let list = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: list.id, result: #"{"data":[\#(thread)],"nextCursor":null}"#)
+        _ = try await pageTask.value
+        let first = await runtime.attachEvents(sessionID: threadID)
+        let second = await runtime.attachEvents(sessionID: threadID)
+        let connect = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let resume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 2)
+        transportResponse(transport, id: resume.id, result: #"{"thread":\#(thread)}"#)
+        try await connect.value
+
+        first.cancel()
+        for _ in 0..<10 { await Task.yield() }
+        let observerCount = await runtime.eventMailboxesBySessionID[threadID]?.count
+        let requestsAfterFirstCancel = await transport.sentMessages().compactMap {
+            try? decodeAppServerRequest($0)
+        }
+        XCTAssertEqual(observerCount, 1)
+        XCTAssertEqual(requestsAfterFirstCancel.filter { $0.method == "thread/unsubscribe" }.count, 0)
+
+        second.cancel()
+        let unsubscribe = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/unsubscribe",
+            after: 3
+        )
+        transportResponse(transport, id: unsubscribe.id, result: #"{"status":"unsubscribed"}"#)
+
+        for _ in 0..<10 { await Task.yield() }
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        let remainsResumed = await runtime.threadsResumedOnConnection.contains(threadID)
+        XCTAssertEqual(requests.filter { $0.method == "thread/unsubscribe" }.count, 1)
+        XCTAssertFalse(remainsResumed)
+    }
+
+    func testProducerFinishDoesNotCreateConnectionToUnsubscribe() async {
+        let project = AgentProject(id: "proj_producer_finish", name: "Producer Finish", path: "/tmp/producer-finish")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "thread/list", "thread/resume"]
+                )
+            }
+        )
+        let threadID = "thr_producer_finish"
+        let thread = #"{"id":"thr_producer_finish","sessionId":"thr_producer_finish","preview":"生产者结束","ephemeral":false,"modelProvider":"openai","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/producer-finish","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"生产者结束","turns":[]}"#
+        let pageTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try! await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let list = try! await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: list.id, result: #"{"data":[\#(thread)],"nextCursor":null}"#)
+        _ = try! await pageTask.value
+        let events = await runtime.attachEvents(sessionID: threadID)
+        let connect = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let resume = try! await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 2)
+        transportResponse(transport, id: resume.id, result: #"{"thread":\#(thread)}"#)
+        _ = try! await connect.value
+
+        await runtime.finishAttachedEventStreams()
+        events.cancel()
+        for _ in 0..<10 { await Task.yield() }
+
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        let lease = await runtime.threadSubscriptionLeaseBySessionID[threadID]
+        XCTAssertEqual(requests.filter { $0.method == "thread/unsubscribe" }.count, 0)
+        XCTAssertTrue(lease?.wantsEvents == true)
+    }
+
+    func testObserverCancelDuringPhysicalDisconnectDoesNotReconnectToUnsubscribe() async throws {
+        let project = AgentProject(id: "proj_disconnect_cancel", name: "Disconnect Cancel", path: "/tmp/disconnect-cancel")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: [
+                        "initialize", "initialized", "thread/list", "thread/resume", "thread/unsubscribe"
+                    ]
+                )
+            }
+        )
+        let threadID = "thr_disconnect_cancel"
+        let thread = #"{"id":"thr_disconnect_cancel","sessionId":"thr_disconnect_cancel","preview":"断线取消","ephemeral":false,"modelProvider":"openai","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/disconnect-cancel","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"断线取消","turns":[]}"#
+        let pageTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let list = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: list.id, result: #"{"data":[\#(thread)],"nextCursor":null}"#)
+        _ = try await pageTask.value
+        let events = await runtime.attachEvents(sessionID: threadID)
+        let connect = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let resume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 2)
+        transportResponse(transport, id: resume.id, result: #"{"thread":\#(thread)}"#)
+        try await connect.value
+
+        // 固定竞态窗口：底层连接已断开，但 producer pump 尚未清理邮箱。
+        // 自动退订只能放弃发送，不能通过 ensureConnection 创建第二条连接。
+        let notificationPump = await runtime.notificationPumpTask
+        notificationPump?.cancel()
+        let activeConnection = await runtime.connection
+        await activeConnection?.disconnect()
+        events.cancel()
+        for _ in 0..<20 { await Task.yield() }
+
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        XCTAssertEqual(requests.filter { $0.method == "initialize" }.count, 1)
+        XCTAssertEqual(requests.filter { $0.method == "thread/unsubscribe" }.count, 0)
+        let lease = await runtime.threadSubscriptionLeaseBySessionID[threadID]
+        XCTAssertTrue(lease?.wantsEvents == false)
+    }
+
+    func testArchiveClearsSubscriptionStateAndReopenResumesAfterUnarchive() async throws {
+        let project = AgentProject(id: "proj_archive_subscription", name: "Archive Subscription", path: "/tmp/archive-subscription")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: [
+                        "initialize", "initialized", "thread/archive", "thread/unarchive",
+                        "thread/read", "thread/resume"
+                    ]
+                )
+            }
+        )
+        let threadID = "thr_archive_subscription"
+        let thread = #"{"id":"thr_archive_subscription","sessionId":"thr_archive_subscription","preview":"归档订阅","ephemeral":false,"modelProvider":"openai","createdAt":1780490900,"updatedAt":1780490901,"status":{"type":"active","activeFlags":[]},"path":null,"cwd":"/tmp/archive-subscription","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"归档订阅","turns":[]}"#
+        let pageTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#)
+        let list = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: list.id, result: #"{"data":[\#(thread)],"nextCursor":null}"#)
+        _ = try await pageTask.value
+        let events = await runtime.attachEvents(sessionID: threadID)
+        let initialConnect = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let initialResume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 2)
+        transportResponse(transport, id: initialResume.id, result: #"{"thread":\#(thread)}"#)
+        try await initialConnect.value
+
+        let archiveTask = Task { try await runtime.setSessionArchived(id: threadID, archived: true) }
+        let archive = try await waitForFakeAppServerRequest(transport, method: "thread/archive", after: 3)
+        transportResponse(transport, id: archive.id, result: #"{}"#)
+        try await archiveTask.value
+
+        let remainsResumedAfterArchive = await runtime.threadsResumedOnConnection.contains(threadID)
+        let leaseAfterArchive = await runtime.threadSubscriptionLeaseBySessionID[threadID]
+        let observersAfterArchive = await runtime.eventMailboxesBySessionID[threadID]
+        XCTAssertFalse(remainsResumedAfterArchive)
+        XCTAssertNil(leaseAfterArchive)
+        XCTAssertNil(observersAfterArchive)
+        events.cancel()
+
+        let unarchiveTask = Task { try await runtime.setSessionArchived(id: threadID, archived: false) }
+        let unarchive = try await waitForFakeAppServerRequest(transport, method: "thread/unarchive", after: 4)
+        transportResponse(transport, id: unarchive.id, result: #"{}"#)
+        try await unarchiveTask.value
+
+        let reopen = Task { try await runtime.connectForEvents(sessionID: threadID) }
+        let read = try await waitForFakeAppServerRequest(transport, method: "thread/read", after: 5)
+        transportResponse(transport, id: read.id, result: #"{"thread":\#(thread)}"#)
+        let resume = try await waitForFakeAppServerRequest(transport, method: "thread/resume", after: 6)
+        transportResponse(transport, id: resume.id, result: #"{"thread":\#(thread)}"#)
+        try await reopen.value
+        let resumedAfterUnarchive = await runtime.threadsResumedOnConnection.contains(threadID)
+        XCTAssertTrue(resumedAfterUnarchive)
+    }
 }


### PR DESCRIPTION
## 目标

彻底修复共享 SSH App Server 长时间运行后耗尽文件描述符、导致会话无法恢复的问题。

## 根因

- Mimi 页面离开时只取消本地事件流，没有向 App Server 发送 `thread/unsubscribe`。已恢复 Thread 会一直留在当前连接的订阅集合中。
- 每个已加载 Thread 会保留 session、rollout 和 MCP 子进程资源。旧 SSH resident 又继承 macOS SSH 登录的 256 open-file soft limit，因此正常使用也会撞到 `EMFILE`。
- agentd 的 SSH proxy 在物理连接关闭时能正确退出，不是单个 proxy 自身泄漏。

## 实现

- 最后一个本地观察者离开时发送 `thread/unsubscribe`；多观察者只由最后一个退订。
- 物理连接已经断开时不为清理动作重新连接；归档时同步清理本地订阅状态和事件流。
- 新 SSH resident 启动前保证 open-file soft limit 至少为 8192。无法提高时拒绝以低上限启动；不会降低已有更高限制。
- 补充迁移与安全重启文档。现有 resident 的进程限制不会热更新。

## 验证

- `go test ./internal/appserver ./internal/httpapi ./internal/doctor`：通过。
- 7 条 iOS 订阅、断线、归档与待输入回放回归：7/7 通过。
- `bash ./scripts/check-source-size.sh`：通过。
- `git diff --check`：通过。
- 真实共享环境中，通过 agentd 建立独立连接并执行 resume/unsubscribe，服务端返回 unsubscribed；关闭测试连接后，原有多个 SSH proxy 和共享 App Server 均保持存活。

## 已知环境问题

- `go test ./...` 仍命中既有的 `internal/setup` 超时断言失败，本分支未修改该包。
- 全量 iOS 回归中的既有快照环境有 16 项不匹配；本次相关逻辑用例已单独更新并通过。

## 上线边界

当前旧 resident 已达到 256 个数字文件描述符。因仍有其他 SSH 客户端在线，本次没有强制重启。合并并部署 agentd/Mimi 后，需要在活跃 Turn 结束时协调重启唯一的共享 Unix resident，才能让新进程继承 8192 soft limit。