### PR TITLE
MIM-88 Fix Tailcat macOS notarization

### DIFF
--- a/scripts/build-macos-installer.sh
+++ b/scripts/build-macos-installer.sh
@@ -310,19 +310,22 @@ xcodebuild \
 APP_PATH="$DERIVED_DATA/Build/Products/Release/Mimi Remote Mac.app"
 AGENT_PATH="$APP_PATH/Contents/Resources/agentd"
 BRIDGE_PATH="$APP_PATH/Contents/Resources/alleycat-claude-bridge"
-if [[ ! -d "$APP_PATH" || ! -x "$AGENT_PATH" || ! -x "$BRIDGE_PATH" ]]; then
-  echo "Mac 安装包构建失败：Release App、内嵌 agentd 或 Claude bridge 不存在。" >&2
+TAILCAT_PATH="$APP_PATH/Contents/Resources/mimi-tailcat-experiment"
+if [[ ! -d "$APP_PATH" || ! -x "$AGENT_PATH" || ! -x "$BRIDGE_PATH" || ! -x "$TAILCAT_PATH" ]]; then
+  echo "Mac 安装包构建失败：Release App、内嵌 agentd、Claude bridge 或 Tailcat 不存在。" >&2
   exit 1
 fi
 
 APP_ARCHS="$(lipo -archs "$APP_PATH/Contents/MacOS/Mimi Remote Mac")"
 AGENT_ARCHS="$(lipo -archs "$AGENT_PATH")"
 BRIDGE_ARCHS="$(lipo -archs "$BRIDGE_PATH")"
+TAILCAT_ARCHS="$(lipo -archs "$TAILCAT_PATH")"
 for required_arch in arm64 x86_64; do
   if [[ " $APP_ARCHS " != *" $required_arch "* \
     || " $AGENT_ARCHS " != *" $required_arch "* \
-    || " $BRIDGE_ARCHS " != *" $required_arch "* ]]; then
-    echo "Mac 安装包构建失败：App/agentd/Claude bridge 缺少 ${required_arch}，App=${APP_ARCHS} agentd=${AGENT_ARCHS} bridge=${BRIDGE_ARCHS}。" >&2
+    || " $BRIDGE_ARCHS " != *" $required_arch "* \
+    || " $TAILCAT_ARCHS " != *" $required_arch "* ]]; then
+    echo "Mac 安装包构建失败：App/agentd/Claude bridge/Tailcat 缺少 ${required_arch}，App=${APP_ARCHS} agentd=${AGENT_ARCHS} bridge=${BRIDGE_ARCHS} tailcat=${TAILCAT_ARCHS}。" >&2
     exit 1
   fi
 done
@@ -390,8 +393,14 @@ elif [[ "$DEVELOPMENT_SIGNING" == "1" ]]; then
   fi
 fi
 
-echo "==> 从内到外签名 Claude bridge、agentd 与 App"
+echo "==> 从内到外签名 Tailcat、Claude bridge、agentd 与 App"
 if [[ "$SNAPSHOT" == "1" || "$DEVELOPMENT_SIGNING" == "1" ]]; then
+  codesign --force \
+    --sign "$CODESIGN_IDENTITY" \
+    --identifier com.gaixianggeng.mimi.mac.tailcat \
+    --options runtime \
+    "${CODESIGN_TIMESTAMP[@]}" \
+    "$TAILCAT_PATH"
   codesign --force \
     --sign "$CODESIGN_IDENTITY" \
     --identifier com.gaixianggeng.mimi.mac.claude-bridge \
@@ -412,6 +421,13 @@ if [[ "$SNAPSHOT" == "1" || "$DEVELOPMENT_SIGNING" == "1" ]]; then
     --entitlements "$ROOT_DIR/macos/MimiRemoteMac/Resources/MimiRemoteMac.entitlements" \
     "$APP_PATH"
 else
+  codesign --force \
+    --sign "$CODESIGN_IDENTITY" \
+    --keychain "$KEYCHAIN_PATH" \
+    --identifier com.gaixianggeng.mimi.mac.tailcat \
+    --options runtime \
+    "${CODESIGN_TIMESTAMP[@]}" \
+    "$TAILCAT_PATH"
   codesign --force \
     --sign "$CODESIGN_IDENTITY" \
     --keychain "$KEYCHAIN_PATH" \
@@ -436,6 +452,10 @@ else
     "$APP_PATH"
 fi
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+for binary_path in "$AGENT_PATH" "$BRIDGE_PATH" "$TAILCAT_PATH"; do
+  # --deep 不会可靠拒绝 Resources 下新增的裸 Mach-O，发布前必须直接验证。
+  codesign --verify --strict --verbose=2 "$binary_path"
+done
 
 DMG_ROOT="$WORK_DIR/dmg-root"
 DMG_WRITABLE_PATH="$WORK_DIR/Mimi-Remote-Mac-writable.dmg"

--- a/scripts/check-macos-installer.sh
+++ b/scripts/check-macos-installer.sh
@@ -106,11 +106,12 @@ APP_PATH="$MOUNT_DIR/Mimi Remote Mac.app"
 APP_EXECUTABLE_PATH="$APP_PATH/Contents/MacOS/Mimi Remote Mac"
 AGENT_PATH="$APP_PATH/Contents/Resources/agentd"
 BRIDGE_PATH="$APP_PATH/Contents/Resources/alleycat-claude-bridge"
+TAILCAT_PATH="$APP_PATH/Contents/Resources/mimi-tailcat-experiment"
 LAUNCH_AGENT_PATH="$APP_PATH/Contents/Library/LaunchAgents/com.gaixianggeng.mimi.mac.agentd.plist"
 INFO_PLIST_PATH="$APP_PATH/Contents/Info.plist"
 
-if [[ ! -d "$APP_PATH" || ! -x "$AGENT_PATH" || ! -x "$BRIDGE_PATH" || ! -f "$LAUNCH_AGENT_PATH" ]]; then
-  echo "Mac 安装包校验失败：DMG 缺少 App、agentd、Claude bridge 或 LaunchAgent。" >&2
+if [[ ! -d "$APP_PATH" || ! -x "$AGENT_PATH" || ! -x "$BRIDGE_PATH" || ! -x "$TAILCAT_PATH" || ! -f "$LAUNCH_AGENT_PATH" ]]; then
+  echo "Mac 安装包校验失败：DMG 缺少 App、agentd、Claude bridge、Tailcat 或 LaunchAgent。" >&2
   exit 1
 fi
 if [[ ! -L "$MOUNT_DIR/Applications" || "$(readlink "$MOUNT_DIR/Applications")" != "/Applications" ]]; then
@@ -179,6 +180,7 @@ fi
 
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 codesign --verify --strict --verbose=2 "$BRIDGE_PATH"
+codesign --verify --strict --verbose=2 "$TAILCAT_PATH"
 plutil -lint "$LAUNCH_AGENT_PATH" >/dev/null
 
 if plutil -extract NSPhotoLibraryUsageDescription raw -o - "$INFO_PLIST_PATH" >/dev/null 2>&1; then
@@ -214,6 +216,7 @@ run_native_version_probe() {
 }
 
 run_native_version_probe "$AGENT_PATH" version >/dev/null
+run_native_version_probe "$TAILCAT_PATH" version >/dev/null
 bridge_version_output="$(run_native_version_probe "$BRIDGE_PATH" --version)"
 if [[ "$bridge_version_output" =~ ^alleycat-claude-bridge[[:space:]]+([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
   bridge_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
@@ -246,6 +249,9 @@ while IFS= read -r -d '' candidate_path; do
   fi
 
   macho_count=$((macho_count + 1))
+  # codesign --deep 不会可靠拒绝 Resources 下新增的裸 Mach-O。逐个校验，避免未签名
+  # sidecar 一直拖到 Apple 公证阶段才暴露。
+  codesign --verify --strict --verbose=2 "$candidate_path"
   binary_archs="$(lipo -archs "$candidate_path")"
   if [[ " $binary_archs " != *" arm64 "* ]]; then
     echo "Mac 安装包校验失败：${candidate_path#"$APP_PATH"/} 是 x86-only Mach-O，缺少 arm64。" >&2
@@ -279,7 +285,7 @@ if [[ "$macho_count" -eq 0 ]]; then
   exit 1
 fi
 
-for binary_path in "$APP_EXECUTABLE_PATH" "$AGENT_PATH" "$BRIDGE_PATH"; do
+for binary_path in "$APP_EXECUTABLE_PATH" "$AGENT_PATH" "$BRIDGE_PATH" "$TAILCAT_PATH"; do
   binary_archs="$(lipo -archs "$binary_path")"
   for required_arch in arm64 x86_64; do
     if [[ " $binary_archs " != *" $required_arch "* ]]; then
@@ -292,25 +298,30 @@ done
 app_signing_details="$(codesign -d --verbose=4 "$APP_PATH" 2>&1)"
 agent_signing_details="$(codesign -d --verbose=4 "$AGENT_PATH" 2>&1)"
 bridge_signing_details="$(codesign -d --verbose=4 "$BRIDGE_PATH" 2>&1)"
+tailcat_signing_details="$(codesign -d --verbose=4 "$TAILCAT_PATH" 2>&1)"
 # 先完整读取 codesign 输出，避免 pipefail 将 awk 提前退出造成的 SIGPIPE 误判为签名失败。
 app_identifier="$(awk -F= '$1 == "Identifier" { print $2; exit }' <<<"$app_signing_details")"
 agent_identifier="$(awk -F= '$1 == "Identifier" { print $2; exit }' <<<"$agent_signing_details")"
 bridge_identifier="$(awk -F= '$1 == "Identifier" { print $2; exit }' <<<"$bridge_signing_details")"
+tailcat_identifier="$(awk -F= '$1 == "Identifier" { print $2; exit }' <<<"$tailcat_signing_details")"
 if [[ "$app_identifier" != "com.gaixianggeng.mimi.mac" \
   || "$agent_identifier" != "com.gaixianggeng.mimi.mac.agentd" \
-  || "$bridge_identifier" != "com.gaixianggeng.mimi.mac.claude-bridge" ]]; then
-  echo "Mac 安装包校验失败：App、agentd 或 Claude bridge 签名 identifier 不稳定。" >&2
+  || "$bridge_identifier" != "com.gaixianggeng.mimi.mac.claude-bridge" \
+  || "$tailcat_identifier" != "com.gaixianggeng.mimi.mac.tailcat" ]]; then
+  echo "Mac 安装包校验失败：App、agentd、Claude bridge 或 Tailcat 签名 identifier 不稳定。" >&2
   exit 1
 fi
 
 app_team_identifier="$(awk -F= '$1 == "TeamIdentifier" { print $2; exit }' <<<"$app_signing_details")"
 agent_team_identifier="$(awk -F= '$1 == "TeamIdentifier" { print $2; exit }' <<<"$agent_signing_details")"
 bridge_team_identifier="$(awk -F= '$1 == "TeamIdentifier" { print $2; exit }' <<<"$bridge_signing_details")"
+tailcat_team_identifier="$(awk -F= '$1 == "TeamIdentifier" { print $2; exit }' <<<"$tailcat_signing_details")"
 if [[ "$REQUIRE_TEAM_SIGNING" == "1" ]]; then
   if [[ ! "$app_team_identifier" =~ ^[A-Z0-9]+$ \
     || "$agent_team_identifier" != "$app_team_identifier" \
-    || "$bridge_team_identifier" != "$app_team_identifier" ]]; then
-    echo "Mac 安装包校验失败：App、agentd 与 Claude bridge 必须使用同一非空 Team ID 签名。" >&2
+    || "$bridge_team_identifier" != "$app_team_identifier" \
+    || "$tailcat_team_identifier" != "$app_team_identifier" ]]; then
+    echo "Mac 安装包校验失败：App、agentd、Claude bridge 与 Tailcat 必须使用同一非空 Team ID 签名。" >&2
     exit 1
   fi
 fi
@@ -319,8 +330,9 @@ if [[ "$REQUIRE_NOTARIZATION" == "1" ]]; then
   codesign --verify --strict --verbose=2 "$DMG_PATH"
   if ! grep -Fq 'Authority=Developer ID Application:' <<<"$app_signing_details" \
     || ! grep -Fq 'Authority=Developer ID Application:' <<<"$agent_signing_details" \
-    || ! grep -Fq 'Authority=Developer ID Application:' <<<"$bridge_signing_details"; then
-    echo "Mac 安装包校验失败：App、agentd 或 Claude bridge 不是有效的 Developer ID Application 签名。" >&2
+    || ! grep -Fq 'Authority=Developer ID Application:' <<<"$bridge_signing_details" \
+    || ! grep -Fq 'Authority=Developer ID Application:' <<<"$tailcat_signing_details"; then
+    echo "Mac 安装包校验失败：App、agentd、Claude bridge 或 Tailcat 不是有效的 Developer ID Application 签名。" >&2
     exit 1
   fi
   xcrun stapler validate "$DMG_PATH"
@@ -332,4 +344,4 @@ team_summary=""
 if [[ "$REQUIRE_TEAM_SIGNING" == "1" ]]; then
   team_summary="、Team ID ${app_team_identifier} 一致"
 fi
-echo "Mac 安装包校验通过：已枚举 ${macho_count} 个 Mach-O，全部包含 arm64 且 macOS 构建元数据可读取；universal App、agentd、Claude bridge ${bridge_version}（要求 >= ${minimum_bridge_version}）、LaunchAgent、拖放入口和签名结构完整${team_summary}。"
+echo "Mac 安装包校验通过：已枚举 ${macho_count} 个 Mach-O，全部已签名、包含 arm64 且 macOS 构建元数据可读取；universal App、agentd、Claude bridge ${bridge_version}（要求 >= ${minimum_bridge_version}）、Tailcat、LaunchAgent、拖放入口和签名结构完整${team_summary}。"

--- a/scripts/check-packaging.sh
+++ b/scripts/check-packaging.sh
@@ -178,6 +178,10 @@ grep -Fq -- '--require-team-signing' scripts/check-macos-installer.sh \
   || fail "Mac 安装包门禁没有提供 App/agentd/bridge Team ID 一致性校验。"
 grep -Fq 'com.gaixianggeng.mimi.mac.claude-bridge' scripts/build-macos-installer.sh \
   || fail "Mac 安装包构建没有为内嵌 Claude bridge 设置稳定签名 identifier。"
+grep -Fq 'com.gaixianggeng.mimi.mac.tailcat' scripts/build-macos-installer.sh \
+  || fail "Mac 安装包构建没有为内嵌 Tailcat 设置稳定签名 identifier。"
+grep -Fq 'for binary_path in "$AGENT_PATH" "$BRIDGE_PATH" "$TAILCAT_PATH"' scripts/build-macos-installer.sh \
+  || fail "Mac 安装包构建没有在公证前直接校验内嵌二进制签名。"
 ! grep -Fq 'com.apple.security.personal-information.photos-library' \
   macos/MimiRemoteMac/Resources/MimiRemoteMac.entitlements \
   || fail "Mac App 仍声明已移除的照片图库 entitlement。"
@@ -193,6 +197,10 @@ grep -Fq 'main_executable_count' scripts/check-macos-installer.sh \
   || fail "Mac 安装包门禁没有校验 Contents/MacOS 主可执行文件唯一性。"
 grep -Fq 'BRIDGE_PATH="$APP_PATH/Contents/Resources/alleycat-claude-bridge"' scripts/check-macos-installer.sh \
   || fail "Mac 安装包门禁没有校验内嵌 Claude bridge。"
+grep -Fq 'TAILCAT_PATH="$APP_PATH/Contents/Resources/mimi-tailcat-experiment"' scripts/check-macos-installer.sh \
+  || fail "Mac 安装包门禁没有校验内嵌 Tailcat。"
+grep -Fq 'codesign --verify --strict --verbose=2 "$candidate_path"' scripts/check-macos-installer.sh \
+  || fail "Mac 安装包门禁没有逐个校验 App 内 Mach-O 签名。"
 grep -Fq 'internal/claudebridge/version.go' scripts/check-macos-installer.sh \
   || fail "Mac 安装包门禁没有读取 agentd 的 Claude bridge 最低版本。"
 grep -Fq 'version_at_least "$bridge_version" "$minimum_bridge_version"' scripts/check-macos-installer.sh \


### PR DESCRIPTION
## 问题

v0.3.11 发布在 Apple 公证阶段失败。新内嵌的 `mimi-tailcat-experiment` 没有在 DMG 提交前使用 Developer ID、hardened runtime 和安全时间戳签名。

失败发布：https://github.com/gaixianggeng/mimi-remote/actions/runs/33609825161
Apple submission：`553fe39d-0c0e-4f71-80c6-80efb4ac7543`

## 修复

- 从内到外显式签名 Tailcat、Claude bridge、agentd 和 App。
- 发布前直接校验每个内嵌二进制签名。
- DMG 门禁逐个校验所有 Mach-O，并检查 Tailcat 的 identifier、Team ID 和 Developer ID。

## 验证

- `git diff --check`
- `bash -n ./scripts/build-macos-installer.sh ./scripts/check-macos-installer.sh ./scripts/check-packaging.sh`
- `bash ./scripts/check-source-size.sh`
- `bash ./scripts/check-packaging.sh` 未完整执行：当前 Windows/WSL 环境缺少 Ruby；交由 PR CI 的 macOS runner 完整构建和验收。