### PR TITLE
MIM-240 Fix iPad workspace runtime tab restoration

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		A7BFE2529FB2612C5B111B56 /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-mini-744-light.png in Resources */ = {isa = PBXBuildFile; fileRef = AA3FAE227E24D21CD42E3761 /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-mini-744-light.png */; };
 		A7CF7C20E5D854D900452377 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-390-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = 1F4C7F055E8F17853BC7CB04 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-390-dark.png */; };
 		A88F2FBBEE8A6F5F5C0283F5 /* UnifiedWorkbenchShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089CDD9B409CEDE6D600DA58 /* UnifiedWorkbenchShell.swift */; };
+		317000000000000000000002 /* WorkspaceWorkbenchRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317000000000000000000001 /* WorkspaceWorkbenchRootView.swift */; };
 		A9672A5CCD14CB34B13ED66A /* CodexAppServerThreadOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3F9E8A8ED2FD8317FB92F2 /* CodexAppServerThreadOwnership.swift */; };
 		AADCBC7617C842DC51799171 /* MimiInteractionFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C746BA73EAA9E0C19B0C0E4 /* MimiInteractionFeedback.swift */; };
 		AD2BA4EB75791D6DA68D6A46 /* ConversationConnectionRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */; };
@@ -383,6 +384,7 @@
 		07BAA9DB4A44577D0DBAC730 /* SkillInterfaceViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillInterfaceViews.swift; sourceTree = "<group>"; };
 		08549513F9D308C94B5C1938 /* WorkbenchSidebarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkbenchSidebarComponents.swift; sourceTree = "<group>"; };
 		089CDD9B409CEDE6D600DA58 /* UnifiedWorkbenchShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedWorkbenchShell.swift; sourceTree = "<group>"; };
+		317000000000000000000001 /* WorkspaceWorkbenchRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceWorkbenchRootView.swift; sourceTree = "<group>"; };
 		0CD3911F5991428A7A3D47EE /* testConnectedStateStaysQuiet.connected-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testConnectedStateStaysQuiet.connected-compact.png"; sourceTree = "<group>"; };
 		0FC920B8D7FE7F76E2C18FD7 /* testConversationBubbleAlignment.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testConversationBubbleAlignment.1.png; sourceTree = "<group>"; };
 		1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshotCoordinator.swift; sourceTree = "<group>"; };
@@ -1221,6 +1223,7 @@
 				B7E83526E3C22DF48B2DD911 /* NewSessionPresentationSource.swift */,
 				E992D8F1A54C9726692225BA /* NewSessionSheet.swift */,
 				089CDD9B409CEDE6D600DA58 /* UnifiedWorkbenchShell.swift */,
+				317000000000000000000001 /* WorkspaceWorkbenchRootView.swift */,
 				08549513F9D308C94B5C1938 /* WorkbenchSidebarComponents.swift */,
 			);
 			path = Shell;
@@ -1868,6 +1871,7 @@
 				8793E07E19375B78629AC0F3 /* TokenActivityView.swift in Sources */,
 				958AE82A3087284FEE63DBB8 /* TokenStore.swift in Sources */,
 				A88F2FBBEE8A6F5F5C0283F5 /* UnifiedWorkbenchShell.swift in Sources */,
+				317000000000000000000002 /* WorkspaceWorkbenchRootView.swift in Sources */,
 				B5BAC2CFD69E8F6E30996369 /* VoiceInputPreferences.swift in Sources */,
 				26187C1CD9C32B84B41153D0 /* WorkbenchChrome.swift in Sources */,
 				94E3CCCEB33D4DB58965C7DB /* WorkbenchSidebarComponents.swift in Sources */,

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -249,7 +249,7 @@ struct WorkspaceRootView: View {
     private let currentDate: () -> Date
 
     @State private var selectedWorkspaceID: String?
-    @State private var selectedSessionRuntime: WorkspaceSessionRuntimeChoice = .codex
+    @Binding private var selectedSessionRuntime: WorkspaceSessionRuntimeChoice
     @State private var catalogLoad = WorkspaceCatalogLoadCoordinator()
     @State private var runtimeSessionPagesByKey: [WorkspaceSessionPresentationKey: WorkspaceRuntimeSessionPageState] = [:]
     @State private var sessionLoadStates: [WorkspaceSessionPresentationKey: WorkspaceSessionLoadState] = [:]
@@ -267,6 +267,7 @@ struct WorkspaceRootView: View {
     @State private var pendingHapticWorkspaceID: String?
     @State private var suppressedHapticWorkspaceID: String?
     init(
+        selectedSessionRuntime: Binding<WorkspaceSessionRuntimeChoice>,
         onStartSession: @escaping (AgentProject, WorkspaceSessionRuntimeChoice) -> Void,
         onOpenSession: @escaping (AgentSession) -> Void = { _ in },
         manageConnections: (() -> Void)? = nil,
@@ -280,6 +281,7 @@ struct WorkspaceRootView: View {
         self.manageConnections = manageConnections
         self.embedsNavigationStack = embedsNavigationStack
         self.currentDate = currentDate
+        _selectedSessionRuntime = selectedSessionRuntime
         _appearanceStore = StateObject(wrappedValue: appearanceStore ?? WorkspaceAppearanceStore())
         // 正常入口仍由 synchronizeSelection 恢复选择；显式初值只服务于确定性的预览和视觉快照。
         _selectedWorkspaceID = State(initialValue: initialWorkspaceID)

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -34,6 +34,7 @@ struct UnifiedWorkbenchShell: View {
     @State private var didApplyDebugLaunchRoute = false
     @State private var selectedRelatedSubagent: SessionContextSubagent?
     @State private var relatedSubagentParentID: SessionID?
+    @State private var selectedWorkspaceSessionRuntime: WorkspaceSessionRuntimeChoice = .codex
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
@@ -1209,6 +1210,7 @@ struct UnifiedWorkbenchShell: View {
         }
 
         return WorkspaceRootView(
+            selectedSessionRuntime: $selectedWorkspaceSessionRuntime,
             onStartSession: { project, runtimeChoice in
                 Task {
                     await sessionStore.startNewSession(in: project, runtimeProvider: runtimeChoice.runtimeProvider)

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -94,6 +94,7 @@ struct UnifiedWorkbenchShell: View {
             }
             .onChange(of: appStore.activeHostScope.profileID) { _, _ in
                 synchronizeSidebarLifecycle()
+                selectedWorkspaceSessionRuntime = .codex // Runtime 能力按主机隔离，切换后不能继承旧主机选择。
             }
             .onChange(of: layout.usesCompactNavigation) { _, usesCompactNavigation in
                 handleLayoutModeChange(

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -34,7 +34,7 @@ struct UnifiedWorkbenchShell: View {
     @State private var didApplyDebugLaunchRoute = false
     @State private var selectedRelatedSubagent: SessionContextSubagent?
     @State private var relatedSubagentParentID: SessionID?
-    @State private var selectedWorkspaceSessionRuntime: WorkspaceSessionRuntimeChoice = .codex
+    @State private var workspaceRuntimeSelection = WorkspaceRuntimeSelectionState()
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
@@ -94,7 +94,7 @@ struct UnifiedWorkbenchShell: View {
             }
             .onChange(of: appStore.activeHostScope.profileID) { _, _ in
                 synchronizeSidebarLifecycle()
-                selectedWorkspaceSessionRuntime = .codex // Runtime 能力按主机隔离，切换后不能继承旧主机选择。
+                workspaceRuntimeSelection.resetForHostChange()
             }
             .onChange(of: layout.usesCompactNavigation) { _, usesCompactNavigation in
                 handleLayoutModeChange(
@@ -1201,32 +1201,17 @@ struct UnifiedWorkbenchShell: View {
     }
 
     private func workspaces(layout: WorkbenchLayout) -> some View {
-        let manageConnections: (() -> Void)?
-        if layout.usesCompactNavigation && layout.isPhone {
-            manageConnections = {
+        WorkspaceWorkbenchRootView(
+            usesCompactNavigation: layout.usesCompactNavigation,
+            isPhone: layout.isPhone,
+            onManageConnections: {
                 openConnectionSettings(layout: layout)
-            }
-        } else {
-            manageConnections = nil
-        }
-
-        return WorkspaceRootView(
-            selectedSessionRuntime: $selectedWorkspaceSessionRuntime,
-            onStartSession: { project, runtimeChoice in
-                Task {
-                    await sessionStore.startNewSession(in: project, runtimeProvider: runtimeChoice.runtimeProvider)
-                }
             },
             onOpenSession: { session in
                 // 选择会话和切换路由由同一个入口发起，避免 selectedSessionID 的回调再次 open。
                 openSession(session, source: .workspaces, layout: layout)
             },
-            manageConnections: manageConnections,
-            // 紧凑布局的 destination 必须复用外层绑定 path 的 NavigationStack。
-            embedsNavigationStack: WorkspaceRootView.shouldEmbedNavigationStack(
-                usesCompactNavigation: layout.usesCompactNavigation
-            ),
-            appearanceStore: workspaceAppearanceStore
+            selectedRuntime: $workspaceRuntimeSelection.selectedRuntime
         )
     }
 

--- a/ios/MimiRemote/Sources/Features/Shell/WorkspaceWorkbenchRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/WorkspaceWorkbenchRootView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// 选择值必须由 Shell 持有，确保会话详情替换工作区根视图时不会丢失；
+/// 状态规则留在独立类型中，避免继续把工作区职责堆入 Shell。
+struct WorkspaceRuntimeSelectionState {
+    var selectedRuntime: WorkspaceSessionRuntimeChoice = .codex
+
+    mutating func resetForHostChange() {
+        selectedRuntime = .codex
+    }
+}
+
+struct WorkspaceWorkbenchRootView: View {
+    @EnvironmentObject private var sessionStore: SessionStore
+    @EnvironmentObject private var workspaceAppearanceStore: WorkspaceAppearanceStore
+
+    let usesCompactNavigation: Bool
+    let isPhone: Bool
+    let onManageConnections: () -> Void
+    let onOpenSession: (AgentSession) -> Void
+    @Binding var selectedRuntime: WorkspaceSessionRuntimeChoice
+
+    var body: some View {
+        WorkspaceRootView(
+            selectedSessionRuntime: $selectedRuntime,
+            onStartSession: startSession,
+            onOpenSession: onOpenSession,
+            manageConnections: manageConnections,
+            embedsNavigationStack: WorkspaceRootView.shouldEmbedNavigationStack(
+                usesCompactNavigation: usesCompactNavigation
+            ),
+            appearanceStore: workspaceAppearanceStore
+        )
+    }
+
+    private var manageConnections: (() -> Void)? {
+        guard usesCompactNavigation, isPhone else { return nil }
+        return onManageConnections
+    }
+
+    private func startSession(
+        project: AgentProject,
+        runtimeChoice: WorkspaceSessionRuntimeChoice
+    ) {
+        Task {
+            await sessionStore.startNewSession(
+                in: project,
+                runtimeProvider: runtimeChoice.runtimeProvider
+            )
+        }
+    }
+}

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -168,6 +168,7 @@ extension SessionStore {
         let selectedSessionID = "debug-session-layout"
         let runningSessionID = "debug-session-running"
         let historySessionID = "debug-session-workspace"
+        let claudeSessionID = "debug-session-claude"
         // MCP 审批样例只在显式 Debug 参数下出现，用于真机检查 Codex 声明的
         // 一次、会话和永久信任入口；不连接真实 MCP，也不会写入用户授权配置。
         let mcpApproval = appStore.shouldSeedDebugMCPApprovalUI
@@ -227,6 +228,20 @@ extension SessionStore {
                 createdAt: now.addingTimeInterval(-60 * 180),
                 updatedAt: now.addingTimeInterval(-60 * 28),
                 preview: L10n.text("ui.supplemented_with_executable_commands_configuration_examples_and_troubleshooting")
+            ),
+            AgentSession(
+                id: claudeSessionID,
+                projectID: mimiDemo.id,
+                project: mimiDemo.name,
+                dir: mimiDemo.path,
+                title: L10n.text("ui.organize_open_source_release_notes"),
+                status: SessionStatus.completed.rawValue,
+                source: "debug",
+                runtimeProvider: "claude",
+                resumeID: claudeSessionID,
+                createdAt: now.addingTimeInterval(-60 * 55),
+                updatedAt: now.addingTimeInterval(-60 * 4),
+                preview: L10n.text("ui.review_installation_steps_architecture_diagrams_privacy_boundaries_and")
             )
         ]
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceStripPresentationTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import MimiRemote
 
 final class WorkspaceStripPresentationTests: XCTestCase {
+    func testWorkspaceRuntimeSelectionResetsForHostChange() {
+        var state = WorkspaceRuntimeSelectionState(selectedRuntime: .claude)
+
+        state.resetForHostChange()
+
+        XCTAssertEqual(state.selectedRuntime, .codex)
+    }
+
     func testBottomTabBarMappingUsesDeviceSizeClassAndSystemGeneration() {
         XCTAssertTrue(
             WorkbenchPageLayout.hasBottomTabBar(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceVisualSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceVisualSnapshotTests.swift
@@ -263,6 +263,7 @@ final class WorkspaceVisualSnapshotTests: XCTestCase {
             : max(bottomSafeAreaInset, WorkbenchPageLayout.regularPadding)
 
         let view = WorkspaceRootView(
+            selectedSessionRuntime: .constant(.codex),
             onStartSession: { _, _ in },
             onOpenSession: { _ in },
             manageConnections: hasBottomTabBar ? {} : nil,

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/MimiRemotePhysicalSmokeUITests.swift
@@ -832,8 +832,13 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
         let workspaceBrowser = app.descendant(identifier: "workspace.browser")
         XCTAssertTrue(workspaceBrowser.waitForExistence(timeout: 10), "工作区内容应保持可访问")
 
-        let session = app.descendant(identifier: "workspace.session.debug-session-layout")
-        XCTAssertTrue(scrollUntilHittable(session), "工作区应提供可点击的 Debug 会话入口")
+        let claudeRuntime = app.descendant(identifier: "workspace.sessions.runtime.claude")
+        XCTAssertTrue(claudeRuntime.waitForExistence(timeout: 8), "工作区应提供 Claude Runtime 标签")
+        claudeRuntime.tap()
+        XCTAssertTrue(claudeRuntime.isSelected, "Claude Runtime 标签应进入选中态")
+
+        let session = app.descendant(identifier: "workspace.session.debug-session-claude")
+        XCTAssertTrue(scrollUntilHittable(session), "工作区应提供可点击的 Claude Debug 会话入口")
         session.tap()
 
         let workspaceBack = app.descendant(identifier: "sessionDetail.workspaceBack")
@@ -873,6 +878,7 @@ final class MimiRemotePhysicalSmokeUITests: XCTestCase {
             workspaceBack.waitForNonExistence(timeout: 8),
             "回到工作区后不应残留会话详情返回按钮"
         )
+        XCTAssertTrue(claudeRuntime.isSelected, "返回工作区后应保留进入详情前的 Claude Runtime 标签")
         if showSidebar.exists {
             // 恢复共享的 SceneStorage 状态，避免影响后续 UI 用例。
             showSidebar.tap()


### PR DESCRIPTION
## 变更

- 将工作区 Runtime 标签选择状态提升到长期存活的 Shell
- 避免 iPad 宽布局从会话详情返回时重建根视图并重置为 Codex
- 增加 Claude Debug 会话和对应的返回路径 UI 回归

## 验证

- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/WorkspaceStripPresentationTests`：7 项通过，0 失败
- `SCHEME=MimiRemotePhysicalUITests bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteUITests/MimiRemotePhysicalSmokeUITests/testWideIPadWorkspaceSessionDetailShowsWorkspaceBackButton`：1 项通过，0 失败
- `git diff --check`：通过

## 已知限制

- `bash ./scripts/check-source-size.sh` 会扫描仓库现有 `.claude/worktrees/**`，并被其中的超限文件阻断。本次 5 个改动文件均低于对应上限。

Linear: https://linear.app/code89757/issue/MIM-240/ipad-从-claude-会话详情返回后错误切到-codex-标签