### PR TITLE
MIM-263 Launch shared App Server from a stable working directory

### DIFF
--- a/internal/appserver/shared_local.go
+++ b/internal/appserver/shared_local.go
@@ -245,8 +245,16 @@ func startSharedLocalAppServer(ctx context.Context, options SharedLocalOptions) 
 }
 
 func startResidentCommand(bin string, args []string, extraEnv map[string]string) error {
+	workingDirectory, err := sharedLocalWorkingDirectory(extraEnv)
+	if err != nil {
+		return err
+	}
 	cmd := exec.CommandContext(context.Background(), bin, args...)
 	configureSharedLocalCommand(cmd)
+	// The installer may invoke agentd from a temporary extraction directory.
+	// The resident server outlives that directory, and Codex needs a valid cwd
+	// later when it resolves thread/list workspace filters.
+	cmd.Dir = workingDirectory
 	cmd.Env = buildManagedEnv(extraEnv)
 	cmd.Stdout = io.Discard
 	// resident outlives agentd. It must not retain a pipe whose reader
@@ -263,6 +271,31 @@ func startResidentCommand(bin string, args []string, extraEnv map[string]string)
 	case <-time.After(sharedLocalStartGrace):
 		return nil
 	}
+}
+
+func sharedLocalWorkingDirectory(extraEnv map[string]string) (string, error) {
+	home, overridden := extraEnv["HOME"]
+	if !overridden {
+		home = os.Getenv("HOME")
+	}
+	home = strings.TrimSpace(home)
+	if home == "" {
+		return "", errors.New("启动共享 Codex App Server 需要有效的 HOME")
+	}
+	if !filepath.IsAbs(home) {
+		return "", errors.New("启动共享 Codex App Server 要求 HOME 使用绝对路径")
+	}
+	info, err := os.Stat(home)
+	if err != nil {
+		return "", fmt.Errorf("共享 Codex App Server 的 HOME 不存在或不可访问：%w", err)
+	}
+	if !info.IsDir() {
+		return "", errors.New("共享 Codex App Server 的 HOME 不是目录")
+	}
+	if canonical, evalErr := filepath.EvalSymlinks(home); evalErr == nil {
+		home = canonical
+	}
+	return filepath.Clean(home), nil
 }
 
 func cloneStringMap(source map[string]string) map[string]string {

--- a/internal/appserver/shared_local_test.go
+++ b/internal/appserver/shared_local_test.go
@@ -141,6 +141,65 @@ func TestSharedLocalTransportDoesNotReplaceUnresponsiveSocket(t *testing.T) {
 	}
 }
 
+func TestStartResidentCommandUsesStableHome(t *testing.T) {
+	originalDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	launchDirectory := filepath.Join(root, "temporary-launch")
+	home := filepath.Join(root, "home")
+	for _, directory := range []string{launchDirectory, home} {
+		if err := os.Mkdir(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chdir(launchDirectory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalDirectory) })
+
+	marker := filepath.Join(root, "resident-cwd")
+	err = startResidentCommand(
+		"/bin/sh",
+		[]string{"-c", `pwd > "$MIMI_SHARED_LOCAL_CWD_MARKER"; sleep 1`},
+		map[string]string{
+			"HOME":                         home,
+			"MIMI_SHARED_LOCAL_CWD_MARKER": marker,
+		},
+	)
+	if chdirErr := os.Chdir(originalDirectory); chdirErr != nil {
+		t.Fatal(chdirErr)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(launchDirectory); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(contents)); got != home {
+		t.Fatalf("resident cwd = %q, want stable HOME %q", got, home)
+	}
+}
+
+func TestSharedLocalWorkingDirectoryRejectsInvalidHome(t *testing.T) {
+	for name, home := range map[string]string{
+		"empty":    "",
+		"relative": "relative/home",
+		"missing":  filepath.Join(t.TempDir(), "missing"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := sharedLocalWorkingDirectory(map[string]string{"HOME": home}); err == nil {
+				t.Fatalf("HOME %q should be rejected", home)
+			}
+		})
+	}
+}
+
 func shortSharedLocalCodexHome(t *testing.T) string {
 	t.Helper()
 	root, err := os.MkdirTemp("/tmp", "msl-")


### PR DESCRIPTION
## Summary
- launch the resident shared Codex App Server from the effective user HOME
- reject missing, relative, inaccessible, or non-directory HOME values with an actionable error
- cover startup from a temporary directory and prove the resident process uses stable HOME

## Root cause
The Linux installer starts agentd from a temporary extraction directory. The shared App Server outlives agentd and inherited that directory as cwd. Once the installer removed it, Codex thread/list rejected valid absolute cwd filters with ENOENT.

## Validation
- go test ./...
- bash ./scripts/check-source-size.sh
- git diff --check
- real systemd-run --user --scope cwd inheritance check

## Dependency
Stacked on MIM-242 / PR #318, where the Linux shared local App Server transport is introduced.