### PR TITLE
MIM-221 隐藏无需用户处理的 Codex 内部警告

### DIFF
--- a/ios/MimiRemote/Sources/State/EventReducer.swift
+++ b/ios/MimiRemote/Sources/State/EventReducer.swift
@@ -255,6 +255,11 @@ actor EventReducer {
                 sessionID: fallbackSessionID,
                 seq: nil
             ))
+            // Skill 简介压缩只说明 Codex 的内部上下文降级，用户没有可执行操作。
+            // 保留日志供诊断，但不要把这类提示放进会话正文制造故障感。
+            guard !isInternalSkillContextBudgetWarning(payload.message) else {
+                break
+            }
             output.messageMutations.append(.system(payload.message, fallbackSessionID, .warning, metadata))
         case .error(let payload, let metadata):
             let id = metadata.sessionID ?? fallbackSessionID
@@ -383,5 +388,12 @@ actor EventReducer {
         default:
             return false
         }
+    }
+
+    private func isInternalSkillContextBudgetWarning(_ message: String) -> Bool {
+        let normalized = message.lowercased()
+        // 同时匹配两个稳定片段，避免误隐藏其他包含 Skill 描述的可操作警告。
+        return normalized.contains("skill descriptions were shortened")
+            && normalized.contains("skills context budget")
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -3011,6 +3011,30 @@ final class ConversationDataFlowTests: XCTestCase {
         }
     }
 
+    func testEventReducerKeepsInternalSkillBudgetWarningOutOfConversation() async throws {
+        let metadata = AgentEventMetadata(
+            seq: 45,
+            sessionID: "codex_thread",
+            turnID: nil,
+            itemID: nil,
+            messageID: nil,
+            clientMessageID: nil,
+            revision: nil,
+            createdAt: nil
+        )
+        let warning = "Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill."
+
+        let output = await EventReducer().reduce(
+            .warning(AgentErrorPayload(message: warning, code: "warning", retryable: false), metadata),
+            fallbackSessionID: "codex_thread",
+            outputIdleClearDelay: 0
+        )
+
+        XCTAssertTrue(output.messageMutations.isEmpty)
+        XCTAssertEqual(output.logAppends.count, 1)
+        XCTAssertTrue(output.logAppends[0].text.contains(warning))
+    }
+
     func testEventReducerPresentsClaudeAuthenticationFailureAsRecoverableChineseNotice() async throws {
         let reducer = EventReducer()
         let metadata = AgentEventMetadata(


### PR DESCRIPTION
## 结果

- Skill 上下文预算内部提示继续写入诊断日志，但不再进入会话正文
- 其他需要用户关注的 warning 继续显示为黄色运行警告
- 真实 error 逻辑不变

## 验证

- 固定 iPad Pro 13-inch (M5) Simulator 定向测试：2 条通过
- bash ./scripts/check-source-size.sh：通过
- git diff --check：通过

Linear: MIM-221