### PR TITLE
MIM-235 修复 TestFlight 构建设置解析失败

### DIFF
--- a/scripts/ios_testflight_ci.sh
+++ b/scripts/ios_testflight_ci.sh
@@ -147,8 +147,10 @@ settings="$(
     -configuration Release \
     -showBuildSettings
 )"
-marketing_version="$(printf '%s\n' "$settings" | awk -F= '/^[[:space:]]*MARKETING_VERSION[[:space:]]*=/{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}')"
-current_build="$(printf '%s\n' "$settings" | awk -F= '/^[[:space:]]*CURRENT_PROJECT_VERSION[[:space:]]*=/{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}')"
+# 不能在首个匹配后退出 awk。settings 较大且 pipefail 开启时，提前关闭管道会让
+# printf 收到 SIGPIPE，使发布在归档前误判失败。
+marketing_version="$(printf '%s\n' "$settings" | awk -F= '!found && /^[[:space:]]*MARKETING_VERSION[[:space:]]*=/{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; found=1}')"
+current_build="$(printf '%s\n' "$settings" | awk -F= '!found && /^[[:space:]]*CURRENT_PROJECT_VERSION[[:space:]]*=/{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; found=1}')"
 [[ -n "$marketing_version" ]] || fail "MARKETING_VERSION not found"
 [[ "$current_build" =~ ^[0-9]+$ ]] || fail "CURRENT_PROJECT_VERSION must be an integer"
 

--- a/scripts/test-ios-asc-cli.sh
+++ b/scripts/test-ios-asc-cli.sh
@@ -187,6 +187,8 @@ altool = source.index('xcrun altool --', second_shadow) or abort("missing altool
 abort("before-archive shadow ordering is wrong") unless first_shadow < archive
 abort("before-upload shadow ordering is wrong") unless archive < second_shadow && second_shadow < altool
 abort("asc unexpectedly assigns real build_number") if source.match?(/build_number=.*ASC_CLI_/)
+abort("Xcode build settings parser can still close the pipe early") if source.match?(/MARKETING_VERSION[^\n]*;\s*exit\}/) || source.match?(/CURRENT_PROJECT_VERSION[^\n]*;\s*exit\}/)
+abort("Xcode build settings parser does not consume the full pipe") unless source.include?("!found && /^[[:space:]]*MARKETING_VERSION") && source.include?("!found && /^[[:space:]]*CURRENT_PROJECT_VERSION")
 RUBY
 
 # 本地 --ref 发布必须从目标提交的隔离 worktree 校验 asc pin，不能读取当前


### PR DESCRIPTION
## 变更

- 解析 Xcode build settings 时不再提前关闭管道
- 增加发布脚本静态回归，防止 `pipefail` 下再次触发 broken pipe

## 验证

- `bash -n scripts/ios_testflight_ci.sh scripts/test-ios-asc-cli.sh`
- `bash scripts/test-ios-asc-cli.sh`
- `bash scripts/check-source-size.sh`
- 约 6 MB build settings 输入解析测试

修复发布失败运行：https://github.com/gaixianggeng/mimi-remote/actions/runs/33655894039

Linear: MIM-235