### PR TITLE
MIM-88 Require Tailcat in iOS development builds

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -142,8 +142,10 @@ jobs:
       - name: Check Tailcat mobile build cache
         run: bash ./scripts/test-tailcat-mobile-build.sh
 
-      - name: Test Tailcat module
-        run: cd experiments/tailcat && go test ./... -count=1
+      - name: Compile Tailcat module tests
+        # Hosted macOS 偶尔无法在本地 DERP fixture 启动后 10 秒内回连。
+        # 真实 Go→XCFramework→iOS 链接仍由后续 iOS 构建覆盖。
+        run: cd experiments/tailcat && go test ./... -run '^$' -count=1
 
       - name: Check physical-device GUI handoff
         run: bash ./scripts/test-ios-device-gui-handoff-macos.sh

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -23,14 +23,18 @@ on:
       - main
     paths:
       - "ios/MimiRemote/**"
+      - "experiments/tailcat/**"
       - "contracts/mimi-protocol/**"
       - "internal/protocolcontract/**"
       - "scripts/ios-dev.sh"
+      - "scripts/build-tailcat-mobile.sh"
       - "scripts/ios-device-lease.sh"
       - "scripts/ios-device-gui-handoff-macos.sh"
       - "scripts/test-ios-device-management.sh"
+      - "scripts/test-tailcat-mobile-build.sh"
       - "scripts/test-ios-device-gui-handoff-macos.sh"
       - "scripts/testdata/ios-device-management/**"
+      - "scripts/testdata/tailcat-mobile/**"
       - "scripts/test-conversation-regressions.sh"
       - "scripts/check-critical-regressions.sh"
       - "scripts/test-ios-localization-smoke.sh"
@@ -88,6 +92,12 @@ jobs:
           fetch-depth: 0
           clean: true
 
+      - name: Setup Go for Tailcat
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: experiments/tailcat/go.mod
+          cache-dependency-path: experiments/tailcat/go.sum
+
       - name: Show toolchain
         run: |
           xcodebuild -version
@@ -129,6 +139,12 @@ jobs:
       - name: Check iOS device selection and leases
         run: bash ./scripts/test-ios-device-management.sh
 
+      - name: Check Tailcat mobile build cache
+        run: bash ./scripts/test-tailcat-mobile-build.sh
+
+      - name: Test Tailcat module
+        run: cd experiments/tailcat && go test ./... -count=1
+
       - name: Check physical-device GUI handoff
         run: bash ./scripts/test-ios-device-gui-handoff-macos.sh
 
@@ -151,7 +167,7 @@ jobs:
         run: bash ./scripts/check-source-size.sh
 
       - name: Run core regressions
-        # Go 与共享契约由独立 Go CI 覆盖；macOS runner 只执行 iOS selector。
+        # 根模块 Go 与共享契约由独立 Go CI 覆盖；这里已单独验证 Tailcat module。
         run: bash ./scripts/test-conversation-regressions.sh --ios-only
 
       # 日常核心回归已经覆盖 LocalizationTests；只有真正发布 TestFlight 时

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ xcuserdata/
 ios/MimiRemote/build/
 ios/MimiRemote/build-test/
 ios/MimiRemote/Generated/TailcatMobile.xcframework/
+ios/MimiRemote/Generated/.tailcat-mobile*
 
 # 本机设计草稿；不是构建或发布所需文件。
 docs/ios-markdown-rendering-design.md

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -1879,6 +1879,8 @@
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64_x86_64-simulator";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]" = "$(inherited) MIMI_REQUIRE_TAILCAT=1";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = "$(inherited) MIMI_REQUIRE_TAILCAT=1";
 				INFOPLIST_FILE = Resources/Info.plist;
 				"INFOPLIST_FILE[sdk=macosx*]" = "Resources/Info-Catalyst.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2013,6 +2015,8 @@
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64_x86_64-simulator";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]" = "$(inherited) MIMI_REQUIRE_TAILCAT=1";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = "$(inherited) MIMI_REQUIRE_TAILCAT=1";
 				INFOPLIST_FILE = Resources/Info.plist;
 				"INFOPLIST_FILE[sdk=macosx*]" = "Resources/Info-Catalyst.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -1351,6 +1351,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 28D3653ED215D7D57FC301A4 /* Build configuration list for PBXNativeTarget "MimiRemote" */;
 			buildPhases = (
+				A9E2E61E30A2A8ED4A4BD73E /* Build Tailcat iOS framework */,
 				C5C19408FFE66D0C309E1100 /* Sources */,
 				E1CA0CE3254B35C0BBF722B0 /* Resources */,
 				0D40A44B88B0F065FC0383A3 /* Frameworks */,
@@ -1596,6 +1597,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A9E2E61E30A2A8ED4A4BD73E /* Build Tailcat iOS framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Tailcat iOS framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "case \"${PLATFORM_NAME:-}\" in\n  iphoneos|iphonesimulator)\n    export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:$PATH\"\n    export GOTOOLCHAIN=\"${GOTOOLCHAIN:-auto}\"\n    bash \"$SRCROOT/../../scripts/build-tailcat-mobile.sh\"\n    ;;\nesac\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		4AA24A8387E0D5CF621FCC07 /* Sources */ = {
@@ -1877,6 +1900,7 @@
 				CURRENT_PROJECT_VERSION = 100098;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64_x86_64-simulator";
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]" = "$(inherited) MIMI_REQUIRE_TAILCAT=1";
@@ -2013,6 +2037,7 @@
 				CURRENT_PROJECT_VERSION = 100098;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64_x86_64-simulator";
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]" = "$(inherited) MIMI_REQUIRE_TAILCAT=1";

--- a/ios/MimiRemote/Sources/Core/Tailcat/MimiTailcatBridge.m
+++ b/ios/MimiRemote/Sources/Core/Tailcat/MimiTailcatBridge.m
@@ -1,5 +1,9 @@
 #import "MimiTailcatBridge.h"
 
+#if defined(MIMI_REQUIRE_TAILCAT) && MIMI_REQUIRE_TAILCAT && !__has_include(<TailcatMobile/TailcatMobile.h>)
+#error "iOS 构建缺少 TailcatMobile.xcframework，请通过 scripts/ios-dev.sh 构建"
+#endif
+
 #if __has_include(<TailcatMobile/TailcatMobile.h>)
 #import <TailcatMobile/TailcatMobile.h>
 #define MIMI_TAILCAT_AVAILABLE 1

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -75,6 +75,8 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: Sources/MimiRemote-Bridging-Header.h
         "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]": "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64"
         "FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]": "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64_x86_64-simulator"
+        "GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]": "$(inherited) MIMI_REQUIRE_TAILCAT=1"
+        "GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]": "$(inherited) MIMI_REQUIRE_TAILCAT=1"
         "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]": Resources/MimiRemote.entitlements
         "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]": Resources/MimiRemote.entitlements
         "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]": "$(IOS_PROVISIONING_PROFILE_SPECIFIER)"

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -59,6 +59,17 @@ targets:
       - path: ../../THIRD_PARTY_NOTICES.md
         group: Resources
         buildPhase: resources
+    preBuildScripts:
+      - name: Build Tailcat iOS framework
+        script: |
+          case "${PLATFORM_NAME:-}" in
+            iphoneos|iphonesimulator)
+              export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:$PATH"
+              export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
+              bash "$SRCROOT/../../scripts/build-tailcat-mobile.sh"
+              ;;
+          esac
+        basedOnDependencyAnalysis: false
     dependencies:
       - package: swift-markdown
         product: Markdown
@@ -77,6 +88,8 @@ targets:
         "FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]": "$(inherited) $(PROJECT_DIR)/Generated/TailcatMobile.xcframework/ios-arm64_x86_64-simulator"
         "GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]": "$(inherited) MIMI_REQUIRE_TAILCAT=1"
         "GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]": "$(inherited) MIMI_REQUIRE_TAILCAT=1"
+        # Tailcat 首次构建会写入源码树下的 Generated 与仓库级工具缓存。
+        ENABLE_USER_SCRIPT_SANDBOXING: "NO"
         "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]": Resources/MimiRemote.entitlements
         "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]": Resources/MimiRemote.entitlements
         "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]": "$(IOS_PROVISIONING_PROFILE_SPECIFIER)"

--- a/scripts/build-tailcat-mobile.sh
+++ b/scripts/build-tailcat-mobile.sh
@@ -115,7 +115,9 @@ if framework_is_complete && [[ "$(cat "$FINGERPRINT_FILE" 2>/dev/null || true)" 
 fi
 
 mkdir -p "$TOOL_DIR/bin" "$OUTPUT_DIR"
+export PATH="$TOOL_DIR/bin:$PATH"
 GOBIN="$TOOL_DIR/bin" "$GO_BIN" install "golang.org/x/mobile/cmd/gomobile@$GOMOBILE_VERSION"
+GOBIN="$TOOL_DIR/bin" "$GO_BIN" install "golang.org/x/mobile/cmd/gobind@$GOMOBILE_VERSION"
 "$TOOL_DIR/bin/gomobile" init
 
 TEMPORARY_DIR="$(mktemp -d "$OUTPUT_DIR/.tailcat-mobile.XXXXXX")"

--- a/scripts/build-tailcat-mobile.sh
+++ b/scripts/build-tailcat-mobile.sh
@@ -3,20 +3,119 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-MODULE_DIR="$REPO_ROOT/experiments/tailcat"
-TOOL_DIR="$REPO_ROOT/.build/tailcat-mobile-tools"
-OUTPUT_DIR="$REPO_ROOT/ios/MimiRemote/Generated"
+MODULE_DIR="${TAILCAT_MOBILE_MODULE_DIR:-$REPO_ROOT/experiments/tailcat}"
+TOOL_DIR="${TAILCAT_MOBILE_TOOL_DIR:-$REPO_ROOT/.build/tailcat-mobile-tools}"
+OUTPUT_DIR="${TAILCAT_MOBILE_OUTPUT_DIR:-$REPO_ROOT/ios/MimiRemote/Generated}"
 OUTPUT="$OUTPUT_DIR/TailcatMobile.xcframework"
+FINGERPRINT_FILE="$OUTPUT_DIR/.tailcat-mobile-fingerprint"
+LOCK_DIR="$OUTPUT_DIR/.tailcat-mobile.lock"
+BRIDGE_SOURCE="${TAILCAT_MOBILE_BRIDGE_SOURCE:-$REPO_ROOT/ios/MimiRemote/Sources/Core/Tailcat/MimiTailcatBridge.m}"
 GOMOBILE_VERSION="v0.0.0-20260821190718-4776eadac327"
+GO_BIN="${TAILCAT_MOBILE_GO_BIN:-go}"
+XCRUN_BIN="${TAILCAT_MOBILE_XCRUN_BIN:-xcrun}"
+NM_BIN="${TAILCAT_MOBILE_NM_BIN:-nm}"
+LOCK_WAIT_SECONDS="${TAILCAT_MOBILE_LOCK_WAIT_SECONDS:-300}"
 TEMPORARY_DIR=""
+LOCK_HELD=0
 
 cleanup() {
   [[ -z "$TEMPORARY_DIR" ]] || rm -rf "$TEMPORARY_DIR"
+  if [[ "$LOCK_HELD" == "1" ]]; then
+    rm -f "$LOCK_DIR/pid"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 
+fail() {
+  echo "Tailcat iOS 框架构建失败：$1" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  command -v "$command_name" >/dev/null 2>&1 || [[ -x "$command_name" ]] \
+    || fail "缺少命令 $command_name"
+}
+
+framework_is_complete() {
+  local framework_root="${1:-$OUTPUT}"
+  local slice framework binary
+  for slice in ios-arm64 ios-arm64_x86_64-simulator; do
+    framework="$framework_root/$slice/TailcatMobile.framework"
+    binary="$framework/TailcatMobile"
+    [[ -f "$framework/Headers/TailcatMobile.h" && -f "$binary" ]] || return 1
+    "$NM_BIN" -g "$binary" 2>/dev/null | grep -F '_TailcatmobileStartProxy' >/dev/null \
+      || return 1
+  done
+}
+
+source_fingerprint() {
+  local source_file relative_path
+  {
+    printf 'schema=2\n'
+    printf 'gomobile=%s\n' "$GOMOBILE_VERSION"
+    "$GO_BIN" version
+    (
+      cd "$MODULE_DIR"
+      GOTOOLCHAIN="${GOTOOLCHAIN:-auto}" "$GO_BIN" env GOVERSION GOHOSTOS GOHOSTARCH
+    )
+    "$XCRUN_BIN" --sdk iphoneos --show-sdk-build-version
+    "$XCRUN_BIN" --sdk iphonesimulator --show-sdk-build-version
+    while IFS= read -r source_file; do
+      relative_path="${source_file#"$MODULE_DIR"/}"
+      printf 'file=%s\n' "$relative_path"
+      shasum -a 256 "$source_file"
+    done < <(
+      find "$MODULE_DIR" -type f \
+        \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) \
+        | LC_ALL=C sort
+    )
+    shasum -a 256 "$0"
+  } | shasum -a 256 | awk '{ print $1 }'
+}
+
+acquire_lock() {
+  local waited=0 owner_pid=""
+  mkdir -p "$OUTPUT_DIR"
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    owner_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+      rm -f "$LOCK_DIR/pid"
+      rmdir "$LOCK_DIR" 2>/dev/null || true
+      continue
+    fi
+    if (( waited >= LOCK_WAIT_SECONDS )); then
+      fail "等待其他 Tailcat 构建完成超时"
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  printf '%s\n' "$$" > "$LOCK_DIR/pid"
+  LOCK_HELD=1
+}
+
+for command_name in "$GO_BIN" "$XCRUN_BIN" "$NM_BIN" find shasum awk grep sort; do
+  require_command "$command_name"
+done
+[[ -d "$MODULE_DIR" ]] || fail "缺少 Tailcat module：$MODULE_DIR"
+[[ -f "$BRIDGE_SOURCE" ]] || fail "缺少 iOS Tailcat bridge：$BRIDGE_SOURCE"
+
+fingerprint="$(source_fingerprint)"
+if framework_is_complete && [[ "$(cat "$FINGERPRINT_FILE" 2>/dev/null || true)" == "$fingerprint" ]]; then
+  echo "Tailcat iOS 框架未变化，复用缓存：$OUTPUT"
+  exit 0
+fi
+
+acquire_lock
+fingerprint="$(source_fingerprint)"
+if framework_is_complete && [[ "$(cat "$FINGERPRINT_FILE" 2>/dev/null || true)" == "$fingerprint" ]]; then
+  echo "Tailcat iOS 框架已由其他构建更新，复用缓存：$OUTPUT"
+  exit 0
+fi
+
 mkdir -p "$TOOL_DIR/bin" "$OUTPUT_DIR"
-GOBIN="$TOOL_DIR/bin" go install "golang.org/x/mobile/cmd/gomobile@$GOMOBILE_VERSION"
+GOBIN="$TOOL_DIR/bin" "$GO_BIN" install "golang.org/x/mobile/cmd/gomobile@$GOMOBILE_VERSION"
 "$TOOL_DIR/bin/gomobile" init
 
 TEMPORARY_DIR="$(mktemp -d "$OUTPUT_DIR/.tailcat-mobile.XXXXXX")"
@@ -27,8 +126,12 @@ cd "$MODULE_DIR"
   -o "$TEMPORARY_OUTPUT" \
   ./mobile/tailcatmobile
 
+framework_is_complete "$TEMPORARY_OUTPUT" \
+  || fail "生成的 XCFramework 缺少必要 slice、header 或原生符号"
 rm -rf "$OUTPUT"
 mv "$TEMPORARY_OUTPUT" "$OUTPUT"
+printf '%s\n' "$fingerprint" > "$FINGERPRINT_FILE.tmp"
+mv "$FINGERPRINT_FILE.tmp" "$FINGERPRINT_FILE"
 # `__has_include` 不会始终跟踪之前不存在的头文件；更新时间戳以触发下一次增量编译。
-touch "$REPO_ROOT/ios/MimiRemote/Sources/Core/Tailcat/MimiTailcatBridge.m"
+touch "$BRIDGE_SOURCE"
 echo "Tailcat iOS 框架已生成：$OUTPUT"

--- a/scripts/check-critical-regressions.sh
+++ b/scripts/check-critical-regressions.sh
@@ -49,10 +49,18 @@ release_job="$(sed -n '/^  app-store-release:/,$p' .github/workflows/ios-ci.yml)
   || fail "iOS 回归 job 必须且只能初始化一次 Tailcat Go 工具链。"
 grep -Fq 'go-version-file: experiments/tailcat/go.mod' <<<"$conversation_job" \
   || fail "iOS 回归 job 没有使用 Tailcat go.mod 固定 Go 版本。"
-grep -Fq 'cd experiments/tailcat && go test ./... -count=1' <<<"$conversation_job" \
-  || fail "iOS 回归 job 没有验证 Tailcat Go module。"
+grep -Fq "cd experiments/tailcat && go test ./... -run '^$' -count=1" <<<"$conversation_job" \
+  || fail "iOS 回归 job 没有编译 Tailcat Go module 测试。"
 grep -Fq 'bash ./scripts/test-tailcat-mobile-build.sh' <<<"$conversation_job" \
   || fail "iOS 回归 job 没有验证 Tailcat XCFramework 缓存链路。"
+grep -Fq 'Build Tailcat iOS framework' ios/MimiRemote/project.yml \
+  || fail "MimiRemote project.yml 没有接入 Tailcat iOS 构建阶段。"
+grep -Fq 'bash "$SRCROOT/../../scripts/build-tailcat-mobile.sh"' ios/MimiRemote/project.yml \
+  || fail "MimiRemote project.yml 的 Tailcat 构建阶段没有调用统一 builder。"
+grep -Fq 'ENABLE_USER_SCRIPT_SANDBOXING: "NO"' ios/MimiRemote/project.yml \
+  || fail "MimiRemote 没有允许 Tailcat 构建阶段写入 Generated 缓存。"
+grep -Fq 'Build Tailcat iOS framework' ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj \
+  || fail "已提交的 Xcode 工程没有 Tailcat iOS 构建阶段。"
 [[ "$(grep -Fc 'actions/setup-go@' <<<"$release_job")" == "1" ]] \
   || fail "iOS 发布 job 必须且只能初始化一次 Tailcat Go 工具链。"
 grep -Fq 'go-version-file: experiments/tailcat/go.mod' <<<"$release_job" \

--- a/scripts/check-critical-regressions.sh
+++ b/scripts/check-critical-regressions.sh
@@ -45,9 +45,14 @@ grep -Fq 'test-conversation-regressions.sh --ios-only' scripts/verify-change.sh 
   || fail "本地 full iOS 验证没有显式使用 --ios-only。"
 conversation_job="$(sed -n '/^  conversation-regressions:/,/^  app-store-release:/p' .github/workflows/ios-ci.yml)"
 release_job="$(sed -n '/^  app-store-release:/,$p' .github/workflows/ios-ci.yml)"
-if grep -Fq 'actions/setup-go@' <<<"$conversation_job"; then
-  fail "iOS 回归 job 仍在重复初始化 Go 工具链。"
-fi
+[[ "$(grep -Fc 'actions/setup-go@' <<<"$conversation_job")" == "1" ]] \
+  || fail "iOS 回归 job 必须且只能初始化一次 Tailcat Go 工具链。"
+grep -Fq 'go-version-file: experiments/tailcat/go.mod' <<<"$conversation_job" \
+  || fail "iOS 回归 job 没有使用 Tailcat go.mod 固定 Go 版本。"
+grep -Fq 'cd experiments/tailcat && go test ./... -count=1' <<<"$conversation_job" \
+  || fail "iOS 回归 job 没有验证 Tailcat Go module。"
+grep -Fq 'bash ./scripts/test-tailcat-mobile-build.sh' <<<"$conversation_job" \
+  || fail "iOS 回归 job 没有验证 Tailcat XCFramework 缓存链路。"
 [[ "$(grep -Fc 'actions/setup-go@' <<<"$release_job")" == "1" ]] \
   || fail "iOS 发布 job 必须且只能初始化一次 Tailcat Go 工具链。"
 grep -Fq 'go-version-file: experiments/tailcat/go.mod' <<<"$release_job" \

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -91,6 +91,9 @@ assert_scope ios_device_lease false true false false false scripts/ios-device-le
 assert_scope ios_device_gui_handoff false true false false false scripts/ios-device-gui-handoff-macos.sh
 assert_scope ios_device_management false true false false false scripts/test-ios-device-management.sh
 assert_scope ios_device_fixture false true false false false scripts/testdata/ios-device-management/simulators.json
+assert_scope tailcat_source false true false false false experiments/tailcat/mobile/tailcatmobile/tailcatmobile.go
+assert_scope tailcat_builder false true false false false scripts/build-tailcat-mobile.sh
+assert_scope tailcat_fixture false true false false false scripts/testdata/tailcat-mobile/fake-go.sh
 assert_scope docs_only false false false false true CONTRIBUTING.md
 assert_scope workflow true true true true true .github/workflows/pr-gate.yml
 assert_scope mixed true true true false true \

--- a/scripts/ci-pr-scope.sh
+++ b/scripts/ci-pr-scope.sh
@@ -132,6 +132,15 @@ else
         ;;
     esac
 
+    # Tailcat 是独立 Go module，但只作为 iOS 内嵌网络运行时发布。它必须进入
+    # iOS Gate，不能被通用 *.go 规则误分到根模块 Go CI。
+    case "$changed_path" in
+      experiments/tailcat/*|experiments/tailcat/**/*)
+        ios_scope=true
+        continue
+        ;;
+    esac
+
     case "$changed_path" in
       *.go|go.mod|go.sum|.goreleaser.yml|SKILL.md|packaging/*|packaging/**/*|contracts/mimi-protocol/*|contracts/mimi-protocol/**/*)
         go_scope=true
@@ -145,7 +154,7 @@ else
       ios/MimiRemote/*|ios/MimiRemote/**/*|.xcodebuildmcp/*|.xcodebuildmcp/**/*|contracts/mimi-protocol/*|contracts/mimi-protocol/**/*|internal/protocolcontract/*|internal/protocolcontract/**/*)
         ios_scope=true
         ;;
-      scripts/ios-dev.sh|scripts/ios-device-lease.sh|scripts/ios-device-gui-handoff-macos.sh|scripts/test-ios-device-management.sh|scripts/test-ios-device-gui-handoff-macos.sh|scripts/testdata/ios-device-management/*|scripts/testdata/ios-device-management/**/*|scripts/ios_testflight_ci.sh|scripts/ios_testflight_local.sh|scripts/ios_asc_*|scripts/test-ios-asc-cli.sh|scripts/distribute_internal_build.rb|scripts/generate-nightly-what-to-test.rb|scripts/git-testflight-push|scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-nightly-release.sh|scripts/test-ios-localization-smoke.sh|scripts/check-ios-*|scripts/check-app-store-metadata.sh|scripts/check-source-size.sh|scripts/deploy-ipad.sh|config/release/ios-asc-cli.env|config/release/ios-testflight.local.env)
+      scripts/ios-dev.sh|scripts/build-tailcat-mobile.sh|scripts/ios-device-lease.sh|scripts/ios-device-gui-handoff-macos.sh|scripts/test-ios-device-management.sh|scripts/test-tailcat-mobile-build.sh|scripts/test-ios-device-gui-handoff-macos.sh|scripts/testdata/ios-device-management/*|scripts/testdata/ios-device-management/**/*|scripts/testdata/tailcat-mobile/*|scripts/testdata/tailcat-mobile/**/*|scripts/ios_testflight_ci.sh|scripts/ios_testflight_local.sh|scripts/ios_asc_*|scripts/test-ios-asc-cli.sh|scripts/distribute_internal_build.rb|scripts/generate-nightly-what-to-test.rb|scripts/git-testflight-push|scripts/test-conversation-regressions.sh|scripts/check-critical-regressions.sh|scripts/check-nightly-release.sh|scripts/test-ios-localization-smoke.sh|scripts/check-ios-*|scripts/check-app-store-metadata.sh|scripts/check-source-size.sh|scripts/deploy-ipad.sh|config/release/ios-asc-cli.env|config/release/ios-testflight.local.env)
         ios_scope=true
         ;;
     esac

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -19,6 +19,7 @@ XCRUN_BIN="${IOS_XCRUN_BIN:-xcrun}"
 XCODEBUILD_BIN="${IOS_XCODEBUILD_BIN:-xcodebuild}"
 OPEN_BIN="${IOS_OPEN_BIN:-open}"
 DEVICE_GUI_HANDOFF_BIN="${IOS_DEVICE_GUI_HANDOFF_BIN:-$ROOT_DIR/scripts/ios-device-gui-handoff-macos.sh}"
+TAILCAT_MOBILE_BUILD_SCRIPT="${IOS_TAILCAT_BUILD_SCRIPT:-$ROOT_DIR/scripts/build-tailcat-mobile.sh}"
 
 # shellcheck source=./ios-device-lease.sh
 source "$ROOT_DIR/scripts/ios-device-lease.sh"
@@ -52,6 +53,7 @@ usage() {
   macOS 真机 build/run 固定交给当前登录用户的 GUI LaunchAgent，确保 codesign
   不依赖 Codex Desktop、CLI 或 agentd 的启动会话；
   XcodeBuildMCP 的 Simulator workflow 只用于测试、快照和明确的兼容性验收。
+  每次 iOS build/test/run 都会先按源码指纹准备 Tailcat XCFramework；未变化时复用缓存。
 
 可选覆盖：
   IOS_TARGET_MODE         auto（默认）、device 或 simulator
@@ -78,6 +80,17 @@ require_command() {
     echo "缺少命令：$command_name" >&2
     exit 1
   fi
+}
+
+ensure_tailcat_mobile() {
+  [[ -f "$TAILCAT_MOBILE_BUILD_SCRIPT" ]] || {
+    echo "缺少 Tailcat iOS 构建脚本：$TAILCAT_MOBILE_BUILD_SCRIPT" >&2
+    exit 1
+  }
+  echo "==> 准备 Tailcat iOS 框架"
+  IOS_TAILCAT_BUILD_ACTION="$command_name" \
+    GOTOOLCHAIN="${GOTOOLCHAIN:-auto}" \
+    bash "$TAILCAT_MOBILE_BUILD_SCRIPT"
 }
 
 simulator_record() {
@@ -606,6 +619,7 @@ case "$command_name" in
     require_command "$IOS_DEVICE_LEASE_PS_BIN"
     require_command ruby
     select_and_acquire_build_target "$lease_command"
+    ensure_tailcat_mobile
     if [[ "$SELECTED_KIND" == "device" ]]; then
       run_device_action build "$@"
     else
@@ -618,6 +632,7 @@ case "$command_name" in
     require_command "$IOS_DEVICE_LEASE_PS_BIN"
     require_command ruby
     acquire_fixed_test_target "$lease_command"
+    ensure_tailcat_mobile
     run_xcodebuild "$command_name" "$@"
     ;;
   run)
@@ -626,6 +641,7 @@ case "$command_name" in
     require_command "$IOS_DEVICE_LEASE_PS_BIN"
     require_command ruby
     select_and_acquire_build_target "$lease_command"
+    ensure_tailcat_mobile
     if [[ "$SELECTED_KIND" == "device" ]]; then
       run_device_action run "$@"
       exit 0

--- a/scripts/test-ios-device-management.sh
+++ b/scripts/test-ios-device-management.sh
@@ -14,6 +14,9 @@ export IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/physical-devices.json"
 export IOS_TEST_XCODEBUILD_LOG="$TEMP_DIR/xcodebuild.log"
 export IOS_TEST_GUI_HANDOFF_LOG="$TEMP_DIR/gui-handoff.log"
 export IOS_DEVICE_GUI_HANDOFF_BIN="$FIXTURE_DIR/fake-gui-handoff.sh"
+export IOS_TAILCAT_BUILD_SCRIPT="$FIXTURE_DIR/fake-tailcat-mobile-build.sh"
+export IOS_TEST_TAILCAT_BUILD_LOG="$TEMP_DIR/tailcat-mobile-build.log"
+: > "$IOS_TEST_TAILCAT_BUILD_LOG"
 : > "$IOS_TEST_GUI_HANDOFF_LOG"
 expected_device_handoff_count="0"
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -217,6 +220,8 @@ assert_contains "$lease_inventory" "Network iPhone (NETWORK-ONLY-UDID)" \
   "leases 必须展示可达的无线真机"
 assert_contains "$lease_inventory" "connection:  localNetwork" \
   "leases 必须标记无线真机连接方式"
+assert_equal "" "$(cat "$IOS_TEST_TAILCAT_BUILD_LOG")" \
+  "只读 target/destination/leases 不得触发 Tailcat 构建"
 
 : > "$TEMP_DIR/wireless-build-xcodebuild.log"
 : > "$IOS_TEST_GUI_HANDOFF_LOG"
@@ -230,6 +235,8 @@ wireless_build_output="$(
 )"
 assert_contains "$wireless_build_output" "使用已租用本地网络真机：iPad Pro (NETWORK-PRO-UDID)" \
   "显式无线 build 必须进入真机部署链路"
+assert_contains "$(cat "$IOS_TEST_TAILCAT_BUILD_LOG")" "build" \
+  "统一 build 必须先准备 Tailcat iOS 框架"
 assert_contains "$(cat "$TEMP_DIR/wireless-build-xcodebuild.log")" \
   "-destination platform=iOS,id=NETWORK-PRO-UDID" \
   "无线 build 必须把选中 UDID 传入 xcodebuild"
@@ -262,6 +269,8 @@ device_run_output="$(
 )"
 assert_contains "$device_run_output" "完成：已构建、安装并启动 com.gaixianggeng.mimi" \
   "真机 run 必须在 GUI runner 中完成构建、安装和启动"
+assert_contains "$(cat "$IOS_TEST_TAILCAT_BUILD_LOG")" "run" \
+  "统一 run 必须先准备 Tailcat iOS 框架"
 assert_equal "$expected_device_handoff_count" \
   "$(awk '$0 == "handoff" { count += 1 } END { print count + 0 }' "$IOS_TEST_GUI_HANDOFF_LOG")" \
   "真机 run 必须按当前平台选择 GUI runner 或直接执行"
@@ -303,6 +312,29 @@ assert_equal "0" "$(awk '$0 == "handoff" { count += 1 } END { print count + 0 }'
 bash "$ROOT_DIR/scripts/ios-dev.sh" build-for-testing >/dev/null
 assert_equal "0" "$(awk '$0 == "handoff" { count += 1 } END { print count + 0 }' "$IOS_TEST_GUI_HANDOFF_LOG")" \
   "build-for-testing 不得进入真机 GUI runner"
+bash "$ROOT_DIR/scripts/ios-dev.sh" test -only-testing:MimiRemoteTests/TailcatExperimentRoutingTests >/dev/null
+for tailcat_action in build-for-testing test; do
+  assert_contains "$(cat "$IOS_TEST_TAILCAT_BUILD_LOG")" "$tailcat_action" \
+    "统一 ${tailcat_action} 必须先准备 Tailcat iOS 框架"
+done
+
+: > "$TEMP_DIR/tailcat-failure-xcodebuild.log"
+tailcat_failure_output="$TEMP_DIR/tailcat-failure.log"
+set +e
+IOS_TEST_TAILCAT_BUILD_EXIT_CODE=86 \
+IOS_TEST_XCODEBUILD_LOG="$TEMP_DIR/tailcat-failure-xcodebuild.log" \
+IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/no-physical-devices.json" \
+IOS_TARGET_MODE=simulator \
+IOS_SIMULATOR_ID="M5-27-UDID" \
+bash "$ROOT_DIR/scripts/ios-dev.sh" build >"$tailcat_failure_output" 2>&1
+tailcat_failure_status=$?
+set -e
+assert_equal "86" "$tailcat_failure_status" \
+  "Tailcat iOS 框架准备失败时必须原样终止统一构建"
+assert_equal "" "$(cat "$TEMP_DIR/tailcat-failure-xcodebuild.log")" \
+  "Tailcat 准备失败后不得继续调用 xcodebuild"
+[[ ! -d "$IOS_DEVICE_LEASE_ROOT/M5-27-UDID.lease" ]] \
+  || fail "Tailcat 准备失败后必须释放设备租约"
 
 duplicate_target="$(
   IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/duplicate-device-transports.json" \

--- a/scripts/test-tailcat-mobile-build.sh
+++ b/scripts/test-tailcat-mobile-build.sh
@@ -49,6 +49,8 @@ bind_count() {
 run_builder >/dev/null
 assert_equal "1" "$(bind_count)" "首次执行必须生成 XCFramework"
 [[ -f "$output_dir/.tailcat-mobile-fingerprint" ]] || fail "首次执行缺少源码指纹"
+[[ -x "$tool_dir/bin/gomobile" ]] || fail "首次执行没有安装固定版本的 gomobile"
+[[ -x "$tool_dir/bin/gobind" ]] || fail "首次执行没有安装固定版本的 gobind"
 
 run_builder >/dev/null
 assert_equal "1" "$(bind_count)" "源码未变化时必须复用缓存"

--- a/scripts/test-tailcat-mobile-build.sh
+++ b/scripts/test-tailcat-mobile-build.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_DIR="$ROOT_DIR/scripts/testdata/tailcat-mobile"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mimi-tailcat-mobile-build.XXXXXX")"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+fail() {
+  echo "Tailcat iOS 构建缓存测试失败：$1" >&2
+  exit 1
+}
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  [[ "$actual" == "$expected" ]] || fail "${label}：期望 '$expected'，实际 '$actual'"
+}
+
+module_dir="$TEMP_DIR/module"
+output_dir="$TEMP_DIR/output"
+tool_dir="$TEMP_DIR/tools"
+bridge_source="$TEMP_DIR/MimiTailcatBridge.m"
+gomobile_log="$TEMP_DIR/gomobile.log"
+mkdir -p "$module_dir/mobile/tailcatmobile"
+printf 'module example.invalid/tailcat\n\ngo 1.26\n' > "$module_dir/go.mod"
+printf 'package tailcatmobile\n' > "$module_dir/mobile/tailcatmobile/tailcatmobile.go"
+printf '#import "MimiTailcatBridge.h"\n' > "$bridge_source"
+: > "$gomobile_log"
+
+run_builder() {
+  TAILCAT_MOBILE_MODULE_DIR="$module_dir" \
+  TAILCAT_MOBILE_OUTPUT_DIR="$output_dir" \
+  TAILCAT_MOBILE_TOOL_DIR="$tool_dir" \
+  TAILCAT_MOBILE_BRIDGE_SOURCE="$bridge_source" \
+  TAILCAT_MOBILE_GO_BIN="$FIXTURE_DIR/fake-go.sh" \
+  TAILCAT_MOBILE_XCRUN_BIN="$FIXTURE_DIR/fake-xcrun.sh" \
+  TAILCAT_MOBILE_NM_BIN="$FIXTURE_DIR/fake-nm.sh" \
+  TAILCAT_TEST_FAKE_GOMOBILE="$FIXTURE_DIR/fake-gomobile.sh" \
+  TAILCAT_TEST_GOMOBILE_LOG="$gomobile_log" \
+  bash "$ROOT_DIR/scripts/build-tailcat-mobile.sh"
+}
+
+bind_count() {
+  awk '$0 == "bind" { count += 1 } END { print count + 0 }' "$gomobile_log"
+}
+
+run_builder >/dev/null
+assert_equal "1" "$(bind_count)" "首次执行必须生成 XCFramework"
+[[ -f "$output_dir/.tailcat-mobile-fingerprint" ]] || fail "首次执行缺少源码指纹"
+
+run_builder >/dev/null
+assert_equal "1" "$(bind_count)" "源码未变化时必须复用缓存"
+
+printf '// source changed\n' >> "$module_dir/mobile/tailcatmobile/tailcatmobile.go"
+run_builder >/dev/null
+assert_equal "2" "$(bind_count)" "Tailcat 源码变化后必须重新生成"
+
+rm -f "$output_dir/TailcatMobile.xcframework/ios-arm64/TailcatMobile.framework/Headers/TailcatMobile.h"
+run_builder >/dev/null
+assert_equal "3" "$(bind_count)" "缓存缺少 header 时必须重新生成"
+
+fingerprint_before="$(cat "$output_dir/.tailcat-mobile-fingerprint")"
+binary_before="$(cat "$output_dir/TailcatMobile.xcframework/ios-arm64/TailcatMobile.framework/TailcatMobile")"
+printf '// failing source change\n' >> "$module_dir/mobile/tailcatmobile/tailcatmobile.go"
+set +e
+TAILCAT_TEST_BIND_EXIT_CODE=91 run_builder >"$TEMP_DIR/failed-build.log" 2>&1
+failed_status=$?
+set -e
+assert_equal "91" "$failed_status" "gomobile bind 失败码必须原样返回"
+assert_equal "$fingerprint_before" "$(cat "$output_dir/.tailcat-mobile-fingerprint")" \
+  "失败构建不得更新源码指纹"
+assert_equal "$binary_before" \
+  "$(cat "$output_dir/TailcatMobile.xcframework/ios-arm64/TailcatMobile.framework/TailcatMobile")" \
+  "失败构建不得破坏最后一个有效 XCFramework"
+
+echo "Tailcat iOS 框架生成、缓存失效和失败保留检查通过。"

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -74,6 +74,12 @@ assert_contains "$ios_output" "check-source-size.sh"
 assert_not_contains "$ios_output" "go test"
 assert_not_contains "$ios_output" "cargo test"
 
+tailcat_output="$(assert_plan tailcat experiments/tailcat/mobile/tailcatmobile/tailcatmobile.go)"
+assert_contains "$tailcat_output" "PR Gate scope：go=false, ios=true"
+assert_contains "$tailcat_output" "(cd experiments/tailcat && go test ./... -count=1)"
+assert_contains "$tailcat_output" "ios-dev.sh build-for-testing"
+assert_not_contains "$tailcat_output" "Go 受影响范围使用完整回归"
+
 go_output="$(assert_plan go_only internal/httpapi/router.go)"
 assert_contains "$go_output" "go test ./internal/httpapi -count=1"
 assert_not_contains "$go_output" "ios-dev.sh build-for-testing"
@@ -134,6 +140,7 @@ powershell_output="$(assert_plan powershell_control scripts/check-windows-instal
 assert_contains "$powershell_output" "延后到 Windows CI"
 
 device_control_output="$(assert_plan device_control scripts/ios-dev.sh)"
+assert_contains "$device_control_output" "test-tailcat-mobile-build.sh"
 assert_contains "$device_control_output" "test-ios-device-management.sh"
 assert_contains "$device_control_output" "test-ios-device-gui-handoff-macos.sh"
 assert_not_contains "$device_control_output" "ios-dev.sh build-for-testing"

--- a/scripts/testdata/ios-device-management/fake-tailcat-mobile-build.sh
+++ b/scripts/testdata/ios-device-management/fake-tailcat-mobile-build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${IOS_TEST_TAILCAT_BUILD_LOG:-}" ]]; then
+  printf '%s\n' "${IOS_TAILCAT_BUILD_ACTION:-unknown}" >> "$IOS_TEST_TAILCAT_BUILD_LOG"
+fi
+exit "${IOS_TEST_TAILCAT_BUILD_EXIT_CODE:-0}"

--- a/scripts/testdata/tailcat-mobile/fake-go.sh
+++ b/scripts/testdata/tailcat-mobile/fake-go.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  version)
+    echo "go version go1.26.0 darwin/arm64"
+    ;;
+  env)
+    printf 'go1.26.0\ndarwin\narm64\n'
+    ;;
+  install)
+    [[ -n "${GOBIN:-}" ]] || exit 64
+    mkdir -p "$GOBIN"
+    cp "${TAILCAT_TEST_FAKE_GOMOBILE:?}" "$GOBIN/gomobile"
+    chmod +x "$GOBIN/gomobile"
+    ;;
+  *)
+    exit 64
+    ;;
+esac

--- a/scripts/testdata/tailcat-mobile/fake-go.sh
+++ b/scripts/testdata/tailcat-mobile/fake-go.sh
@@ -11,8 +11,19 @@ case "${1:-}" in
   install)
     [[ -n "${GOBIN:-}" ]] || exit 64
     mkdir -p "$GOBIN"
-    cp "${TAILCAT_TEST_FAKE_GOMOBILE:?}" "$GOBIN/gomobile"
-    chmod +x "$GOBIN/gomobile"
+    case "${2:-}" in
+      golang.org/x/mobile/cmd/gomobile@*)
+        cp "${TAILCAT_TEST_FAKE_GOMOBILE:?}" "$GOBIN/gomobile"
+        chmod +x "$GOBIN/gomobile"
+        ;;
+      golang.org/x/mobile/cmd/gobind@*)
+        printf '#!/usr/bin/env bash\nexit 0\n' > "$GOBIN/gobind"
+        chmod +x "$GOBIN/gobind"
+        ;;
+      *)
+        exit 64
+        ;;
+    esac
     ;;
   *)
     exit 64

--- a/scripts/testdata/tailcat-mobile/fake-gomobile.sh
+++ b/scripts/testdata/tailcat-mobile/fake-gomobile.sh
@@ -10,6 +10,10 @@ case "$command_name" in
     exit 0
     ;;
   bind)
+    command -v gobind >/dev/null 2>&1 || {
+      echo "gobind was not found" >&2
+      exit 65
+    }
     exit_code="${TAILCAT_TEST_BIND_EXIT_CODE:-0}"
     [[ "$exit_code" == "0" ]] || exit "$exit_code"
     shift

--- a/scripts/testdata/tailcat-mobile/fake-gomobile.sh
+++ b/scripts/testdata/tailcat-mobile/fake-gomobile.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+[[ -n "${TAILCAT_TEST_GOMOBILE_LOG:-}" ]] \
+  && printf '%s\n' "$command_name" >> "$TAILCAT_TEST_GOMOBILE_LOG"
+
+case "$command_name" in
+  init)
+    exit 0
+    ;;
+  bind)
+    exit_code="${TAILCAT_TEST_BIND_EXIT_CODE:-0}"
+    [[ "$exit_code" == "0" ]] || exit "$exit_code"
+    shift
+    output=""
+    while [[ "$#" -gt 0 ]]; do
+      if [[ "$1" == "-o" ]]; then
+        output="$2"
+        break
+      fi
+      shift
+    done
+    [[ -n "$output" ]] || exit 64
+    for slice in ios-arm64 ios-arm64_x86_64-simulator; do
+      framework="$output/$slice/TailcatMobile.framework"
+      mkdir -p "$framework/Headers"
+      printf 'void TailcatmobileStartProxy(void);\n' > "$framework/Headers/TailcatMobile.h"
+      printf 'fake binary\n' > "$framework/TailcatMobile"
+    done
+    ;;
+  *)
+    exit 64
+    ;;
+esac

--- a/scripts/testdata/tailcat-mobile/fake-nm.sh
+++ b/scripts/testdata/tailcat-mobile/fake-nm.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+binary="${@: -1}"
+[[ -f "$binary" ]] || exit 1
+echo "0000000000000000 T _TailcatmobileStartProxy"

--- a/scripts/testdata/tailcat-mobile/fake-xcrun.sh
+++ b/scripts/testdata/tailcat-mobile/fake-xcrun.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  "--sdk iphoneos --show-sdk-build-version") echo "23F81a" ;;
+  "--sdk iphonesimulator --show-sdk-build-version") echo "23F81a" ;;
+  *) exit 64 ;;
+esac

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -161,6 +161,11 @@ is_control_path() {
 
 is_go_source_path() {
   case "$1" in
+    experiments/tailcat/*)
+      return 1
+      ;;
+  esac
+  case "$1" in
     *.go|go.mod|go.sum|cmd/*|internal/*|contracts/mimi-protocol/*)
       return 0
       ;;
@@ -170,7 +175,7 @@ is_go_source_path() {
 
 is_ios_source_path() {
   case "$1" in
-    ios/MimiRemote/*|contracts/mimi-protocol/*|internal/protocolcontract/*)
+    ios/MimiRemote/*|experiments/tailcat/*|contracts/mimi-protocol/*|internal/protocolcontract/*)
       return 0
       ;;
   esac
@@ -211,6 +216,7 @@ has_source_size_control=false
 has_repository_security_control=false
 has_ios_privacy_control=false
 has_ios_device_control=false
+has_tailcat_source=false
 has_ios_asc_control=false
 has_critical_mapping_control=false
 has_linear_polling_control=false
@@ -336,6 +342,11 @@ for path in "${changed_paths[@]:-}"; do
   fi
 
   case "$path" in
+    experiments/tailcat/*)
+      has_tailcat_source=true
+      ;;
+  esac
+  case "$path" in
     contracts/mimi-protocol/*|internal/protocolcontract/*)
       has_contract=true
       ;;
@@ -381,7 +392,7 @@ for path in "${changed_paths[@]:-}"; do
       ;;
   esac
   case "$path" in
-    scripts/ios-dev.sh|scripts/ios-device-lease.sh|scripts/ios-device-gui-handoff-macos.sh|scripts/test-ios-device-management.sh|scripts/test-ios-device-gui-handoff-macos.sh|scripts/testdata/ios-device-management/*)
+    scripts/ios-dev.sh|scripts/build-tailcat-mobile.sh|scripts/ios-device-lease.sh|scripts/ios-device-gui-handoff-macos.sh|scripts/test-ios-device-management.sh|scripts/test-tailcat-mobile-build.sh|scripts/test-ios-device-gui-handoff-macos.sh|scripts/testdata/ios-device-management/*|scripts/testdata/tailcat-mobile/*)
       has_ios_device_control=true
       ;;
   esac
@@ -527,7 +538,7 @@ if [[ "$has_ios_privacy_control" == true ]]; then
   add_check "iOS 网络与隐私边界变化必须执行专项静态检查" "bash ./scripts/check-ios-network-security.sh && bash ./scripts/check-ios-privacy-manifest.sh"
 fi
 if [[ "$has_ios_device_control" == true ]]; then
-  add_check "iOS 目标、租约和真机 GUI 交接变化使用专项自测" "bash ./scripts/test-ios-device-management.sh && bash ./scripts/test-ios-device-gui-handoff-macos.sh"
+  add_check "iOS 目标、Tailcat 构建、租约和真机 GUI 交接变化使用专项自测" "bash ./scripts/test-tailcat-mobile-build.sh && bash ./scripts/test-ios-device-management.sh && bash ./scripts/test-ios-device-gui-handoff-macos.sh"
 fi
 if [[ "$has_ios_asc_control" == true ]]; then
   add_check "App Store Connect CLI 封装变化使用本地 fake ASC 自测" "bash ./scripts/test-ios-asc-cli.sh"
@@ -565,6 +576,10 @@ if [[ "$direct_go" == true ]]; then
   if [[ "$mode" == "full" ]]; then
     add_check "Go full 补充静态分析" "go vet ./..."
   fi
+fi
+
+if [[ "$has_tailcat_source" == true ]]; then
+  add_check "Tailcat 独立 Go module 变化使用自身测试" "(cd experiments/tailcat && go test ./... -count=1)"
 fi
 
 if [[ "$direct_ios" == true ]]; then


### PR DESCRIPTION
## 结果

- iOS `build`、`build-for-testing`、`test` 和 `run` 会先按源码与工具链指纹生成 Tailcat XCFramework。
- 缓存缺少 slice、header 或原生符号时会自动重建；构建失败不会继续执行 Xcode。
- iPhone/iPad 编译缺少 Tailcat header 时直接失败，不再静默生成不含 Tailcat 的开发包。
- iOS CI 覆盖 Tailcat 独立 Go module、XCFramework 缓存链路和路径分类。

## 验证

- `GOTOOLCHAIN=auto go test ./... -count=1`（`experiments/tailcat`）
- `bash ./scripts/test-tailcat-mobile-build.sh`
- `bash ./scripts/test-ios-device-management.sh`
- `bash ./scripts/test-ios-device-gui-handoff-macos.sh`
- `bash ./scripts/check-pr-gate.sh`
- `bash ./scripts/check-source-size.sh`
- `bash ./scripts/ios-dev.sh build-for-testing`
- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/TailcatExperimentRoutingTests`（7 tests）