### PR TITLE
MIM-222/223/224/225/226 收口 App Server 授权、连接与退出链路

### DIFF
--- a/internal/appserver/ssh.go
+++ b/internal/appserver/ssh.go
@@ -52,7 +52,7 @@ type SSHTransportOptions struct {
 }
 
 // SSHTransport 负责把每个本地 WebSocket 连接映射到一个短生命周期 SSH proxy。
-// 它不拥有远端 App Server；Close 只关闭本地 proxy，不会停止 resident Codex。
+// 它不拥有远端 App Server；Shutdown 只结束本地工作，不会停止 resident Codex。
 type SSHTransport struct {
 	target string
 	sshBin string
@@ -62,8 +62,16 @@ type SSHTransport struct {
 	retryInterval    time.Duration
 
 	readyMu       sync.Mutex
-	readyErr      error
-	readyInFlight chan struct{}
+	readyInFlight *sshReadyFlight
+	lifetimeCtx   context.Context
+	lifetimeStop  context.CancelFunc
+	closed        bool
+	proxies       map[*sshProxyConn]struct{}
+}
+
+type sshReadyFlight struct {
+	done chan struct{}
+	err  error
 }
 
 // NewSSHTransport 构造 SSH transport。空 target 不在这里默默替换，调用方应先
@@ -89,12 +97,16 @@ func NewSSHTransport(options SSHTransportOptions) (*SSHTransport, error) {
 	if retryInterval <= 0 {
 		retryInterval = defaultSSHRetryInterval
 	}
+	lifetimeCtx, lifetimeStop := context.WithCancel(context.Background())
 	return &SSHTransport{
 		target:           target,
 		sshBin:           sshBin,
 		readyTimeout:     readyTimeout,
 		bootstrapTimeout: bootstrapTimeout,
 		retryInterval:    retryInterval,
+		lifetimeCtx:      lifetimeCtx,
+		lifetimeStop:     lifetimeStop,
+		proxies:          map[*sshProxyConn]struct{}{},
 	}, nil
 }
 
@@ -172,34 +184,74 @@ func (t *SSHTransport) EnsureReady(ctx context.Context) error {
 	if t == nil {
 		return errors.New("SSH transport 未初始化")
 	}
-	t.readyMu.Lock()
-	if t.readyInFlight != nil {
-		inFlight := t.readyInFlight
-		t.readyMu.Unlock()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-inFlight:
-		}
-		t.readyMu.Lock()
-		err := t.readyErr
-		t.readyMu.Unlock()
-		return err
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	inFlight := make(chan struct{})
-	t.readyInFlight = inFlight
+	t.readyMu.Lock()
+	if t.closed {
+		t.readyMu.Unlock()
+		return errors.New("SSH transport 已关闭")
+	}
+	flight := t.readyInFlight
+	if flight == nil {
+		flight = &sshReadyFlight{done: make(chan struct{})}
+		t.readyInFlight = flight
+		go t.runReadyFlight(flight)
+	}
 	t.readyMu.Unlock()
 
-	readyCtx, cancel := context.WithTimeout(ctx, t.readyTimeout)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-flight.done:
+		return flight.err
+	}
+}
+
+func (t *SSHTransport) runReadyFlight(flight *sshReadyFlight) {
+	readyCtx, cancel := context.WithTimeout(t.lifetimeCtx, t.readyTimeout)
 	err := t.ensureReadyOnce(readyCtx)
 	cancel()
 
 	t.readyMu.Lock()
-	t.readyErr = err
-	t.readyInFlight = nil
-	close(inFlight)
+	flight.err = err
+	if t.readyInFlight == flight {
+		t.readyInFlight = nil
+	}
+	close(flight.done)
 	t.readyMu.Unlock()
-	return err
+}
+
+// Shutdown 只终止 agentd 自己仍在执行的 readiness/bootstrap。
+// 每条已建立的 proxy 由 Router 持有并关闭；远端常驻 App Server 不属于本 transport。
+func (t *SSHTransport) Shutdown() {
+	if t == nil {
+		return
+	}
+	t.readyMu.Lock()
+	if t.closed {
+		t.readyMu.Unlock()
+		return
+	}
+	t.closed = true
+	stop := t.lifetimeStop
+	proxies := make([]*sshProxyConn, 0, len(t.proxies))
+	for proxy := range t.proxies {
+		proxies = append(proxies, proxy)
+	}
+	t.readyMu.Unlock()
+	if stop != nil {
+		stop()
+	}
+	var closeGroup sync.WaitGroup
+	closeGroup.Add(len(proxies))
+	for _, proxy := range proxies {
+		go func() {
+			defer closeGroup.Done()
+			_ = proxy.Close()
+		}()
+	}
+	closeGroup.Wait()
 }
 
 func (t *SSHTransport) ensureReadyOnce(ctx context.Context) error {
@@ -280,6 +332,12 @@ func (t *SSHTransport) WebSocketDialer(timeout time.Duration) (websocket.Dialer,
 	if err := ValidateSSHTarget(t.target); err != nil {
 		return websocket.Dialer{}, err
 	}
+	t.readyMu.Lock()
+	closed := t.closed
+	t.readyMu.Unlock()
+	if closed {
+		return websocket.Dialer{}, errors.New("SSH transport 已关闭")
+	}
 	if timeout <= 0 {
 		timeout = 4 * time.Second
 	}
@@ -324,6 +382,21 @@ func (t *SSHTransport) probeProxy(ctx context.Context) error {
 
 func (t *SSHTransport) dialWebSocketRaw(ctx context.Context, headers http.Header) (*websocket.Conn, *http.Response, error) {
 	var proxy *sshProxyConn
+	var proxyMu sync.Mutex
+	watchDone := make(chan struct{})
+	defer close(watchDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			proxyMu.Lock()
+			activeProxy := proxy
+			proxyMu.Unlock()
+			if activeProxy != nil {
+				_ = activeProxy.Close()
+			}
+		case <-watchDone:
+		}
+	}()
 	dialer, err := t.WebSocketDialer(4 * time.Second)
 	if err != nil {
 		return nil, nil, err
@@ -332,15 +405,24 @@ func (t *SSHTransport) dialWebSocketRaw(ctx context.Context, headers http.Header
 	dialer.NetDialContext = func(dialCtx context.Context, network, address string) (net.Conn, error) {
 		conn, err := baseDial(dialCtx, network, address)
 		if typed, ok := conn.(*sshProxyConn); ok {
+			proxyMu.Lock()
 			proxy = typed
+			canceled := ctx.Err() != nil
+			proxyMu.Unlock()
+			if canceled {
+				_ = typed.Close()
+			}
 		}
 		return conn, err
 	}
 	conn, response, err := dialer.DialContext(ctx, CodexAppServerWebSocketURL, headers)
 	if err != nil {
-		if proxy != nil {
-			proxy.Close()
-			return nil, response, proxy.dialError(err)
+		proxyMu.Lock()
+		failedProxy := proxy
+		proxyMu.Unlock()
+		if failedProxy != nil {
+			_ = failedProxy.Close()
+			return nil, response, failedProxy.dialError(err)
 		}
 		return nil, response, err
 	}
@@ -627,6 +709,12 @@ type sshProxyConn struct {
 }
 
 func (t *SSHTransport) openProxy(_ context.Context) (net.Conn, error) {
+	t.readyMu.Lock()
+	closed := t.closed
+	t.readyMu.Unlock()
+	if closed {
+		return nil, &SSHProxyError{StartError: errors.New("SSH transport 已关闭"), ExitCode: -1}
+	}
 	if err := t.SSHBinaryAvailable(); err != nil {
 		return nil, &SSHProxyError{StartError: err, ExitCode: -1}
 	}
@@ -661,12 +749,25 @@ func (t *SSHTransport) openProxy(_ context.Context) (net.Conn, error) {
 		waitCh: make(chan error, 1),
 		doneCh: make(chan struct{}),
 	}
+	t.readyMu.Lock()
+	registered := !t.closed
+	if registered {
+		t.proxies[proxy] = struct{}{}
+	}
+	t.readyMu.Unlock()
 	go proxy.captureStderr(stderr)
 	go func() {
 		err := cmd.Wait()
+		t.readyMu.Lock()
+		delete(t.proxies, proxy)
+		t.readyMu.Unlock()
 		proxy.waitCh <- err
 		close(proxy.doneCh)
 	}()
+	if !registered {
+		_ = proxy.Close()
+		return nil, &SSHProxyError{StartError: errors.New("SSH transport 已关闭"), ExitCode: -1}
+	}
 	// Gorilla v1.5.3 会在 DialContext 返回时取消它为 HandshakeTimeout
 	// 派生的 context。这里不能把该 context 当作连接生命周期；握手失败时
 	// Gorilla 自己会关闭 net.Conn，握手超时则由它设置在连接上的 deadline 负责。

--- a/internal/appserver/ssh_ready_lifecycle_test.go
+++ b/internal/appserver/ssh_ready_lifecycle_test.go
@@ -1,0 +1,102 @@
+package appserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSSHTransportReadyFlightSurvivesLeaderCancellation(t *testing.T) {
+	transport, logPath, _, _ := newSSHHelperTransport(t, true)
+	t.Cleanup(transport.Shutdown)
+	t.Setenv(sshHelperProxyDelayEnv, "150ms")
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderResult := make(chan error, 1)
+	go func() {
+		leaderResult <- transport.EnsureReady(leaderCtx)
+	}()
+	waitForSSHHelperCommand(t, logPath, sshProxyRemoteCommand)
+
+	followerResult := make(chan error, 1)
+	go func() {
+		followerResult <- transport.EnsureReady(context.Background())
+	}()
+	cancelLeader()
+
+	if err := <-leaderResult; !errors.Is(err, context.Canceled) {
+		t.Fatalf("leader 应只结束自己的等待：%v", err)
+	}
+	select {
+	case err := <-followerResult:
+		if err != nil {
+			t.Fatalf("leader 取消不应终止共享 readiness：%v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("follower 未收到共享 readiness 结果")
+	}
+	if got := countSSHHelperCommand(t, logPath, sshProxyRemoteCommand); got != 1 {
+		t.Fatalf("leader 与 follower 必须共享一次 proxy 探测，got=%d", got)
+	}
+}
+
+func TestSSHTransportShutdownCancelsReadyFlightAndRejectsNewWork(t *testing.T) {
+	transport, logPath, _, _ := newSSHHelperTransport(t, true)
+	t.Setenv(sshHelperProxyDelayEnv, "5s")
+
+	result := make(chan error, 1)
+	go func() {
+		result <- transport.EnsureReady(context.Background())
+	}()
+	waitForSSHHelperCommand(t, logPath, sshProxyRemoteCommand)
+	transport.Shutdown()
+	transport.Shutdown()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("shutdown 后 readiness 不应成功")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown 未及时结束 readiness 子进程")
+	}
+	if err := transport.EnsureReady(context.Background()); err == nil {
+		t.Fatal("shutdown 后不得启动新 readiness")
+	}
+}
+
+func TestSSHTransportShutdownClosesEstablishedProxyButKeepsResidentServer(t *testing.T) {
+	transport, _, serverMarker, _ := newSSHHelperTransport(t, true)
+	conn, _, err := transport.DialWebSocket(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	transport.Shutdown()
+	_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("shutdown 后已建立的 SSH proxy 应关闭")
+	}
+	if !helperFileExists(serverMarker) {
+		t.Fatal("shutdown 不得停止共享 resident App Server")
+	}
+	transport.readyMu.Lock()
+	activeProxies := len(transport.proxies)
+	transport.readyMu.Unlock()
+	if activeProxies != 0 {
+		t.Fatalf("shutdown 后 SSH 子进程注册表应为空，got=%d", activeProxies)
+	}
+}
+
+func waitForSSHHelperCommand(t *testing.T, logPath string, command string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if helperFileExists(logPath) && countSSHHelperCommand(t, logPath, command) > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("等待 SSH helper 命令超时：%s", command)
+}

--- a/internal/appserver/ssh_test.go
+++ b/internal/appserver/ssh_test.go
@@ -20,7 +20,10 @@ import (
 	"time"
 )
 
-const sshHelperEnv = "MIMI_SSH_HELPER"
+const (
+	sshHelperEnv           = "MIMI_SSH_HELPER"
+	sshHelperProxyDelayEnv = "MIMI_SSH_PROXY_DELAY"
+)
 
 func TestSSHHelperProcess(t *testing.T) {
 	if os.Getenv(sshHelperEnv) != "1" {
@@ -60,6 +63,9 @@ func TestSSHHelperProcess(t *testing.T) {
 	case sshProxyRemoteCommand:
 		if !helperFileExists(os.Getenv("MIMI_SSH_SERVER_MARKER")) || helperFileExists(os.Getenv("MIMI_SSH_FAIL_MARKER")) {
 			os.Exit(92)
+		}
+		if delay, err := time.ParseDuration(os.Getenv(sshHelperProxyDelayEnv)); err == nil && delay > 0 {
+			time.Sleep(delay)
 		}
 		serveSSHHelperWebSocket()
 		if exitMarker := os.Getenv("MIMI_SSH_PROXY_EXIT_MARKER"); exitMarker != "" {

--- a/internal/httpapi/appserver_bandwidth_control_test.go
+++ b/internal/httpapi/appserver_bandwidth_control_test.go
@@ -20,9 +20,14 @@ import (
 func TestAppServerGatewayRedactsImageGenerationNotificationsAndDeduplicates(t *testing.T) {
 	t.Setenv("AGENTD_MEDIA_REDACT_NOTIFICATIONS", "")
 	router := &Router{historyMedia: newAppServerHistoryMediaStore()}
-	policy := &appServerGatewayPolicy{router: router, runtimeID: "codex"}
+	policy := &appServerGatewayPolicy{
+		router: router, runtimeID: "codex",
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-media": {id: "thread-media", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
+		},
+	}
 	imagePayload := base64.StdEncoding.EncodeToString(testHistoryNoisyPNG(t, 256, 256))
-	payload := []byte(`{"method":"item/completed","params":{"item":{"type":"imageGeneration","id":"ig_1","status":"completed","result":"` + imagePayload + `"}}}`)
+	payload := []byte(`{"method":"item/completed","params":{"threadId":"thread-media","item":{"type":"imageGeneration","id":"ig_1","status":"completed","result":"` + imagePayload + `"}}}`)
 
 	first, forward, policyErr := policy.observeUpstreamFrame(1, payload)
 	if policyErr != nil || !forward {
@@ -46,9 +51,14 @@ func TestAppServerGatewayRedactsImageGenerationNotificationsAndDeduplicates(t *t
 func TestAppServerGatewayNotificationRedactionCanBeDisabled(t *testing.T) {
 	t.Setenv("AGENTD_MEDIA_REDACT_NOTIFICATIONS", "off")
 	router := &Router{historyMedia: newAppServerHistoryMediaStore()}
-	policy := &appServerGatewayPolicy{router: router, runtimeID: "codex"}
+	policy := &appServerGatewayPolicy{
+		router: router, runtimeID: "codex",
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-media": {id: "thread-media", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
+		},
+	}
 	imagePayload := base64.StdEncoding.EncodeToString(testHistoryNoisyPNG(t, 256, 256))
-	payload := []byte(`{"method":"item/completed","params":{"item":{"type":"imageGeneration","result":"` + imagePayload + `"}}}`)
+	payload := []byte(`{"method":"item/completed","params":{"threadId":"thread-media","item":{"type":"imageGeneration","result":"` + imagePayload + `"}}}`)
 
 	got, forward, policyErr := policy.observeUpstreamFrame(1, payload)
 	if policyErr != nil || !forward {

--- a/internal/httpapi/appserver_gateway.go
+++ b/internal/httpapi/appserver_gateway.go
@@ -3,7 +3,9 @@ package httpapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -31,6 +33,7 @@ const (
 	// 个人/小团队场景通常只有 1–2 个移动端。保留重连余量，同时限制一个泄漏的 token
 	// 无限建立“移动端 WS + 本机 upstream WS”连接，避免耗尽文件描述符和 goroutine。
 	appServerGatewayMaxConnections = 8
+	appServerGatewayShutdownWait   = 2 * time.Second
 	appServerGatewayThreadCacheMax = 2048
 	appServerGatewayThreadCacheTTL = 24 * time.Hour
 	defaultCodexReasoningEffort    = "xhigh"
@@ -45,6 +48,72 @@ const (
 	appServerGatewayInitialTurnsMaxLimit     = 5
 	appServerGatewayGlobalCursorMax          = 128
 )
+
+var (
+	errCodexGatewayClosing = errors.New("Codex gateway 正在关闭")
+	errCodexGatewayFull    = errors.New("Codex gateway 连接数已达上限")
+)
+
+type codexGatewayConnection struct {
+	mu       sync.Mutex
+	cancel   context.CancelFunc
+	client   io.Closer
+	upstream io.Closer
+	closed   bool
+}
+
+func (c *codexGatewayConnection) attachClient(conn *websocket.Conn) bool {
+	return c.attach(conn, true)
+}
+
+func (c *codexGatewayConnection) attachUpstream(conn *websocket.Conn) bool {
+	return c.attach(conn, false)
+}
+
+func (c *codexGatewayConnection) attach(conn io.Closer, client bool) bool {
+	if c == nil || conn == nil {
+		return false
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		_ = conn.Close()
+		return false
+	}
+	if client {
+		c.client = conn
+	} else {
+		c.upstream = conn
+	}
+	c.mu.Unlock()
+	return true
+}
+
+func (c *codexGatewayConnection) close() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	cancel := c.cancel
+	client := c.client
+	upstream := c.upstream
+	c.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if client != nil {
+		_ = client.Close()
+	}
+	if upstream != nil {
+		_ = upstream.Close()
+	}
+}
 
 var (
 	appServerGatewayReadLimit  int64 = 64 << 20
@@ -555,12 +624,22 @@ func (r *Router) appServerCodexGatewayWS(w http.ResponseWriter, req *http.Reques
 		writeError(w, http.StatusBadRequest, "app-server gateway 需要 WebSocket Upgrade")
 		return
 	}
-	if !r.acquireCodexGatewaySlot() {
+	gateway, gatewayCtx, err := r.acquireCodexGateway(req.Context())
+	if errors.Is(err, errCodexGatewayClosing) {
+		writeError(w, http.StatusServiceUnavailable, "Codex gateway 正在关闭")
+		return
+	}
+	if errors.Is(err, errCodexGatewayFull) {
 		w.Header().Set("Retry-After", "1")
 		writeError(w, http.StatusTooManyRequests, "Codex gateway 连接数已达上限，请稍后重试")
 		return
 	}
-	defer r.releaseCodexGatewaySlot()
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "Codex gateway 暂时不可用")
+		return
+	}
+	defer r.releaseCodexGateway(gateway)
+	req = req.WithContext(gatewayCtx)
 
 	upstreamURL, err := r.appServerUpstreamWebSocketURL()
 	if err != nil {
@@ -585,13 +664,16 @@ func (r *Router) appServerCodexGatewayWS(w http.ResponseWriter, req *http.Reques
 		return
 	}
 	defer client.Close()
+	if !gateway.attachClient(client) {
+		return
+	}
 
 	// 正常链路直接建立这一条连接，避免为每个移动端连接额外创建 readiness proxy。
 	// 只有首次拨号失败时才进入带 single-flight 的 Socket 探测/bootstrap，然后重试一次。
 	// 外侧握手必须先成功，畸形请求和超额连接不能触发任何 SSH 子进程。
 	dialUpstream := func() (*websocket.Conn, time.Duration, error) {
 		dialStart := time.Now()
-		conn, response, dialErr := dialer.DialContext(req.Context(), upstreamURL, upstreamHeaders)
+		conn, response, dialErr := dialer.DialContext(gatewayCtx, upstreamURL, upstreamHeaders)
 		if response != nil && response.Body != nil {
 			_ = response.Body.Close()
 		}
@@ -599,7 +681,7 @@ func (r *Router) appServerCodexGatewayWS(w http.ResponseWriter, req *http.Reques
 	}
 	upstream, dialDuration, err := dialUpstream()
 	if err != nil {
-		readyCtx, cancelReady := context.WithTimeout(req.Context(), 15*time.Second)
+		readyCtx, cancelReady := context.WithTimeout(gatewayCtx, 15*time.Second)
 		readyErr := r.appServerSSH.EnsureReady(readyCtx)
 		cancelReady()
 		if readyErr == nil {
@@ -614,28 +696,104 @@ func (r *Router) appServerCodexGatewayWS(w http.ResponseWriter, req *http.Reques
 		return
 	}
 	defer upstream.Close()
+	if !gateway.attachUpstream(upstream) {
+		return
+	}
 
 	log.Printf("app-server gateway connected upstream=%s", sanitizeGatewayURL(upstreamURL))
 	monitor := r.monitor.startGatewayConnection(requestRemoteHost(req), req.Host, sanitizeGatewayURL(upstreamURL), dialDuration)
-	r.proxyAppServerGateway(req.Context(), client, upstream, monitor)
+	r.proxyAppServerGateway(gatewayCtx, client, upstream, monitor)
 }
 
-func (r *Router) acquireCodexGatewaySlot() bool {
+func (r *Router) acquireCodexGateway(parent context.Context) (*codexGatewayConnection, context.Context, error) {
+	if r == nil {
+		return nil, nil, errors.New("Codex gateway 未初始化")
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
 	r.codexGatewayMu.Lock()
 	defer r.codexGatewayMu.Unlock()
-	if r.activeCodexGateway >= appServerGatewayMaxConnections {
-		return false
+	if r.codexGatewayClosing {
+		return nil, nil, errCodexGatewayClosing
 	}
-	r.activeCodexGateway++
-	return true
+	if len(r.codexGateways) >= appServerGatewayMaxConnections {
+		return nil, nil, errCodexGatewayFull
+	}
+	if r.codexGateways == nil {
+		r.codexGateways = map[uint64]*codexGatewayConnection{}
+	}
+	ctx, cancel := context.WithCancel(parent)
+	r.codexGatewayNextID++
+	connection := &codexGatewayConnection{cancel: cancel}
+	r.codexGateways[r.codexGatewayNextID] = connection
+	r.codexGatewayWG.Add(1)
+	return connection, ctx, nil
 }
 
-func (r *Router) releaseCodexGatewaySlot() {
+func (r *Router) releaseCodexGateway(connection *codexGatewayConnection) {
+	if r == nil || connection == nil {
+		return
+	}
+	connection.close()
 	r.codexGatewayMu.Lock()
-	if r.activeCodexGateway > 0 {
-		r.activeCodexGateway--
+	for id, current := range r.codexGateways {
+		if current == connection {
+			delete(r.codexGateways, id)
+			r.codexGatewayWG.Done()
+			break
+		}
 	}
 	r.codexGatewayMu.Unlock()
+}
+
+func (r *Router) shutdownCodexGateways() {
+	if r == nil {
+		return
+	}
+	r.codexGatewayMu.Lock()
+	r.codexGatewayClosing = true
+	connections := make([]*codexGatewayConnection, 0, len(r.codexGateways))
+	for _, connection := range r.codexGateways {
+		connections = append(connections, connection)
+	}
+	r.codexGatewayMu.Unlock()
+
+	var cleanup sync.WaitGroup
+	cleanup.Add(len(connections))
+	for _, connection := range connections {
+		go func() {
+			defer cleanup.Done()
+			connection.close()
+		}()
+	}
+	if transport, ok := r.appServerSSH.(interface{ Shutdown() }); ok {
+		cleanup.Add(1)
+		go func() {
+			defer cleanup.Done()
+			transport.Shutdown()
+		}()
+	}
+	done := make(chan struct{})
+	go func() {
+		cleanup.Wait()
+		r.codexGatewayWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(appServerGatewayShutdownWait):
+		log.Printf("Codex gateway 关闭等待超时 active=%d", r.activeCodexGatewayCount())
+	}
+}
+
+func (r *Router) activeCodexGatewayCount() int {
+	if r == nil {
+		return 0
+	}
+	r.codexGatewayMu.Lock()
+	defer r.codexGatewayMu.Unlock()
+	return len(r.codexGateways)
 }
 
 func writeCodexGatewayRuntimeError(conn *websocket.Conn, code string, message string) {
@@ -645,6 +803,9 @@ func writeCodexGatewayRuntimeError(conn *websocket.Conn, code string, message st
 		"error": map[string]any{
 			"code":    appServerPolicyErrorCode,
 			"message": code + ": " + message,
+			"data": map[string]any{
+				"reason": strings.ToLower(code),
+			},
 		},
 	})
 	if err != nil {

--- a/internal/httpapi/appserver_gateway_inbound_policy_test.go
+++ b/internal/httpapi/appserver_gateway_inbound_policy_test.go
@@ -1,0 +1,169 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+	"github.com/gaixianggeng/mimi-remote/internal/projects"
+)
+
+func newCodexInboundPolicyForTest(t *testing.T) (*appServerGatewayPolicy, string) {
+	t.Helper()
+	projectDir := t.TempDir()
+	registry, err := projects.NewRegistry([]config.ProjectConfig{{
+		ID: "project", Name: "Project", Path: projectDir,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := &Router{
+		cfg: config.Config{}, projects: registry,
+		gatewayThreads: map[string]appServerGatewayAllowedThread{},
+	}
+	policy := &appServerGatewayPolicy{
+		router:                router,
+		runtimeID:             "codex",
+		pendingThreads:        map[string]appServerGatewayPendingThreadRequest{},
+		allowedThreads:        map[string]appServerGatewayAllowedThread{},
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	policy.allowThread(appServerGatewayAllowedThread{
+		id: "allowed", runtimeID: "codex", cwd: projectDir, scopeID: "project",
+	})
+	return policy, projectDir
+}
+
+func TestCodexGatewayAuthorizesInboundNotificationsByThread(t *testing.T) {
+	policy, projectDir := newCodexInboundPolicyForTest(t)
+
+	cases := []struct {
+		name    string
+		payload string
+		forward bool
+	}{
+		{name: "top level allowed", payload: `{"method":"turn/completed","params":{"threadId":"allowed","turnId":"turn-1"}}`, forward: true},
+		{name: "nested allowed", payload: `{"method":"thread/name/updated","params":{"thread":{"id":"allowed"}}}`, forward: true},
+		{name: "unknown thread", payload: `{"method":"turn/completed","params":{"threadId":"desktop-only"}}`, forward: false},
+		{name: "missing thread", payload: `{"method":"item/completed","params":{"item":{"id":"secret"}}}`, forward: false},
+		{name: "global rate limits", payload: `{"method":"account/rateLimits/updated","params":{}}`, forward: true},
+		{name: "global mcp startup", payload: `{"method":"mcpServer/startupStatus/updated","params":{}}`, forward: true},
+		{name: "global deprecation", payload: `{"method":"deprecationNotice","params":{}}`, forward: true},
+		{name: "unknown global", payload: `{"method":"account/private/updated","params":{}}`, forward: false},
+		{name: "started authorized thread", payload: `{"method":"thread/started","params":{"thread":{"id":"allowed","cwd":` + quoteJSON(projectDir) + `}}}`, forward: true},
+		{name: "started allowlisted but unauthorized", payload: `{"method":"thread/started","params":{"thread":{"id":"new-thread","cwd":` + quoteJSON(projectDir) + `}}}`, forward: false},
+		{name: "started outside cwd", payload: `{"method":"thread/started","params":{"thread":{"id":"outside","cwd":` + quoteJSON(filepath.Dir(projectDir)) + `}}}`, forward: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := []byte(tc.payload)
+			got, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, payload)
+			if policyErr != nil || forward != tc.forward {
+				t.Fatalf("forward=%t want=%t err=%+v", forward, tc.forward, policyErr)
+			}
+			if forward && !bytes.Equal(got, payload) {
+				t.Fatalf("notification 应原样透传 got=%s want=%s", got, payload)
+			}
+		})
+	}
+	if _, ok := policy.allowedThread("new-thread"); ok {
+		t.Fatal("只有 cwd 白名单、没有本连接响应授权的 thread/started 不得登记")
+	}
+	if _, ok := policy.allowedThread("outside"); ok {
+		t.Fatal("allowlist 外的 thread/started 不得登记")
+	}
+
+	id := json.RawMessage(`99`)
+	if err := policy.rememberPendingThreadResponse(&id, "thread/start", projectDir, "project"); err != nil {
+		t.Fatal(err)
+	}
+	response := []byte(`{"id":99,"result":{"thread":{"id":"new-thread","cwd":` + quoteJSON(projectDir) + `}}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, response); policyErr != nil || !forward {
+		t.Fatalf("本连接 thread/start 响应应建立授权 forward=%t err=%+v", forward, policyErr)
+	}
+	started := []byte(`{"method":"thread/started","params":{"thread":{"id":"new-thread","cwd":` + quoteJSON(projectDir) + `}}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, started); policyErr != nil || !forward {
+		t.Fatalf("响应授权后的 thread/started 应透传 forward=%t err=%+v", forward, policyErr)
+	}
+}
+
+func TestCodexGatewayRequiresAuthorizedThreadForReverseRequests(t *testing.T) {
+	policy, _ := newCodexInboundPolicyForTest(t)
+
+	allowed := []byte(`{"id":"approval-ok","method":"item/commandExecution/requestApproval","params":{"threadId":"allowed","itemId":"item-1"}}`)
+	if got, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, allowed); policyErr != nil || !forward || !bytes.Equal(got, allowed) {
+		t.Fatalf("授权 thread 的 reverse request 应透传 forward=%t err=%+v got=%s", forward, policyErr, got)
+	}
+
+	for _, payload := range [][]byte{
+		[]byte(`{"id":"approval-other","method":"item/commandExecution/requestApproval","params":{"threadId":"desktop-only"}}`),
+		[]byte(`{"id":"approval-unscoped","method":"item/commandExecution/requestApproval","params":{}}`),
+		[]byte(`{"id":"unknown","method":"future/serverRequest","params":{"threadId":"allowed"}}`),
+	} {
+		if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, payload); forward || policyErr != nil {
+			t.Fatalf("未授权或未知 reverse request 应静默丢弃 forward=%t err=%+v payload=%s", forward, policyErr, payload)
+		}
+	}
+	for _, rawID := range []string{`"approval-other"`, `"approval-unscoped"`, `"unknown"`} {
+		id := json.RawMessage(rawID)
+		if _, ok := policy.consumePendingServerRequest(&id); ok {
+			t.Fatalf("被丢弃的 reverse request 不得登记 pending id=%s", rawID)
+		}
+	}
+}
+
+func TestCodexGatewayAuthorizesResolvedBeforeClearingPending(t *testing.T) {
+	policy, _ := newCodexInboundPolicyForTest(t)
+	request := []byte(`{"id":"approval-ok","method":"item/tool/requestUserInput","params":{"threadId":"allowed","turnId":"turn-1","itemId":"item-1"}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request); policyErr != nil || !forward {
+		t.Fatalf("准备 reverse request 失败 forward=%t err=%+v", forward, policyErr)
+	}
+
+	blocked := []byte(`{"method":"serverRequest/resolved","params":{"requestId":"not-pending","threadId":"desktop-only"}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, blocked); forward || policyErr != nil {
+		t.Fatalf("未授权 resolved 应静默丢弃 forward=%t err=%+v", forward, policyErr)
+	}
+	id := json.RawMessage(`"approval-ok"`)
+	if _, ok := policy.consumePendingServerRequest(&id); !ok {
+		t.Fatal("被拒绝的 resolved 不得清理其他 pending")
+	}
+
+	if err := policy.rememberPendingServerRequest(&id, "item/tool/requestUserInput", json.RawMessage(`{"threadId":"allowed","turnId":"turn-1","itemId":"item-1"}`)); err != nil {
+		t.Fatal(err)
+	}
+	resolved := []byte(`{"method":"serverRequest/resolved","params":{"requestId":"approval-ok"}}`)
+	if got, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, resolved); policyErr != nil || !forward || !bytes.Equal(got, resolved) {
+		t.Fatalf("已授权 pending 的无 thread resolved 应透传 forward=%t err=%+v got=%s", forward, policyErr, got)
+	}
+	if _, ok := policy.consumePendingServerRequest(&id); ok {
+		t.Fatal("合法 resolved 应清理 pending")
+	}
+}
+
+func TestCodexGatewayOnlyAllowsRelatedThreadsFromAuthorizedParent(t *testing.T) {
+	policy, _ := newCodexInboundPolicyForTest(t)
+	allowedParent := []byte(`{"method":"item/completed","params":{"threadId":"allowed","item":{"type":"collabAgentToolCall","receiverThreadIds":["child-ok"]}}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, allowedParent); policyErr != nil || !forward {
+		t.Fatalf("授权父 thread 通知应透传 forward=%t err=%+v", forward, policyErr)
+	}
+	if child, ok := policy.allowedThread("child-ok"); !ok || !child.readOnly {
+		t.Fatalf("授权父 thread 应登记只读 child child=%+v ok=%t", child, ok)
+	}
+
+	unknownParent := []byte(`{"method":"item/completed","params":{"threadId":"desktop-only","item":{"type":"collabAgentToolCall","receiverThreadIds":["child-no"]}}}`)
+	if _, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, unknownParent); forward || policyErr != nil {
+		t.Fatalf("未授权父 thread 通知应丢弃 forward=%t err=%+v", forward, policyErr)
+	}
+	if _, ok := policy.allowedThread("child-no"); ok {
+		t.Fatal("未授权父 thread 不得登记 child")
+	}
+}
+
+func quoteJSON(value string) string {
+	raw, _ := json.Marshal(value)
+	return string(raw)
+}

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -1795,6 +1795,9 @@ func TestAppServerGatewayServerRequestAllowlistMatchesMobileCapabilities(t *test
 	policy := &appServerGatewayPolicy{
 		runtimeID:             "codex",
 		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-mobile": {id: "thread-mobile", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
+		},
 	}
 	allowed := []string{
 		"applyPatchApproval",
@@ -1807,7 +1810,7 @@ func TestAppServerGatewayServerRequestAllowlistMatchesMobileCapabilities(t *test
 	}
 	for index, method := range allowed {
 		id := index + 1
-		payload := []byte(fmt.Sprintf(`{"id":%d,"method":%q,"params":{}}`, id, method))
+		payload := []byte(fmt.Sprintf(`{"id":%d,"method":%q,"params":{"threadId":"thread-mobile"}}`, id, method))
 		got, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, payload)
 		if policyErr != nil || !forward || !bytes.Equal(got, payload) {
 			t.Fatalf("已支持 server request 应转发 method=%s forward=%v err=%+v got=%s", method, forward, policyErr, got)
@@ -1840,6 +1843,9 @@ func TestAppServerGatewayPassesCodexMCPToolApprovalMetadataAndDecisionUnchanged(
 	policy := &appServerGatewayPolicy{
 		runtimeID:             "codex",
 		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-1": {id: "thread-1", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
+		},
 	}
 	request := []byte(`{"id":"mcp-approval-1","method":"mcpServer/elicitation/request","params":{"threadId":"thread-1","serverName":"linear","mode":"form","message":"Allow save_issue?","requestedSchema":{"type":"object","properties":{}},"_meta":{"codex_approval_kind":"mcp_tool_call","persist":["session","always"]}}}`)
 	forwarded, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request)
@@ -1892,7 +1898,13 @@ func TestAppServerGatewayRejectsUnsupportedServerRequestBackToUpstream(t *testin
 
 func TestAppServerGatewayRewritesPermissionsApprovalResponse(t *testing.T) {
 	var sentApprovalRequest atomic.Bool
+	var projectDir string
 	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var frame appServerGatewayFrame
+		if json.Unmarshal(payload, &frame) == nil && frame.Method == "thread/list" {
+			respondToThreadListAuthorization(t, conn, payload, projectDir, "thread-1")
+			return
+		}
 		if sentApprovalRequest.Swap(true) {
 			return
 		}
@@ -1901,12 +1913,14 @@ func TestAppServerGatewayRewritesPermissionsApprovalResponse(t *testing.T) {
 			t.Errorf("fake upstream 写 permissions request 失败：%v", err)
 		}
 	})
-	handler, _ := appServerGatewayRouterFixture(t, upstreamURL)
+	handler, dir := appServerGatewayRouterFixture(t, upstreamURL)
+	projectDir = dir
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
 	conn := dialAuthedGateway(t, server.URL)
 	defer conn.Close()
+	authorizeGatewayThread(t, conn, received, projectDir, "thread-1")
 
 	initialize := []byte(`{"id":1,"method":"initialize","params":{}}`)
 	if err := conn.WriteMessage(websocket.TextMessage, initialize); err != nil {
@@ -1940,7 +1954,13 @@ func TestAppServerGatewayRewritesPermissionsApprovalResponse(t *testing.T) {
 func TestAppServerGatewayForwardsOnlyRequestedPermissionSubset(t *testing.T) {
 	requestedPermissions := `{"fileSystem":{"entries":[{"access":"read","path":{"type":"path","path":"/tmp/report.txt"}},{"access":"write","path":{"type":"special","value":{"kind":"project_roots","subpath":"output"}}}]},"network":{"enabled":true}}`
 	var sentApprovalRequest atomic.Bool
+	var projectDir string
 	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var frame appServerGatewayFrame
+		if json.Unmarshal(payload, &frame) == nil && frame.Method == "thread/list" {
+			respondToThreadListAuthorization(t, conn, payload, projectDir, "thread-1")
+			return
+		}
 		if sentApprovalRequest.Swap(true) {
 			return
 		}
@@ -1949,12 +1969,14 @@ func TestAppServerGatewayForwardsOnlyRequestedPermissionSubset(t *testing.T) {
 			t.Errorf("fake upstream 写 permissions request 失败：%v", err)
 		}
 	})
-	handler, _ := appServerGatewayRouterFixture(t, upstreamURL)
+	handler, dir := appServerGatewayRouterFixture(t, upstreamURL)
+	projectDir = dir
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
 	conn := dialAuthedGateway(t, server.URL)
 	defer conn.Close()
+	authorizeGatewayThread(t, conn, received, projectDir, "thread-1")
 	initialize := []byte(`{"id":1,"method":"initialize","params":{}}`)
 	if err := conn.WriteMessage(websocket.TextMessage, initialize); err != nil {
 		t.Fatal(err)
@@ -1990,7 +2012,13 @@ func TestAppServerGatewayForwardsOnlyRequestedPermissionSubset(t *testing.T) {
 
 func TestAppServerGatewayDropsOverGrantedPermissions(t *testing.T) {
 	var sentApprovalRequest atomic.Bool
+	var projectDir string
 	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var frame appServerGatewayFrame
+		if json.Unmarshal(payload, &frame) == nil && frame.Method == "thread/list" {
+			respondToThreadListAuthorization(t, conn, payload, projectDir, "thread-1")
+			return
+		}
 		if sentApprovalRequest.Swap(true) {
 			return
 		}
@@ -1999,12 +2027,14 @@ func TestAppServerGatewayDropsOverGrantedPermissions(t *testing.T) {
 			t.Errorf("fake upstream 写 permissions request 失败：%v", err)
 		}
 	})
-	handler, _ := appServerGatewayRouterFixture(t, upstreamURL)
+	handler, dir := appServerGatewayRouterFixture(t, upstreamURL)
+	projectDir = dir
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
 	conn := dialAuthedGateway(t, server.URL)
 	defer conn.Close()
+	authorizeGatewayThread(t, conn, received, projectDir, "thread-1")
 	initialize := []byte(`{"id":1,"method":"initialize","params":{}}`)
 	if err := conn.WriteMessage(websocket.TextMessage, initialize); err != nil {
 		t.Fatal(err)
@@ -2182,7 +2212,10 @@ func TestAppServerGatewayServerRequestPendingUsesLongerTTLThanThreadResponses(t 
 			t.Errorf("fake upstream 写 permissions request 失败：%v", err)
 		}
 	})
-	handler, _ := appServerGatewayRouterFixture(t, upstreamURL)
+	handler, router, projectDir := buildAppServerGatewayFixture(t, upstreamURL, nil)
+	router.allowGatewayThread(appServerGatewayAllowedThread{
+		id: "thread-1", runtimeID: "codex", cwd: projectDir, scopeID: "demo",
+	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -2233,6 +2266,10 @@ func TestAppServerGatewayTerminalNotificationsClearPendingServerRequests(t *test
 	policy := &appServerGatewayPolicy{
 		runtimeID:             "codex",
 		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-1": {id: "thread-1", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
+			"thread-2": {id: "thread-2", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
+		},
 	}
 
 	resolvedRequest := []byte(`{"id":"resolved-1","method":"mcpServer/elicitation/request","params":{"threadId":"thread-1","turnId":"turn-1","mode":"form","message":"Allow?","requestedSchema":{"type":"object","properties":{}}}}`)
@@ -2269,7 +2306,7 @@ func TestAppServerGatewayTerminalNotificationsClearPendingServerRequests(t *test
 	}
 }
 
-func TestClaudeGatewayRejectsUnknownReverseRequest(t *testing.T) {
+func TestClaudeGatewayKeepsUnknownReverseRequestSilent(t *testing.T) {
 	policy := &appServerGatewayPolicy{runtimeID: "claude"}
 	request := []byte(`{"id":"unknown-1","method":"claude/private/request","params":{}}`)
 	_, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request)
@@ -2286,7 +2323,13 @@ func TestAppServerGatewayRejectsOverflowServerRequestBeforeForwardingToClient(t 
 	})
 
 	var sentRequests atomic.Bool
+	var projectDir string
 	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
+		var frame appServerGatewayFrame
+		if json.Unmarshal(payload, &frame) == nil && frame.Method == "thread/list" {
+			respondToThreadListAuthorization(t, conn, payload, projectDir, "thread-1")
+			return
+		}
 		if sentRequests.Swap(true) {
 			return
 		}
@@ -2299,12 +2342,14 @@ func TestAppServerGatewayRejectsOverflowServerRequestBeforeForwardingToClient(t 
 			t.Errorf("fake upstream 写第二个 server request 失败：%v", err)
 		}
 	})
-	handler, _ := appServerGatewayRouterFixture(t, upstreamURL)
+	handler, dir := appServerGatewayRouterFixture(t, upstreamURL)
+	projectDir = dir
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
 	conn := dialAuthedGateway(t, server.URL)
 	defer conn.Close()
+	authorizeGatewayThread(t, conn, received, projectDir, "thread-1")
 
 	initialize := []byte(`{"id":1,"method":"initialize","params":{}}`)
 	if err := conn.WriteMessage(websocket.TextMessage, initialize); err != nil {
@@ -2536,7 +2581,7 @@ func TestAppServerGatewayAllowsExternalSkillPathForTurnSteer(t *testing.T) {
 
 func TestAppServerGatewayForwardsAuthorizedFrameUnchanged(t *testing.T) {
 	upstreamResponse := []byte(`{"id":7,"result":{"ok":true}}`)
-	upstreamNotification := []byte(`{"method":"item/agentMessage/delta","params":{"delta":"hello"}}`)
+	upstreamNotification := []byte(`{"method":"item/agentMessage/delta","params":{"threadId":"thread-1","delta":"hello"}}`)
 	var projectDir string
 	upstreamURL, received, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, messageType int, payload []byte) {
 		var frame appServerGatewayFrame
@@ -2655,13 +2700,18 @@ func TestAppServerGatewayNotificationRedactsInlineImagesForCodexAndClaude(t *tes
 	pngBytes := append([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}, bytes.Repeat([]byte{0xAB}, 20<<10)...)
 	resultPayload := base64.StdEncoding.EncodeToString(pngBytes)
 	// item/completed 通知帧：有 method、无 id，走 observeUpstreamFrame 的通知分支。
-	notification := []byte(`{"method":"item/completed","params":{"item":{"type":"imageGeneration","id":"ig_1","status":"completed","result":"` + resultPayload + `","savedPath":"/tmp/mockup.png"}}}`)
+	notification := []byte(`{"method":"item/completed","params":{"threadId":"thread-media","item":{"type":"imageGeneration","id":"ig_1","status":"completed","result":"` + resultPayload + `","savedPath":"/tmp/mockup.png"}}}`)
 
 	// codex 与 claude 两条 runtime 都必须把直播通知里的裸 base64 改写成短 URL。
 	for _, runtimeID := range []string{"codex", "claude"} {
 		t.Run(runtimeID, func(t *testing.T) {
 			router := &Router{historyMedia: newAppServerHistoryMediaStore()}
 			policy := &appServerGatewayPolicy{router: router, runtimeID: runtimeID}
+			if runtimeID == "codex" {
+				policy.allowedThreads = map[string]appServerGatewayAllowedThread{
+					"thread-media": {id: "thread-media", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
+				}
+			}
 			forwarded, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, notification)
 			if policyErr != nil || !forward {
 				t.Fatalf("通知帧应转发：forward=%v err=%+v", forward, policyErr)

--- a/internal/httpapi/appserver_gateway_shutdown_test.go
+++ b/internal/httpapi/appserver_gateway_shutdown_test.go
@@ -1,0 +1,136 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestRouterShutdownClosesRegisteredCodexGateways(t *testing.T) {
+	transport := &shutdownTrackingAppServerTransport{}
+	router := &Router{
+		appServerSSH:  transport,
+		codexGateways: map[uint64]*codexGatewayConnection{},
+	}
+	connection, connectionCtx, err := router.acquireCodexGateway(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &trackingCloser{}
+	upstream := &trackingCloser{}
+	if !connection.attach(client, true) || !connection.attach(upstream, false) {
+		t.Fatal("shutdown 前应能登记两端连接")
+	}
+	released := make(chan struct{})
+	go func() {
+		<-connectionCtx.Done()
+		router.releaseCodexGateway(connection)
+		close(released)
+	}()
+
+	router.Shutdown()
+	router.Shutdown()
+
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("Router shutdown 未结束 gateway handler")
+	}
+	if !client.closed.Load() || !upstream.closed.Load() {
+		t.Fatalf("Router shutdown 必须关闭 client 和 upstream：client=%t upstream=%t", client.closed.Load(), upstream.closed.Load())
+	}
+	if !transport.shutdown.Load() {
+		t.Fatal("Router shutdown 必须取消 SSH transport 的后台 readiness")
+	}
+	if got := router.activeCodexGatewayCount(); got != 0 {
+		t.Fatalf("Router shutdown 后 gateway 数量必须归零：%d", got)
+	}
+	if _, _, err := router.acquireCodexGateway(context.Background()); !errors.Is(err, errCodexGatewayClosing) {
+		t.Fatalf("Router shutdown 后必须拒绝新 gateway：%v", err)
+	}
+}
+
+func TestRouterShutdownClosesMultipleLiveCodexGatewayWebSockets(t *testing.T) {
+	upstreamURL, _, upstreamConnections := fakeAppServerUpstream(t, nil)
+	handler, router := appServerGatewayRouterFixtureWithRouter(t, upstreamURL, nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	clients := []*websocket.Conn{
+		dialAuthedGateway(t, server.URL),
+		dialAuthedGateway(t, server.URL),
+	}
+	deadline := time.Now().Add(time.Second)
+	for (router.activeCodexGatewayCount() != len(clients) || upstreamConnections.Load() != int64(len(clients))) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := router.activeCodexGatewayCount(); got != len(clients) {
+		t.Fatalf("shutdown 前应登记所有活动 gateway：got=%d want=%d", got, len(clients))
+	}
+	if got := upstreamConnections.Load(); got != int64(len(clients)) {
+		t.Fatalf("每条 gateway 应建立一条 upstream：got=%d want=%d", got, len(clients))
+	}
+
+	router.Shutdown()
+	if got := router.activeCodexGatewayCount(); got != 0 {
+		t.Fatalf("shutdown 返回时活动 gateway 应归零：%d", got)
+	}
+	for _, client := range clients {
+		_ = client.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		if _, _, err := client.ReadMessage(); err == nil {
+			t.Fatal("shutdown 后移动端 WebSocket 应关闭")
+		}
+		_ = client.Close()
+	}
+
+	target := wsURL(server.URL, appServerGatewayPath)
+	conn, response, err := websocket.DefaultDialer.Dial(target, http.Header{
+		"Authorization": []string{"Bearer " + testToken},
+	})
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if err == nil || response == nil || response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("shutdown 后新连接应收到 503：response=%v err=%v", response, err)
+	}
+	_ = response.Body.Close()
+}
+
+type trackingCloser struct {
+	closed atomic.Bool
+}
+
+func (c *trackingCloser) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+type shutdownTrackingAppServerTransport struct {
+	shutdown atomic.Bool
+}
+
+func (t *shutdownTrackingAppServerTransport) EnsureReady(context.Context) error {
+	return nil
+}
+
+func (t *shutdownTrackingAppServerTransport) WebSocketURL() (string, error) {
+	return "", errors.New("shutdown transport 不提供 upstream")
+}
+
+func (t *shutdownTrackingAppServerTransport) WebSocketHeaders() (http.Header, error) {
+	return nil, nil
+}
+
+func (t *shutdownTrackingAppServerTransport) WebSocketDialer(time.Duration) (websocket.Dialer, error) {
+	return websocket.Dialer{}, nil
+}
+
+func (t *shutdownTrackingAppServerTransport) Shutdown() {
+	t.shutdown.Store(true)
+}

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -1041,6 +1041,9 @@ func TestAppServerGatewayDoesNotUseLegacyUpstreamWSToken(t *testing.T) {
 	if !strings.Contains(errFrame.message, "CODEX_UPSTREAM_UNAVAILABLE") {
 		t.Fatalf("未携带旧 WS token 时应安全报告 upstream 不可用：%+v", errFrame)
 	}
+	if errFrame.data["reason"] != "codex_upstream_unavailable" {
+		t.Fatalf("upstream 不可用错误应携带稳定 reason：%+v", errFrame)
+	}
 	if connections.Load() == 0 {
 		t.Fatal("共享 SSH gateway 应至少尝试一次无旧 token 的连接")
 	}

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -141,6 +141,9 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 			// 能力的 owner；保持沉默，由其他订阅入口处理，不向上游代替拒绝。
 			return payload, false, nil
 		}
+		if normalizeAppServerRuntimeID(p.runtimeID) == "codex" && !p.codexServerRequestAllowed(frame.Params) {
+			return payload, false, nil
+		}
 		if err := p.rememberPendingServerRequest(frame.ID, frame.Method, frame.Params); err != nil {
 			return payload, false, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
 		}
@@ -148,6 +151,9 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 	}
 	if strings.TrimSpace(frame.Method) != "" && frame.ID == nil {
 		if p.runtimeID == "codex" && p.router.isAutoThreadTitleNotification(frame.Params) {
+			return payload, false, nil
+		}
+		if normalizeAppServerRuntimeID(p.runtimeID) == "codex" && !p.codexNotificationAllowed(&frame) {
 			return payload, false, nil
 		}
 		p.clearPendingServerRequestsForNotification(&frame)
@@ -311,6 +317,124 @@ func sanitizeThreadForkResponse(payload []byte) ([]byte, json.RawMessage, error)
 		return nil, nil, fmt.Errorf("thread/fork response 无法裁剪")
 	}
 	return rewritten, resultRaw, nil
+}
+
+var codexGlobalNotificationMethods = map[string]struct{}{
+	"account/rateLimits/updated":      {},
+	"mcpServer/startupStatus/updated": {},
+	"deprecationNotice":               {},
+}
+
+func (p *appServerGatewayPolicy) codexServerRequestAllowed(rawParams json.RawMessage) bool {
+	threadID, _, _ := appServerGatewayServerRequestScope(rawParams)
+	_, ok := p.allowedThread(threadID)
+	return ok
+}
+
+func (p *appServerGatewayPolicy) codexNotificationAllowed(frame *appServerGatewayFrame) bool {
+	method := strings.TrimSpace(frame.Method)
+	if _, ok := codexGlobalNotificationMethods[method]; ok {
+		return true
+	}
+	if method == "serverRequest/resolved" {
+		return p.codexResolvedNotificationAllowed(frame.Params)
+	}
+	threadID := appServerGatewayThreadIDFromParams(frame.Params)
+	if method == "thread/started" {
+		return p.allowCodexStartedThread(frame.Params, threadID)
+	}
+	_, ok := p.allowedThread(threadID)
+	return ok
+}
+
+func appServerGatewayThreadIDFromParams(rawParams json.RawMessage) string {
+	params, err := decodeGatewayParams(rawParams)
+	if err != nil {
+		return ""
+	}
+	for _, key := range []string{"threadId", "thread_id", "sessionId", "session_id", "conversationId", "conversation_id"} {
+		if threadID, _ := gatewayStringParam(params, key); threadID != "" {
+			return threadID
+		}
+	}
+	if thread, ok := params["thread"].(map[string]any); ok {
+		for _, key := range []string{"id", "threadId", "thread_id", "sessionId", "session_id"} {
+			if threadID, _ := gatewayStringParam(thread, key); threadID != "" {
+				return threadID
+			}
+		}
+	}
+	return ""
+}
+
+func (p *appServerGatewayPolicy) allowCodexStartedThread(rawParams json.RawMessage, threadID string) bool {
+	params, err := decodeGatewayParams(rawParams)
+	if err != nil || threadID == "" || p.router == nil {
+		return false
+	}
+	// 共享 App Server 会把其他本地客户端创建的 thread 广播到所有连接。
+	// cwd 白名单只能证明目录可访问，不能证明这个 thread 属于当前 Bearer
+	// Token。新 thread 必须先通过本连接请求的响应进入授权表；这里仅校验并
+	// 转发已经授权的 thread/started，避免跨客户端把广播误登记为本连接会话。
+	allowed, ok := p.allowedThread(threadID)
+	if !ok {
+		return false
+	}
+	thread, _ := params["thread"].(map[string]any)
+	cwd, _ := gatewayStringParam(thread, "cwd")
+	if cwd == "" {
+		cwd, _ = gatewayStringParam(thread, "path")
+	}
+	if cwd == "" {
+		cwd, _ = gatewayStringParam(params, "cwd")
+	}
+	if cwd == "" || cwd != strings.TrimSpace(cwd) || !filepath.IsAbs(cwd) {
+		return false
+	}
+	scope, ok := p.router.gatewayScopeForPath(cwd)
+	if !ok || scope.id != allowed.scopeID {
+		return false
+	}
+	return true
+}
+
+func (p *appServerGatewayPolicy) codexResolvedNotificationAllowed(rawParams json.RawMessage) bool {
+	threadID, _, _ := appServerGatewayServerRequestScope(rawParams)
+	if _, ok := p.allowedThread(threadID); ok {
+		return true
+	}
+	for _, key := range gatewayResolutionRequestKeys(rawParams) {
+		p.mu.Lock()
+		pending, ok := p.pendingServerRequests[key]
+		p.mu.Unlock()
+		if ok {
+			if _, allowed := p.allowedThread(pending.threadID); allowed {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func gatewayResolutionRequestKeys(rawParams json.RawMessage) []string {
+	var params struct {
+		RequestID  json.RawMessage `json:"requestId"`
+		RequestID2 json.RawMessage `json:"request_id"`
+		ID         json.RawMessage `json:"id"`
+		ApprovalID json.RawMessage `json:"approvalId"`
+		ItemID     json.RawMessage `json:"itemId"`
+		ItemID2    json.RawMessage `json:"item_id"`
+	}
+	if json.Unmarshal(rawParams, &params) != nil {
+		return nil
+	}
+	keys := make([]string, 0, 6)
+	for _, id := range []json.RawMessage{params.RequestID, params.RequestID2, params.ID, params.ApprovalID, params.ItemID, params.ItemID2} {
+		if key := gatewayRequestIDKey(rawMessagePointer(id)); key != "" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
 }
 
 func (p *appServerGatewayPolicy) resolveGlobalListCursor(params map[string]any) error {
@@ -897,6 +1021,15 @@ func appServerGatewayServerRequestScope(rawParams json.RawMessage) (string, stri
 	for _, key := range []string{"threadId", "thread_id", "sessionId", "session_id", "conversationId", "conversation_id"} {
 		if threadID, _ = gatewayStringParam(params, key); threadID != "" {
 			break
+		}
+	}
+	if threadID == "" {
+		if thread, ok := params["thread"].(map[string]any); ok {
+			for _, key := range []string{"id", "threadId", "thread_id", "sessionId", "session_id"} {
+				if threadID, _ = gatewayStringParam(thread, key); threadID != "" {
+					break
+				}
+			}
 		}
 	}
 	turnID, _ := gatewayStringParam(params, "turnId")

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -82,7 +82,10 @@ type Router struct {
 	gatewayThreadsMu              sync.Mutex
 	gatewayThreads                map[string]appServerGatewayAllowedThread
 	codexGatewayMu                sync.Mutex
-	activeCodexGateway            int
+	codexGatewayClosing           bool
+	codexGatewayNextID            uint64
+	codexGateways                 map[uint64]*codexGatewayConnection
+	codexGatewayWG                sync.WaitGroup
 	appServerSSH                  appServerSSHTransport
 	gatewayHistoryBudgetMu        sync.Mutex
 	gatewayHistoryGlobalBudget    appServerGatewayHistoryBudget
@@ -102,6 +105,7 @@ type Router struct {
 	// TestFlight 发布会持续数分钟，使用内存任务保存当前进度，避免让移动端 HTTP 请求长时间挂起。
 	gitTestFlightMu   sync.Mutex
 	gitTestFlightJobs map[string]*gitTestFlightReleaseJob
+	shutdownOnce      sync.Once
 }
 
 // RouterOptions 只承载必须在构造时固定的进程级资源路径。
@@ -191,6 +195,7 @@ func NewRouterWithInstallationIDAndOptions(
 		capabilities:                newCapabilityRegistry(cfg, fileUploads),
 		tailscalePathLookup:         defaultTailscaleNetworkPathLookup,
 		gatewayThreads:              map[string]appServerGatewayAllowedThread{},
+		codexGateways:               map[uint64]*codexGatewayConnection{},
 		managedWorktrees:            map[string]managedWorktree{},
 		managedWorktreeCleanupPlans: map[string]worktreeCleanupPlan{},
 		managedWorktreePendingUses:  map[string]int{},
@@ -286,14 +291,21 @@ func (r *Router) Shutdown() {
 	if r == nil {
 		return
 	}
-	if r.autoThreadTitles != nil {
-		r.autoThreadTitles.Close()
-	}
-	r.runtimeStatus.Close()
-	r.claudeBridge.shutdown()
-	if r.tailcat != nil {
-		r.tailcat.Close()
-	}
+	r.shutdownOnce.Do(func() {
+		r.shutdownCodexGateways()
+		if r.autoThreadTitles != nil {
+			r.autoThreadTitles.Close()
+		}
+		if r.runtimeStatus != nil {
+			r.runtimeStatus.Close()
+		}
+		if r.claudeBridge != nil {
+			r.claudeBridge.shutdown()
+		}
+		if r.tailcat != nil {
+			r.tailcat.Close()
+		}
+	})
 }
 
 func sameOriginOrNoOrigin(r *http.Request) bool {

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -110,8 +110,11 @@
 		50544A89C240A84DC7F0C6BE /* RecentWorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1E5753D86397B541589878 /* RecentWorkspaceStore.swift */; };
 		509445C02B3E5D545DB2808B /* SessionStoreNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7DA3118F7DF5B276A9BE1D /* SessionStoreNetworking.swift */; };
 		523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */; };
+		A2240001A2240001A2240001 /* CodexAppServerConnectionReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2240002A2240002A2240002 /* CodexAppServerConnectionReliabilityTests.swift */; };
+		A2240003A2240003A2240003 /* ConversationMessageDeliveryUncertaintyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2240004A2240004A2240004 /* ConversationMessageDeliveryUncertaintyTests.swift */; };
 		5264A96AC8B711B42087FA3F /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C86A8DFF7254C2458488075 /* SessionListView.swift */; };
 		5344C41233BA0E47A0C29FDA /* CodexAppServerSessionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */; };
+		A223C001A223C001A223C001 /* CodexAppServerSessionConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A223C002A223C002A223C002 /* CodexAppServerSessionConnection.swift */; };
 		55A91A4B582F169DCE0C1197 /* ConversationMessageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B508E4FD0E447D4EEE2CC8 /* ConversationMessageRow.swift */; };
 		55C47BB6B9F792685CF30178 /* CarStatusSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F194D291F4AC7CA28CE52FD /* CarStatusSnapshot.swift */; };
 		55D43B731CFE9C5246B02D1C /* testComposerStatusTrayCrowdedState.1.png in Resources */ = {isa = PBXBuildFile; fileRef = E4C85188C13516219753D4ED /* testComposerStatusTrayCrowdedState.1.png */; };
@@ -275,6 +278,8 @@
 		D6D632D45E8487C3DEAC4429 /* NewSessionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E992D8F1A54C9726692225BA /* NewSessionSheet.swift */; };
 		D8263551DECB2E7EBCD66E3B /* testSessionRuntimeBadgesInConversationList.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */; };
 		DAAB5AD21F6B77F6D691B94F /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373EDA921B7F6B3F6B680140 /* ConversationStore.swift */; };
+		C224D001C224D001C224D001 /* ConversationStoreDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = C224D002C224D002C224D002 /* ConversationStoreDelivery.swift */; };
+		A2250001A2250001A2250001 /* ConversationMessageDeliveryReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2250002A2250002A2250002 /* ConversationMessageDeliveryReconciler.swift */; };
 		DC2F420929F4E30D3B6AC6DE /* ConnectionProfileModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6C8F9B82DA43620543124E /* ConnectionProfileModels.swift */; };
 		DDB05F720316DF94C27BB541 /* AppStoreConnectionTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934F6F53C8E42FE3700DFDD9 /* AppStoreConnectionTesting.swift */; };
 		DDCFB91D621190F7BA26678D /* AppExternalLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28C291AC46CF73586F8764A /* AppExternalLinks.swift */; };
@@ -366,6 +371,8 @@
 		00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCrowdedCompactWidth.1.png; sourceTree = "<group>"; };
 		023D47371A66B1C8E92BB3D4 /* testSessionLibraryDensityAndAccessibilityLayouts.iphone-390-light.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSessionLibraryDensityAndAccessibilityLayouts.iphone-390-light.png"; sourceTree = "<group>"; };
 		025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeTests.swift; sourceTree = "<group>"; };
+		A2240002A2240002A2240002 /* CodexAppServerConnectionReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerConnectionReliabilityTests.swift; sourceTree = "<group>"; };
+		A2240004A2240004A2240004 /* ConversationMessageDeliveryUncertaintyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageDeliveryUncertaintyTests.swift; sourceTree = "<group>"; };
 		02BA631A94730FC521FE15F6 /* AssistantTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantTextNormalizer.swift; sourceTree = "<group>"; };
 		033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationRuntimeFlowTests.swift; sourceTree = "<group>"; };
 		04740AD795D6AEEF87C98B35 /* ConversationMessageAccessories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageAccessories.swift; sourceTree = "<group>"; };
@@ -435,6 +442,8 @@
 		3555A6B1D0904604B0ADC859 /* testUnsupportedActivityShowsExplanation.unsupported-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testUnsupportedActivityShowsExplanation.unsupported-compact.png"; sourceTree = "<group>"; };
 		36A4616D85FD81D7258E0C6B /* testFailedActivityWithoutPreviousResult.failed-empty-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testFailedActivityWithoutPreviousResult.failed-empty-compact.png"; sourceTree = "<group>"; };
 		373EDA921B7F6B3F6B680140 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
+		C224D002C224D002C224D002 /* ConversationStoreDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStoreDelivery.swift; sourceTree = "<group>"; };
+		A2250002A2250002A2250002 /* ConversationMessageDeliveryReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageDeliveryReconciler.swift; sourceTree = "<group>"; };
 		37D188E86B957818696CFF00 /* FloatingSidebarPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingSidebarPresentationTests.swift; sourceTree = "<group>"; };
 		38004512B302AB5F8AD23644 /* testEmptyConversationState.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testEmptyConversationState.1.png; sourceTree = "<group>"; };
 		3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationGuidanceFallbackTests.swift; sourceTree = "<group>"; };
@@ -618,6 +627,7 @@
 		CEE63E1F88F94DC3D0C543CF /* testComposerStatusTrayExtremelyNarrowCompactWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayExtremelyNarrowCompactWidth.1.png; sourceTree = "<group>"; };
 		D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionRuntime.swift; sourceTree = "<group>"; };
 		D231C6876074429C2374261A /* ForkOnWriterConflictProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkOnWriterConflictProtocolTests.swift; sourceTree = "<group>"; };
+		A223C002A223C002A223C002 /* CodexAppServerSessionConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionConnection.swift; sourceTree = "<group>"; };
 		D283CD0291735DA4425D91A4 /* WorkspaceRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRootView.swift; sourceTree = "<group>"; };
 		D28C291AC46CF73586F8764A /* AppExternalLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExternalLinks.swift; sourceTree = "<group>"; };
 		D2F4BF550566258A06CF1F9B /* testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390-remote-url.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390-remote-url.png"; sourceTree = "<group>"; };
@@ -826,6 +836,7 @@
 				657215B4124C9FDDEA161D2C /* AppleVoiceStartupWatchdogTests.swift */,
 				54AAB784C642D2B0234E48BA /* CameraAttachmentTests.swift */,
 				83CFAE116262795C7501365E /* CarStatusSnapshotTests.swift */,
+				A2240002A2240002A2240002 /* CodexAppServerConnectionReliabilityTests.swift */,
 				FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */,
 				B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */,
 				1254FA91BFD2E858AFBD539D /* ConversationAppServerProjectorTests.swift */,
@@ -840,6 +851,7 @@
 				025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */,
 				3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */,
 				F5EC542E43C2955804F35E34 /* ConversationHistoryItemEnrichmentTests.swift */,
+				A2240004A2240004A2240004 /* ConversationMessageDeliveryUncertaintyTests.swift */,
 				FBF29C4EA9F4D0ECC4709B97 /* ConversationProcessGrouperTests.swift */,
 				033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */,
 				D9A1F29F52DC5CC790708ACC /* ConversationRuntimeTestSupport.swift */,
@@ -965,6 +977,7 @@
 				A571C41AE73754FB6C9FD6BC /* CodexAppServerQueueSubmission.swift */,
 				469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */,
 				D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */,
+				A223C002A223C002A223C002 /* CodexAppServerSessionConnection.swift */,
 				DD3F9E8A8ED2FD8317FB92F2 /* CodexAppServerThreadOwnership.swift */,
 				BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */,
 				5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */,
@@ -1293,7 +1306,9 @@
 				1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */,
 				332F6935AFF261FAA35F289A /* CarStatusSnapshotMapping.swift */,
 				6C6C8F9B82DA43620543124E /* ConnectionProfileModels.swift */,
+				A2250002A2250002A2250002 /* ConversationMessageDeliveryReconciler.swift */,
 				373EDA921B7F6B3F6B680140 /* ConversationStore.swift */,
+				C224D002C224D002C224D002 /* ConversationStoreDelivery.swift */,
 				20A922D9A3D4C72236D9CFBA /* ConversationTimelineReducer.swift */,
 				D6D8E5F1F33563965409D9D4 /* DebugLaunchConfiguration.swift */,
 				52051A97BB3979091B39EB95 /* EventReducer.swift */,
@@ -1638,6 +1653,7 @@
 				EF35A98EC4F810C40B19975F /* AppleVoiceStartupWatchdogTests.swift in Sources */,
 				03E7996441667D59DF2F9E3A /* CameraAttachmentTests.swift in Sources */,
 				101A9079E24B09BCAB8B54FF /* CarStatusSnapshotTests.swift in Sources */,
+				A2240001A2240001A2240001 /* CodexAppServerConnectionReliabilityTests.swift in Sources */,
 				523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */,
 				3CE709A723920DFD80FE96D0 /* ConnectionProfileRenameTests.swift in Sources */,
 				2ACE5B224FFACB3AA6391C46 /* ConversationAppServerProjectorTests.swift in Sources */,
@@ -1652,6 +1668,7 @@
 				E790247242197F065BB1F1DE /* ConversationDirectRuntimeTests.swift in Sources */,
 				699762120516E7B19DB681E9 /* ConversationGuidanceFallbackTests.swift in Sources */,
 				696F45B5F56A3EB290292B28 /* ConversationHistoryItemEnrichmentTests.swift in Sources */,
+				A2240003A2240003A2240003 /* ConversationMessageDeliveryUncertaintyTests.swift in Sources */,
 				388033847B02B31529D2BFCA /* ConversationProcessGrouperTests.swift in Sources */,
 				7813EDBB1DC23A88A94CAF56 /* ConversationRuntimeFlowTests.swift in Sources */,
 				2B372F78E1EC09D8E4B7210F /* ConversationRuntimeTestSupport.swift in Sources */,
@@ -1742,6 +1759,7 @@
 				293498CD48F70C646F0DD612 /* CodexAppServerQueueSubmission.swift in Sources */,
 				FAD77559CF6FDCD943849D7C /* CodexAppServerSessionClients.swift in Sources */,
 				5344C41233BA0E47A0C29FDA /* CodexAppServerSessionRuntime.swift in Sources */,
+				A223C001A223C001A223C001 /* CodexAppServerSessionConnection.swift in Sources */,
 				A9672A5CCD14CB34B13ED66A /* CodexAppServerThreadOwnership.swift in Sources */,
 				C1F8D4D973088684344C9DB6 /* CodexAppServerTransport.swift in Sources */,
 				45C1DA2766CF0D3F7DB0843C /* CodexAppServerTurnStartObservation.swift in Sources */,
@@ -1765,7 +1783,9 @@
 				0E761373BD02FB2C656475B7 /* ConversationProcessGroupRow.swift in Sources */,
 				F996F870AD345E2888F2913B /* ConversationProcessGrouper.swift in Sources */,
 				CB8A7C0CC676C74BADF4901C /* ConversationScreenModel.swift in Sources */,
+				A2250001A2250001A2250001 /* ConversationMessageDeliveryReconciler.swift in Sources */,
 				DAAB5AD21F6B77F6D691B94F /* ConversationStore.swift in Sources */,
+				C224D001C224D001C224D001 /* ConversationStoreDelivery.swift in Sources */,
 				217C4D1F6988BDFF59701290 /* ConversationTimelineCache.swift in Sources */,
 				1158695E26ECDFF99A3B695C /* ConversationTimelineItemBuilder.swift in Sources */,
 				B30C71B98AEF44473D80C926 /* ConversationTimelineModels.swift in Sources */,

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -1995,6 +1995,24 @@
         }
       }
     },
+    "ui.app_server_request_outcome_unknown_value_value_value": {
+      "comment": "App Server write request whose result cannot be determined after transmission began.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Server request outcome is unknown: %1$@ (%2$@), %3$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Server 请求结果无法确认：%1$@（%2$@），%3$@"
+          }
+        }
+      }
+    },
     "ui.app_server_request_parameters_are_unsafe_value": {
       "comment": "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations": {
@@ -5213,6 +5231,24 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex 会在 Mac 端保存此选择；本设备不保存 MCP 凭据。"
+          }
+        }
+      }
+    },
+    "ui.codex_upstream_unavailable": {
+      "comment": "The local Codex App Server cannot currently be reached through SSH.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The local Codex service is unavailable. Check SSH and the Codex App Server."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机 Codex 服务不可用，请检查 SSH 和 Codex App Server。"
           }
         }
       }
@@ -21868,6 +21904,24 @@
         }
       }
     },
+    "ui.request_cancelled_after_sending": {
+      "comment": "Reason shown when a request is cancelled after bytes may have been sent.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cancelled after sending began"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发送开始后被取消"
+          }
+        }
+      }
+    },
     "ui.request_doctor_diagnosis_results_from_mac_assistant": {
       "comment": "User-facing UI text. Keep this stable semantic key; never use catalog values for protocol fields or log parsing.",
       "localizations": {
@@ -24159,6 +24213,24 @@
           "stringUnit": {
             "state": "translated",
             "value": "发送失败：WebSocket 未连接"
+          }
+        }
+      }
+    },
+    "ui.sending_result_pending_confirmation": {
+      "comment": "Neutral message delivery state when the request may have reached the server.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delivery pending confirmation"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发送结果待确认"
           }
         }
       }
@@ -39425,6 +39497,24 @@
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "Protocol" } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "协议" } }
+      }
+    },
+    "ui.request_timed_out_after_sending": {
+      "comment": "Reason shown when a request times out after bytes may have been sent.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "timed out after sending began"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发送开始后超时"
+          }
+        }
       }
     },
     "ui.requested_permissions": {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerEventProjection.swift
@@ -164,12 +164,19 @@ extension CodexAppServerSessionRuntime {
         threadsResumedOnConnection.insert(session.id)
     }
 
+    /// 写出之后再超时会归类成 outcomeUnknown，而 fork 正是最需要兜底的那类请求：
+    /// 服务端可能已经建好 thread，只是响应没回来，随后的 thread/started 才是唯一
+    /// 能确认结果的信号。两种分类都必须进入事件对账，否则超时即失败。
     func isThreadForkTimeout(_ error: Error) -> Bool {
-        guard let connectionError = error as? CodexAppServerConnectionError,
-              case .timeout(let method, _) = connectionError else {
+        guard let connectionError = error as? CodexAppServerConnectionError else {
             return false
         }
-        return method == "thread/fork"
+        switch connectionError {
+        case .timeout(let method, _), .outcomeUnknown(let method, _, _):
+            return method == "thread/fork"
+        default:
+            return false
+        }
     }
 
     private func compactTrailingBufferedDeltas(_ events: inout [AgentEvent]) {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionConnection.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionConnection.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+extension CodexAppServerSessionRuntime {
+    func ensureConnection() async throws -> CodexAppServerConnection {
+        if let connection {
+            if await connection.isReadyForRequests() { return connection }
+            await retireConnection(connection)
+        }
+        if let connectionAttempt { return try await awaitConnectionAttempt(connectionAttempt) }
+
+        let config = try await connectionConfig()
+        // 配置读取会让 actor 重入；恢复后必须重新检查，避免并发冷启动创建第二条连接。
+        if let connection {
+            if await connection.isReadyForRequests() { return connection }
+            await retireConnection(connection)
+        }
+        if let connectionAttempt { return try await awaitConnectionAttempt(connectionAttempt) }
+        guard runtimeGatewayAvailable(in: config) else {
+            throw CodexAppServerSessionRuntimeError.gatewayUnavailable
+        }
+
+        let gatewayURL = try gatewayURL(from: config)
+        let next = CodexAppServerConnection(transport: transportFactory(), requestTimeout: requestTimeout)
+        let task = Task { [next, gatewayURL, token] in
+            let notifications = await next.notifications()
+            let serverRequests = await next.serverRequests()
+            try await next.connect(url: gatewayURL, token: token)
+            return CodexAppServerPreparedConnection(
+                connection: next,
+                notifications: notifications,
+                serverRequests: serverRequests
+            )
+        }
+        let attempt = CodexAppServerConnectionAttempt(
+            id: UUID(),
+            connection: next,
+            task: task,
+            waiterIDs: []
+        )
+        connectionAttempt = attempt
+        return try await awaitConnectionAttempt(attempt)
+    }
+
+    func awaitConnectionAttempt(
+        _ snapshot: CodexAppServerConnectionAttempt
+    ) async throws -> CodexAppServerConnection {
+        let waiterID = UUID()
+        guard var current = connectionAttempt, current.id == snapshot.id else {
+            if let connection, await connection.isReadyForRequests() { return connection }
+            throw CancellationError()
+        }
+        current.waiterIDs.insert(waiterID)
+        connectionAttempt = current
+        return try await installPreparedConnectionIfNeeded(from: current, waiterID: waiterID)
+    }
+
+    func installPreparedConnectionIfNeeded(
+        from attempt: CodexAppServerConnectionAttempt,
+        waiterID: UUID
+    ) async throws -> CodexAppServerConnection {
+        let prepared: CodexAppServerPreparedConnection
+        do {
+            prepared = try await waitForPreparedConnection(attempt, waiterID: waiterID)
+            // 仍持有 attempt 租约时完成取消检查；抛出后由 catch 释放当前 waiter。
+            // 清空 connectionAttempt 后不再抛取消，避免遗留无人安装的 candidate。
+            try Task.checkCancellation()
+        } catch {
+            await releaseConnectionAttemptWaiter(attemptID: attempt.id, waiterID: waiterID)
+            throw error
+        }
+
+        // 第一个成功 waiter 安装连接；其他 waiter 复用已安装连接，不能覆盖新代次。
+        guard connectionAttempt?.id == attempt.id else {
+            if let connection, await connection.isReadyForRequests() { return connection }
+            await prepared.connection.disconnect()
+            throw CancellationError()
+        }
+        connectionAttempt = nil
+        if let connection, await connection.isReadyForRequests() {
+            if connection !== prepared.connection { await prepared.connection.disconnect() }
+            return connection
+        }
+        installConnection(prepared)
+        return prepared.connection
+    }
+
+    func waitForPreparedConnection(
+        _ attempt: CodexAppServerConnectionAttempt,
+        waiterID: UUID
+    ) async throws -> CodexAppServerPreparedConnection {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                connectionAttemptWaiters[waiterID] = continuation
+                Task {
+                    let result = await attempt.task.result
+                    self.completeConnectionAttemptWaiter(waiterID, result: result)
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.cancelConnectionAttemptWaiter(attemptID: attempt.id, waiterID: waiterID)
+            }
+        }
+    }
+
+    func completeConnectionAttemptWaiter(
+        _ waiterID: UUID,
+        result: Result<CodexAppServerPreparedConnection, Error>
+    ) {
+        guard let continuation = connectionAttemptWaiters.removeValue(forKey: waiterID) else { return }
+        continuation.resume(with: result)
+    }
+
+    func cancelConnectionAttemptWaiter(attemptID: UUID, waiterID: UUID) async {
+        connectionAttemptWaiters.removeValue(forKey: waiterID)?.resume(throwing: CancellationError())
+        await releaseConnectionAttemptWaiter(attemptID: attemptID, waiterID: waiterID)
+    }
+
+    func releaseConnectionAttemptWaiter(attemptID: UUID, waiterID: UUID) async {
+        guard var attempt = connectionAttempt, attempt.id == attemptID else { return }
+        attempt.waiterIDs.remove(waiterID)
+        guard attempt.waiterIDs.isEmpty else {
+            connectionAttempt = attempt
+            return
+        }
+        connectionAttempt = nil
+        connectionAttemptWaiters.removeAll(keepingCapacity: true)
+        attempt.task.cancel()
+        await attempt.connection.disconnect()
+    }
+
+    func cancelConnectionAttempt(id: UUID? = nil) async {
+        guard let attempt = connectionAttempt, id == nil || attempt.id == id else { return }
+        connectionAttempt = nil
+        let waiters = connectionAttemptWaiters
+        connectionAttemptWaiters.removeAll(keepingCapacity: true)
+        for continuation in waiters.values { continuation.resume(throwing: CancellationError()) }
+        attempt.task.cancel()
+        await attempt.connection.disconnect()
+    }
+
+    func connectionConfig() async throws -> CodexAppServerConfigResponse {
+        let cached = try await ensureConfig()
+        if runtimeGatewayAvailable(in: cached) { return cached }
+        let fresh = try await ensureConfig(forceRefresh: true)
+        if runtimeGatewayAvailable(in: fresh) { return fresh }
+        throw CodexAppServerSessionRuntimeError.gatewayUnavailable
+    }
+
+    func installConnection(_ prepared: CodexAppServerPreparedConnection) {
+        notificationPumpTask?.cancel()
+        serverRequestPumpTask?.cancel()
+        cancelAllTurnInterruptRecoveryTasks()
+        threadResumeTasksBySessionID.values.forEach { $0.task.cancel() }
+        threadResumeTasksBySessionID.removeAll(keepingCapacity: true)
+        threadsResumedOnConnection.removeAll(keepingCapacity: true)
+        connection = prepared.connection
+        notificationPumpTask = Task { [weak self, notifications = prepared.notifications, installedConnection = prepared.connection] in
+            for await notification in notifications { await self?.handle(notification) }
+            guard !Task.isCancelled else { return }
+            await self?.handleNotificationStreamEnded(for: installedConnection)
+        }
+        serverRequestPumpTask = Task { [weak self, serverRequests = prepared.serverRequests] in
+            for await request in serverRequests { await self?.handle(request) }
+        }
+    }
+
+    func handleNotificationStreamEnded(for endedConnection: CodexAppServerConnection) async {
+        guard let current = connection, current === endedConnection else { return }
+
+        // 底层 receive 失败会结束 notification stream。这里必须继续结束上层 AgentEvent stream，
+        // 否则 SessionWebSocketClient 的 for-await 永远不退出，UI 会一直误认为连接仍是 connected。
+        notificationPumpTask = nil
+        serverRequestPumpTask?.cancel()
+        serverRequestPumpTask = nil
+        cancelThreadResumeTasks(for: endedConnection)
+        connection = nil
+        threadsResumedOnConnection.removeAll(keepingCapacity: true)
+        threadUnsubscribeRetryTasksBySessionID.values.forEach { $0.task.cancel() }
+        threadUnsubscribeRetryTasksBySessionID.removeAll(keepingCapacity: true)
+        let affected = clearAllPendingServerRequests()
+        for sessionID in affected.approvalSessionIDs { emitApprovalResolved(sessionID: sessionID) }
+        for sessionID in affected.userInputSessionIDs {
+            emitUserInputResolved(sessionID: sessionID, skipped: false)
+        }
+        finishAttachedEventStreams()
+        await endedConnection.disconnect()
+    }
+
+    func finishAttachedEventStreams() {
+        let mailboxes = eventMailboxesBySessionID.values.flatMap { $0.values }
+        eventMailboxesBySessionID.removeAll(keepingCapacity: true)
+        for mailbox in mailboxes { mailbox.finishFromProducer() }
+    }
+
+    func finishAttachedEventStreams(sessionID: SessionID) {
+        let mailboxes = eventMailboxesBySessionID.removeValue(forKey: sessionID)?.values ?? [:].values
+        for mailbox in mailboxes { mailbox.finishFromProducer() }
+    }
+}

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -94,6 +94,7 @@ struct CodexAppServerConnectionAttempt {
     let id: UUID
     let connection: CodexAppServerConnection
     let task: Task<CodexAppServerPreparedConnection, Error>
+    var waiterIDs: Set<UUID>
 }
 
 struct CodexAppServerResolvedServerRequests {
@@ -179,6 +180,7 @@ actor CodexAppServerSessionRuntime {
     var config: CodexAppServerConfigResponse?
     var connection: CodexAppServerConnection?
     var connectionAttempt: CodexAppServerConnectionAttempt?
+    var connectionAttemptWaiters: [UUID: CheckedContinuation<CodexAppServerPreparedConnection, Error>] = [:]
     var notificationPumpTask: Task<Void, Never>?
     var serverRequestPumpTask: Task<Void, Never>?
     var projector = CodexAppServerEventProjector()
@@ -2944,172 +2946,6 @@ actor CodexAppServerSessionRuntime {
         return next
     }
 
-    func ensureConnection() async throws -> CodexAppServerConnection {
-        if let connection {
-            if await connection.isReadyForRequests() {
-                return connection
-            }
-            await retireConnection(connection)
-        }
-        if let connectionAttempt {
-            return try await installPreparedConnectionIfNeeded(from: connectionAttempt)
-        }
-        let config = try await connectionConfig()
-        guard runtimeGatewayAvailable(in: config) else {
-            throw CodexAppServerSessionRuntimeError.gatewayUnavailable
-        }
-        let gatewayURL = try gatewayURL(from: config)
-        let next = CodexAppServerConnection(transport: transportFactory(), requestTimeout: requestTimeout)
-        let task = Task { [next, gatewayURL, token] in
-            let notifications = await next.notifications()
-            let serverRequests = await next.serverRequests()
-            try await next.connect(url: gatewayURL, token: token)
-            return CodexAppServerPreparedConnection(
-                connection: next,
-                notifications: notifications,
-                serverRequests: serverRequests
-            )
-        }
-        let attempt = CodexAppServerConnectionAttempt(
-            id: UUID(),
-            connection: next,
-            task: task
-        )
-        connectionAttempt = attempt
-        return try await installPreparedConnectionIfNeeded(from: attempt)
-    }
-
-    func installPreparedConnectionIfNeeded(
-        from attempt: CodexAppServerConnectionAttempt
-    ) async throws -> CodexAppServerConnection {
-        try await withTaskCancellationHandler {
-            let prepared: CodexAppServerPreparedConnection
-            do {
-                prepared = try await attempt.task.value
-                try Task.checkCancellation()
-            } catch {
-                await cancelConnectionAttempt(id: attempt.id)
-                throw error
-            }
-
-            // 相同 single-flight 可能有多个等待者；只有仍持有租约的第一个等待者可以安装连接。
-            // 旧尝试即使迟到成功，也只能复用已经安装的新连接或立即释放，不能覆盖当前代次。
-            guard connectionAttempt?.id == attempt.id else {
-                if let connection, await connection.isReadyForRequests() {
-                    return connection
-                }
-                await prepared.connection.disconnect()
-                throw CancellationError()
-            }
-            connectionAttempt = nil
-            if let connection, await connection.isReadyForRequests() {
-                if connection !== prepared.connection {
-                    await prepared.connection.disconnect()
-                }
-                return connection
-            }
-            try Task.checkCancellation()
-            installConnection(prepared)
-            return prepared.connection
-        } onCancel: {
-            // Task.value 不会把等待者的取消自动传给非结构化 Task。转回 runtime actor 后按租约
-            // 同时取消连接任务和 candidate，disconnect 会恢复 initialize 的挂起 continuation。
-            Task {
-                await self.cancelConnectionAttempt(id: attempt.id)
-            }
-        }
-    }
-
-    func cancelConnectionAttempt(id: UUID? = nil) async {
-        guard let attempt = connectionAttempt,
-              id == nil || attempt.id == id else {
-            return
-        }
-        connectionAttempt = nil
-        attempt.task.cancel()
-        await attempt.connection.disconnect()
-    }
-
-    func connectionConfig() async throws -> CodexAppServerConfigResponse {
-        let cached = try await ensureConfig()
-        if runtimeGatewayAvailable(in: cached) {
-            return cached
-        }
-        // 首次冷启动时 agentd 可能先返回项目列表，但 app-server gateway 仍在启动。
-        // 这种不可用 config 不能长期缓存，否则 bootstrap 重试会一直复用旧状态，直到用户杀掉 APP。
-        let fresh = try await ensureConfig(forceRefresh: true)
-        if runtimeGatewayAvailable(in: fresh) {
-            return fresh
-        }
-        throw CodexAppServerSessionRuntimeError.gatewayUnavailable
-    }
-
-    func installConnection(_ prepared: CodexAppServerPreparedConnection) {
-        notificationPumpTask?.cancel()
-        serverRequestPumpTask?.cancel()
-        cancelAllTurnInterruptRecoveryTasks()
-        threadResumeTasksBySessionID.values.forEach { $0.task.cancel() }
-        threadResumeTasksBySessionID.removeAll(keepingCapacity: true)
-        // 新连接还没在 app-server 上 resume 任何 thread，清空记录，逼迫下一次发送先补 resume。
-        threadsResumedOnConnection.removeAll(keepingCapacity: true)
-        connection = prepared.connection
-        notificationPumpTask = Task { [weak self, notifications = prepared.notifications, installedConnection = prepared.connection] in
-            for await notification in notifications {
-                await self?.handle(notification)
-            }
-            guard !Task.isCancelled else {
-                return
-            }
-            await self?.handleNotificationStreamEnded(for: installedConnection)
-        }
-        serverRequestPumpTask = Task { [weak self, serverRequests = prepared.serverRequests] in
-            for await request in serverRequests {
-                await self?.handle(request)
-            }
-        }
-    }
-
-    func handleNotificationStreamEnded(for endedConnection: CodexAppServerConnection) async {
-        guard let current = connection, current === endedConnection else {
-            return
-        }
-
-        // 底层 receive 失败会结束 notification stream。这里必须继续结束上层 AgentEvent stream，
-        // 否则 SessionWebSocketClient 的 for-await 永远不退出，UI 会一直误认为连接仍是 connected。
-        notificationPumpTask = nil
-        serverRequestPumpTask?.cancel()
-        serverRequestPumpTask = nil
-        cancelThreadResumeTasks(for: endedConnection)
-        connection = nil
-        threadsResumedOnConnection.removeAll(keepingCapacity: true)
-        threadUnsubscribeRetryTasksBySessionID.values.forEach { $0.task.cancel() }
-        threadUnsubscribeRetryTasksBySessionID.removeAll(keepingCapacity: true)
-        let affected = clearAllPendingServerRequests()
-        for sessionID in affected.approvalSessionIDs {
-            emitApprovalResolved(sessionID: sessionID)
-        }
-        for sessionID in affected.userInputSessionIDs {
-            emitUserInputResolved(sessionID: sessionID, skipped: false)
-        }
-        finishAttachedEventStreams()
-        await endedConnection.disconnect()
-    }
-
-    func finishAttachedEventStreams() {
-        let mailboxes = eventMailboxesBySessionID.values.flatMap { $0.values }
-        eventMailboxesBySessionID.removeAll(keepingCapacity: true)
-        for mailbox in mailboxes {
-            mailbox.finishFromProducer()
-        }
-    }
-
-    func finishAttachedEventStreams(sessionID: SessionID) {
-        let mailboxes = eventMailboxesBySessionID.removeValue(forKey: sessionID)?.values ?? [:].values
-        for mailbox in mailboxes {
-            mailbox.finishFromProducer()
-        }
-    }
-
     func sendRecoveringFromStaleInitialization(
         _ request: CodexAppServerRequestSpec,
         timeout: TimeInterval? = nil
@@ -3190,11 +3026,15 @@ actor CodexAppServerSessionRuntime {
             return false
         }
         switch error {
-        case .disconnected, .notInitialized, .transport:
+        case .disconnected, .notInitialized, .transport, .decoding:
             return true
+        case .outcomeUnknown:
+            // 写入后的超时也使用 outcomeUnknown，但连接及事件流仍然健康；真实 transport
+            // 断线会由 connection 自身结束 notification stream 并触发淘汰，不在这里误杀。
+            return false
         case .appServer(let appServerError):
             return isStaleInitializationAppServerError(appServerError)
-        case .timeout, .duplicateRequestID, .decoding:
+        case .timeout, .duplicateRequestID:
             return false
         }
     }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
@@ -633,6 +633,12 @@ actor CodexAppServerConnection {
         guard case .writeStarted = pending.phase else {
             return error
         }
+        // 凭证被拒是明确结论，不是"结果未知"：握手 401/403 时请求根本没有被接受。
+        // 包成 outcomeUnknown 会同时丢掉 invalidatesCredentials 和被拒指纹，
+        // 让上层把过期 token 当成可重试的网关故障而不是提示重新配对。
+        if isCredentialInvalidatingError(error) {
+            return error
+        }
         return CodexAppServerConnectionError.outcomeUnknown(
             method: pending.method,
             id: id,

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerTransport.swift
@@ -180,6 +180,7 @@ enum CodexAppServerConnectionError: LocalizedError, CredentialInvalidatingError 
     case notInitialized
     case duplicateRequestID(CodexAppServerRequestID)
     case timeout(method: String, id: CodexAppServerRequestID)
+    case outcomeUnknown(method: String, id: CodexAppServerRequestID, cause: String)
     case appServer(CodexAppServerError)
     case decoding(Error)
     case transport(Error)
@@ -208,7 +209,12 @@ enum CodexAppServerConnectionError: LocalizedError, CredentialInvalidatingError 
             return L10n.format("ui.duplicate_json_rpc_request_id_value", id)
         case .timeout(let method, let id):
             return L10n.format("ui.app_server_request_timeout_value_value", method, id)
+        case .outcomeUnknown(let method, let id, let cause):
+            return L10n.format("ui.app_server_request_outcome_unknown_value_value_value", method, id, cause)
         case .appServer(let error):
+            if error.data?.objectValue?["reason"]?.stringValue == "codex_upstream_unavailable" {
+                return L10n.text("ui.codex_upstream_unavailable")
+            }
             return error.localizedDescription
         case .decoding(let error):
             return L10n.format("ui.app_server_message_parsing_failed_value", error.localizedDescription)
@@ -218,10 +224,16 @@ enum CodexAppServerConnectionError: LocalizedError, CredentialInvalidatingError 
     }
 }
 
+private enum PendingCodexAppServerResponsePhase {
+    case registered
+    case writeStarted
+}
+
 private struct PendingCodexAppServerResponse {
     let method: String
     let continuation: CheckedContinuation<CodexAppServerJSONValue?, Error>
     let timeoutTask: Task<Void, Never>
+    var phase: PendingCodexAppServerResponsePhase
 }
 
 /// JSON-RPC 请求 id 的全进程分配器：每条连接都从上一条连接用完的地方继续，
@@ -442,25 +454,68 @@ actor CodexAppServerConnection {
         }
 
         let timeoutNanoseconds = timeout.map { UInt64(max(0.1, $0) * 1_000_000_000) } ?? requestTimeoutNanoseconds
-        return try await withCheckedThrowingContinuation { continuation in
-            let timeoutTask = Task { [timeoutNanoseconds] in
-                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
-                self.timeoutRequest(id: request.id)
-            }
-            pendingResponses[request.id] = PendingCodexAppServerResponse(
-                method: request.method,
-                continuation: continuation,
-                timeoutTask: timeoutTask
-            )
-            Task {
-                do {
-                    try await self.sendEncodedRequest(request)
-                } catch {
-                    let wrapped = CodexAppServerConnectionError.transport(error)
-                    self.failPendingRequest(id: request.id, error: wrapped)
-                    self.markDisconnected(with: wrapped)
+        try Task.checkCancellation()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let timeoutTask = Task { [timeoutNanoseconds] in
+                    try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    self.timeoutRequest(id: request.id)
+                }
+                pendingResponses[request.id] = PendingCodexAppServerResponse(
+                    method: request.method,
+                    continuation: continuation,
+                    timeoutTask: timeoutTask,
+                    phase: .registered
+                )
+                // cancellation handler 可能先于 actor 上的注册任务执行。注册后再读一次当前
+                // Task 状态，封住“handler 已返回、随后仍发送”的窗口。
+                guard !Task.isCancelled else {
+                    cancelPendingRequest(id: request.id)
+                    return
+                }
+                Task {
+                    guard self.beginSendingRequest(id: request.id) else {
+                        return
+                    }
+                    do {
+                        try await self.sendEncodedRequest(request)
+                    } catch {
+                        let wrapped = CodexAppServerConnectionError.transport(error)
+                        self.failPendingRequest(id: request.id, error: wrapped)
+                        self.markDisconnected(with: wrapped)
+                    }
                 }
             }
+        } onCancel: {
+            Task {
+                await self.cancelPendingRequest(id: request.id)
+            }
+        }
+    }
+
+    private func beginSendingRequest(id: CodexAppServerRequestID) -> Bool {
+        guard var pending = pendingResponses[id] else {
+            return false
+        }
+        pending.phase = .writeStarted
+        pendingResponses[id] = pending
+        return true
+    }
+
+    private func cancelPendingRequest(id: CodexAppServerRequestID) {
+        guard let pending = pendingResponses.removeValue(forKey: id) else {
+            return
+        }
+        pending.timeoutTask.cancel()
+        switch pending.phase {
+        case .registered:
+            pending.continuation.resume(throwing: CancellationError())
+        case .writeStarted:
+            pending.continuation.resume(throwing: CodexAppServerConnectionError.outcomeUnknown(
+                method: pending.method,
+                id: id,
+                cause: L10n.text("ui.request_cancelled_after_sending")
+            ))
         }
     }
 
@@ -495,12 +550,17 @@ actor CodexAppServerConnection {
                 serverRequestContinuation?.yield(request)
             }
         } catch {
-            // 单个坏帧不能拖垮整条 JSON-RPC 连接；真正丢失的响应会由对应请求的超时兜底。
-            return
+            failProtocolConnection(CodexAppServerConnectionError.decoding(error))
         }
     }
 
     private func resolve(_ response: CodexAppServerResponse) {
+        if response.id == .null {
+            failProtocolConnection(CodexAppServerConnectionError.appServer(
+                response.error ?? CodexAppServerError(code: -32600, message: "JSON-RPC response id is null", data: nil)
+            ))
+            return
+        }
         if let error = response.error,
            error.data?.objectValue?["response_to_server_request"]?.boolValue == true {
             // server request 的 response 是 fire-and-forget，不在 pendingResponses
@@ -536,7 +596,16 @@ actor CodexAppServerConnection {
         guard let pending = pendingResponses.removeValue(forKey: id) else {
             return
         }
-        pending.continuation.resume(throwing: CodexAppServerConnectionError.timeout(method: pending.method, id: id))
+        switch pending.phase {
+        case .registered:
+            pending.continuation.resume(throwing: CodexAppServerConnectionError.timeout(method: pending.method, id: id))
+        case .writeStarted:
+            pending.continuation.resume(throwing: CodexAppServerConnectionError.outcomeUnknown(
+                method: pending.method,
+                id: id,
+                cause: L10n.text("ui.request_timed_out_after_sending")
+            ))
+        }
     }
 
     private func failPendingRequest(id: CodexAppServerRequestID, error: Error) {
@@ -544,16 +613,38 @@ actor CodexAppServerConnection {
             return
         }
         pending.timeoutTask.cancel()
-        pending.continuation.resume(throwing: error)
+        pending.continuation.resume(throwing: failureForPending(pending, id: id, underlying: error))
     }
 
     private func failAllPending(with error: Error) {
         let pending = pendingResponses
         pendingResponses.removeAll(keepingCapacity: false)
-        for item in pending.values {
+        for (id, item) in pending {
             item.timeoutTask.cancel()
-            item.continuation.resume(throwing: error)
+            item.continuation.resume(throwing: failureForPending(item, id: id, underlying: error))
         }
+    }
+
+    private func failureForPending(
+        _ pending: PendingCodexAppServerResponse,
+        id: CodexAppServerRequestID,
+        underlying error: Error
+    ) -> Error {
+        guard case .writeStarted = pending.phase else {
+            return error
+        }
+        return CodexAppServerConnectionError.outcomeUnknown(
+            method: pending.method,
+            id: id,
+            cause: error.localizedDescription
+        )
+    }
+
+    private func failProtocolConnection(_ error: Error) {
+        receiveTask?.cancel()
+        receiveTask = nil
+        markDisconnected(with: error)
+        Task { await transport.close() }
     }
 
     private func markDisconnected(with error: Error) {

--- a/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AgentModels.swift
@@ -1690,6 +1690,7 @@ enum MessageKind: String, Codable, Hashable {
 enum MessageSendStatus: String, Codable, Hashable {
     case local
     case sending
+    case uncertain
     case sent
     case failed
     case confirmed

--- a/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageRow.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/Messages/ConversationMessageRow.swift
@@ -129,6 +129,8 @@ struct MessageRow: View, Equatable {
                 .foregroundStyle(.red)
         case .sending:
             deliveryCaption(sendingDeliveryCaption)
+        case .uncertain:
+            deliveryCaption(L10n.text("ui.sending_result_pending_confirmation"))
         case .sent:
             if message.userDelivery == .injected {
                 deliveryCaption(L10n.text("ui.conversation_guided"))

--- a/ios/MimiRemote/Sources/Features/Conversation/SkillInterfaceViews.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/SkillInterfaceViews.swift
@@ -578,6 +578,9 @@ struct SkillInvocationCard: View {
         case .failed:
             Image(systemName: "exclamationmark.circle.fill")
                 .foregroundStyle(.red)
+        case .uncertain:
+            Image(systemName: "questionmark.circle.fill")
+                .foregroundStyle(tint)
         case .sent, .confirmed:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(tint)

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -1771,9 +1771,9 @@ final class AppStore: ObservableObject {
             return false
         }
         switch connectionError {
-        case .disconnected, .notInitialized, .timeout, .transport:
+        case .disconnected, .notInitialized, .timeout, .transport, .outcomeUnknown, .decoding:
             return true
-        case .duplicateRequestID, .appServer, .decoding:
+        case .duplicateRequestID, .appServer:
             return false
         }
     }

--- a/ios/MimiRemote/Sources/State/ConversationMessageDeliveryReconciler.swift
+++ b/ios/MimiRemote/Sources/State/ConversationMessageDeliveryReconciler.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+enum ConversationMessageDeliveryReconciler {
+    static func hasTerminalTurnAfterLatestUser(
+        _ messages: [ConversationMessage],
+        turnLifecycles: [TurnID: ConversationTurnLifecycle]
+    ) -> Bool {
+        guard let latestUser = messages.last(where: { $0.role == .user && $0.kind == .message }) else {
+            return false
+        }
+
+        // 历史 rebase 可能暂时同时保留本地 user 与权威 user。权威副本已取得 turnID 时，
+        // 用相同 clientMessageID 补齐本地副本的范围，不能退回依赖数组相对顺序。
+        let resolvedTurnID = latestUser.turnID.flatMap { $0.isEmpty ? nil : $0 }
+            ?? latestUser.clientMessageID.flatMap { clientMessageID in
+                messages.last(where: {
+                    $0.role == .user
+                        && $0.clientMessageID == clientMessageID
+                        && $0.turnID?.isEmpty == false
+                })?.turnID
+            }
+        if let resolvedTurnID {
+            if latestUser.turnLifecycle?.isTerminal == true
+                || turnLifecycles[resolvedTurnID]?.isTerminal == true {
+                return true
+            }
+            return messages.contains {
+                $0.turnID == resolvedTurnID && $0.turnLifecycle?.isTerminal == true
+            }
+        }
+
+        var sawTerminalAssistant = false
+        for message in messages.reversed() where message.kind == .message {
+            if message.role == .assistant {
+                sawTerminalAssistant = sawTerminalAssistant || message.turnLifecycle?.isTerminal == true
+            } else if message.role == .user {
+                return message.turnLifecycle?.isTerminal == true || sawTerminalAssistant
+            }
+        }
+        return false
+    }
+
+    static func markSendingUncertain(
+        _ messages: [ConversationMessage],
+        now: Date = Date()
+    ) -> [ConversationMessage]? {
+        var updated = messages
+        var changed = false
+        for index in updated.indices where updated[index].role == .user
+            && updated[index].sendStatus == .sending
+            && updated[index].userDelivery != .queued {
+            updated[index].sendStatus = .uncertain
+            updated[index].updatedAt = now
+            changed = true
+        }
+        return changed ? updated : nil
+    }
+
+    static func reconcileGuided(
+        _ messages: [ConversationMessage],
+        authoritativeHistory: [CodexHistoryMessage],
+        historyIsComplete: Bool,
+        turnLifecycles: [TurnID: ConversationTurnLifecycle],
+        now: Date = Date()
+    ) -> [ConversationMessage]? {
+        let confirmedPairs = Set(authoritativeHistory.compactMap { message -> String? in
+            guard message.role == "user",
+                  let clientMessageID = message.clientMessageID,
+                  let turnID = message.turnID,
+                  !turnID.isEmpty else { return nil }
+            return pairKey(clientMessageID: clientMessageID, turnID: turnID)
+        })
+        var updated = messages
+        var changed = false
+        for index in updated.indices where updated[index].role == .user
+            && updated[index].userDelivery == .guided
+            && updated[index].sendStatus == .uncertain {
+            guard let clientMessageID = updated[index].clientMessageID,
+                  let turnID = updated[index].turnID,
+                  !turnID.isEmpty else { continue }
+            if confirmedPairs.contains(pairKey(clientMessageID: clientMessageID, turnID: turnID)) {
+                updated[index].sendStatus = .confirmed
+                updated[index].updatedAt = now
+                changed = true
+            } else if historyIsComplete, turnLifecycles[turnID]?.isTerminal == true {
+                updated[index].sendStatus = .failed
+                updated[index].updatedAt = now
+                changed = true
+            }
+        }
+        return changed ? updated : nil
+    }
+
+    private static func pairKey(clientMessageID: ClientMessageID, turnID: TurnID) -> String {
+        "\(clientMessageID)\u{1f}\(turnID)"
+    }
+}

--- a/ios/MimiRemote/Sources/State/ConversationStore.swift
+++ b/ios/MimiRemote/Sources/State/ConversationStore.swift
@@ -24,7 +24,9 @@ struct ConversationHistoryTimelineMutation: Equatable {
 @MainActor
 final class ConversationStore: ObservableObject {
     @Published private var activeProfileID = ""
-    @Published private var messagesByScopedSessionID: [ScopedSessionID: [ConversationMessage]] = [:]
+    // 读取放开到模块内，写入仍限本文件：投递对账扩展只读快照，改写一律走
+    // replaceMessagesWithoutEquivalenceCheck，避免绕过索引重建。
+    @Published private(set) var messagesByScopedSessionID: [ScopedSessionID: [ConversationMessage]] = [:]
 
     private var loadedHistorySessionIDs: Set<ScopedSessionID> = []
     private var lastSeenSeqBySessionID: [ScopedSessionID: EventSequence] = [:]
@@ -36,7 +38,7 @@ final class ConversationStore: ObservableObject {
     private var historyProjectionCacheBySessionID: [ScopedSessionID: HistoryProjectionCache] = [:]
     private var pendingAssistantDeltasBySessionID: [ScopedSessionID: PendingAssistantDelta] = [:]
     private var assistantDeltaFlushTasks: [ScopedSessionID: Task<Void, Never>] = [:]
-    private var turnLifecycleBySessionID: [ScopedSessionID: [TurnID: ConversationTurnLifecycle]] = [:]
+    private(set) var turnLifecycleBySessionID: [ScopedSessionID: [TurnID: ConversationTurnLifecycle]] = [:]
     private var historyTimelineMutationBySessionID: [ScopedSessionID: ConversationHistoryTimelineMutation] = [:]
     private var historyTimelineMutationGeneration: UInt64 = 0
     private var sessionAccessTickBySessionID: [ScopedSessionID: UInt64] = [:]
@@ -211,7 +213,7 @@ final class ConversationStore: ObservableObject {
                 continue
             }
             switch message.sendStatus {
-            case .sending, .sent, .failed:
+            case .sending, .uncertain, .sent, .failed:
                 return true
             case .local, .confirmed:
                 return false
@@ -224,17 +226,11 @@ final class ConversationStore: ObservableObject {
         // authoritative reopen 只有在历史明确带回终态 turn 后才能清理“等待回复”。
         // 空首屏会保留本地消息；本地 waiting/partial assistant 都没有终态 lifecycle，
         // 因而不会被误当成已经对账完成。
-        var sawTerminalAssistant = false
-        for message in messages(for: sessionID).reversed() where message.kind == .message {
-            if message.role == .assistant {
-                sawTerminalAssistant = sawTerminalAssistant || message.turnLifecycle?.isTerminal == true
-                continue
-            }
-            if message.role == .user {
-                return message.turnLifecycle?.isTerminal == true || sawTerminalAssistant
-            }
-        }
-        return false
+        let scopedSessionID = scopedSessionID(for: sessionID)
+        return ConversationMessageDeliveryReconciler.hasTerminalTurnAfterLatestUser(
+            messages(for: sessionID),
+            turnLifecycles: turnLifecycleBySessionID[scopedSessionID] ?? [:]
+        )
     }
 
     func lastSeenSeq(for sessionID: String?) -> EventSequence? {
@@ -825,7 +821,25 @@ final class ConversationStore: ObservableObject {
         let displayKind: MessageKind = message.role == .tool && message.kind == .message ? .commandSummary : message.kind
 
         var list = messagesByScopedSessionID[scopedSessionID] ?? []
-        if let index = messageIndex(stableID: stableID, sessionID: sessionID) ?? clientMessageID.flatMap({ messageIndex(clientMessageID: $0, sessionID: sessionID) }) {
+        let matchingClientIndex = clientMessageID.flatMap { clientMessageID -> Int? in
+            guard let index = messageIndex(clientMessageID: clientMessageID, sessionID: sessionID) else {
+                return nil
+            }
+            let boundTurnID = list[index].turnID?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let incomingTurnID = message.turnID?.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard boundTurnID?.isEmpty != false || boundTurnID == incomingTurnID else {
+                return nil
+            }
+            return index
+        }
+        let matchingStableIndex = messageIndex(stableID: stableID, sessionID: sessionID).flatMap { index -> Int? in
+            guard clientMessageID != nil,
+                  list[index].clientMessageID == clientMessageID,
+                  let boundTurnID = list[index].turnID,
+                  !boundTurnID.isEmpty else { return index }
+            return message.turnID == boundTurnID ? index : nil
+        }
+        if let index = matchingStableIndex ?? matchingClientIndex {
             let previous = list[index]
             list[index].stableID = stableID
             // 服务端 user item 回显可能早于或晚于 turn/start ACK。两条链路都要把
@@ -1038,6 +1052,8 @@ final class ConversationStore: ObservableObject {
             return next == .confirmed
         case .failed:
             return next == .sending
+        case .uncertain:
+            return next == .sent || next == .confirmed || next == .failed || next == .sending
         case .sending, .local:
             return true
         }
@@ -1287,7 +1303,7 @@ final class ConversationStore: ObservableObject {
         return true
     }
 
-    private func replaceMessagesWithoutEquivalenceCheck(
+    func replaceMessagesWithoutEquivalenceCheck(
         _ list: [ConversationMessage],
         sessionID: String,
         rebuildIndexes: Bool = true,
@@ -1970,7 +1986,7 @@ final class ConversationStore: ObservableObject {
         }
     }
 
-    private func scopedSessionID(for sessionID: SessionID) -> ScopedSessionID {
+    func scopedSessionID(for sessionID: SessionID) -> ScopedSessionID {
         ScopedSessionID(profileID: activeProfileID, sessionID: sessionID)
     }
 

--- a/ios/MimiRemote/Sources/State/ConversationStoreDelivery.swift
+++ b/ios/MimiRemote/Sources/State/ConversationStoreDelivery.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// 发送结果对账：把"结果未知"的用户消息与权威历史核对，避免误报失败诱导重复执行。
+/// 与 ConversationStore 主体拆开，保持单文件在 scripts/check-source-size.sh 的上限内。
+extension ConversationStore {
+    func markSendingUserMessagesUncertain(sessionID: String) {
+        guard let current = messagesByScopedSessionID[scopedSessionID(for: sessionID)],
+              let updated = ConversationMessageDeliveryReconciler.markSendingUncertain(current)
+        else { return }
+        replaceMessagesWithoutEquivalenceCheck(updated, sessionID: sessionID, rebuildIndexes: false)
+    }
+
+    func reconcileUncertainGuidedMessages(
+        sessionID: String,
+        authoritativeHistory: [CodexHistoryMessage],
+        historyIsComplete: Bool
+    ) {
+        let scoped = scopedSessionID(for: sessionID)
+        guard let current = messagesByScopedSessionID[scoped],
+              let updated = ConversationMessageDeliveryReconciler.reconcileGuided(
+                  current,
+                  authoritativeHistory: authoritativeHistory,
+                  historyIsComplete: historyIsComplete,
+                  turnLifecycles: turnLifecycleBySessionID[scoped] ?? [:]
+              )
+        else { return }
+        replaceMessagesWithoutEquivalenceCheck(updated, sessionID: sessionID, rebuildIndexes: false)
+    }
+}

--- a/ios/MimiRemote/Sources/State/ConversationTimelineReducer.swift
+++ b/ios/MimiRemote/Sources/State/ConversationTimelineReducer.swift
@@ -93,6 +93,13 @@ struct ConversationTimelineReducer {
             let candidates = current.indices.filter { index in
                 guard !consumedCurrentIndices.contains(index) else { return false }
                 let local = current[index]
+                // 有 client id 的 Guided 消息已经绑定目标 turn。历史必须同时匹配两者；
+                // 相同 client id 出现在其他 turn 时不能走正文/时间兼容路径误确认。
+                if let localTurnID = local.turnID, !localTurnID.isEmpty,
+                   local.clientMessageID != nil {
+                    guard local.clientMessageID == history.clientMessageID,
+                          history.turnID == localTurnID else { return false }
+                }
                 let isUnconfirmedLocalEcho = local.sendStatus != .confirmed
                 let isConfirmedLegacyClaudeEcho = local.sendStatus == .confirmed
                     && local.role == .user
@@ -347,9 +354,12 @@ struct ConversationTimelineReducer {
             switch status {
             case .local: return 0
             case .sending: return 1
-            case .failed: return 2
-            case .sent: return 3
-            case .confirmed: return 4
+            // uncertain 比 sending 多知道"可能已写出"，但仍弱于任何已经定案的结果：
+            // 对账一旦得出 failed/sent/confirmed，就应该覆盖掉待确认态。
+            case .uncertain: return 2
+            case .failed: return 3
+            case .sent: return 4
+            case .confirmed: return 5
             }
         }
         return rank(snapshot) >= rank(existing) ? snapshot : existing
@@ -390,6 +400,9 @@ struct ConversationTimelineReducer {
 
     private func primaryKey(for message: ConversationMessage) -> String? {
         if let clientMessageID = message.clientMessageID {
+            if let turnID = message.turnID, !turnID.isEmpty {
+                return "client:\(clientMessageID):turn:\(turnID)"
+            }
             return "client:\(clientMessageID)"
         }
         if let itemID = message.itemID, !itemID.isEmpty {

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -1234,6 +1234,11 @@ final class SessionStore: ObservableObject {
             turnPayload: item.payload,
             userDelivery: .guided
         )
+        conversationStore.bindTurnID(
+            activeTurnID,
+            clientMessageID: item.clientMessageID,
+            sessionID: session.id
+        )
         setForegroundActivity(.waitingForAssistant, sessionID: session.id)
         setStatusMessage(L10n.text("ui.directed_current_reply_immediately"))
         return true

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -417,7 +417,7 @@ extension SessionStore {
                 sessionID: sessionID,
                 message: L10n.text("ui.the_connection_has_been_interrupted_sending_results_requires")
             )
-            conversationStore.markSendingUserMessagesFailed(sessionID: sessionID)
+            conversationStore.markSendingUserMessagesUncertain(sessionID: sessionID)
             clearPendingApprovalDecisions(sessionID: sessionID)
             clearPendingUserInputResponses(sessionID: sessionID)
             clearForegroundActivity(sessionID: sessionID)
@@ -467,7 +467,7 @@ extension SessionStore {
                 sessionID: sessionID,
                 message: L10n.text("ui.the_connection_has_been_interrupted_sending_results_requires")
             )
-            conversationStore.markSendingUserMessagesFailed(sessionID: sessionID)
+            conversationStore.markSendingUserMessagesUncertain(sessionID: sessionID)
             clearPendingApprovalDecisions(sessionID: sessionID)
             clearForegroundActivity(sessionID: sessionID)
             if canReconnect {
@@ -570,7 +570,7 @@ extension SessionStore {
                 sessionID: previousSessionID,
                 message: L10n.text("ui.the_connection_has_been_interrupted_sending_results_requires")
             )
-            conversationStore.markSendingUserMessagesFailed(sessionID: previousSessionID)
+            conversationStore.markSendingUserMessagesUncertain(sessionID: previousSessionID)
         }
         pendingApprovalDecisionIDsBySessionID.removeAll()
         pendingUserInputResponseIDsBySessionID.removeAll()

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -1242,6 +1242,11 @@ extension SessionStore {
             sessionID: sessionID,
             authoritativeCompletedTurnItems: page.authoritativeCompletedTurnItems
         )
+        conversationStore.reconcileUncertainGuidedMessages(
+            sessionID: sessionID,
+            authoritativeHistory: page.messages,
+            historyIsComplete: page.loadMode == .full && !page.hasMoreBefore
+        )
         reconcilePendingPermissionTurnBoundaries(
             sessionID: sessionID,
             historyMessages: page.messages

--- a/ios/MimiRemote/Sources/State/SessionStoreQueuedTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreQueuedTurns.swift
@@ -1392,10 +1392,13 @@ extension SessionStore {
             conversationStore.updateSendStatus(
                 clientMessageID: clientMessageID,
                 sessionID: sessionID,
-                status: .failed
+                status: .uncertain
             )
             clearForegroundActivity(sessionID: sessionID)
-            setErrorMessage(L10n.format("ui.the_result_of_the_message_to_be_sent", message))
+            // 写入已开始后的断线/超时不是明确失败。保持中性待确认状态，不能展示会诱导
+            // 普通重试的错误横幅；持久化队列已在上面的专用分支进入 needsConfirmation。
+            setErrorMessage(nil)
+            setStatusMessage(L10n.text("ui.sending_result_pending_confirmation"))
         }
     }
 }

--- a/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreTurns.swift
@@ -370,6 +370,11 @@ extension SessionStore {
                 authoritativeCompletedTurnItems: page.authoritativeCompletedTurnItems,
                 timelineMutationKind: .prepend
             )
+            conversationStore.reconcileUncertainGuidedMessages(
+                sessionID: session.id,
+                authoritativeHistory: page.messages,
+                historyIsComplete: page.loadMode == .full && !page.hasMoreBefore
+            )
             setHistoryLoadProgress(sessionID: session.id, title: L10n.text("ui.update_interface"), fraction: 0.94)
             updateHistoryPageState(
                 sessionID: session.id,
@@ -934,6 +939,11 @@ extension SessionStore {
                 setErrorMessage(L10n.text("ui.failed_to_guide_conversation_there_is_no_active"))
                 return false
             }
+            conversationStore.bindTurnID(
+                activeTurnID,
+                clientMessageID: clientMessageID,
+                sessionID: session.id
+            )
             let didAcceptLocally = socket.sendGuidance(payload, clientMessageID: clientMessageID, expectedTurnID: activeTurnID)
             guard didAcceptLocally else {
                 conversationStore.updateSendStatus(clientMessageID: clientMessageID, sessionID: session.id, status: .failed)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerConnectionReliabilityTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerConnectionReliabilityTests.swift
@@ -21,6 +21,36 @@ private actor CancelBeforeWriteGate {
     }
 }
 
+/// 握手正常、但在指定方法写出时抛出凭证失效错误，用于验证"结果未知"包装不会吞掉凭证结论。
+private final class CredentialRejectingTransport: CodexAppServerTransport {
+    private let inner: FakeCodexAppServerTransport
+    private let rejectingMethod: String
+
+    init(inner: FakeCodexAppServerTransport, rejectingMethod: String) {
+        self.inner = inner
+        self.rejectingMethod = rejectingMethod
+    }
+
+    func connect(url: URL, token: String) async throws {
+        try await inner.connect(url: url, token: token)
+    }
+
+    func send(_ text: String) async throws {
+        if let request = try? decodeAppServerRequest(text), request.method == rejectingMethod {
+            throw AgentAPIError.credentialsInvalid(status: 401, credentialFingerprint: "stale-token")
+        }
+        try await inner.send(text)
+    }
+
+    func receive() async throws -> String? {
+        try await inner.receive()
+    }
+
+    func close() async {
+        await inner.close()
+    }
+}
+
 final class CodexAppServerConnectionReliabilityTests: XCTestCase {
     func testCancellingOneConnectionWaiterDoesNotCancelSharedCandidate() async throws {
         let project = AgentProject(id: "reliability", name: "Reliability", path: "/tmp/reliability")
@@ -150,6 +180,32 @@ final class CodexAppServerConnectionReliabilityTests: XCTestCase {
 
         let sentCount = await transport.sentMessages().count
         XCTAssertEqual(sentCount, 2, "cancelled request must not reach the wire")
+        await connection.disconnect()
+    }
+
+    func testCredentialRejectionAfterWriteStartedKeepsCredentialOutcome() async throws {
+        let inner = FakeCodexAppServerTransport()
+        let transport = CredentialRejectingTransport(inner: inner, rejectingMethod: "turn/steer")
+        let connection = CodexAppServerConnection(transport: transport, requestTimeout: 2)
+        try await connectFakeAppServer(connection, transport: inner)
+
+        do {
+            _ = try await connection.send(CodexAppServerRequestSpec(method: "turn/steer"))
+            XCTFail("Expected credential rejection")
+        } catch {
+            // 凭证被拒必须保持可识别，否则上层会把过期 token 当成可重试的网关故障。
+            // isRetryableGatewayInitializationError 正是按这个谓词放行重试，
+            // 所以保住它就等于保住"过期 token 不进重试路径"。
+            XCTAssertTrue(
+                isCredentialInvalidatingError(error),
+                "凭证失效不能被 outcomeUnknown 吞掉：\(error)"
+            )
+            XCTAssertEqual(
+                credentialFingerprintRejectedByError(error),
+                "stale-token",
+                "被拒指纹必须一起保留，否则无法定位该作废哪份凭据"
+            )
+        }
         await connection.disconnect()
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerConnectionReliabilityTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerConnectionReliabilityTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import MimiRemote
+
+private actor ConnectionWaiterCompletionProbe {
+    private(set) var completed = false
+    func markCompleted() { completed = true }
+}
+
+private actor CancelBeforeWriteGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private(set) var isWaiting = false
+
+    func wait() async {
+        isWaiting = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+final class CodexAppServerConnectionReliabilityTests: XCTestCase {
+    func testCancellingOneConnectionWaiterDoesNotCancelSharedCandidate() async throws {
+        let project = AgentProject(id: "reliability", name: "Reliability", path: "/tmp/reliability")
+        let pool = FakeCodexAppServerTransportPool()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:7777",
+            token: "token",
+            transportFactory: { pool.make() },
+            requestTimeout: 2,
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+
+        let first = Task { try await runtime.ensureConnection() }
+        let transport = try await waitForFakeAppServerTransport(in: pool, index: 0)
+        _ = try await waitForFakeAppServerMessages(transport, count: 1)
+        let second = Task { try await runtime.ensureConnection() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        first.cancel()
+
+        let completionProbe = ConnectionWaiterCompletionProbe()
+        let cancelledWaiter = Task {
+            defer { Task { await completionProbe.markCompleted() } }
+            return try await first.value
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let didCompleteCancellation = await completionProbe.completed
+        let closeCountBeforeInitialize = await transport.closeCallCount()
+        XCTAssertTrue(didCompleteCancellation, "cancelled waiter must return before initialize completes")
+        XCTAssertEqual(closeCountBeforeInitialize, 0, "another waiter still owns the candidate")
+        XCTAssertNil(pool.transport(at: 1), "single-flight must create only one transport")
+
+        let initialize = try decodeAppServerRequest((await transport.sentMessages())[0])
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: initialize.id)),"result":{}}"#)
+        _ = try await second.value
+        do {
+            _ = try await cancelledWaiter.value
+            XCTFail("Expected the cancelled waiter to stop")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            XCTFail("Unexpected cancellation error: \(error)")
+        }
+        await runtime.cancelConnectionAttempt()
+    }
+
+    func testNullIDUpstreamErrorRetiresConnectionAndPreservesReason() async throws {
+        let transport = FakeCodexAppServerTransport()
+        let connection = CodexAppServerConnection(transport: transport, requestTimeout: 2)
+        try await connectFakeAppServer(connection, transport: transport)
+
+        let requestTask = Task {
+            try await connection.send(CodexAppServerRequestSpec(method: "thread/list"))
+        }
+        _ = try await waitForFakeAppServerMessages(transport, count: 3)
+        transport.enqueue(#"{"id":null,"error":{"code":-32098,"message":"upstream unavailable","data":{"reason":"codex_upstream_unavailable"}}}"#)
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("Expected uncertain request outcome")
+        } catch CodexAppServerConnectionError.outcomeUnknown(let method, _, let cause) {
+            XCTAssertEqual(method, "thread/list")
+            XCTAssertTrue(cause.contains(L10n.text("ui.codex_upstream_unavailable")))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        let isReady = await connection.isReadyForRequests()
+        let closeCallCount = await transport.closeCallCount()
+        XCTAssertFalse(isReady)
+        XCTAssertGreaterThanOrEqual(closeCallCount, 1)
+    }
+
+    func testCancellationAfterWriteStartedReturnsOutcomeUnknownAndIgnoresLateResponse() async throws {
+        let transport = FakeCodexAppServerTransport()
+        let connection = CodexAppServerConnection(transport: transport, requestTimeout: 2)
+        try await connectFakeAppServer(connection, transport: transport)
+
+        let task = Task {
+            try await connection.send(CodexAppServerRequestSpec(method: "turn/steer"))
+        }
+        let messages = try await waitForFakeAppServerMessages(transport, count: 3)
+        let request = try decodeAppServerRequest(messages[2])
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected uncertain request outcome")
+        } catch CodexAppServerConnectionError.outcomeUnknown(let method, let id, _) {
+            XCTAssertEqual(method, "turn/steer")
+            XCTAssertEqual(id, request.id)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: request.id)),"result":{}}"#)
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let isReady = await connection.isReadyForRequests()
+        let sentCount = await transport.sentMessages().count
+        XCTAssertTrue(isReady)
+        XCTAssertEqual(sentCount, 3)
+        await connection.disconnect()
+    }
+
+    func testCancellationBeforeWriteDoesNotSendRequest() async throws {
+        let transport = FakeCodexAppServerTransport()
+        let connection = CodexAppServerConnection(transport: transport, requestTimeout: 2)
+        try await connectFakeAppServer(connection, transport: transport)
+
+        let gate = CancelBeforeWriteGate()
+        let task = Task {
+            await gate.wait()
+            return try await connection.send(CodexAppServerRequestSpec(method: "turn/steer"))
+        }
+        while !(await gate.isWaiting) {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        task.cancel()
+        await gate.release()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation before write")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let sentCount = await transport.sentMessages().count
+        XCTAssertEqual(sentCount, 2, "cancelled request must not reach the wire")
+        await connection.disconnect()
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1301,7 +1301,7 @@ extension ConversationDataFlowTests {
         do {
             _ = try await timeoutTask.value
             XCTFail("turn/start timeout should fail")
-        } catch CodexAppServerConnectionError.timeout(let method, _) {
+        } catch CodexAppServerConnectionError.outcomeUnknown(let method, _, _) {
             XCTAssertEqual(method, "turn/start")
         } catch {
             XCTFail("Unexpected timeout error: \(error)")

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
@@ -511,7 +511,7 @@ extension ConversationDataFlowTests {
         await connection.disconnect()
     }
 
-    func testCodexAppServerConnectionSkipsMalformedFrameWithoutFailingPendingRequests() async throws {
+    func testCodexAppServerConnectionRetiresMalformedFrameAndFailsPendingRequests() async throws {
         let transport = FakeCodexAppServerTransport()
         let connection = CodexAppServerConnection(transport: transport, requestTimeout: 2)
         try await connectFakeAppServer(connection, transport: transport)
@@ -528,10 +528,16 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(request.method, "thread/list")
 
         transport.enqueue(#"{"id": "#)
-        transport.enqueue(#"{"id":\#(try jsonFragment(for: request.id)),"result":{"name":"still-ok"}}"#)
-
-        let result = try await requestTask.value?.objectValue
-        XCTAssertEqual(result?["name"]?.stringValue, "still-ok")
+        do {
+            _ = try await requestTask.value
+            XCTFail("Expected malformed frame to retire the connection")
+        } catch CodexAppServerConnectionError.outcomeUnknown(let method, _, _) {
+            XCTAssertEqual(method, "thread/list")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        let isReady = await connection.isReadyForRequests()
+        XCTAssertFalse(isReady)
 
         await connection.disconnect()
     }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationMessageDeliveryUncertaintyTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationMessageDeliveryUncertaintyTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class ConversationMessageDeliveryUncertaintyTests: XCTestCase {
+    func testDisconnectMarksDirectAndGuidedMessagesUncertainButKeepsQueuedMessage() {
+        let store = ConversationStore()
+        store.appendLocalUser("direct", sessionID: "thread", clientMessageID: "direct", sendStatus: .sending)
+        store.appendLocalUser(
+            "guided",
+            sessionID: "thread",
+            clientMessageID: "guided",
+            sendStatus: .sending,
+            userDelivery: .guided
+        )
+        store.appendLocalUser(
+            "queued",
+            sessionID: "thread",
+            clientMessageID: "queued",
+            sendStatus: .sending,
+            userDelivery: .queued
+        )
+
+        store.markSendingUserMessagesUncertain(sessionID: "thread")
+
+        let statuses: [String: MessageSendStatus] = Dictionary(
+            uniqueKeysWithValues: store.messages(for: "thread").compactMap {
+            guard let clientMessageID = $0.clientMessageID else { return nil }
+            return (clientMessageID, $0.sendStatus)
+            }
+        )
+        XCTAssertEqual(statuses["direct"], .uncertain)
+        XCTAssertEqual(statuses["guided"], .uncertain)
+        XCTAssertEqual(statuses["queued"], .sending)
+        XCTAssertTrue(store.hasLocallyUnreconciledUserDelivery(sessionID: "thread"))
+    }
+
+    func testUncertainMessageCanReconcileButCannotRegressFromConfirmed() {
+        let store = ConversationStore()
+        store.appendLocalUser("message", sessionID: "thread", clientMessageID: "message", sendStatus: .sending)
+
+        XCTAssertTrue(store.updateSendStatus(clientMessageID: "message", sessionID: "thread", status: .uncertain))
+        XCTAssertTrue(store.updateSendStatus(clientMessageID: "message", sessionID: "thread", status: .confirmed))
+        XCTAssertFalse(store.updateSendStatus(clientMessageID: "message", sessionID: "thread", status: .failed))
+        XCTAssertEqual(store.messages(for: "thread").first?.sendStatus, .confirmed)
+    }
+
+    func testGuidedHistoryRequiresMatchingClientAndTurnPair() {
+        let store = ConversationStore()
+        store.appendLocalUser(
+            "guide",
+            sessionID: "thread",
+            clientMessageID: "client",
+            sendStatus: .uncertain,
+            userDelivery: .guided
+        )
+        XCTAssertTrue(store.bindTurnID("turn-a", clientMessageID: "client", sessionID: "thread"))
+
+        let history = [
+            CodexHistoryMessage(
+                role: "user",
+                content: "guide",
+                createdAt: Date(),
+                clientMessageID: "client",
+                turnID: "turn-b"
+            )
+        ]
+        store.replaceHistorySnapshot(history, sessionID: "thread")
+        store.reconcileUncertainGuidedMessages(
+            sessionID: "thread",
+            authoritativeHistory: history,
+            historyIsComplete: false
+        )
+
+        let original = store.messages(for: "thread").first { $0.turnID == "turn-a" }
+        XCTAssertEqual(original?.sendStatus, .uncertain)
+        XCTAssertEqual(original?.turnID, "turn-a")
+    }
+
+    func testGuidedMatchingPairConfirmsAndCompleteTerminalAbsenceFails() {
+        let store = ConversationStore()
+        for (clientID, turnID) in [("matched", "turn-match"), ("missing", "turn-missing")] {
+            store.appendLocalUser(
+                clientID,
+                sessionID: "thread",
+                clientMessageID: clientID,
+                sendStatus: .uncertain,
+                userDelivery: .guided
+            )
+            XCTAssertTrue(store.bindTurnID(turnID, clientMessageID: clientID, sessionID: "thread"))
+        }
+        let history = [
+            CodexHistoryMessage(
+                role: "user",
+                content: "matched",
+                createdAt: Date(),
+                clientMessageID: "matched",
+                turnID: "turn-match",
+                turnLifecycle: .completed
+            ),
+            CodexHistoryMessage(
+                role: "assistant",
+                content: "done",
+                createdAt: Date(),
+                turnID: "turn-missing",
+                turnLifecycle: .completed
+            )
+        ]
+        store.replaceHistorySnapshot(history, sessionID: "thread")
+        store.reconcileUncertainGuidedMessages(
+            sessionID: "thread",
+            authoritativeHistory: history,
+            historyIsComplete: true
+        )
+
+        let messages = store.messages(for: "thread")
+        XCTAssertEqual(messages.first { $0.clientMessageID == "matched" }?.sendStatus, .confirmed)
+        XCTAssertEqual(messages.first { $0.clientMessageID == "missing" }?.sendStatus, .failed)
+    }
+
+    func testFinalEarlierHistoryPageFailsMissingGuidanceOnlyAfterPaginationCompletes() async {
+        let project = makeProject(id: "guided-pagination")
+        let session = makeSession(
+            id: "guided-pagination-thread",
+            projectID: project.id,
+            title: "Guided pagination",
+            status: "history",
+            source: "codex",
+            resumeID: "guided-pagination-thread"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [session],
+            historyPages: [
+                session.id: HistoryMessagesPage(
+                    messages: [],
+                    previousCursor: "older",
+                    hasMoreBefore: true,
+                    loadMode: .full
+                )
+            ],
+            historyCursorPages: [
+                "older": HistoryMessagesPage(
+                    messages: [
+                        CodexHistoryMessage(
+                            role: "assistant",
+                            content: "turn completed without the guidance item",
+                            createdAt: Date(),
+                            turnID: "turn-guided",
+                            turnLifecycle: .completed
+                        )
+                    ],
+                    hasMoreBefore: false,
+                    loadMode: .full
+                )
+            ]
+        )
+        let conversationStore = ConversationStore()
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        await store.refreshAll(autoAttach: false)
+        await store.selectSession(session)
+        conversationStore.appendLocalUser(
+            "guidance",
+            sessionID: session.id,
+            clientMessageID: "guided-client",
+            sendStatus: .uncertain,
+            userDelivery: .guided
+        )
+        XCTAssertTrue(conversationStore.bindTurnID(
+            "turn-guided",
+            clientMessageID: "guided-client",
+            sessionID: session.id
+        ))
+        XCTAssertEqual(
+            conversationStore.messages(for: session.id).first { $0.clientMessageID == "guided-client" }?.sendStatus,
+            .uncertain
+        )
+
+        await store.loadEarlierHistoryForSelectedSession()
+
+        XCTAssertEqual(client.requestedMessageCursors, [nil, "older"])
+        XCTAssertEqual(
+            conversationStore.messages(for: session.id).first { $0.clientMessageID == "guided-client" }?.sendStatus,
+            .failed
+        )
+    }
+
+    func testNonQueuedUncertainOutcomeUsesNeutralStatusInsteadOfErrorBanner() {
+        let conversationStore = ConversationStore()
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: conversationStore,
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
+        )
+        // SessionStore 初始化时会把 ConversationStore 切到当前 Host scope。
+        // 测试消息必须在切换后写入，才能和发送结果使用同一个索引。
+        conversationStore.appendLocalUser(
+            "guidance",
+            sessionID: "thread",
+            clientMessageID: "client",
+            sendStatus: .sending,
+            userDelivery: .guided
+        )
+
+        store.handleTurnSendOutcome(
+            clientMessageID: "client",
+            sessionID: "thread",
+            outcome: .uncertain(message: "ack lost")
+        )
+
+        XCTAssertNil(store.errorMessage)
+        XCTAssertEqual(store.statusMessage, L10n.text("ui.sending_result_pending_confirmation"))
+        XCTAssertEqual(conversationStore.messages(for: "thread").first?.sendStatus, .uncertain)
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationWorkspaceHistoryTests.swift
@@ -3974,6 +3974,7 @@ extension ConversationDataFlowTests {
                 $0.role == .assistant && $0.content == "程序员去海边，发现浪都是递归的。"
             }
         )
+        XCTAssertTrue(conversationStore.hasTerminalTurnAfterLatestUserMessage(sessionID: running.id))
         XCTAssertNil(store.foregroundActivityBySessionID[running.id])
         XCTAssertFalse(store.activeSessions.contains { $0.id == running.id })
         XCTAssertTrue(store.recentHistorySessions.contains { $0.id == running.id })
@@ -4050,6 +4051,7 @@ extension ConversationDataFlowTests {
         )
         await secondReopen.value
 
+        XCTAssertTrue(conversationStore.hasTerminalTurnAfterLatestUserMessage(sessionID: completed.id))
         XCTAssertNil(store.foregroundActivityBySessionID[completed.id])
         XCTAssertTrue(
             conversationStore.messages(for: completed.id).contains {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/AgentCommandClient.swift
@@ -4,6 +4,7 @@ struct AgentCommandClient: Sendable {
     var configExists: @Sendable () -> Bool
     var setup: @Sendable (_ workspaceRoot: URL) async throws -> PairingInfo
     var status: @Sendable () async throws -> AgentStatus
+    var readiness: @Sendable () async throws -> AgentStatus
     var statusAt: @Sendable (_ binary: URL) async throws -> AgentStatus
     var doctor: @Sendable (_ fix: Bool) async throws -> DoctorFixResults
     var configureClaude: @Sendable (
@@ -95,6 +96,14 @@ extension AgentCommandClient {
                 return try decode(AgentStatus.self, from: try await execute(
                     binary: binary,
                     arguments: statusArguments(includeRuntime: true),
+                    timeout: .seconds(8)
+                ))
+            },
+            readiness: {
+                let binary = try requireEmbeddedBinary()
+                return try decode(AgentStatus.self, from: try await execute(
+                    binary: binary,
+                    arguments: statusArguments(includeRuntime: false),
                     timeout: .seconds(8)
                 ))
             },

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -141,6 +141,8 @@ final class HostStore {
     private var runtimeStatusFollowUpTask: Task<Void, Never>?
     private var stopServiceAndQuitTask: Task<Void, Never>?
     private var lastStatusRefreshAt: Date?
+    private var lastReadinessCommandSuccessAt: Date?
+    private var readinessFailureStartedAt: Date?
     // 每次开始 agent.status() 都先分配单调序号，只允许最新请求落地。
     private var statusRequestSequence: UInt64 = 0
 
@@ -1067,7 +1069,7 @@ final class HostStore {
         )
     }
 
-    private func refreshMacAgentStatus() async {
+    private func refreshMacAgentStatus(preserveStateOnCommandFailure: Bool = false, now: Date = Date()) async {
         switch services.agentStatus() {
         case .enabled:
             do {
@@ -1075,7 +1077,11 @@ final class HostStore {
             } catch is CancellationError {
                 return
             } catch {
-                fail(error)
+                if preserveStateOnCommandFailure {
+                    applyReadinessStalenessIfNeeded(now: now)
+                } else {
+                    fail(error)
+                }
             }
         case .requiresApproval:
             lifecycle = .degraded("请在系统设置的登录项中允许 Mimi Remote Mac。")
@@ -1147,6 +1153,8 @@ final class HostStore {
         status = resolved
         doctor = resolved.doctor
         lastStatusRefreshAt = Date()
+        lastReadinessCommandSuccessAt = Date()
+        readinessFailureStartedAt = nil
         if resolved.serviceOK {
             lifecycle = .ready
         } else if resolved.processOK {
@@ -1237,18 +1245,70 @@ final class HostStore {
                 try? await Task.sleep(for: .seconds(10))
                 guard let self, !Task.isCancelled else { return }
                 tick += 1
-                if let endpoint = self.status?.endpoint,
-                   (self.lifecycle == .ready || self.lifecycle == .migrationRequired),
-                   !(await self.health.check(endpoint))
-                {
-                    await self.refresh()
-                } else if tick.isMultiple(of: 30) {
-                    // 常驻监控每 10 秒只做 loopback healthz；完整 status 会执行带鉴权的
-                    // upstream WebSocket readiness，降到 5 分钟一次，避免控制面持续干扰数据面。
-                    await self.refresh()
-                }
+                await self.performMonitoringTick(tick, now: Date())
             }
         }
+    }
+
+    /// 常驻监控始终以 healthz 作为进程探针；readiness 和完整 runtime 状态按不同频率读取。
+    /// 保持该入口为 internal，测试可以直接推进 tick，无需真实等待五分钟。
+    func performMonitoringTick(_ tick: Int, now: Date) async {
+        guard owner != .none, let endpoint = status?.endpoint else { return }
+        guard await health.check(endpoint) else {
+            await refresh()
+            return
+        }
+        if owner == .homebrew {
+            if tick.isMultiple(of: 30) {
+                await refresh()
+            }
+            return
+        }
+        if tick.isMultiple(of: 30) {
+            // 完整 status 已包含 readyz，本轮不再重复执行轻量 readiness。
+            await refreshMacAgentStatus(preserveStateOnCommandFailure: true, now: now)
+            // healthz 已在本轮确认进程存活；status 中的 process_ok 即使瞬时为 false，
+            // 也不能把一个明确的 readiness 故障误报为进程停止。
+            if let current = status, !current.serviceOK {
+                lifecycle = .degraded(current.serviceError ?? "Codex 服务尚未就绪。")
+            }
+        } else if tick.isMultiple(of: 6) {
+            await refreshReadinessStatus(now: now)
+        } else {
+            applyReadinessStalenessIfNeeded(now: now)
+        }
+    }
+
+    private func refreshReadinessStatus(now: Date) async {
+        // 轻量 readiness 与完整 status 写入同一份状态。二者必须共享请求序号，
+        // 否则先发出的慢 readiness 会在较新的完整状态之后回写旧结果。
+        let sequence = nextStatusRequestSequence()
+        do {
+            let current = try await agent.readiness()
+            guard sequence == statusRequestSequence else { return }
+            lastReadinessCommandSuccessAt = now
+            readinessFailureStartedAt = nil
+            let resolved = preservingRuntimeSnapshotIfNeeded(in: current)
+            status = resolved
+            doctor = resolved.doctor
+            lastStatusRefreshAt = now
+            lifecycle = current.serviceOK
+                ? .ready
+                : .degraded(current.serviceError ?? "Codex 服务尚未就绪。")
+        } catch is CancellationError {
+            return
+        } catch {
+            applyReadinessStalenessIfNeeded(now: now)
+        }
+    }
+
+    func applyReadinessStalenessIfNeeded(now: Date) {
+        if readinessFailureStartedAt == nil {
+            readinessFailureStartedAt = now
+        }
+        guard let baseline = lastReadinessCommandSuccessAt ?? readinessFailureStartedAt,
+              now.timeIntervalSince(baseline) >= 90 else { return }
+        lifecycle = .degraded("进程存活，但 Codex 服务状态暂时无法确认")
     }
 
     private func scheduleRuntimeStatusFollowUp() {
@@ -1423,6 +1483,7 @@ final class HostStore {
             configExists: { lifecycle != .notConfigured },
             setup: { _ in PairingInfo(endpoint: status.endpoint, pairURL: "mimiremote://pair?pair_sig=preview", expiresAt: "10 分钟后", warnings: []) },
             status: { status },
+            readiness: { status },
             statusAt: { _ in status },
             doctor: { _ in DoctorFixResults(fixes: [], results: doctor) },
             configureClaude: { preference, restoreEnabled in

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -4,6 +4,138 @@ import XCTest
 
 @MainActor
 final class HostStoreTests: XCTestCase {
+    func testMonitoringUsesLightReadinessEveryMinuteAndFullStatusEveryFiveMinutes() async {
+        let fullCalls = CallCounter()
+        let readinessCalls = CallCounter()
+        let healthCalls = CallCounter()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            status: {
+                _ = fullCalls.increment()
+                return Self.readyStatus
+            },
+            readiness: {
+                _ = readinessCalls.increment()
+                return Self.readyStatus
+            },
+            healthCheck: { _ in
+                _ = healthCalls.increment()
+                return true
+            }
+        )
+        await store.bootstrap()
+        let now = Date()
+
+        await store.performMonitoringTick(5, now: now)
+        XCTAssertEqual(readinessCalls.current, 0)
+        XCTAssertEqual(fullCalls.current, 1)
+
+        await store.performMonitoringTick(6, now: now.addingTimeInterval(60))
+        XCTAssertEqual(readinessCalls.current, 1)
+        XCTAssertEqual(fullCalls.current, 1)
+
+        await store.performMonitoringTick(30, now: now.addingTimeInterval(300))
+        XCTAssertEqual(readinessCalls.current, 1, "完整 status 轮次不得重复轻量 readiness")
+        XCTAssertEqual(fullCalls.current, 2)
+        XCTAssertEqual(healthCalls.current, 3, "每个 10 秒 monitoring tick 都必须先检查 healthz")
+    }
+
+    func testMonitoringDegradesImmediatelyWhenReadinessReportsServiceUnavailable() async {
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            readiness: { Self.stoppedStatus }
+        )
+        await store.bootstrap()
+
+        await store.performMonitoringTick(6, now: Date().addingTimeInterval(60))
+
+        XCTAssertEqual(store.lifecycle, .degraded("readyz 不可用"))
+    }
+
+    func testMonitoringKeepsLiveProcessOutOfStoppedWhileReadinessIsStaleAndRecovers() async {
+        let readinessCalls = CallCounter()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            readiness: {
+                if readinessCalls.increment() == 1 {
+                    throw AgentClientError.commandFailed("temporary failure")
+                }
+                return Self.readyStatus
+            }
+        )
+        await store.bootstrap()
+        let baseline = Date()
+
+        await store.performMonitoringTick(6, now: baseline.addingTimeInterval(89))
+        XCTAssertEqual(store.lifecycle, .ready)
+
+        await store.performMonitoringTick(9, now: baseline.addingTimeInterval(91))
+        XCTAssertEqual(
+            store.lifecycle,
+            .degraded("进程存活，但 Codex 服务状态暂时无法确认")
+        )
+
+        await store.performMonitoringTick(12, now: baseline.addingTimeInterval(120))
+        XCTAssertEqual(store.lifecycle, .ready)
+    }
+
+    func testMonitoringFullStatusKeepsHealthConfirmedProcessDegradedInsteadOfStopped() async {
+        let fullCalls = CallCounter()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            status: {
+                fullCalls.increment() == 1 ? Self.readyStatus : Self.stoppedStatus
+            }
+        )
+        await store.bootstrap()
+
+        await store.performMonitoringTick(30, now: Date().addingTimeInterval(300))
+
+        XCTAssertEqual(store.lifecycle, .degraded("readyz 不可用"))
+    }
+
+    func testOlderReadinessCannotOverwriteNewerFullStatus() async {
+        let readinessGate = SuspendedStatusGate()
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { .enabled },
+            readiness: {
+                await readinessGate.suspendReturning(Self.stoppedStatus)
+            }
+        )
+        await store.bootstrap()
+        let baseline = Date()
+
+        let readinessTask = Task { @MainActor in
+            await store.performMonitoringTick(6, now: baseline.addingTimeInterval(60))
+        }
+        await readinessGate.waitUntilSuspended()
+        await store.performMonitoringTick(30, now: baseline.addingTimeInterval(300))
+        readinessGate.resume()
+        await readinessTask.value
+
+        XCTAssertEqual(store.lifecycle, .ready)
+        XCTAssertEqual(store.status?.serviceOK, true)
+    }
+
+    func testReadinessStalenessStartsAtFirstFailureWhenNoSuccessExists() {
+        let store = makeStore(configExists: false)
+        let firstFailure = Date()
+
+        store.applyReadinessStalenessIfNeeded(now: firstFailure)
+        XCTAssertEqual(store.lifecycle, .loading)
+
+        store.applyReadinessStalenessIfNeeded(now: firstFailure.addingTimeInterval(90))
+        XCTAssertEqual(
+            store.lifecycle,
+            .degraded("进程存活，但 Codex 服务状态暂时无法确认")
+        )
+    }
+
     func testBootstrapRegistersBundledAgentWhenServiceRecordIsNotFound() async {
         let events = EventRecorder()
         var registrationState = ServiceRegistrationState.notFound
@@ -1155,6 +1287,7 @@ final class HostStoreTests: XCTestCase {
         status: @escaping @Sendable () async throws -> AgentStatus = {
             HostStoreTests.readyStatus
         },
+        readiness: (@Sendable () async throws -> AgentStatus)? = nil,
         doctor: @escaping @Sendable (Bool) async throws -> DoctorFixResults = { _ in
             DoctorFixResults(fixes: [], results: HostStoreTests.readyStatus.doctor)
         },
@@ -1205,6 +1338,7 @@ final class HostStoreTests: XCTestCase {
             configExists: { configExists },
             setup: { _ in Self.pairing },
             status: status,
+            readiness: readiness ?? status,
             statusAt: { _ in readyStatus },
             doctor: doctor,
             configureClaude: configureClaude,


### PR DESCRIPTION
把 8/31 停在 `codex/mim-222-226-app-ssh-flow-hardening` 上的 wip checkpoint（`f84df210`）摘到当前 main，并补齐 checkpoint 之后 main 的增量与 checkpoint 自身缺失的部分。五张 issue 在 Linear 上都停在 `Verify`，但代码一直没有进 main。

## 五条修复

| Issue | 结果 |
|---|---|
| MIM-222 | 阻止未授权 Codex Thread 下行事件进入移动端 |
| MIM-223 | 并发与取消期间只建立一条 iOS App Server 连接 |
| MIM-224 | 发送结果不确定时避免重复执行消息 |
| MIM-225 | agentd 退出时可靠回收 SSH Gateway 连接 |
| MIM-226 | Mac 菜单及时识别 Codex 服务未就绪 |

## 移植过程中补上的四处缺口

原 checkpoint 基于 8/30 的 `e21453b5`，落后 main 五十多个提交，直接取用会静默回退别人的修复。

1. **找回 MIM-158（#285）的两处改动**。checkpoint 把连接逻辑整块搬进新的 `CodexAppServerSessionConnection.swift`，用的是分支点快照，导致 `handleNotificationStreamEnded` 里 `threadUnsubscribeRetryTasksBySessionID` 的取消与清空丢失，`finishAttachedEventStreams(sessionID:)` 整个函数消失——后者在 `CodexAppServerSessionRuntime.swift:890` 仍被调用。两处已补回。
2. **补 5 条本地化文案**。`ui.sending_result_pending_confirmation` 等 key 只存在于未提交的工作区副本里，缺失时界面会直接显示 `ui.*` 原始 key。
3. **补 `ConversationTimelineReducer` 的 `.uncertain` 排序分支**。新增枚举值没有同步这个 switch，checkpoint 因此无法编译。`.uncertain` 排在 `sending` 与 `failed` 之间，与 `canTransition` 的方向一致。
4. **拆出 `ConversationStoreDelivery.swift`**。`ConversationStore.swift` 被加到 2015 行、超过 `check-source-size.sh` 的 2000 行上限，按职责把投递对账拆走后回到 1991 行。相应把 `messagesByScopedSessionID`、`turnLifecycleBySessionID` 放宽为 `private(set)`（模块内只读、写入仍限本文件），`replaceMessagesWithoutEquivalenceCheck` 与 `scopedSessionID(for:)` 放宽为 internal。

冲突解决另有两处值得留意：`router.go` 保留了 main 新增的 `tailcat.Close()` 并移入 `shutdownOnce` 块；`project.pbxproj` 没有简单取并集——checkpoint 用自己的 UUID 重复注册了 main 已注册的 `CodexAppServerQueueSubmission.swift`，只保留了真正新增的文件。

## 验证

- `go build ./...`、`go test ./internal/httpapi/... ./internal/appserver/...`（rebase 后 `-count=1` 复跑）全绿
- `bash ./scripts/test-macos-app.sh`：68 项全过，比 main 多 6 项，即 MIM-226 新增用例
- `bash ./scripts/ios-dev.sh test`：873 项、15 个失败，与 `origin/main` 干净基线**逐条一致**（`ConversationDataFlowTests` 2 项 + `ConversationSnapshotTests` 13 项，均为 main 上既有失败），无新增回归
- `bash ./scripts/check-source-size.sh` 通过

## 尚未完成

- 运行态验证未做：MIM-225 的 agentd 真实退出回收、MIM-226 的 Mac 菜单状态跃迁都只有单测覆盖
- `go test ./...` 全量另有 2 个失败（`internal/claudeenv`、`internal/setup`），已在干净的 `origin/main` worktree 上复现，属于既有问题，与本 PR 无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)
