### PR TITLE
MIM-220 让模型设置跟随移动端会话控制权

### DIFF
--- a/docs/codex-protocol-support.md
+++ b/docs/codex-protocol-support.md
@@ -36,7 +36,7 @@ Go Gateway 当前开放 31 个 client frame method，其中 `initialized` 是 no
 
 共享 SSH 模式的普通用户消息只使用 `thread/queue/add`。客户端初始化时必须声明 `experimentalApi: true`。发送结果不确定时，客户端用同一个 `clientUserMessageId` 依次查询 `thread/queue/list` 和 `thread/items/list`，不能盲目重发。`turn/start` 只保留给非共享旧链路和内部标题任务。
 
-历史读取固定使用 `thread/read(includeTurns:false)`，随后分页调用 `thread/turns/list` 和 `thread/items/list`。线程模型、工作目录和权限是共享状态；普通消息不能隐式修改它们，只有用户明确操作时才调用 `thread/settings/update`。
+历史读取固定使用 `thread/read(includeTurns:false)`，随后分页调用 `thread/turns/list` 和 `thread/items/list`。线程模型、工作目录和权限是共享状态；`thread/queue/add` 不隐式修改它们。移动端提交共享队列消息时，会先用独立的 `thread/settings/update` 应用 Composer 为下一回合明确选择的模型、推理强度和协作模式，确认成功后才调用 `thread/queue/add`；权限继续走独立的受控链路。
 
 Claude 实验通道使用更小的独立 allowlist，当前要求 `alleycat-claude-bridge >= 0.2.7`。`0.2.1` 首次开放 `account/rateLimits/read`，请求参数固定改写为 `{}`；`0.2.3` 起补齐事件百分比映射。`0.2.5` 起优先复用 Claude Code 已登录凭据主动读取 OAuth usage：macOS 从登录 Keychain 的 `Claude Code-credentials` 获取短期 access token，其他平台可使用权限收紧的 `~/.claude/.credentials.json`，随后请求固定的 Anthropic OAuth usage beta endpoint，将 5h/7d 窗口映射为现有协议。`0.2.6` 起，macOS token 过期或接口返回 401 时通过系统 PTY 执行 Claude CLI `/status` 认证路径，等待 Keychain 更新后只重试一次；`0.2.7` 起支持受控的运行期 `thread/list.refreshHistory`。bridge 不直接读取、消费或覆盖 refresh token。access token 只通过子进程 stdin 传给禁用 `.curlrc` 的系统 `curl`，不进入命令参数、日志或磁盘缓存；成功快照缓存 60 秒，Keychain、scope、续期、网络、HTTP 或解析失败均不影响会话链路。
 

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -15819,6 +15819,23 @@
         }
       }
     },
+    "ui.model_and_plan_mode_require_session_control": {
+      "comment": "Composer notice shown when this device cannot edit settings for the next turn.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This device must control the session to change the model or Plan mode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前设备拥有会话控制权时，才能修改模型或计划模式"
+          }
+        }
+      }
+    },
     "ui.model_list_refreshed": {
       "comment": "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations": {
@@ -32563,23 +32580,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "改用手动连接"
-          }
-        }
-      }
-    },
-    "ui.use_shared_thread_settings_change_them_on_desktop": {
-      "comment": "Composer notice explaining that model and Plan mode are managed by Desktop for a shared thread.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Model and Plan mode use shared thread settings; change them on Desktop"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "模型和计划模式沿用共享线程设置；请在 Desktop 修改"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerQueueSubmission.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerQueueSubmission.swift
@@ -54,6 +54,7 @@ extension CodexAppServerSessionRuntime {
 
         let config = try await ensureConfig()
         let requiredMethods = [
+            "thread/settings/update",
             "thread/queue/add",
             "thread/queue/list",
             "thread/items/list"
@@ -74,6 +75,28 @@ extension CodexAppServerSessionRuntime {
         )
 
         do {
+            _ = try await connection.send(
+                try builder.threadSettingsUpdate(
+                    threadID: sessionID,
+                    cwd: context.cwd,
+                    options: payload.options
+                ),
+                timeout: longRunningRequestTimeout
+            )
+        } catch {
+            // 设置是幂等赋值，但 ACK 丢失时不能猜测结果后继续入队。终止本次发送，
+            // 用户重试会再次写入同一设置，同时保证消息没有被重复提交。
+            await retireCurrentConnectionAfterRecoverableError(connection, error: error)
+            if let method = serverQueueUnavailableMethod(
+                from: error,
+                attemptedMethod: "thread/settings/update"
+            ) {
+                throw CodexAppServerSessionRuntimeError.serverQueueUnavailable(method)
+            }
+            throw error
+        }
+
+        do {
             let result = try await connection.send(
                 try builder.threadQueueAdd(
                     threadID: sessionID,
@@ -91,7 +114,10 @@ extension CodexAppServerSessionRuntime {
             }
             return (submissionID, nil)
         } catch {
-            if let method = serverQueueUnavailableMethod(from: error) {
+            if let method = serverQueueUnavailableMethod(
+                from: error,
+                attemptedMethod: "thread/queue/add"
+            ) {
                 throw CodexAppServerSessionRuntimeError.serverQueueUnavailable(method)
             }
             // queue/add 是写请求，任何错误都不能直接重发。只允许以同一 client id 做只读三段核对。
@@ -115,7 +141,7 @@ extension CodexAppServerSessionRuntime {
         }
     }
 
-    func serverQueueUnavailableMethod(from error: Error) -> String? {
+    func serverQueueUnavailableMethod(from error: Error, attemptedMethod: String) -> String? {
         guard case CodexAppServerConnectionError.appServer(let appError) = error else {
             return nil
         }
@@ -123,12 +149,12 @@ extension CodexAppServerSessionRuntime {
         if appError.code == -32601
             || message.contains("experimentalapi")
             || message.contains("experimental api")
-            || (message.contains("thread/queue/add")
+            || (message.contains(attemptedMethod)
                 && (message.contains("unsupported")
                     || message.contains("not supported")
                     || message.contains("not found")
                     || message.contains("not allowed"))) {
-            return "thread/queue/add"
+            return attemptedMethod
         }
         return nil
     }

--- a/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
@@ -632,6 +632,28 @@ struct CodexAppServerRequestBuilder {
         ]))
     }
 
+    func threadSettingsUpdate(
+        threadID: String,
+        cwd: String,
+        options: CodexAppServerTurnOptions
+    ) throws -> CodexAppServerRequestSpec {
+        let path = try allowlistedPath(cwd)
+        let turnParams = options.turnParams(projectPath: path)
+        var params: [String: CodexAppServerJSONValue?] = [
+            "threadId": .string(threadID)
+        ]
+        // 共享队列不接收 turn 级设置。只把本轮明确支持的运行设置提升为 Thread 设置，
+        // 权限、输出结构和自定义指令仍走各自的受控链路，不能在普通消息里顺带改写。
+        for key in ["model", "effort", "collaborationMode"] {
+            params[key] = turnParams[key] ?? nil
+        }
+        try validateRemoteSafeParams(params, projectPath: path)
+        return CodexAppServerRequestSpec(
+            method: "thread/settings/update",
+            params: .object(params.compactMapValues { $0 })
+        )
+    }
+
     func threadQueueAdd(
         threadID: String,
         cwd: String,

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // 模型目录过滤、默认值选择和会话 runtime 锁定集中在这里，避免 ComposerView
 // 同时承担视图布局与模型策略。成员保持 module-internal，供 ComposerView 跨文件扩展协作。
 extension ComposerView {
-    var sharedThreadModelControl: some View {
+    var unavailableModelControl: some View {
         Menu {
             Section {
                 Button(action: {}) {
@@ -12,7 +12,7 @@ extension ComposerView {
                 }
                 .disabled(true)
 
-                Text(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
+                Text(ComposerTurnSettingsPolicy.unavailableMenuNotice)
             }
         } label: {
             composerToolbarControlLabel(
@@ -24,9 +24,9 @@ extension ComposerView {
         }
         .buttonStyle(MimiPressButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.text("ui.model"))
-        .accessibilityValue(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
-        .accessibilityIdentifier("composer.model.sharedThreadManaged")
-        .help(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
+        .accessibilityValue(ComposerTurnSettingsPolicy.unavailableMenuNotice)
+        .accessibilityIdentifier("composer.model.unavailable")
+        .help(ComposerTurnSettingsPolicy.unavailableMenuNotice)
     }
 
     @ViewBuilder

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -41,29 +41,16 @@ enum ComposerDraftScopeKey: Hashable {
 
 enum ComposerTurnSettingsPolicy: Equatable {
     case editable
-    case sharedThreadManaged
+    case unavailable
 
-    static let sharedThreadSettingsMenuNotice = String(
-        localized: "ui.use_shared_thread_settings_change_them_on_desktop"
+    static let unavailableMenuNotice = String(
+        localized: "ui.model_and_plan_mode_require_session_control"
     )
 
-    static func resolve(
-        scope: ComposerDraftScopeKey,
-        sessionRuntimeProvider: String?,
-        isLocalSession: Bool,
-        isArchivedSession: Bool
-    ) -> ComposerTurnSettingsPolicy {
-        // MIM-207 的生产 Codex 路径固定走共享 SSH 队列；不要再用尚未连接的 socket
-        // 推断 transport，否则首帧会把本地默认值误当成共享线程当前设置。
-        guard sessionRuntimeProvider == "codex",
-              !isLocalSession,
-              !isArchivedSession,
-              case .session(let sessionID) = scope,
-              !sessionID.hasPrefix("local:")
-        else {
-            return .editable
-        }
-        return .sharedThreadManaged
+    static func resolve(canControlSession: Bool) -> ComposerTurnSettingsPolicy {
+        // 模型和计划模式都是下一回合设置，应跟随真实 Writer 控制权，而不是会话来源。
+        // 这样移动端创建或接管的共享 Thread 不会在首轮发送后被误锁。
+        canControlSession ? .editable : .unavailable
     }
 
     var allowsTurnSettingsEditing: Bool {

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerView.swift
@@ -496,10 +496,7 @@ struct ComposerView: View {
             return .editable
         }
         return ComposerTurnSettingsPolicy.resolve(
-            scope: scope,
-            sessionRuntimeProvider: normalizedRuntimeProvider(session.runtimeProvider ?? session.source),
-            isLocalSession: session.source == "local",
-            isArchivedSession: sessionStore.isSessionArchived(sessionID)
+            canControlSession: sessionStore.canControlSession(session)
         )
     }
 
@@ -510,9 +507,6 @@ struct ComposerView: View {
         showsModelGridPicker = false
         showsAdvancedOptionsSheet = false
         showsAddContentPanel = false
-        if composerState.isPlanModeSelected {
-            setSendMode(.standard)
-        }
     }
 
     func switchComposerDraftScope(to nextScope: ComposerDraftScopeKey) {
@@ -1346,7 +1340,7 @@ struct ComposerView: View {
     @inline(never)
     func compactModelControlBox(showsTitle: Bool) -> AnyView {
         guard composerTurnSettingsPolicy.allowsTurnSettingsEditing else {
-            return AnyView(sharedThreadModelControl)
+            return AnyView(unavailableModelControl)
         }
         return AnyView(modelPickerControl(showsTitle: showsTitle, usesCompactTitle: isPhoneComposer))
     }
@@ -1385,14 +1379,14 @@ struct ComposerView: View {
         // 模型固定在底部主工具栏；权限与 Skill 在 iPad 上平铺、在 iPhone 上进入「+」。
         // 这里仅保留低频运行参数和发送模式，避免同一屏幕出现两套配置面。
         Menu {
-            if composerTurnSettingsPolicy == .sharedThreadManaged {
+            if composerTurnSettingsPolicy == .unavailable {
                 Section {
                     Button(action: {}) {
                         Label(L10n.text("ui.planning_mode"), systemImage: "list.clipboard")
                     }
                     .disabled(true)
 
-                    Text(ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice)
+                    Text(ComposerTurnSettingsPolicy.unavailableMenuNotice)
                 }
             }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationComposerSubmissionAndPendingInputTests.swift
@@ -5,48 +5,68 @@ import XCTest
 
 @MainActor
 extension ConversationDataFlowTests {
-    func testSharedThreadComposerTurnSettingsPolicyOnlyLocksExistingSharedSessions() {
+    func testComposerTurnSettingsPolicyFollowsWriterControl() {
+        XCTAssertEqual(ComposerTurnSettingsPolicy.resolve(canControlSession: true), .editable)
+        XCTAssertEqual(ComposerTurnSettingsPolicy.resolve(canControlSession: false), .unavailable)
+        XCTAssertTrue(ComposerTurnSettingsPolicy.editable.allowsTurnSettingsEditing)
+        XCTAssertFalse(ComposerTurnSettingsPolicy.unavailable.allowsTurnSettingsEditing)
         XCTAssertEqual(
-            ComposerTurnSettingsPolicy.resolve(
-                scope: .session("shared-thread"),
-                sessionRuntimeProvider: "codex",
-                isLocalSession: false,
-                isArchivedSession: false
-            ),
-            .sharedThreadManaged
+            ComposerTurnSettingsPolicy.unavailableMenuNotice,
+            "当前设备拥有会话控制权时，才能修改模型或计划模式"
         )
-        XCTAssertFalse(ComposerTurnSettingsPolicy.sharedThreadManaged.allowsTurnSettingsEditing)
-        XCTAssertEqual(
-            ComposerTurnSettingsPolicy.sharedThreadSettingsMenuNotice,
-            "模型和计划模式沿用共享线程设置；请在 Desktop 修改"
+    }
+
+    func testComposerTurnSettingsPolicyUsesSessionControlState() {
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore()
+        )
+        let running = makeSession(
+            id: "composer-control-running",
+            projectID: "composer-control-project",
+            title: "控制权测试",
+            status: "running",
+            source: "codex",
+            activeTurnID: "composer-control-turn"
         )
 
-        let editableCases: [(
-            scope: ComposerDraftScopeKey,
-            runtimeProvider: String?,
-            isLocal: Bool,
-            isArchived: Bool
-        )] = [
-            (.session("local:project:message"), "codex", false, false),
-            (.session("optimistic-thread"), "codex", true, false),
-            (.newSession(projectID: "project"), "codex", false, false),
-            (.none, "codex", false, false),
-            (.session("claude-thread"), "claude", false, false),
-            (.session("chatgpt-thread"), "chatgpt", false, false),
-            (.session("archived-thread"), "codex", false, true),
-        ]
-        for item in editableCases {
+        for state in [SessionControlState.ipadOwned, .takenOver] {
+            store.sessionControlStateByID[running.id] = state
             XCTAssertEqual(
-                ComposerTurnSettingsPolicy.resolve(
-                    scope: item.scope,
-                    sessionRuntimeProvider: item.runtimeProvider,
-                    isLocalSession: item.isLocal,
-                    isArchivedSession: item.isArchived
-                ),
+                ComposerTurnSettingsPolicy.resolve(canControlSession: store.canControlSession(running)),
                 .editable
             )
         }
-        XCTAssertTrue(ComposerTurnSettingsPolicy.editable.allowsTurnSettingsEditing)
+
+        store.sessionControlStateByID[running.id] = .observing
+        XCTAssertEqual(
+            ComposerTurnSettingsPolicy.resolve(canControlSession: store.canControlSession(running)),
+            .unavailable
+        )
+
+        store.sessionControlStateByID[running.id] = .takenOver
+        store.setActiveWriterConflict(true, sessionID: running.id)
+        XCTAssertEqual(
+            ComposerTurnSettingsPolicy.resolve(canControlSession: store.canControlSession(running)),
+            .unavailable
+        )
+
+        store.setActiveWriterConflict(false, sessionID: running.id)
+        var readOnly = running
+        readOnly.canAcceptDirectInput = false
+        XCTAssertEqual(
+            ComposerTurnSettingsPolicy.resolve(canControlSession: store.canControlSession(readOnly)),
+            .unavailable
+        )
+
+        var idle = running
+        idle.status = SessionStatus.completed.rawValue
+        idle.activeTurnID = nil
+        XCTAssertEqual(
+            ComposerTurnSettingsPolicy.resolve(canControlSession: store.canControlSession(idle)),
+            .editable
+        )
     }
 
     func testCompactComposerModelTitleUsesDeterministicWidthPolicy() {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SharedSSHAppServerQueueTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SharedSSHAppServerQueueTests.swift
@@ -93,13 +93,34 @@ extension ConversationDataFlowTests {
         let createRequests = await appServerRequests(transport)
         XCTAssertFalse(createRequests.contains { $0.method == "turn/start" })
 
+        var queueOptions = CodexAppServerTurnOptions.default
+        queueOptions.model = "gpt-5.6-luna"
+        queueOptions.reasoningEffort = .high
+        queueOptions.collaborationMode = .plan
         let submitTask = Task {
             try await runtime.submitTurnOutcome(
                 sessionID: "thread-active",
-                payload: CodexAppServerTurnPayload(prompt: "排进共享队列"),
+                payload: CodexAppServerTurnPayload(prompt: "排进共享队列", options: queueOptions),
                 clientMessageID: "client-first"
             )
         }
+        let settings = try await waitForFakeAppServerRequest(transport, method: "thread/settings/update")
+        let settingsParams = try XCTUnwrap(settings.params?.objectValue)
+        XCTAssertEqual(Set(settingsParams.keys), ["threadId", "model", "effort", "collaborationMode"])
+        XCTAssertEqual(settingsParams["threadId"]?.stringValue, "thread-active")
+        XCTAssertEqual(settingsParams["model"]?.stringValue, "gpt-5.6-luna")
+        XCTAssertEqual(settingsParams["effort"]?.stringValue, "high")
+        let collaborationMode = try XCTUnwrap(settingsParams["collaborationMode"]?.objectValue)
+        XCTAssertEqual(collaborationMode["mode"]?.stringValue, "plan")
+        let collaborationSettings = try XCTUnwrap(collaborationMode["settings"]?.objectValue)
+        XCTAssertEqual(Set(collaborationSettings.keys), ["model", "reasoning_effort", "developer_instructions"])
+        XCTAssertEqual(collaborationSettings["model"]?.stringValue, "gpt-5.6-luna")
+        XCTAssertEqual(collaborationSettings["reasoning_effort"]?.stringValue, "high")
+        XCTAssertEqual(collaborationSettings["developer_instructions"], .null)
+        let requestsBeforeSettingsACK = await appServerRequests(transport)
+        XCTAssertEqual(requestsBeforeSettingsACK.last?.method, "thread/settings/update")
+        XCTAssertFalse(requestsBeforeSettingsACK.contains { $0.method == "thread/queue/add" })
+        transportResponse(transport, id: settings.id, result: #"{}"#)
         let add = try await waitForFakeAppServerRequest(transport, method: "thread/queue/add")
         let params = try XCTUnwrap(add.params?.objectValue)
         XCTAssertEqual(Set(params.keys), ["threadId", "input", "clientUserMessageId"])
@@ -112,7 +133,9 @@ extension ConversationDataFlowTests {
         let submitOutcome = try await submitTask.value
         XCTAssertEqual(submitOutcome, .serverQueued(submissionID: "submission-first", startedTurnID: nil))
         let requestsAfterSubmit = await appServerRequests(transport)
-        XCTAssertFalse(requestsAfterSubmit.contains { $0.method == "thread/settings/update" })
+        let settingsIndex = try XCTUnwrap(requestsAfterSubmit.firstIndex { $0.method == "thread/settings/update" })
+        let addIndex = try XCTUnwrap(requestsAfterSubmit.firstIndex { $0.method == "thread/queue/add" })
+        XCTAssertLessThan(settingsIndex, addIndex)
         XCTAssertFalse(requestsAfterSubmit.contains { $0.method == "turn/start" })
 
         let beforeUnsupported = await transport.sentMessages().count
@@ -123,6 +146,12 @@ extension ConversationDataFlowTests {
                 clientMessageID: "client-unsupported"
             )
         }
+        let unsupportedSettings = try await waitForFakeAppServerRequest(
+            transport,
+            method: "thread/settings/update",
+            after: beforeUnsupported
+        )
+        transportResponse(transport, id: unsupportedSettings.id, result: #"{}"#)
         let unsupportedAdd = try await waitForFakeAppServerRequest(
             transport,
             method: "thread/queue/add",
@@ -140,6 +169,71 @@ extension ConversationDataFlowTests {
         let unsupportedRequests = Array((await appServerRequests(transport)).dropFirst(beforeUnsupported))
         XCTAssertFalse(unsupportedRequests.contains { $0.method == "thread/queue/list" })
         XCTAssertFalse(unsupportedRequests.contains { $0.method == "thread/items/list" })
+    }
+
+    func testSharedSSHSettingsFailureDoesNotQueueAndClearsSubmissionInFlight() async throws {
+        let project = AgentProject(id: "shared-settings-error", name: "Shared Settings Error", path: "/tmp/shared-settings-error")
+        let pool = FakeCodexAppServerTransportPool()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { pool.make() },
+            configProvider: { makeSharedSSHConfig(project: project) }
+        )
+        let first = try await prepareEmptySharedThread(
+            runtime: runtime,
+            pool: pool,
+            project: project,
+            id: "thread-settings-error"
+        )
+        let firstSubmit = Task {
+            try await runtime.submitTurnOutcome(
+                sessionID: "thread-settings-error",
+                payload: CodexAppServerTurnPayload(prompt: "first"),
+                clientMessageID: "client-settings-error"
+            )
+        }
+        let firstResume = try await waitForFakeAppServerRequest(first, method: "thread/resume")
+        transportResponse(
+            first,
+            id: firstResume.id,
+            result: sharedIdleThreadJSON(id: "thread-settings-error", cwd: project.path)
+        )
+        let failedSettings = try await waitForFakeAppServerRequest(first, method: "thread/settings/update")
+        transportErrorResponse(first, id: failedSettings.id, code: -32600, message: "settings rejected")
+        do {
+            _ = try await firstSubmit.value
+            XCTFail("settings/update 失败时必须终止提交")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("settings rejected"))
+        }
+        let failedRequests = await appServerRequests(first)
+        XCTAssertFalse(failedRequests.contains { $0.method == "thread/queue/add" })
+        let retryStartIndex = await first.sentMessages().count
+
+        let retrySubmit = Task {
+            try await runtime.submitTurnOutcome(
+                sessionID: "thread-settings-error",
+                payload: CodexAppServerTurnPayload(prompt: "retry"),
+                clientMessageID: "client-settings-retry"
+            )
+        }
+        try await respondToSharedSettingsUpdate(first, after: retryStartIndex)
+        let retryAdd = try await waitForFakeAppServerRequest(
+            first,
+            method: "thread/queue/add",
+            after: retryStartIndex
+        )
+        transportResponse(
+            first,
+            id: retryAdd.id,
+            result: #"{"queuedSubmission":{"id":"submission-retry","clientUserMessageId":"client-settings-retry"}}"#
+        )
+        let retryOutcome = try await retrySubmit.value
+        XCTAssertEqual(
+            retryOutcome,
+            .serverQueued(submissionID: "submission-retry", startedTurnID: nil)
+        )
     }
 
     func testSharedSSHQueueACKLossReconcilesQueueItemsQueueWithFullPagination() async throws {
@@ -166,7 +260,8 @@ extension ConversationDataFlowTests {
             id: initialResume.id,
             result: sharedIdleThreadJSON(id: "thread-reconcile", cwd: project.path)
         )
-        let add = try await waitForFakeAppServerRequest(first, method: "thread/queue/add")
+        try await respondToSharedSettingsUpdate(first)
+        _ = try await waitForFakeAppServerRequest(first, method: "thread/queue/add")
         first.failReceive()
 
         let second = try await waitForFakeAppServerTransport(in: pool, index: 1)
@@ -233,7 +328,8 @@ extension ConversationDataFlowTests {
             id: initialResume.id,
             result: sharedIdleThreadJSON(id: "thread-not-found", cwd: project.path)
         )
-        let add = try await waitForFakeAppServerRequest(first, method: "thread/queue/add")
+        try await respondToSharedSettingsUpdate(first)
+        _ = try await waitForFakeAppServerRequest(first, method: "thread/queue/add")
         first.failReceive()
 
         let second = try await waitForFakeAppServerTransport(in: pool, index: 1)
@@ -275,6 +371,7 @@ extension ConversationDataFlowTests {
         }
         let initialResume = try await waitForFakeAppServerRequest(first, method: "thread/resume")
         transportResponse(first, id: initialResume.id, result: sharedIdleThreadJSON(id: "thread-items", cwd: project.path))
+        try await respondToSharedSettingsUpdate(first)
         _ = try await waitForFakeAppServerRequest(first, method: "thread/queue/add")
         first.failReceive()
 
@@ -903,7 +1000,8 @@ private func makeSharedSSHConfig(project: AgentProject) -> CodexAppServerConfigR
         policy: CodexAppServerPolicyMetadata(
             allowedMethods: [
                 "initialize", "initialized", "thread/start", "thread/resume", "thread/read",
-                "thread/turns/list", "thread/items/list", "thread/queue/add", "thread/queue/list"
+                "thread/turns/list", "thread/items/list", "thread/settings/update",
+                "thread/queue/add", "thread/queue/list"
             ],
             projectsSource: "agentd_allowlist"
         )
@@ -912,6 +1010,22 @@ private func makeSharedSSHConfig(project: AgentProject) -> CodexAppServerConfigR
 
 private func appServerRequests(_ transport: FakeCodexAppServerTransport) async -> [CodexAppServerRequest] {
     await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+}
+
+private func respondToSharedSettingsUpdate(
+    _ transport: FakeCodexAppServerTransport,
+    after startIndex: Int = 0
+) async throws {
+    let settings = try await waitForFakeAppServerRequest(
+        transport,
+        method: "thread/settings/update",
+        after: startIndex
+    )
+    let requestsBeforeSettingsACK = await appServerRequests(transport)
+    XCTAssertFalse(requestsBeforeSettingsACK.contains { request in
+        request.method == "thread/queue/add"
+    })
+    transportResponse(transport, id: settings.id, result: #"{}"#)
 }
 
 @MainActor


### PR DESCRIPTION
## 目标

移动端拥有会话控制权时，可以继续调整下一回合的模型、推理强度和计划模式；观察态、只读或 Writer 冲突仍保持锁定。

## 改动

- Composer 设置策略复用 `SessionStore.canControlSession(_:)`，不再按已有远程会话统一锁定。
- `.ipadOwned`、`.takenOver` 和可发送的空闲会话保持可编辑。
- `.observing`、协议只读、连接切换和 active-writer 冲突保持锁定。
- 接管成功后由现有控制权状态立即驱动界面解锁。
- 锁定提示改为基于控制权的准确说明。
- 临时失去控制权时保留下一回合设置，不再静默清除计划模式。

## 验证

- 新增策略与控制状态定向测试：通过。
- 新会话真实 ID 迁移、历史会话接管、协议只读回归：通过。
- Compact Composer 渲染回归：通过。
- LocalizationTests：通过。
- `bash ./scripts/check-source-size.sh`：通过。
- `git diff --check`：通过。

Linear: MIM-220