### PR TITLE
MIM-212 优化共享会话的 Desktop 设置提示

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -32568,18 +32568,18 @@
       }
     },
     "ui.use_shared_thread_settings_change_them_on_desktop": {
-      "comment": "Composer notice explaining that shared thread settings are managed by Desktop.",
+      "comment": "Composer notice explaining that model and Plan mode are managed by Desktop for a shared thread.",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Use shared thread settings; change them on Desktop"
+            "value": "Model and Plan mode use shared thread settings; change them on Desktop"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "沿用共享线程设置；请在 Desktop 修改"
+            "value": "模型和计划模式沿用共享线程设置；请在 Desktop 修改"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerInputExtensions.swift
@@ -4,17 +4,6 @@ import SwiftUI
 
 // 权限选择、能力降级和队列边界属于输入状态协作，不让 ComposerView 主体继续增长。
 extension ComposerView {
-    @ViewBuilder
-    var sharedThreadSettingsNotice: some View {
-        if composerTurnSettingsPolicy == .sharedThreadManaged {
-            Label(ComposerTurnSettingsPolicy.sharedThreadNotice, systemImage: "desktopcomputer")
-                .font(themeStore.uiFont(.caption))
-                .foregroundStyle(themeStore.tokens(for: colorScheme).secondaryText)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .accessibilityIdentifier("composer.sharedThreadSettingsNotice")
-        }
-    }
-
     func applyDefaultPermissionMode() {
         let stored = ComposerPermissionMode.stored(defaultPermissionModeID)
         composerState.applyPermissionMode(safePermissionMode(stored))

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
@@ -4,6 +4,31 @@ import SwiftUI
 // 模型目录过滤、默认值选择和会话 runtime 锁定集中在这里，避免 ComposerView
 // 同时承担视图布局与模型策略。成员保持 module-internal，供 ComposerView 跨文件扩展协作。
 extension ComposerView {
+    var sharedThreadModelControl: some View {
+        Menu {
+            Section {
+                Button(action: {}) {
+                    Label(L10n.text("ui.model"), systemImage: "cpu")
+                }
+                .disabled(true)
+
+                Text(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
+            }
+        } label: {
+            composerToolbarControlLabel(
+                title: nil,
+                systemImage: "cpu",
+                trailingSystemImage: "lock.fill",
+                accessibilityLabel: L10n.text("ui.model")
+            )
+        }
+        .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
+        .accessibilityLabel(L10n.text("ui.model"))
+        .accessibilityValue(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
+        .accessibilityIdentifier("composer.model.sharedThreadManaged")
+        .help(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
+    }
+
     @ViewBuilder
     var modelPickerControl: some View {
         modelPickerControl(showsTitle: true, usesCompactTitle: false)

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -43,7 +43,7 @@ enum ComposerTurnSettingsPolicy: Equatable {
     case editable
     case sharedThreadManaged
 
-    static let sharedThreadNotice = String(
+    static let sharedThreadSettingsMenuNotice = String(
         localized: "ui.use_shared_thread_settings_change_them_on_desktop"
     )
 

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -107,7 +107,6 @@ struct ComposerView: View {
                 .environmentObject(themeStore)
             attachmentStrip
             composerStatusRow
-            sharedThreadSettingsNotice
             composerInputRow(tokens: tokens)
         }
         // 零尺寸键盘快捷键不能作为 VStack 的 arranged child：即使自身是 0×0，
@@ -1386,6 +1385,12 @@ struct ComposerView: View {
         // 模型固定在底部主工具栏；权限与 Skill 在 iPad 上平铺、在 iPhone 上进入「+」。
         // 这里仅保留低频运行参数和发送模式，避免同一屏幕出现两套配置面。
         Menu {
+            if composerTurnSettingsPolicy == .sharedThreadManaged {
+                Section {
+                    Text(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
+                }
+            }
+
             if composerTurnSettingsPolicy.allowsTurnSettingsEditing {
                 runSettingsMenu
 

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -1346,7 +1346,7 @@ struct ComposerView: View {
     @inline(never)
     func compactModelControlBox(showsTitle: Bool) -> AnyView {
         guard composerTurnSettingsPolicy.allowsTurnSettingsEditing else {
-            return AnyView(EmptyView())
+            return AnyView(sharedThreadModelControl)
         }
         return AnyView(modelPickerControl(showsTitle: showsTitle, usesCompactTitle: isPhoneComposer))
     }
@@ -1387,6 +1387,11 @@ struct ComposerView: View {
         Menu {
             if composerTurnSettingsPolicy == .sharedThreadManaged {
                 Section {
+                    Button(action: {}) {
+                        Label(L10n.text("ui.planning_mode"), systemImage: "list.clipboard")
+                    }
+                    .disabled(true)
+
                     Text(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
                 }
             }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
@@ -18,7 +18,7 @@ extension ConversationDataFlowTests {
         XCTAssertFalse(ComposerTurnSettingsPolicy.sharedThreadManaged.allowsTurnSettingsEditing)
         XCTAssertEqual(
             ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice,
-            "沿用共享线程设置；请在 Desktop 修改"
+            "模型和计划模式沿用共享线程设置；请在 Desktop 修改"
         )
 
         let editableCases: [(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
@@ -17,7 +17,7 @@ extension ConversationDataFlowTests {
         )
         XCTAssertFalse(ComposerTurnSettingsPolicy.sharedThreadManaged.allowsTurnSettingsEditing)
         XCTAssertEqual(
-            ComposerTurnSettingsPolicy.sharedThreadNotice,
+            ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice,
             "沿用共享线程设置；请在 Desktop 修改"
         )
 


### PR DESCRIPTION
## 变更

- 移除输入框上方常驻的 Desktop 设置提示
- 将模型和计划模式的设置归属说明移入相关锁定入口与“会话选项”
- iPhone 保留共享模型的锁定入口，不增加编辑能力

## 验证

- 固定 M5 Simulator 定向测试通过
- `bash ./scripts/check-source-size.sh` 通过

Linear: MIM-212