### PR TITLE
MIM-88 修复首次 Tailcat 配对二维码失效

### DIFF
--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -78,7 +78,6 @@ struct MenuBarContentView: View {
                     isEnabled: store.status != nil
                 ) {
                     presentWindow(.pairing)
-                    Task { await store.refreshPairing() }
                 }
 
                 Divider()

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -26,6 +26,7 @@ final class HostStore {
     private(set) var tailcatError: String?
     private(set) var tailcatNotice: String?
     var lastError: String?
+    @ObservationIgnored private var pairingRefreshGeneration = 0
 
     var canRestoreHomebrew: Bool {
         owner == .macApp && homebrew.installedAgentBinary() != nil
@@ -357,13 +358,18 @@ final class HostStore {
 
     func refreshPairing(network: PairingNetwork? = nil) async {
         guard !isBusy else { return }
+        pairingRefreshGeneration &+= 1
+        let refreshGeneration = pairingRefreshGeneration
         lastError = nil
         do {
             let nextPairing = try await resolvedPairing(for: network)
+            // 较早的请求不能覆盖用户刚选择的网络和二维码。
+            guard refreshGeneration == pairingRefreshGeneration else { return }
             pairing = nextPairing
             pairingNetwork = nextPairing.network
             lastError = nil
         } catch {
+            guard refreshGeneration == pairingRefreshGeneration else { return }
             lastError = error.localizedDescription
         }
     }

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -679,6 +679,47 @@ final class HostStoreTests: XCTestCase {
         ])
     }
 
+    func testLatestPairingRefreshWinsWhenAutomaticRequestFinishesLast() async {
+        let gate = SuspendedStatusGate()
+        let automaticCalls = CallCounter()
+        let automaticPairing = PairingInfo(
+            endpoint: "http://100.64.0.8:8787",
+            network: .tailscale,
+            pairURL: "mimiremote://pair?pair_sig=automatic",
+            expiresAt: "2026-09-03T12:00:00Z",
+            warnings: []
+        )
+        let tailcatPairing = PairingInfo(
+            endpoint: "http://127.0.0.1:8787",
+            network: .tailcat,
+            pairURL: "mimiremote://pair?transport=tailcat",
+            expiresAt: "2026-09-03T12:00:00Z",
+            warnings: []
+        )
+        let store = makeStore(
+            configExists: true,
+            pair: { network in
+                if network == .automatic {
+                    if automaticCalls.increment() == 1 {
+                        return automaticPairing
+                    }
+                    return await gate.suspendReturning(automaticPairing)
+                }
+                return tailcatPairing
+            }
+        )
+        await store.bootstrap()
+
+        let automaticRefresh = Task { await store.refreshPairing() }
+        await gate.waitUntilSuspended()
+        await store.refreshPairing(network: .tailcat)
+        gate.resume()
+        await automaticRefresh.value
+
+        XCTAssertEqual(store.pairingNetwork, .tailcat)
+        XCTAssertEqual(store.pairing, tailcatPairing)
+    }
+
     func testConfiguringTailcatRelayUpdatesStatusAndClearsOldPairing() async {
         let events = EventRecorder()
         let defaultStatus = TailcatStatus(


### PR DESCRIPTION
## 目标

修复首次打开配对窗口并选择 Tailcat 时，较早的自动配对请求覆盖 Tailcat 二维码的问题。

## 改动

- 菜单只打开配对窗口，不再额外并发生成自动网络票据。
- HostStore 仅接受最后一次配对请求的结果，避免旧 Tailscale 请求覆盖 Tailcat。
- 保留实验页进入路径预先生成的 Tailcat 票据，配对窗口不会重复执行最长 25 秒的请求。
- 增加自动请求晚于 Tailcat 请求完成的并发回归测试。

## 验证

- `bash ./scripts/test-macos-app.sh`：63 个测试通过。
- `bash ./scripts/check-source-size.sh`：通过。
- `git diff --check`：通过。