### PR TITLE
MIM-229 修复大型会话分支缓慢和刷新不可见

### DIFF
--- a/internal/httpapi/appserver_fork_response_test.go
+++ b/internal/httpapi/appserver_fork_response_test.go
@@ -1,0 +1,109 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSanitizedGatewayThreadForkKeepsSourceAndForcesBoundedResponse(t *testing.T) {
+	policy, projectDir, _ := newThreadSearchPolicy(t)
+	params := sanitizedGatewayThreadParams("codex", "thread/fork", map[string]any{
+		"threadId":     "thread-source",
+		"cwd":          projectDir,
+		"threadSource": "duplicate",
+		"excludeTurns": false,
+	})
+	if params["threadSource"] != "duplicate" || params["excludeTurns"] != true {
+		t.Fatalf("thread/fork 必须保留来源并强制小响应：%v", params)
+	}
+
+	largeTurn := strings.Repeat("large-turn-output", 20_000)
+	payload, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      41,
+		"result": map[string]any{
+			"thread": map[string]any{
+				"id":           "thread-forked",
+				"cwd":          projectDir,
+				"threadSource": "duplicate",
+				"turns":        []any{map[string]any{"id": "turn-1", "items": []any{largeTurn}}},
+			},
+			"model": "gpt-5.6-sol",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rewritten, result, err := sanitizeThreadForkResponse(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rewritten) >= len(payload)/10 || bytes.Contains(rewritten, []byte(largeTurn)) {
+		t.Fatalf("thread/fork 完整历史未被裁剪：before=%d after=%d", len(payload), len(rewritten))
+	}
+	var resultFields map[string]json.RawMessage
+	if err := json.Unmarshal(result, &resultFields); err != nil {
+		t.Fatal(err)
+	}
+	var thread struct {
+		ID           string            `json:"id"`
+		ThreadSource string            `json:"threadSource"`
+		Turns        []json.RawMessage `json:"turns"`
+	}
+	if err := json.Unmarshal(resultFields["thread"], &thread); err != nil {
+		t.Fatal(err)
+	}
+	if thread.ID != "thread-forked" || thread.ThreadSource != "duplicate" || len(thread.Turns) != 0 {
+		t.Fatalf("裁剪后必须保留线程元数据并清空 turns：%+v", thread)
+	}
+
+	scope, ok := policy.router.gatewayScopeForPath(projectDir)
+	if !ok {
+		t.Fatal("测试工作区必须可由 gateway 授权")
+	}
+	rawID := json.RawMessage(`41`)
+	if err := policy.rememberPendingThreadRequest(&rawID, appServerGatewayPendingThreadRequest{
+		method: "thread/fork", cwd: projectDir, scopeID: scope.id, threadID: "thread-source",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	forwarded, forward, policyErr := policy.observeUpstreamFrame(1, payload)
+	if policyErr != nil || !forward || bytes.Contains(forwarded, []byte(largeTurn)) {
+		t.Fatalf("gateway 必须转发有界 fork 响应：forward=%t err=%v bytes=%d", forward, policyErr, len(forwarded))
+	}
+	if _, ok := policy.allowedThread("thread-forked"); !ok {
+		t.Fatal("裁剪响应后仍必须授权新分支，保证后续 thread/started 和重命名可用")
+	}
+}
+
+func TestAppServerGatewayKeepsSlowForkPendingForLateReconciliation(t *testing.T) {
+	oldThreadTTL := appServerGatewayPendingThreadTTL
+	oldForkTTL := appServerGatewayPendingForkTTL
+	appServerGatewayPendingThreadTTL = 30 * time.Second
+	appServerGatewayPendingForkTTL = 2 * time.Minute
+	t.Cleanup(func() {
+		appServerGatewayPendingThreadTTL = oldThreadTTL
+		appServerGatewayPendingForkTTL = oldForkTTL
+	})
+
+	createdAt := time.Now().Add(-75 * time.Second)
+	policy := &appServerGatewayPolicy{
+		pendingThreads: map[string]appServerGatewayPendingThreadRequest{
+			"fork": {method: "thread/fork", createdAt: createdAt},
+			"list": {method: "thread/list", createdAt: createdAt},
+		},
+	}
+	policy.mu.Lock()
+	policy.prunePendingThreadsLocked(time.Now())
+	_, keptFork := policy.pendingThreads["fork"]
+	_, keptList := policy.pendingThreads["list"]
+	policy.mu.Unlock()
+
+	if !keptFork || keptList {
+		t.Fatalf("75 秒 fork 应保留对账上下文，普通列表应按 30 秒清理：fork=%t list=%t", keptFork, keptList)
+	}
+}

--- a/internal/httpapi/appserver_fork_response_test.go
+++ b/internal/httpapi/appserver_fork_response_test.go
@@ -80,17 +80,14 @@ func TestSanitizedGatewayThreadForkKeepsSourceAndForcesBoundedResponse(t *testin
 	}
 }
 
-func TestAppServerGatewayKeepsSlowForkPendingForLateReconciliation(t *testing.T) {
+func TestAppServerGatewayKeepsForkPendingUntilResponseOrClose(t *testing.T) {
 	oldThreadTTL := appServerGatewayPendingThreadTTL
-	oldForkTTL := appServerGatewayPendingForkTTL
 	appServerGatewayPendingThreadTTL = 30 * time.Second
-	appServerGatewayPendingForkTTL = 2 * time.Minute
 	t.Cleanup(func() {
 		appServerGatewayPendingThreadTTL = oldThreadTTL
-		appServerGatewayPendingForkTTL = oldForkTTL
 	})
 
-	createdAt := time.Now().Add(-75 * time.Second)
+	createdAt := time.Now().Add(-24 * time.Hour)
 	policy := &appServerGatewayPolicy{
 		pendingThreads: map[string]appServerGatewayPendingThreadRequest{
 			"fork": {method: "thread/fork", createdAt: createdAt},
@@ -104,6 +101,14 @@ func TestAppServerGatewayKeepsSlowForkPendingForLateReconciliation(t *testing.T)
 	policy.mu.Unlock()
 
 	if !keptFork || keptList {
-		t.Fatalf("75 秒 fork 应保留对账上下文，普通列表应按 30 秒清理：fork=%t list=%t", keptFork, keptList)
+		t.Fatalf("fork 应保留到响应或连接关闭，普通列表应按 30 秒清理：fork=%t list=%t", keptFork, keptList)
+	}
+
+	policy.close()
+	policy.mu.Lock()
+	remaining := len(policy.pendingThreads)
+	policy.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("连接关闭必须释放 fork 上下文，remaining=%d", remaining)
 	}
 }

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -57,6 +57,7 @@ var (
 		appServerGatewayLargeFrameMaxWriteWindow + appServerGatewayWriteWindow +
 		appServerGatewayPongGrace
 	appServerGatewayPendingThreadTTL              = 30 * time.Second
+	appServerGatewayPendingForkTTL                = 3 * time.Minute
 	appServerGatewayPendingThreadMax              = 128
 	appServerGatewayPendingClientRequestTTL       = 2 * time.Minute
 	appServerGatewayPendingClientRequestMax       = 256

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -57,7 +57,6 @@ var (
 		appServerGatewayLargeFrameMaxWriteWindow + appServerGatewayWriteWindow +
 		appServerGatewayPongGrace
 	appServerGatewayPendingThreadTTL              = 30 * time.Second
-	appServerGatewayPendingForkTTL                = 3 * time.Minute
 	appServerGatewayPendingThreadMax              = 128
 	appServerGatewayPendingClientRequestTTL       = 2 * time.Minute
 	appServerGatewayPendingClientRequestMax       = 256

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -175,7 +175,10 @@ func (p *appServerGatewayPolicy) validateThreadCapability(frame *appServerGatewa
 		if !scopeOK {
 			return fmt.Errorf("%s.cwd 必须来自已授权工作区", method)
 		}
-		if err := p.rememberPendingThreadResponseWithManagedUse(frame.ID, method, cwd, scope.id, validated.pendingManagedWorktreePath); err != nil {
+		if err := p.rememberPendingThreadRequest(frame.ID, appServerGatewayPendingThreadRequest{
+			method: method, cwd: cwd, scopeID: scope.id, threadID: threadID,
+			managedWorktreePath: validated.pendingManagedWorktreePath,
+		}); err != nil {
 			return err
 		}
 	case "thread/read", "thread/turns/list", "thread/items/list", "thread/queue/list", "thread/settings/update",
@@ -1254,6 +1257,11 @@ func sanitizedGatewayThreadParams(runtimeID string, method string, params map[st
 	}
 	if method == "thread/fork" {
 		copyGatewayParam(safe, params, "lastTurnId")
+		if threadSource, ok := gatewayStringParam(params, "threadSource"); ok && len(threadSource) <= 64 {
+			// fork 没有新用户消息，必须保留调用方声明的来源。否则超时后
+			// 留下的持久化线程会退化成无来源空会话，刷新列表也无法识别。
+			safe["threadSource"] = threadSource
+		}
 	}
 	if method == "thread/resume" || method == "thread/fork" {
 		safe["excludeTurns"] = true

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -71,13 +71,13 @@ func (p *appServerGatewayPolicy) prunePendingThreadsLocked(now time.Time) {
 			// 才能证明该 cwd 不再处于未完成使用窗口。
 			continue
 		}
-		ttl := appServerGatewayPendingThreadTTL
 		if pending.method == "thread/fork" {
-			// fork 需要读取并复制源 rollout。大型会话可能超过普通元数据请求的
-			// 30 秒窗口；过早遗忘会让迟到成功响应绕过裁剪和新线程授权。
-			ttl = appServerGatewayPendingForkTTL
+			// fork 是非幂等写请求，且旧 App Server 可能在任意时长后返回完整历史。
+			// 固定 TTL 会让迟到响应绕过裁剪和新线程授权；只允许明确响应、失败
+			// 或连接关闭释放。pending 总量上限继续约束异常连接的内存占用。
+			continue
 		}
-		if pending.createdAt.IsZero() || now.Sub(pending.createdAt) > ttl {
+		if pending.createdAt.IsZero() || now.Sub(pending.createdAt) > appServerGatewayPendingThreadTTL {
 			delete(p.pendingThreads, id)
 		}
 	}

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -71,7 +71,13 @@ func (p *appServerGatewayPolicy) prunePendingThreadsLocked(now time.Time) {
 			// 才能证明该 cwd 不再处于未完成使用窗口。
 			continue
 		}
-		if pending.createdAt.IsZero() || now.Sub(pending.createdAt) > appServerGatewayPendingThreadTTL {
+		ttl := appServerGatewayPendingThreadTTL
+		if pending.method == "thread/fork" {
+			// fork 需要读取并复制源 rollout。大型会话可能超过普通元数据请求的
+			// 30 秒窗口；过早遗忘会让迟到成功响应绕过裁剪和新线程授权。
+			ttl = appServerGatewayPendingForkTTL
+		}
+		if pending.createdAt.IsZero() || now.Sub(pending.createdAt) > ttl {
 			delete(p.pendingThreads, id)
 		}
 	}
@@ -243,6 +249,17 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 		p.completePendingThreadResponse(key, pending, p.relatedThreadsFromResult(frame.Result, pending))
 		return payload, true, nil
 	}
+	if pending.method == "thread/fork" {
+		rewritten, result, err := sanitizeThreadForkResponse(payload)
+		if err != nil {
+			p.forgetPending(frame.ID)
+			return payload, false, &appServerGatewayPolicyError{
+				id: frame.ID, message: err.Error(), target: "client",
+			}
+		}
+		p.completePendingThreadResponse(key, pending, p.threadsFromResult(result, pending))
+		return rewritten, true, nil
+	}
 	if pending.method == "thread/read" {
 		if err := p.validateReadOnlyThreadResponse(frame.Result, pending); err != nil {
 			p.forgetPending(frame.ID)
@@ -261,6 +278,39 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 	// 成功响应先把 thread 写入连接级与全局 gateway 授权表，再释放
 	// pending-use。转换期间至少有一种保护存在，cleanup 看不到可删除窗口。
 	return payload, true, nil
+}
+
+func sanitizeThreadForkResponse(payload []byte) ([]byte, json.RawMessage, error) {
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return nil, nil, fmt.Errorf("thread/fork response 无效")
+	}
+	var result map[string]json.RawMessage
+	if raw := response["result"]; len(raw) == 0 || json.Unmarshal(raw, &result) != nil {
+		return nil, nil, fmt.Errorf("thread/fork response.result 必须是对象")
+	}
+	var thread map[string]json.RawMessage
+	if raw := result["thread"]; len(raw) == 0 || json.Unmarshal(raw, &thread) != nil {
+		return nil, nil, fmt.Errorf("thread/fork response.thread 必须是对象")
+	}
+	// excludeTurns 是主路径；这里再做响应侧兜底，避免旧 App Server
+	// 忽略该字段时把完整历史写向移动端并阻塞同连接上的后续小 RPC。
+	thread["turns"] = json.RawMessage(`[]`)
+	threadRaw, err := json.Marshal(thread)
+	if err != nil {
+		return nil, nil, fmt.Errorf("thread/fork response.thread 无法裁剪")
+	}
+	result["thread"] = threadRaw
+	resultRaw, err := json.Marshal(result)
+	if err != nil {
+		return nil, nil, fmt.Errorf("thread/fork response.result 无法裁剪")
+	}
+	response["result"] = resultRaw
+	rewritten, err := json.Marshal(response)
+	if err != nil {
+		return nil, nil, fmt.Errorf("thread/fork response 无法裁剪")
+	}
+	return rewritten, resultRaw, nil
 }
 
 func (p *appServerGatewayPolicy) resolveGlobalListCursor(params map[string]any) error {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -68,6 +68,110 @@ extension CodexAppServerSessionRuntime {
         }
     }
 
+    func beginForkReconciliation(
+        sourceThreadID: SessionID,
+        expectedThreadSource: String
+    ) -> UUID {
+        let token = UUID()
+        pendingForkReconciliationsByToken[token] = CodexAppServerPendingForkReconciliation(
+            sourceThreadID: sourceThreadID,
+            expectedThreadSource: expectedThreadSource,
+            startedAt: Date()
+        )
+        return token
+    }
+
+    func waitForForkReconciliation(
+        _ token: UUID,
+        timeout: TimeInterval
+    ) async -> AgentSession? {
+        guard let pending = pendingForkReconciliationsByToken[token] else {
+            return nil
+        }
+        if let session = pending.session {
+            pendingForkReconciliationsByToken.removeValue(forKey: token)
+            return session
+        }
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard var current = pendingForkReconciliationsByToken[token] else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                current.continuation = continuation
+                let timeoutNanoseconds = UInt64(max(0.1, timeout) * 1_000_000_000)
+                current.timeoutTask = Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    guard !Task.isCancelled else { return }
+                    await self?.cancelForkReconciliation(token)
+                }
+                pendingForkReconciliationsByToken[token] = current
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.cancelForkReconciliation(token)
+            }
+        }
+    }
+
+    func cancelForkReconciliation(_ token: UUID) {
+        guard let pending = pendingForkReconciliationsByToken.removeValue(forKey: token) else {
+            return
+        }
+        pending.timeoutTask?.cancel()
+        pending.continuation?.resume(returning: nil)
+    }
+
+    func reconcileForkStarted(
+        thread: [String: CodexAppServerJSONValue],
+        session: AgentSession
+    ) {
+        guard let sourceThreadID = nonEmpty(
+            thread["forkedFromId"]?.stringValue,
+            thread["forked_from_id"]?.stringValue
+        ),
+        let threadSource = nonEmpty(
+            thread["threadSource"]?.stringValue,
+            thread["thread_source"]?.stringValue
+        ) else {
+            return
+        }
+        let createdAt = firstDate(in: thread, keys: ["createdAt", "created_at"])
+        guard let token = pendingForkReconciliationsByToken.first(where: { _, pending in
+            pending.sourceThreadID == sourceThreadID
+                && pending.expectedThreadSource == threadSource
+                && (createdAt.map { $0 >= pending.startedAt.addingTimeInterval(-5) } ?? true)
+        })?.key,
+        var pending = pendingForkReconciliationsByToken[token] else {
+            return
+        }
+        if let continuation = pending.continuation {
+            pendingForkReconciliationsByToken.removeValue(forKey: token)
+            pending.timeoutTask?.cancel()
+            continuation.resume(returning: session)
+        } else {
+            pending.session = session
+            pendingForkReconciliationsByToken[token] = pending
+        }
+    }
+
+    func rememberForkedSession(_ session: AgentSession) {
+        contextsBySessionID[session.id] = CodexAppServerSessionContext(
+            session: session,
+            cwd: session.dir,
+            activeTurnID: session.activeTurnID
+        )
+        threadsResumedOnConnection.insert(session.id)
+    }
+
+    func isThreadForkTimeout(_ error: Error) -> Bool {
+        guard let connectionError = error as? CodexAppServerConnectionError,
+              case .timeout(let method, _) = connectionError else {
+            return false
+        }
+        return method == "thread/fork"
+    }
+
     private func compactTrailingBufferedDeltas(_ events: inout [AgentEvent]) {
         while events.count >= 2 {
             let previousIndex = events.index(events.endIndex, offsetBy: -2)
@@ -130,10 +234,19 @@ extension CodexAppServerSessionRuntime {
             applyAccountRateLimit(summary)
         case "thread/started":
             guard let thread = params["thread"]?.objectValue,
-                  let session = try? agentSession(from: thread, projects: (try? projectsFromCache()) ?? [], fallbackProject: nil, forceRunning: true) else {
+                  let session = try? agentSession(
+                    from: thread,
+                    projects: (try? projectsFromCache()) ?? [],
+                    fallbackProject: nil,
+                    forceRunning: nonEmpty(
+                        thread["forkedFromId"]?.stringValue,
+                        thread["forked_from_id"]?.stringValue
+                    ) == nil
+                  ) else {
                 return
             }
             contextsBySessionID[session.id] = CodexAppServerSessionContext(session: session, cwd: session.dir, activeTurnID: session.activeTurnID)
+            reconcileForkStarted(thread: thread, session: session)
             emit(.session(session))
         case "thread/settings/updated":
             guard let threadID = params["threadId"]?.stringValue else {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -123,6 +123,17 @@ struct CodexAppServerTurnInterruptRecoveryTask {
     let task: Task<Void, Never>
 }
 
+/// fork 的 RPC 可能先在移动端超时，随后才收到 thread/started。
+/// 保留一次有界对账，避免把已经成功创建的分支误报为失败。
+struct CodexAppServerPendingForkReconciliation {
+    let sourceThreadID: SessionID
+    let expectedThreadSource: String
+    let startedAt: Date
+    var session: AgentSession?
+    var continuation: CheckedContinuation<AgentSession?, Never>?
+    var timeoutTask: Task<Void, Never>?
+}
+
 enum CodexAppServerTurnStartOutcome: Equatable {
     // RPC 已接受，且当前仍是这一轮或尚在等待 turn/started。
     case active(turnID: TurnID?)
@@ -225,6 +236,7 @@ actor CodexAppServerSessionRuntime {
     // SessionStore 会一直保留旧 activeTurnID。按被中断的 turn 去重保存有界恢复任务，
     // 只在权威 turns 快照确认终态后补发完成事件。
     var turnInterruptRecoveryTasksBySessionID: [SessionID: CodexAppServerTurnInterruptRecoveryTask] = [:]
+    var pendingForkReconciliationsByToken: [UUID: CodexAppServerPendingForkReconciliation] = [:]
     let requestTimeout: TimeInterval
     let longRunningRequestTimeout: TimeInterval
     let turnInterruptRecoveryDelaysNanoseconds: [UInt64]
@@ -279,6 +291,7 @@ actor CodexAppServerSessionRuntime {
         threadResumeTasksBySessionID.values.forEach { $0.task.cancel() }
         threadUnsubscribeRetryTasksBySessionID.values.forEach { $0.task.cancel() }
         turnInterruptRecoveryTasksBySessionID.values.forEach { $0.task.cancel() }
+        pendingForkReconciliationsByToken.values.forEach { $0.timeoutTask?.cancel() }
     }
 
     func projects() async throws -> [AgentProject] {
@@ -998,26 +1011,40 @@ actor CodexAppServerSessionRuntime {
         var options = CodexAppServerTurnOptions.default
         options.threadSource = reason.rawValue
         options.preservesThreadPermissionSettings = true
-        let result = try await sendRecoveringFromStaleInitialization(
-            try CodexAppServerRequestBuilder(allowlistedProjects: projects).threadFork(
-                threadID: threadID,
-                cwd: workspace.path,
-                lastTurnID: lastTurnID,
-                options: options
-            ),
-            timeout: longRunningRequestTimeout
+        let reconciliationToken = beginForkReconciliation(
+            sourceThreadID: threadID,
+            expectedThreadSource: reason.rawValue
         )
+        let result: CodexAppServerJSONValue?
+        do {
+            result = try await sendRecoveringFromStaleInitialization(
+                try CodexAppServerRequestBuilder(allowlistedProjects: projects).threadFork(
+                    threadID: threadID,
+                    cwd: workspace.path,
+                    lastTurnID: lastTurnID,
+                    options: options
+                ),
+                timeout: longRunningRequestTimeout
+            )
+            cancelForkReconciliation(reconciliationToken)
+        } catch {
+            if isThreadForkTimeout(error),
+               let reconciled = await waitForForkReconciliation(
+                reconciliationToken,
+                timeout: longRunningRequestTimeout
+               ) {
+                rememberForkedSession(reconciled)
+                return reconciled
+            }
+            cancelForkReconciliation(reconciliationToken)
+            throw error
+        }
         guard let thread = threadObject(from: result) else {
             throw AgentAPIError.invalidResponse
         }
         let session = try agentSession(from: thread, projects: projects, fallbackProject: project)
         emitActivePermissionProfile(from: result, threadID: session.id)
-        contextsBySessionID[session.id] = CodexAppServerSessionContext(
-            session: session,
-            cwd: session.dir,
-            activeTurnID: session.activeTurnID
-        )
-        threadsResumedOnConnection.insert(session.id)
+        rememberForkedSession(session)
         return session
     }
 

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1011,10 +1011,17 @@ actor CodexAppServerSessionRuntime {
         var options = CodexAppServerTurnOptions.default
         options.threadSource = reason.rawValue
         options.preservesThreadPermissionSettings = true
-        let reconciliationToken = beginForkReconciliation(
-            sourceThreadID: threadID,
-            expectedThreadSource: reason.rawValue
-        )
+        let reconciliationToken: UUID?
+        if runtimeProvider == "codex" {
+            reconciliationToken = beginForkReconciliation(
+                sourceThreadID: threadID,
+                expectedThreadSource: reason.rawValue
+            )
+        } else {
+            // Claude Bridge 的 thread/fork 不发送 thread/started，不能进入
+            // 只会增加等待时间且永远无法成功的事件对账。
+            reconciliationToken = nil
+        }
         let result: CodexAppServerJSONValue?
         do {
             result = try await sendRecoveringFromStaleInitialization(
@@ -1026,9 +1033,12 @@ actor CodexAppServerSessionRuntime {
                 ),
                 timeout: longRunningRequestTimeout
             )
-            cancelForkReconciliation(reconciliationToken)
+            if let reconciliationToken {
+                cancelForkReconciliation(reconciliationToken)
+            }
         } catch {
-            if isThreadForkTimeout(error),
+            if let reconciliationToken,
+               isThreadForkTimeout(error),
                let reconciled = await waitForForkReconciliation(
                 reconciliationToken,
                 timeout: longRunningRequestTimeout
@@ -1036,7 +1046,9 @@ actor CodexAppServerSessionRuntime {
                 rememberForkedSession(reconciled)
                 return reconciled
             }
-            cancelForkReconciliation(reconciliationToken)
+            if let reconciliationToken {
+                cancelForkReconciliation(reconciliationToken)
+            }
             throw error
         }
         guard let thread = threadObject(from: result) else {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ForkOnWriterConflictProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ForkOnWriterConflictProtocolTests.swift
@@ -74,6 +74,7 @@ final class ForkOnWriterConflictProtocolTests: XCTestCase {
         let fork = try await waitForFakeAppServerRequest(transport, method: "thread/fork", after: 1)
         let params = try XCTUnwrap(fork.params?.objectValue)
         XCTAssertEqual(params["lastTurnId"]?.stringValue, "turn-terminal")
+        XCTAssertEqual(params["threadSource"]?.stringValue, "duplicate")
         XCTAssertEqual(params["mimiPreserveThreadPermissions"]?.boolValue, true)
         XCTAssertNil(params["approvalPolicy"])
         XCTAssertNil(params["approvalsReviewer"])
@@ -88,6 +89,55 @@ final class ForkOnWriterConflictProtocolTests: XCTestCase {
 
         let forked = try await forkTask.value
         XCTAssertEqual(forked.id, "thread-forked")
+    }
+
+    func testForkTimeoutReconcilesLateResponseFromThreadStarted() async throws {
+        let project = AgentProject(id: "proj-late-fork", name: "Late Fork", path: "/tmp/late-fork")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            requestTimeout: 0.1,
+            longRunningRequestTimeout: 0.1,
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "thread/fork"]
+                )
+            }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+
+        let forkTask = Task {
+            try await client.forkSession(
+                threadID: "thread-source",
+                workspace: AgentWorkspace(project: project),
+                reason: .duplicate,
+                lastTurnID: "turn-terminal"
+            )
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-codex","platformFamily":"macos"}"#
+        )
+        let fork = try await waitForFakeAppServerRequest(transport, method: "thread/fork", after: 1)
+
+        try await Task.sleep(nanoseconds: 130_000_000)
+        transportResponse(
+            transport,
+            id: fork.id,
+            result: #"{"thread":{"id":"thread-late","cwd":"/tmp/late-fork","forkedFromId":"thread-source","threadSource":"duplicate","turns":[]}}"#
+        )
+        transport.enqueue(
+            #"{"method":"thread/started","params":{"thread":{"id":"thread-late","sessionId":"thread-late","preview":"","ephemeral":false,"modelProvider":"openai","status":{"type":"idle"},"cwd":"/tmp/late-fork","source":"appServer","threadSource":"duplicate","forkedFromId":"thread-source","turns":[]}}}"#
+        )
+
+        let forked = try await forkTask.value
+        XCTAssertEqual(forked.id, "thread-late")
+        XCTAssertFalse(forked.isRunning)
     }
 
     func testSessionStoreProtocolAndMockCarryOptionalTerminalBoundary() async throws {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ForkOnWriterConflictProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ForkOnWriterConflictProtocolTests.swift
@@ -140,6 +140,50 @@ final class ForkOnWriterConflictProtocolTests: XCTestCase {
         XCTAssertFalse(forked.isRunning)
     }
 
+    func testClaudeForkDoesNotRegisterThreadStartedReconciliation() async throws {
+        let project = AgentProject(id: "proj-claude-fork", name: "Claude Fork", path: "/tmp/claude-fork")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            runtimeProvider: "claude",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(
+                    project: project,
+                    allowedMethods: ["initialize", "initialized", "thread/fork"],
+                    channels: [makeClaudeChannelMetadata()]
+                )
+            }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+
+        let forkTask = Task {
+            try await client.forkSession(
+                threadID: "claude-source",
+                workspace: AgentWorkspace(project: project),
+                reason: .duplicate
+            )
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-claude","platformFamily":"macos"}"#
+        )
+        let fork = try await waitForFakeAppServerRequest(transport, method: "thread/fork", after: 1)
+        let pendingReconciliations = await runtime.pendingForkReconciliationsByToken.count
+        XCTAssertEqual(pendingReconciliations, 0)
+
+        transportResponse(
+            transport,
+            id: fork.id,
+            result: #"{"thread":{"id":"claude-forked","sessionId":"claude-forked","preview":"forked","ephemeral":false,"modelProvider":"anthropic","status":{"type":"idle"},"cwd":"/tmp/claude-fork","source":"appServer","forkedFromId":"claude-source","turns":[]}}"#
+        )
+        let forked = try await forkTask.value
+        XCTAssertEqual(forked.id, "claude-forked")
+    }
+
     func testSessionStoreProtocolAndMockCarryOptionalTerminalBoundary() async throws {
         let project = AgentProject(id: "proj-mock", name: "Mock", path: "/tmp/proj-mock")
         let source = makeSession(


### PR DESCRIPTION
## 目标

修复大型会话执行 thread/fork 时返回完整历史，导致 iOS 等待缓慢、确认超时、重复创建分支以及刷新不可见的问题。

## 修改

- Gateway 强制 excludeTurns，并在响应侧清空 turns，兼容忽略该参数的旧 App Server。
- 保留 threadSource，将 fork pending 对账窗口延长到 3 分钟。
- iOS 在 thread/fork 超时后等待匹配的 thread/started，成功后继续保存、重命名并打开分支。
- 增加大响应裁剪、新分支授权和超时后事件对账测试。

## 验证

- go test ./internal/httpapi -count=1
- bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/ForkOnWriterConflictProtocolTests（7/7 通过）
- bash ./scripts/check-source-size.sh
- git diff --check

iOS 全量测试执行 1463 个。分支相关用例通过；另有 15 个未改动界面的截图基线差异，本 PR 未更新截图。