### PR TITLE
MIM-88 修复 Tailcat TestFlight Go 工具链

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -194,6 +194,12 @@ jobs:
           fetch-depth: 0
           clean: true
 
+      - name: Setup Go for Tailcat
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: experiments/tailcat/go.mod
+          cache-dependency-path: experiments/tailcat/go.sum
+
       # 所有签名材料都在后续 step 才注入；这里先锁定官方仓库当前 main
       # 的同一个 immutable commit，手工从其他分支触发会 fail closed。
       - name: Trust gate before App Store signing

--- a/scripts/check-critical-regressions.sh
+++ b/scripts/check-critical-regressions.sh
@@ -9,7 +9,7 @@ fail() {
   exit 1
 }
 
-for command_name in bash grep; do
+for command_name in bash grep sed; do
   command -v "$command_name" >/dev/null 2>&1 \
     || fail "缺少命令 ${command_name}。"
 done
@@ -43,9 +43,15 @@ grep -Fq 'test-conversation-regressions.sh --ios-only' .github/workflows/ios-ci.
   || fail "iOS CI 没有显式使用 --ios-only。"
 grep -Fq 'test-conversation-regressions.sh --ios-only' scripts/verify-change.sh \
   || fail "本地 full iOS 验证没有显式使用 --ios-only。"
-if grep -Fq 'actions/setup-go@' .github/workflows/ios-ci.yml; then
-  fail "iOS CI 仍在重复初始化 Go 工具链。"
+conversation_job="$(sed -n '/^  conversation-regressions:/,/^  app-store-release:/p' .github/workflows/ios-ci.yml)"
+release_job="$(sed -n '/^  app-store-release:/,$p' .github/workflows/ios-ci.yml)"
+if grep -Fq 'actions/setup-go@' <<<"$conversation_job"; then
+  fail "iOS 回归 job 仍在重复初始化 Go 工具链。"
 fi
+[[ "$(grep -Fc 'actions/setup-go@' <<<"$release_job")" == "1" ]] \
+  || fail "iOS 发布 job 必须且只能初始化一次 Tailcat Go 工具链。"
+grep -Fq 'go-version-file: experiments/tailcat/go.mod' <<<"$release_job" \
+  || fail "iOS 发布 job 没有使用 Tailcat go.mod 固定 Go 版本。"
 if grep -Fq 'bash ./scripts/check-mimi-protocol-contract.sh' .github/workflows/ios-ci.yml; then
   fail "iOS CI 仍在重复执行 Go 协议门禁。"
 fi


### PR DESCRIPTION
## 目标

修复 Tailcat TestFlight 发布在归档前因 macOS runner 缺少 Go 而失败的问题。

## 修改

- Release job 按 `experiments/tailcat/go.mod` 初始化一次固定 Go 工具链。
- 收窄关键链路门禁：Simulator 回归继续禁止 Go 初始化，Release job 必须且只能初始化一次 Tailcat Go。

## 验证

- `bash ./scripts/check-critical-regressions.sh`
- `bash ./scripts/check-nightly-release.sh`
- `bash ./scripts/check-pr-gate.sh`
- `bash ./scripts/check-source-size.sh`
- `git diff --check`

失败发布：https://github.com/gaixianggeng/mimi-remote/actions/runs/33525989328