### PR TITLE
MIM-218 修复服务重启后的 Claude 旧会话恢复

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/index/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod claude_session_scan;
 
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -149,7 +150,7 @@ pub enum HistoryRefreshResult {
 /// 运行期显式历史扫描器。
 ///
 /// `gate` 在扫描期间保持锁定，既让多个连接共享同一冷却窗口，也避免同时遍历
-/// `~/.claude/projects`。这里只把新 session ID 写入索引，不覆盖已有名称、归档等用户状态。
+/// `~/.claude/projects`。扫描结果会修正 Claude 移动后的 transcript 路径，同时保留名称、归档等用户状态。
 pub struct ClaudeHistoryRefresher {
     index: Arc<CoreThreadIndex<ClaudeSessionRef>>,
     hydrator: ClaudeHydrator,
@@ -184,6 +185,7 @@ impl ClaudeHistoryRefresher {
 
         let refresh_result = async {
             let scanned = self.hydrator.scan().await?;
+            let scanned = reconcile_scanned_entries(&self.index, scanned).await?;
             self.index.hydrate_entries(scanned).await
         }
         .await;
@@ -222,40 +224,103 @@ pub async fn open_index_and_hydrate(
 ) -> Result<Arc<CoreThreadIndex<ClaudeSessionRef>>> {
     let index = CoreThreadIndex::<ClaudeSessionRef>::open_at(path).await?;
     let scanned = hydrator.scan().await?;
-    let scanned_by_id: std::collections::HashMap<&str, &IndexEntry> = scanned
+    let scanned = reconcile_scanned_entries(&index, scanned).await?;
+    let scanned_ids: std::collections::HashSet<&str> = scanned
         .iter()
-        .map(|entry| (entry.thread_id.as_str(), entry))
+        .map(|entry| entry.thread_id.as_str())
         .collect();
     let mut invalid_ids = Vec::new();
-    let mut repaired_entries = Vec::new();
-    for mut entry in index.snapshot().await {
+    for entry in index.snapshot().await {
         let preview = entry.preview.trim();
-        let Some(fresh) = scanned_by_id.get(entry.thread_id.as_str()) else {
+        if !scanned_ids.contains(entry.thread_id.as_str()) {
             if preview.is_empty() || is_legacy_invalid_preview(preview) {
                 invalid_ids.push(entry.thread_id);
             }
-            continue;
-        };
-        if is_legacy_invalid_preview(preview) {
-            // 只替换扫描产生的字段，保留用户设置的名称、归档和分叉关系。
-            entry.preview.clone_from(&fresh.preview);
-            entry.cwd.clone_from(&fresh.cwd);
-            entry.updated_at = fresh.updated_at;
-            entry.metadata.clone_from(&fresh.metadata);
-            repaired_entries.push(entry);
         }
     }
     let removed = index.remove_many(&invalid_ids).await?;
-    let repaired = index.upsert_many(repaired_entries).await?;
-    if removed > 0 || repaired > 0 {
-        tracing::info!(
-            removed,
-            repaired,
-            "repaired legacy Claude thread index rows"
-        );
+    if removed > 0 {
+        tracing::info!(removed, "removed invalid legacy Claude thread index rows");
     }
     index.hydrate_entries(scanned).await?;
     Ok(index)
+}
+
+/// Claude 在 EnterWorktree 等流程中会把同一 session 的 JSONL 移到新的编码目录。
+/// 通用索引只按 session ID 补新行，因此这里用扫描结果修正路径，并保留用户维护的字段。
+async fn reconcile_scanned_entries(
+    index: &CoreThreadIndex<ClaudeSessionRef>,
+    scanned: Vec<IndexEntry>,
+) -> Result<Vec<IndexEntry>> {
+    let existing = index.snapshot().await;
+    let scanned = preferred_scanned_entries(scanned, &existing);
+    let scanned_by_id: HashMap<&str, &IndexEntry> = scanned
+        .iter()
+        .map(|entry| (entry.thread_id.as_str(), entry))
+        .collect();
+    let mut repaired_entries = Vec::new();
+
+    for entry in existing {
+        let Some(fresh) = scanned_by_id.get(entry.thread_id.as_str()) else {
+            continue;
+        };
+        let mut repaired = entry.clone();
+        repaired.cwd.clone_from(&fresh.cwd);
+        repaired.created_at = fresh.created_at;
+        repaired.updated_at = fresh.updated_at;
+        repaired.metadata.clone_from(&fresh.metadata);
+        if is_legacy_invalid_preview(entry.preview.trim()) {
+            repaired.preview.clone_from(&fresh.preview);
+        }
+        if repaired != entry {
+            repaired_entries.push(repaired);
+        }
+    }
+
+    index.upsert_many(repaired_entries).await?;
+    Ok(scanned)
+}
+
+/// 同一 session ID 偶尔会在多个 Claude project 目录短暂共存。当前索引路径仍可见时
+/// 继续使用它；否则选择更新时间最新的副本，并用路径作为稳定的并列排序键。
+fn preferred_scanned_entries(scanned: Vec<IndexEntry>, existing: &[IndexEntry]) -> Vec<IndexEntry> {
+    let existing_paths: HashMap<&str, &Path> = existing
+        .iter()
+        .map(|entry| {
+            (
+                entry.thread_id.as_str(),
+                entry.metadata.claude_session_path.as_path(),
+            )
+        })
+        .collect();
+    let mut candidates_by_id: BTreeMap<String, Vec<IndexEntry>> = BTreeMap::new();
+    for entry in scanned {
+        candidates_by_id
+            .entry(entry.thread_id.clone())
+            .or_default()
+            .push(entry);
+    }
+
+    candidates_by_id
+        .into_iter()
+        .filter_map(|(thread_id, mut candidates)| {
+            if let Some(existing_path) = existing_paths.get(thread_id.as_str())
+                && let Some(index) = candidates.iter().position(|entry| {
+                    entry.metadata.claude_session_path.as_path() == *existing_path
+                })
+            {
+                return Some(candidates.swap_remove(index));
+            }
+            candidates.sort_by(|left, right| {
+                right.updated_at.cmp(&left.updated_at).then_with(|| {
+                    left.metadata
+                        .claude_session_path
+                        .cmp(&right.metadata.claude_session_path)
+                })
+            });
+            candidates.into_iter().next()
+        })
+        .collect()
 }
 
 fn is_legacy_invalid_preview(preview: &str) -> bool {
@@ -427,6 +492,98 @@ mod tests {
         assert!(
             repaired.lookup("remote-clean").await.is_some(),
             "扫描目录不可见的正常远端索引不能被顺带清空"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_repairs_moved_transcript_path_and_preserves_user_state() {
+        let dir = TempDir::new().unwrap();
+        let projects_dir = dir.path().join("projects");
+        std::fs::create_dir_all(&projects_dir).unwrap();
+        let moved_path = projects_dir.join("moved.jsonl");
+        std::fs::write(
+            &moved_path,
+            r#"{"type":"user","cwd":"/worktree","message":{"role":"user","content":"真实标题"},"timestamp":"2026-08-31T07:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let index_path = dir.path().join("threads.json");
+        let index = CoreThreadIndex::<ClaudeSessionRef>::open_at(index_path.clone())
+            .await
+            .unwrap();
+        let mut stale = entry("moved", "/old-workspace", 100, 200, true);
+        stale.preview = "用户保留的标题".into();
+        stale.name = Some("用户命名".into());
+        stale.forked_from_id = Some("parent".into());
+        stale.metadata.claude_session_path = PathBuf::from("/missing/moved.jsonl");
+        index.insert(stale).await.unwrap();
+        drop(index);
+
+        let hydrator = ClaudeHydrator::with_override_dir(projects_dir);
+        let repaired = open_index_and_hydrate(index_path, &hydrator).await.unwrap();
+        let row = repaired.lookup("moved").await.unwrap();
+
+        assert_eq!(row.metadata.claude_session_path, moved_path);
+        assert_eq!(row.cwd, "/worktree");
+        assert_eq!(row.preview, "用户保留的标题");
+        assert_eq!(row.name.as_deref(), Some("用户命名"));
+        assert_eq!(row.forked_from_id.as_deref(), Some("parent"));
+        assert!(row.archived);
+    }
+
+    #[tokio::test]
+    async fn runtime_refresh_repairs_moved_transcript_without_reinserting_session() {
+        let dir = TempDir::new().unwrap();
+        let projects_dir = dir.path().join("projects");
+        std::fs::create_dir_all(&projects_dir).unwrap();
+        let moved_path = projects_dir.join("moved.jsonl");
+        std::fs::write(
+            &moved_path,
+            r#"{"type":"user","cwd":"/worktree","message":{"role":"user","content":"真实标题"},"timestamp":"2026-08-31T07:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let index = CoreThreadIndex::<ClaudeSessionRef>::open_at(dir.path().join("threads.json"))
+            .await
+            .unwrap();
+        let mut stale = entry("moved", "/old-workspace", 100, 200, false);
+        stale.metadata.claude_session_path = PathBuf::from("/missing/moved.jsonl");
+        index.insert(stale).await.unwrap();
+        let refresher = ClaudeHistoryRefresher::with_interval(
+            Arc::clone(&index),
+            ClaudeHydrator::with_override_dir(projects_dir),
+            Duration::ZERO,
+        );
+
+        assert_eq!(
+            refresher.refresh_if_due().await.unwrap(),
+            HistoryRefreshResult::Refreshed { inserted: 0 }
+        );
+        assert_eq!(
+            index
+                .lookup("moved")
+                .await
+                .unwrap()
+                .metadata
+                .claude_session_path,
+            moved_path
+        );
+    }
+
+    #[test]
+    fn duplicate_scan_keeps_the_indexed_transcript_while_it_still_exists() {
+        let mut existing = entry("same", "/work", 100, 200, false);
+        existing.metadata.claude_session_path = PathBuf::from("/current/same.jsonl");
+        let current = existing.clone();
+        let mut newer_copy = entry("same", "/new-work", 100, 300, false);
+        newer_copy.metadata.claude_session_path = PathBuf::from("/newer/same.jsonl");
+
+        let selected = preferred_scanned_entries(vec![newer_copy, current], &[existing]);
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(
+            selected[0].metadata.claude_session_path,
+            PathBuf::from("/current/same.jsonl")
         );
     }
 }

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -724,6 +724,11 @@ extension SessionStore {
         }
         do {
             let client = try clientFactory()
+            try await authorizeClaudeSessionBeforeReconnect(
+                current,
+                client: client,
+                reconnectGeneration: reconnectGeneration
+            )
             // 以 preflight 开始时刻判断短缓存，不能等 thread/read 返回后再算；弱网下 read
             // 自身可能跨过 4 秒 TTL，导致明明刚加载成功的首屏仍被重复下载。
             let hadRecentAppliedFullAtPreflightStart = hasRecentFullHistoryFirstPage(sessionID: sessionID)
@@ -762,6 +767,46 @@ extension SessionStore {
             }
             setStatusMessage(L10n.format("ui.snapshot_refresh_failed_before_reconnection_value", error.localizedDescription))
             return current
+        }
+    }
+
+    /// agentd 重启后 gateway 的内存授权会清空。Claude 旧会话必须先由当前连接的
+    /// thread/list 返回，之后 thread/read 和 thread/resume 才能通过同一套能力校验。
+    func authorizeClaudeSessionBeforeReconnect(
+        _ session: AgentSession,
+        client: SessionStoreAPIClient,
+        reconnectGeneration: UInt64
+    ) async throws {
+        guard Self.normalizedRuntimeProvider(session.runtimeProvider ?? session.source) == "claude",
+              let workspace = workspaceForSession(session) else {
+            return
+        }
+
+        var cursor: String?
+        var visitedCursors = Set<String>()
+        for _ in 0..<4 {
+            let page = try await client.sessionsPage(
+                workspace: workspace,
+                runtimeProvider: "claude",
+                cursor: cursor,
+                limit: 100,
+                consistency: cursor == nil ? .authoritative : .fastIndexed
+            )
+            guard !Task.isCancelled,
+                  webSocketReconnectGeneration == reconnectGeneration,
+                  selectedSessionID == session.id else {
+                throw CancellationError()
+            }
+            if page.sessions.contains(where: { $0.id == session.id }) {
+                return
+            }
+            guard page.hasMore,
+                  let nextCursor = page.nextCursor,
+                  !nextCursor.isEmpty,
+                  visitedCursors.insert(nextCursor).inserted else {
+                return
+            }
+            cursor = nextCursor
         }
     }
 

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -784,12 +784,12 @@ extension SessionStore {
 
         var cursor: String?
         var visitedCursors = Set<String>()
-        for _ in 0..<4 {
+        while true {
             let page = try await client.sessionsPage(
                 workspace: workspace,
                 runtimeProvider: "claude",
                 cursor: cursor,
-                limit: 100,
+                limit: 50,
                 consistency: cursor == nil ? .authoritative : .fastIndexed
             )
             guard !Task.isCancelled,
@@ -800,11 +800,13 @@ extension SessionStore {
             if page.sessions.contains(where: { $0.id == session.id }) {
                 return
             }
-            guard page.hasMore,
-                  let nextCursor = page.nextCursor,
+            guard page.hasMore else {
+                throw AgentAPIError.invalidResponse
+            }
+            guard let nextCursor = page.nextCursor,
                   !nextCursor.isEmpty,
                   visitedCursors.insert(nextCursor).inserted else {
-                return
+                throw AgentAPIError.invalidResponse
             }
             cursor = nextCursor
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -466,6 +466,8 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     private let requestLogLock = NSLock()
     private var requestedProjectIDsStorage: [String?] = []
     private var requestedWorkspaceIDsStorage: [String] = []
+    private var requestedWorkspaceCursorsStorage: [String?] = []
+    private var requestedWorkspaceLimitsStorage: [Int?] = []
 
     let projectsResult: [AgentProject]
     let projectsHandler: (() async throws -> [AgentProject])?
@@ -528,6 +530,12 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     }
     var requestedWorkspaceIDs: [String] {
         requestLogLock.withLock { requestedWorkspaceIDsStorage }
+    }
+    var requestedWorkspaceCursors: [String?] {
+        requestLogLock.withLock { requestedWorkspaceCursorsStorage }
+    }
+    var requestedWorkspaceLimits: [Int?] {
+        requestLogLock.withLock { requestedWorkspaceLimitsStorage }
     }
     var requestedThreadSearchQueries: [String] {
         requestLogLock.withLock { requestedThreadSearchQueriesStorage }
@@ -1014,9 +1022,14 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         // 否则并发 append 会让 Array 内存损坏并掩盖真实业务结果。
         requestLogLock.withLock {
             requestedWorkspaceIDsStorage.append(workspace.id)
+            requestedWorkspaceCursorsStorage.append(cursor)
+            requestedWorkspaceLimitsStorage.append(limit)
         }
         if let error = workspaceSessionsError[workspace.id] {
             throw error
+        }
+        if let cursor, let page = cursorPages[cursor] {
+            return page
         }
         if let page = workspacePages[workspace.id] {
             return page

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -786,6 +786,59 @@ extension ConversationDataFlowTests {
         try await waitForWebSocketStatus(.connected, store: store)
     }
 
+    func testClaudeReconnectRefreshesThreadListAuthorizationBeforeResuming() async throws {
+        let project = makeProject(id: "proj_claude_restart_reconnect")
+        let running = makeSession(
+            id: "sess_claude_restart_reconnect",
+            projectID: project.id,
+            title: "Claude 运行中",
+            status: "running",
+            source: "claude",
+            runtimeProvider: "claude"
+        )
+        let appStore = makeIsolatedAppStore()
+        appStore.token = "test-token"
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [running],
+            workspaceSessions: [project.id: [running]],
+            sessionResponses: [
+                running.id: try makeSessionResponse(session: running, recentOutput: nil, lastSeq: nil)
+            ],
+            messagesResult: []
+        )
+        var sockets: [MockWebSocketClient] = []
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client },
+            webSocketFactory: {
+                let socket = MockWebSocketClient()
+                sockets.append(socket)
+                return socket
+            },
+            webSocketReconnectDelayNanoseconds: { _ in 0 }
+        )
+
+        await store.refreshAll(autoAttach: false)
+        store.takeOverSession(running)
+        await store.selectSession(running)
+        sockets[0].emitStatus(.connected)
+        try await waitForWebSocketStatus(.connected, store: store)
+        let workspaceRequestCountBeforeReconnect = client.requestedWorkspaceIDs.count
+
+        sockets[0].emitStatus(.failed("agentd restarted"))
+        for _ in 0..<80 where sockets.count < 2 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertEqual(sockets.count, 2)
+        XCTAssertGreaterThan(client.requestedWorkspaceIDs.count, workspaceRequestCountBeforeReconnect)
+        XCTAssertEqual(client.requestedSessionIDs, [running.id])
+        XCTAssertEqual(sockets[1].connectedSessionIDs, [running.id])
+    }
+
     func testWebSocketAutoReconnectDoesNotGiveUpWhileSessionStaysRunning() async throws {
         let project = makeProject(id: "proj_ws_persistent_reconnect")
         let running = makeSession(id: "sess_ws_persistent_reconnect", projectID: project.id, title: "运行中", status: "running", source: "codex")

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -796,12 +796,35 @@ extension ConversationDataFlowTests {
             source: "claude",
             runtimeProvider: "claude"
         )
+        let authorizationFillers = (1...4).map { index in
+            makeSession(
+                id: "sess_claude_authorization_page_\(index)",
+                projectID: project.id,
+                title: "Claude 历史 \(index)",
+                status: "history",
+                source: "claude",
+                runtimeProvider: "claude"
+            )
+        }
         let appStore = makeIsolatedAppStore()
         appStore.token = "test-token"
         let client = MockSessionStoreClient(
             projects: [project],
             sessions: [running],
             workspaceSessions: [project.id: [running]],
+            workspacePages: [
+                project.id: SessionsPage(
+                    sessions: [authorizationFillers[0]],
+                    nextCursor: "claude_page_2",
+                    hasMore: true
+                )
+            ],
+            cursorPages: [
+                "claude_page_2": SessionsPage(sessions: [authorizationFillers[1]], nextCursor: "claude_page_3", hasMore: true),
+                "claude_page_3": SessionsPage(sessions: [authorizationFillers[2]], nextCursor: "claude_page_4", hasMore: true),
+                "claude_page_4": SessionsPage(sessions: [authorizationFillers[3]], nextCursor: "claude_page_5", hasMore: true),
+                "claude_page_5": SessionsPage(sessions: [running])
+            ],
             sessionResponses: [
                 running.id: try makeSessionResponse(session: running, recentOutput: nil, lastSeq: nil)
             ],
@@ -834,9 +857,55 @@ extension ConversationDataFlowTests {
         }
 
         XCTAssertEqual(sockets.count, 2)
-        XCTAssertGreaterThan(client.requestedWorkspaceIDs.count, workspaceRequestCountBeforeReconnect)
+        XCTAssertEqual(
+            Array(client.requestedWorkspaceCursors.dropFirst(workspaceRequestCountBeforeReconnect)),
+            [nil, "claude_page_2", "claude_page_3", "claude_page_4", "claude_page_5"]
+        )
+        XCTAssertEqual(
+            Array(client.requestedWorkspaceLimits.dropFirst(workspaceRequestCountBeforeReconnect)),
+            Array(repeating: 50, count: 5)
+        )
         XCTAssertEqual(client.requestedSessionIDs, [running.id])
         XCTAssertEqual(sockets[1].connectedSessionIDs, [running.id])
+    }
+
+    func testClaudeReconnectAuthorizationFailsWhenSelectedSessionIsNotListed() async {
+        let project = makeProject(id: "proj_claude_missing_authorization")
+        let missing = makeSession(
+            id: "sess_claude_missing_authorization",
+            projectID: project.id,
+            title: "Claude 已丢失",
+            status: "history",
+            source: "claude",
+            runtimeProvider: "claude"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            workspacePages: [project.id: SessionsPage(sessions: [])]
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        store.workspacesByID[project.id] = AgentWorkspace(project: project)
+        store.selectedSessionID = missing.id
+
+        do {
+            try await store.authorizeClaudeSessionBeforeReconnect(
+                missing,
+                client: client,
+                reconnectGeneration: store.webSocketReconnectGeneration
+            )
+            XCTFail("目标会话未进入授权列表时不应静默成功")
+        } catch AgentAPIError.invalidResponse {
+            XCTAssertEqual(client.requestedWorkspaceLimits.last, 50)
+        } catch {
+            XCTFail("应返回 invalidResponse，实际为 \(error)")
+        }
     }
 
     func testWebSocketAutoReconnectDoesNotGiveUpWhileSessionStaysRunning() async throws {


### PR DESCRIPTION
## 结果

- Claude bridge 在启动和显式历史刷新时修正同一 session 移动后的 JSONL 路径，并保留名称、归档和分叉状态。
- iOS 在 agentd 连接重建后先用 Claude `thread/list` 恢复 gateway 授权，再读取和恢复旧会话。

## 验证

- `cargo test -p alleycat-claude-bridge`：通过。
- M5 Simulator 重连定向测试：3/3 通过。
- `bash ./scripts/check-source-size.sh`：通过。
- 用真实 MIM-218 索引副本验证，旧路径已修正到现存 1.2 MB transcript。
- USB iPad mini 复现了空白详情；本机签名私钥当前返回 `errSecInternalComponent`，等待钥匙串解锁后部署修复版做实体机回归。

Linear: MIM-218