### PR TITLE
MIM-258 在 iOS 中购买和恢复 Mimi 托管连接

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -30,10 +30,10 @@
 		10823423F48BC5168353950D /* HostScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31112285F03CBD9AE20AD0C8 /* HostScope.swift */; };
 		10BBEBA839A9089F9659060F /* AgentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9811B3CE215E02A0D371878C /* AgentModels.swift */; };
 		10BF43237408412ED651F5B4 /* ConversationDataFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315746F97ABB8E16D93F98A4 /* ConversationDataFlowTests.swift */; };
-		A21400000000000000000002 /* ConversationTurnCompletionReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21400000000000000000001 /* ConversationTurnCompletionReconciliationTests.swift */; };
 		1158695E26ECDFF99A3B695C /* ConversationTimelineItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A305FDD191E4C8576AEF05B /* ConversationTimelineItemBuilder.swift */; };
 		1199D418934DD1AD5951DB65 /* SettingsConnectionCardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F394E738574CBD9914E54047 /* SettingsConnectionCardSnapshotTests.swift */; platformFilters = (ios, ); };
 		11C06689A068AD0284665A64 /* SettingsDetailViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CE79F38445F2FA0632F32 /* SettingsDetailViews.swift */; };
+		122264253C13D70043A627F0 /* ManagedConnectionEntitlementStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B963BEE564A9A53336B060 /* ManagedConnectionEntitlementStore.swift */; };
 		14B0D33C7157E674AA188280 /* DiffPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CC79160188BE6A5022A81 /* DiffPanelView.swift */; };
 		15091B49EAC652933A3EC0AC /* ConversationTurnInterruptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FC22D303D4E2D91D9D33EA /* ConversationTurnInterruptTests.swift */; };
 		16DE0C7960A8CAAE1D8A554F /* AppStoreCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB921BC2A9B03335E3C8171 /* AppStoreCapabilities.swift */; };
@@ -55,12 +55,14 @@
 		23AA3B5B65DB2FF5D2EFFD87 /* DataURLImageDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFE36A2B8257E443C9824FD /* DataURLImageDecoderTests.swift */; };
 		25ED4420B6E48AB3E087E472 /* MarkdownBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B8AB5E7FA65B685CDFF988 /* MarkdownBlockView.swift */; };
 		26187C1CD9C32B84B41153D0 /* WorkbenchChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934C51BEAFE68A6631D0331F /* WorkbenchChrome.swift */; };
+		26B42E7402DAE746AA5841B9 /* ConversationMessageDeliveryUncertaintyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB411FA23971D26635E4BC8 /* ConversationMessageDeliveryUncertaintyTests.swift */; };
 		26E3E83C0FD232569104A2BD /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png in Resources */ = {isa = PBXBuildFile; fileRef = CC5A74E63F1B363F7C8143C1 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png */; };
 		26F460F34C7BA2C10839F2CA /* testComposerStatusTrayCrowdedCompactWidth.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */; };
 		26FD0EEAC5360C26BD0CF2D0 /* SessionListLifecycleCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347A38B609AE9F5CCBD52029 /* SessionListLifecycleCoordinatorTests.swift */; };
 		279E8E85742A39CBD64F8C36 /* CarStatusSnapshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */; };
 		293498CD48F70C646F0DD612 /* CodexAppServerQueueSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = A571C41AE73754FB6C9FD6BC /* CodexAppServerQueueSubmission.swift */; };
 		2988A74079D67A66B14DFF98 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92342D7DF3BBF2BC0BF24FC /* SettingsView.swift */; };
+		29EE18E5D572B779CF19F20F /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png in Resources */ = {isa = PBXBuildFile; fileRef = E0EAC4CC35379B613A901E16 /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png */; };
 		2ACE5B224FFACB3AA6391C46 /* ConversationAppServerProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1254FA91BFD2E858AFBD539D /* ConversationAppServerProjectorTests.swift */; };
 		2AE9BDCF262C4E734D7E5EC1 /* testInlineChoiceRowsInDarkAppearance.inline-rows-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = 6C3F9050E71B72EDA2CEB2AC /* testInlineChoiceRowsInDarkAppearance.inline-rows-dark.png */; };
 		2B372F78E1EC09D8E4B7210F /* ConversationRuntimeTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A1F29F52DC5CC790708ACC /* ConversationRuntimeTestSupport.swift */; };
@@ -70,6 +72,7 @@
 		300D1F45B3554C6DBBD6B42B /* SubagentSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A21AAEB96727E4907BCCB3 /* SubagentSessionTests.swift */; };
 		305ECB04E77553124786333E /* WorkspaceStripPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71EF316D7633A27E8BFED9C /* WorkspaceStripPresentation.swift */; };
 		31B351EE974251896BA43252 /* SessionStoreHostSwitching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3369A709F1AC9D2CF790753C /* SessionStoreHostSwitching.swift */; };
+		32A0E61668E067F6489752B3 /* ConversationTurnCompletionReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935BC4C6AC831B2EAF7CA114 /* ConversationTurnCompletionReconciliationTests.swift */; };
 		32DBDC8F3CD7A4D20095C805 /* SessionStoreWorkspaceRuntimePagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = D430A72C9700460B5B2D8E3B /* SessionStoreWorkspaceRuntimePagination.swift */; };
 		332D0CF7E81E796945EFD9F0 /* ConversationActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6FA730D92E0B37BC0393F0 /* ConversationActivityRows.swift */; };
 		34F16E565666DBFB8CEBF4EF /* terms-of-use.md in Resources */ = {isa = PBXBuildFile; fileRef = 26A567B589D55867F71467D4 /* terms-of-use.md */; };
@@ -98,6 +101,7 @@
 		4591D34B23858CCCF543B9E3 /* MimiCarStatusWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9425462CC24F7B671411E87 /* MimiCarStatusWidget.swift */; };
 		45C1DA2766CF0D3F7DB0843C /* CodexAppServerTurnStartObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */; };
 		467ED9D49A463D5F5AF02A3C /* ConversationDataFlowTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078AEE7E4BDAC1751244A05A /* ConversationDataFlowTestSupport.swift */; };
+		491F23C64F7108C5B28BBD1B /* ManagedConnectionEntitlementStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417026D5C6353D2982527627 /* ManagedConnectionEntitlementStoreTests.swift */; };
 		49C17A8B6741B1D16B626FF6 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-claude-popover-420-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = AFDEF6C57E7FE342A5411C7B /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-claude-popover-420-dark.png */; };
 		4B13DBFDB232284E99D2BE1F /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-landscape.png in Resources */ = {isa = PBXBuildFile; fileRef = 7EC08924AD866CA7D83CCD6E /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-landscape.png */; };
 		4B4DDB0179C0326DBC0BBA00 /* GitQuickPublishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2FCF65A5A23A9D87948F4F /* GitQuickPublishTests.swift */; };
@@ -110,11 +114,8 @@
 		50544A89C240A84DC7F0C6BE /* RecentWorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1E5753D86397B541589878 /* RecentWorkspaceStore.swift */; };
 		509445C02B3E5D545DB2808B /* SessionStoreNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7DA3118F7DF5B276A9BE1D /* SessionStoreNetworking.swift */; };
 		523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */; };
-		A2240001A2240001A2240001 /* CodexAppServerConnectionReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2240002A2240002A2240002 /* CodexAppServerConnectionReliabilityTests.swift */; };
-		A2240003A2240003A2240003 /* ConversationMessageDeliveryUncertaintyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2240004A2240004A2240004 /* ConversationMessageDeliveryUncertaintyTests.swift */; };
 		5264A96AC8B711B42087FA3F /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C86A8DFF7254C2458488075 /* SessionListView.swift */; };
 		5344C41233BA0E47A0C29FDA /* CodexAppServerSessionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */; };
-		A223C001A223C001A223C001 /* CodexAppServerSessionConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A223C002A223C002A223C002 /* CodexAppServerSessionConnection.swift */; };
 		55A91A4B582F169DCE0C1197 /* ConversationMessageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B508E4FD0E447D4EEE2CC8 /* ConversationMessageRow.swift */; };
 		55C47BB6B9F792685CF30178 /* CarStatusSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F194D291F4AC7CA28CE52FD /* CarStatusSnapshot.swift */; };
 		55D43B731CFE9C5246B02D1C /* testComposerStatusTrayCrowdedState.1.png in Resources */ = {isa = PBXBuildFile; fileRef = E4C85188C13516219753D4ED /* testComposerStatusTrayCrowdedState.1.png */; };
@@ -126,6 +127,7 @@
 		5CC1C792F93F291FDD49FF09 /* ConnectionSpeedTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C3E59C8D5983AB7784558F /* ConnectionSpeedTestView.swift */; };
 		5CD51AE13B5D23F8FBE444C5 /* SessionStoreSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */; };
 		5FD1DBDBCD89B51F6B22D679 /* ConversationSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7C7C0DF7B33C596EBE5FC7 /* ConversationSnapshotTests.swift */; platformFilters = (ios, ); };
+		5FDCC383AE9448F83273EA84 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png in Resources */ = {isa = PBXBuildFile; fileRef = D2BF59E844D8092111547C64 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png */; };
 		613A97BCD065B780C6162C8E /* ConversationTimelineReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F938DA83B5613E99E202281D /* ConversationTimelineReducerTests.swift */; };
 		61FC963CFB3ED09059EDA70C /* testNoTerminalTurnUsesAccessibleLayeredLayout.1.png in Resources */ = {isa = PBXBuildFile; fileRef = A8E14D359CDA20CBF7E78DD1 /* testNoTerminalTurnUsesAccessibleLayeredLayout.1.png */; };
 		626E053AFAE30F345EEFC01D /* WorkspaceVisualSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327AF69020E348B4AE9F7BBE /* WorkspaceVisualSnapshotTests.swift */; platformFilters = (ios, ); };
@@ -136,6 +138,7 @@
 		6559D30A0E08074AEB1D65B4 /* CarStatusSnapshotMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332F6935AFF261FAA35F289A /* CarStatusSnapshotMapping.swift */; };
 		671C4601FF0BC177E460C60F /* AgentRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BCEEFCD8324800FC52F2DC /* AgentRuntimeModels.swift */; };
 		6825B228E6299F7577E5BB5F /* SessionContextSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68C2F3A2CDF72BEF743E31B /* SessionContextSidebarView.swift */; };
+		68CD22C1EBAF6F4B256A5CFD /* testSessionStateRingSemanticsAndAlignment.light.png in Resources */ = {isa = PBXBuildFile; fileRef = 3045D0EB3BA4153934CFC712 /* testSessionStateRingSemanticsAndAlignment.light.png */; };
 		696F45B5F56A3EB290292B28 /* ConversationHistoryItemEnrichmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EC542E43C2955804F35E34 /* ConversationHistoryItemEnrichmentTests.swift */; };
 		699762120516E7B19DB681E9 /* ConversationGuidanceFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */; };
 		69C750B399975CEDCEBC84B6 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-wide-1024.png in Resources */ = {isa = PBXBuildFile; fileRef = D51F224075928990E52845C8 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-wide-1024.png */; };
@@ -148,6 +151,7 @@
 		6EE0372C42829D55A92DA504 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FAD5B8DE8A8FD7FC216867 /* L10n.swift */; };
 		705F1646646DBB454684A718 /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163EC3A1080DFD2A3BB8F098 /* ComposerView.swift */; };
 		717992D232DA806812FB7A81 /* testFailedActivityWithoutPreviousResult.failed-empty-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = 36A4616D85FD81D7258E0C6B /* testFailedActivityWithoutPreviousResult.failed-empty-compact.png */; };
+		7301810E2D669985BC4C75EC /* testSessionProjectIconAndUnreadIndicatorCombinations.dark.png in Resources */ = {isa = PBXBuildFile; fileRef = E85CF2066687F5E5ED881FB9 /* testSessionProjectIconAndUnreadIndicatorCombinations.dark.png */; };
 		7380C6ED244A91FE8786269B /* QRCodeScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D29856557B35AE9C7C9B5EA /* QRCodeScannerSheet.swift */; };
 		74C33F1F00402E08A331ABBF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 11B71BA07C5D393BC0EA9FD4 /* PrivacyInfo.xcprivacy */; };
 		756EEE669429D13559D42B29 /* SessionStoreWriterConflictFork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56D1548EFFC65F793C18F9F /* SessionStoreWriterConflictFork.swift */; };
@@ -169,6 +173,7 @@
 		7EC0BC9D0E04B06658CC2EFC /* privacy-policy.md in Resources */ = {isa = PBXBuildFile; fileRef = 2210B237FCEF112D24D2B687 /* privacy-policy.md */; };
 		84F5B773E0438B85B671B2F3 /* AgentAPIClientRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC88F25CEBA6C13050A2B4F /* AgentAPIClientRequestTests.swift */; };
 		8579BB85C852E3DD247FF7EE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A3BB200E07DB4CD95503B8F7 /* InfoPlist.strings */; };
+		860DD71D11A4C4AF27322417 /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png in Resources */ = {isa = PBXBuildFile; fileRef = 5A88B5C73E15343C1B24DD2E /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png */; };
 		8721BBEBBD69DB0B07FACFF8 /* AppServerProtocolModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67866EABC0460FF9A4867E87 /* AppServerProtocolModels.swift */; };
 		8793E07E19375B78629AC0F3 /* TokenActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9D0ABC1C5BE608FFBD784A /* TokenActivityView.swift */; };
 		879CC5740352620BC5E9CA37 /* DataURLImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C87937DA9D34D00853E635B /* DataURLImageDecoder.swift */; };
@@ -186,6 +191,7 @@
 		91375DEC431AD94516A09B50 /* testSessionLibraryDensityAndAccessibilityLayouts.split-375-light.png in Resources */ = {isa = PBXBuildFile; fileRef = C3239D66289D53554BE278B7 /* testSessionLibraryDensityAndAccessibilityLayouts.split-375-light.png */; };
 		9361D05BC38C233F2B9EB122 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-popover-420.png in Resources */ = {isa = PBXBuildFile; fileRef = F7A631C01496AAA7C083AA6B /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-popover-420.png */; };
 		94E3CCCEB33D4DB58965C7DB /* WorkbenchSidebarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08549513F9D308C94B5C1938 /* WorkbenchSidebarComponents.swift */; };
+		94EEB0914AE0A3B80C58139C /* testSessionStateRingSemanticsAndAlignment.dark.png in Resources */ = {isa = PBXBuildFile; fileRef = D31234CAC3FCACA63F93285D /* testSessionStateRingSemanticsAndAlignment.dark.png */; };
 		951475AE3120CB42A905E3B3 /* WorkspaceGitSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85879EDF3D64609C3C6BA873 /* WorkspaceGitSummaryTests.swift */; };
 		958AE82A3087284FEE63DBB8 /* TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30F059863E0778E0B00065D /* TokenStore.swift */; };
 		95B2C9AB9817A406C547063F /* ConversationSessionArchiveMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8EF812560A139C665A9D46 /* ConversationSessionArchiveMutationTests.swift */; };
@@ -240,6 +246,7 @@
 		B94659A58D5F94B552D90D4F /* ComposerRequestCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41787BD804E7C9AD16448E38 /* ComposerRequestCards.swift */; };
 		BA0F184AA3E72EE6A5A291B5 /* ConversationDirectRuntimeSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FE3675988DBD54585B3A79 /* ConversationDirectRuntimeSubscriptionTests.swift */; };
 		BA142EA7D865810EAD1A968F /* testEmptyActivityDrawsInactiveGrid.empty-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = 52836A26EDEF7D6BD84CA133 /* testEmptyActivityDrawsInactiveGrid.empty-compact.png */; };
+		BAA573B7BCCDD95153331C04 /* ManagedConnectionStoreKitClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8F22C82C007839E2D06A90 /* ManagedConnectionStoreKitClient.swift */; };
 		BC8113C02839555625D96A97 /* FloatingSidebarPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECDC4F6FDDB66F610BF6FC2D /* FloatingSidebarPresentation.swift */; };
 		BC8B20DA0FE42207D5D2CA8C /* ComposerTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E9EA7D6A93EB6697C0B874 /* ComposerTextEditor.swift */; };
 		BC9DC86B9FC058DBBDDDAE0F /* testPermissionOptionPageShowsEveryDetail.permission-page-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = 73B98B7856DBCB29BD8FA4BB /* testPermissionOptionPageShowsEveryDetail.permission-page-compact.png */; };
@@ -249,6 +256,7 @@
 		C1603B73BC400064D13B6605 /* ConversationMessageAccessories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04740AD795D6AEEF87C98B35 /* ConversationMessageAccessories.swift */; };
 		C1F8D4D973088684344C9DB6 /* CodexAppServerTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */; };
 		C210A34CBF8FA1E9E901C5E1 /* ConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2BF4F63781123B8E297F7E /* ConversationView.swift */; };
+		C2A5B9C8EBB21410389D102D /* testSessionProjectIconAndUnreadIndicatorCombinations.light.png in Resources */ = {isa = PBXBuildFile; fileRef = 9607D17E063FDB600DF0A5D8 /* testSessionProjectIconAndUnreadIndicatorCombinations.light.png */; };
 		C2D97EE88079FB92A5C4607E /* SkillInterfaceViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BAA9DB4A44577D0DBAC730 /* SkillInterfaceViews.swift */; };
 		C307E784005DC26AFE2F011A /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, ); productRef = 049E99C4B10EFCC1501BD5D0 /* SnapshotTesting */; };
 		C3888EEDA33757A28268C27F /* WriterConflictCardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85D6ABA1F92A0E715AA179A7 /* WriterConflictCardSnapshotTests.swift */; };
@@ -274,15 +282,16 @@
 		D4B700AC9DF628887258F469 /* SessionStoreTurns.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38A8CE5A8F1D7EE3889F078 /* SessionStoreTurns.swift */; };
 		D502C332F16B48F95CAAA518 /* HostInstallationSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D9D8852662655DFC4D9FA0 /* HostInstallationSetupView.swift */; };
 		D553354748283A2778CB2BB0 /* SessionIndexRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE054889375B16BD215CC157 /* SessionIndexRow.swift */; };
+		D57E56FF06B77F225C0F436E /* ManagedConnectionEntitlementAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC8F89BF1B2CDD9984B85B7 /* ManagedConnectionEntitlementAPIClient.swift */; };
 		D681218B9C336370B3C784B7 /* WorkspaceAppearancePickers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15CA396BC1238F85AAB82FC /* WorkspaceAppearancePickers.swift */; };
 		D6D632D45E8487C3DEAC4429 /* NewSessionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E992D8F1A54C9726692225BA /* NewSessionSheet.swift */; };
 		D8263551DECB2E7EBCD66E3B /* testSessionRuntimeBadgesInConversationList.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */; };
 		DAAB5AD21F6B77F6D691B94F /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373EDA921B7F6B3F6B680140 /* ConversationStore.swift */; };
-		C224D001C224D001C224D001 /* ConversationStoreDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = C224D002C224D002C224D002 /* ConversationStoreDelivery.swift */; };
-		A2250001A2250001A2250001 /* ConversationMessageDeliveryReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2250002A2250002A2250002 /* ConversationMessageDeliveryReconciler.swift */; };
+		DAF89EB953E1D2438E4AF4E9 /* ConversationMessageDeliveryReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBCEEF3A7D3D84A709984E8 /* ConversationMessageDeliveryReconciler.swift */; };
 		DC2F420929F4E30D3B6AC6DE /* ConnectionProfileModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6C8F9B82DA43620543124E /* ConnectionProfileModels.swift */; };
 		DDB05F720316DF94C27BB541 /* AppStoreConnectionTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934F6F53C8E42FE3700DFDD9 /* AppStoreConnectionTesting.swift */; };
 		DDCFB91D621190F7BA26678D /* AppExternalLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28C291AC46CF73586F8764A /* AppExternalLinks.swift */; };
+		E02D70CAB2822FE39664F749 /* ManagedConnectionSubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507C31D592377CA009E2CCA9 /* ManagedConnectionSubscriptionView.swift */; };
 		E158B34D71964DBF782D1DDF /* MimiRemoteApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B337007E06BFD01501A0C9BD /* MimiRemoteApp.swift */; };
 		E16971051CD43D45FB6F1AC2 /* testComposerStatusTrayCollapsedBlockedObserveDark.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 73D66A2386FC885F7D813B26 /* testComposerStatusTrayCollapsedBlockedObserveDark.1.png */; };
 		E19C681FE60B4E63CF29AA69 /* WorkspaceAppearanceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D0FB9DA0913B603240372D /* WorkspaceAppearanceStore.swift */; };
@@ -298,9 +307,11 @@
 		E7EE1A6D1A2A19F69E8F6513 /* testConversationBubbleAlignment.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 0FC920B8D7FE7F76E2C18FD7 /* testConversationBubbleAlignment.1.png */; };
 		E7FC3AD225CFC9F68DC4A747 /* testFailedActivityWithPreviousResultMarksStale.failed-stale-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = C046E85BE74694A223E5D0A8 /* testFailedActivityWithPreviousResultMarksStale.failed-stale-compact.png */; };
 		E811D57414AC2415D22ADDF0 /* APIResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B02E274C8B9B137FF4ACB /* APIResponses.swift */; };
+		E8A3EE0F4BD132102FB68EAC /* ConversationStoreDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454132341FC2CC31B453D26C /* ConversationStoreDelivery.swift */; };
 		E8CF63B25946995924E1B888 /* InitialConnectionSettingsSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C75EB69B7DE1AAE7350B2C5 /* InitialConnectionSettingsSections.swift */; };
 		E930993420D89B0942BB732C /* testComposerStatusTrayIPadMiniPortraitWidth.1.png in Resources */ = {isa = PBXBuildFile; fileRef = EBF24E2B6355EF529578DE9D /* testComposerStatusTrayIPadMiniPortraitWidth.1.png */; };
 		EA70EC72EE3F9B6B81CF4E71 /* WorkspaceSessionLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C896DA13C5A44DA224A17CAB /* WorkspaceSessionLoadingTests.swift */; };
+		EB5D0D19189AB5059993D8C9 /* CodexAppServerConnectionReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D05A1A4E037DC2EE90B7747 /* CodexAppServerConnectionReliabilityTests.swift */; };
 		EBABC0B9B50741A815FE97E5 /* testWorkspaceCurrentDirectoryBreadcrumbKeepsUnreachablePrefixReadable.1.png in Resources */ = {isa = PBXBuildFile; fileRef = C765EBF0BCDC57B117B98C1F /* testWorkspaceCurrentDirectoryBreadcrumbKeepsUnreachablePrefixReadable.1.png */; };
 		EC9D3E7F32C22BE4965292BA /* testInlineChoiceRowsOnCompactWidth.inline-rows-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = 6D5108122AC9C253A5B8361D /* testInlineChoiceRowsOnCompactWidth.inline-rows-compact.png */; };
 		ED9957215DF250BC0CDFE040 /* HostSwitcherMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01D29CF13ECEA0EBF33BF7C /* HostSwitcherMenu.swift */; };
@@ -315,6 +326,7 @@
 		F430ECB13EE142C8AB67D5DF /* ConversationTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730CE8CD91CC2F2DFB5E6FBA /* ConversationTimelineView.swift */; };
 		F52369AA62CB6C0A7664D4B0 /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 712B1CDEF343C4D9D338DDDC /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png */; };
 		F62ED83D8C47C235F1124972 /* testEmptyConversationShowsCurrentDirectoryAcrossAppearances.ipad-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = B9F486B1F9E0E676B63B7084 /* testEmptyConversationShowsCurrentDirectoryAcrossAppearances.ipad-dark.png */; };
+		F660CF6678E0A20AFBA5755C /* CodexAppServerSessionConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049E1F8A9BBD15AF6BEE9E28 /* CodexAppServerSessionConnection.swift */; };
 		F6BD11C8457F7429102EC4C3 /* FileAttachmentPreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3474AF2F3AA856519A20B642 /* FileAttachmentPreparer.swift */; };
 		F74D6310E9AFC552D2232D9C /* testSingleWindowStaysStackedOnRegularWidth.single-window-regular.png in Resources */ = {isa = PBXBuildFile; fileRef = C7F7AE9D39F38BF3AF9298AE /* testSingleWindowStaysStackedOnRegularWidth.single-window-regular.png */; };
 		F74E4A74B92B6A73077CDFBC /* testWorkspaceOpenCurrentDirectoryToolbarButton.1.png in Resources */ = {isa = PBXBuildFile; fileRef = A402F06F84151CC5CD1041D9 /* testWorkspaceOpenCurrentDirectoryToolbarButton.1.png */; };
@@ -371,11 +383,10 @@
 		00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCrowdedCompactWidth.1.png; sourceTree = "<group>"; };
 		023D47371A66B1C8E92BB3D4 /* testSessionLibraryDensityAndAccessibilityLayouts.iphone-390-light.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSessionLibraryDensityAndAccessibilityLayouts.iphone-390-light.png"; sourceTree = "<group>"; };
 		025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeTests.swift; sourceTree = "<group>"; };
-		A2240002A2240002A2240002 /* CodexAppServerConnectionReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerConnectionReliabilityTests.swift; sourceTree = "<group>"; };
-		A2240004A2240004A2240004 /* ConversationMessageDeliveryUncertaintyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageDeliveryUncertaintyTests.swift; sourceTree = "<group>"; };
 		02BA631A94730FC521FE15F6 /* AssistantTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantTextNormalizer.swift; sourceTree = "<group>"; };
 		033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationRuntimeFlowTests.swift; sourceTree = "<group>"; };
 		04740AD795D6AEEF87C98B35 /* ConversationMessageAccessories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageAccessories.swift; sourceTree = "<group>"; };
+		049E1F8A9BBD15AF6BEE9E28 /* CodexAppServerSessionConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionConnection.swift; sourceTree = "<group>"; };
 		053D35545CB6F6F836EAADBA /* HostWarmSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostWarmSnapshotTests.swift; sourceTree = "<group>"; };
 		073C831970D1BA4EBC3FD572 /* SessionListLifecycleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListLifecycleCoordinator.swift; sourceTree = "<group>"; };
 		075FEFC74C482609AAAEEA39 /* TailcatExperimentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailcatExperimentController.swift; sourceTree = "<group>"; };
@@ -429,9 +440,9 @@
 		2E4A0A29797384D5BD5002D1 /* testProjectSessionDashboard.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testProjectSessionDashboard.1.png; sourceTree = "<group>"; };
 		2EBD11FEEFA3EA7C03993BE1 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png; sourceTree = "<group>"; };
 		302CD30CD51E926987FAD6C3 /* ProfileRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRootView.swift; sourceTree = "<group>"; };
+		3045D0EB3BA4153934CFC712 /* testSessionStateRingSemanticsAndAlignment.light.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionStateRingSemanticsAndAlignment.light.png; sourceTree = "<group>"; };
 		31112285F03CBD9AE20AD0C8 /* HostScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostScope.swift; sourceTree = "<group>"; };
 		315746F97ABB8E16D93F98A4 /* ConversationDataFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDataFlowTests.swift; sourceTree = "<group>"; };
-		A21400000000000000000001 /* ConversationTurnCompletionReconciliationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTurnCompletionReconciliationTests.swift; sourceTree = "<group>"; };
 		327AF69020E348B4AE9F7BBE /* WorkspaceVisualSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceVisualSnapshotTests.swift; sourceTree = "<group>"; };
 		32B0C62898434614552F1165 /* ComposerModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelSelection.swift; sourceTree = "<group>"; };
 		332F6935AFF261FAA35F289A /* CarStatusSnapshotMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshotMapping.swift; sourceTree = "<group>"; };
@@ -442,8 +453,6 @@
 		3555A6B1D0904604B0ADC859 /* testUnsupportedActivityShowsExplanation.unsupported-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testUnsupportedActivityShowsExplanation.unsupported-compact.png"; sourceTree = "<group>"; };
 		36A4616D85FD81D7258E0C6B /* testFailedActivityWithoutPreviousResult.failed-empty-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testFailedActivityWithoutPreviousResult.failed-empty-compact.png"; sourceTree = "<group>"; };
 		373EDA921B7F6B3F6B680140 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
-		C224D002C224D002C224D002 /* ConversationStoreDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStoreDelivery.swift; sourceTree = "<group>"; };
-		A2250002A2250002A2250002 /* ConversationMessageDeliveryReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageDeliveryReconciler.swift; sourceTree = "<group>"; };
 		37D188E86B957818696CFF00 /* FloatingSidebarPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingSidebarPresentationTests.swift; sourceTree = "<group>"; };
 		38004512B302AB5F8AD23644 /* testEmptyConversationState.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testEmptyConversationState.1.png; sourceTree = "<group>"; };
 		3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationGuidanceFallbackTests.swift; sourceTree = "<group>"; };
@@ -455,8 +464,10 @@
 		3E5219F30FB1F37F4EE868FF /* SessionListPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListPresentationTests.swift; sourceTree = "<group>"; };
 		405D5433F81D4DFCDCD6008B /* testLoadedActivityInDarkAppearance.loaded-compact-dark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLoadedActivityInDarkAppearance.loaded-compact-dark.png"; sourceTree = "<group>"; };
 		40A98707004C8DC4ED81CBCD /* ComposerVoiceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceSupport.swift; sourceTree = "<group>"; };
+		417026D5C6353D2982527627 /* ManagedConnectionEntitlementStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionEntitlementStoreTests.swift; sourceTree = "<group>"; };
 		41787BD804E7C9AD16448E38 /* ComposerRequestCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerRequestCards.swift; sourceTree = "<group>"; };
 		433E75D8BEEA45B9D02DDDCE /* testSessionRuntimeBadgesInConversationList.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionRuntimeBadgesInConversationList.1.png; sourceTree = "<group>"; };
+		454132341FC2CC31B453D26C /* ConversationStoreDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStoreDelivery.swift; sourceTree = "<group>"; };
 		469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionClients.swift; sourceTree = "<group>"; };
 		476737709E01875A7992BABB /* SkillModelPickerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillModelPickerSnapshotTests.swift; sourceTree = "<group>"; };
 		47C248AF3269FCB2C74A1925 /* testAccessibilityWorkspaceRowsGrowAndKeepDistinctPreview.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testAccessibilityWorkspaceRowsGrowAndKeepDistinctPreview.1.png; sourceTree = "<group>"; };
@@ -469,6 +480,7 @@
 		4F93698AE10EA771676747F8 /* testCompactWorkspaceRuntimeMenuOnPhoneWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCompactWorkspaceRuntimeMenuOnPhoneWidth.1.png; sourceTree = "<group>"; };
 		4FC2FBFEBA275A5869FC350D /* CameraAttachmentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAttachmentViews.swift; sourceTree = "<group>"; };
 		4FCDE6ACD44D941797C6186A /* testEmptyConversationShowsCurrentDirectoryAcrossAppearances.iphone-long-path-light.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testEmptyConversationShowsCurrentDirectoryAcrossAppearances.iphone-long-path-light.png"; sourceTree = "<group>"; };
+		507C31D592377CA009E2CCA9 /* ManagedConnectionSubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionSubscriptionView.swift; sourceTree = "<group>"; };
 		52051A97BB3979091B39EB95 /* EventReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventReducer.swift; sourceTree = "<group>"; };
 		528144CF5078B2715AF9D696 /* ShareJourneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareJourneyView.swift; sourceTree = "<group>"; };
 		52836A26EDEF7D6BD84CA133 /* testEmptyActivityDrawsInactiveGrid.empty-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testEmptyActivityDrawsInactiveGrid.empty-compact.png"; sourceTree = "<group>"; };
@@ -485,6 +497,7 @@
 		5591601BA7CA64C8C0CF7931 /* direct_app_server_approval_stream.jsonl */ = {isa = PBXFileReference; path = direct_app_server_approval_stream.jsonl; sourceTree = "<group>"; };
 		55BE8A2883C5B158FC8D84FF /* SessionStoreQueuedTurns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreQueuedTurns.swift; sourceTree = "<group>"; };
 		59173E15ED2D45E1BDE19304 /* testConnectedStateInDarkAppearance.connected-dark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testConnectedStateInDarkAppearance.connected-dark.png"; sourceTree = "<group>"; };
+		5A88B5C73E15343C1B24DD2E /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png"; sourceTree = "<group>"; };
 		5C87937DA9D34D00853E635B /* DataURLImageDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLImageDecoder.swift; sourceTree = "<group>"; };
 		5C9DB99DDCE7CA778B616657 /* AppStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStore.swift; sourceTree = "<group>"; };
 		5F0B86402960D3109AD10CE7 /* TailscaleStableHostnameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailscaleStableHostnameTests.swift; sourceTree = "<group>"; };
@@ -508,6 +521,7 @@
 		6D5108122AC9C253A5B8361D /* testInlineChoiceRowsOnCompactWidth.inline-rows-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testInlineChoiceRowsOnCompactWidth.inline-rows-compact.png"; sourceTree = "<group>"; };
 		6D9D0ABC1C5BE608FFBD784A /* TokenActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenActivityView.swift; sourceTree = "<group>"; };
 		6DF3FE084B65924E2014463C /* AppStoreRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreRouting.swift; sourceTree = "<group>"; };
+		6E8F22C82C007839E2D06A90 /* ManagedConnectionStoreKitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionStoreKitClient.swift; sourceTree = "<group>"; };
 		6F194D291F4AC7CA28CE52FD /* CarStatusSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshot.swift; sourceTree = "<group>"; };
 		712B1CDEF343C4D9D338DDDC /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png; sourceTree = "<group>"; };
 		730CE8CD91CC2F2DFB5E6FBA /* ConversationTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTimelineView.swift; sourceTree = "<group>"; };
@@ -545,14 +559,18 @@
 		8B4ECA49F6D4856DA229139E /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		8C746BA73EAA9E0C19B0C0E4 /* MimiInteractionFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiInteractionFeedback.swift; sourceTree = "<group>"; };
 		8CAEACFD2E2425D3DAFDF904 /* THIRD_PARTY_NOTICES.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = THIRD_PARTY_NOTICES.md; path = ../../../THIRD_PARTY_NOTICES.md; sourceTree = "<group>"; };
+		8D05A1A4E037DC2EE90B7747 /* CodexAppServerConnectionReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerConnectionReliabilityTests.swift; sourceTree = "<group>"; };
 		8D23870E31FFF787AC7C14C0 /* WorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; };
 		8E5FA820000C5AD8FB8E1300 /* testDefaultDarkConversationPalette.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testDefaultDarkConversationPalette.1.png; sourceTree = "<group>"; };
 		8EABFF317C695883ECE910D0 /* PairingLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingLinkTests.swift; sourceTree = "<group>"; };
 		90B47F5F094477F8E0CDC100 /* testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390.png"; sourceTree = "<group>"; };
 		9143CBABCA38B2E316A221BB /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png; sourceTree = "<group>"; };
 		9145366BE7345CD146DFA0AE /* AnsiCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnsiCleaner.swift; sourceTree = "<group>"; };
+		91BA7011F99F49B437A5ACEF /* MimiRemote.storekit */ = {isa = PBXFileReference; path = MimiRemote.storekit; sourceTree = "<group>"; };
 		934C51BEAFE68A6631D0331F /* WorkbenchChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkbenchChrome.swift; sourceTree = "<group>"; };
 		934F6F53C8E42FE3700DFDD9 /* AppStoreConnectionTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreConnectionTesting.swift; sourceTree = "<group>"; };
+		935BC4C6AC831B2EAF7CA114 /* ConversationTurnCompletionReconciliationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTurnCompletionReconciliationTests.swift; sourceTree = "<group>"; };
+		9607D17E063FDB600DF0A5D8 /* testSessionProjectIconAndUnreadIndicatorCombinations.light.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionProjectIconAndUnreadIndicatorCombinations.light.png; sourceTree = "<group>"; };
 		96828E6273D517310CB01F52 /* SettingsDashboardViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDashboardViews.swift; sourceTree = "<group>"; };
 		9780397FF2CE07EEB329D676 /* ConversationTimelineCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTimelineCache.swift; sourceTree = "<group>"; };
 		97A0B761520F7AEF2F16D3DC /* SessionStoreConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreConnection.swift; sourceTree = "<group>"; };
@@ -598,6 +616,7 @@
 		BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerTransport.swift; sourceTree = "<group>"; };
 		BE054889375B16BD215CC157 /* SessionIndexRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexRow.swift; sourceTree = "<group>"; };
 		BEFC45E69D906A49E9EB6310 /* WorkspaceSessionRuntimePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionRuntimePicker.swift; sourceTree = "<group>"; };
+		BFC8F89BF1B2CDD9984B85B7 /* ManagedConnectionEntitlementAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionEntitlementAPIClient.swift; sourceTree = "<group>"; };
 		C01D29CF13ECEA0EBF33BF7C /* HostSwitcherMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostSwitcherMenu.swift; sourceTree = "<group>"; };
 		C046E85BE74694A223E5D0A8 /* testFailedActivityWithPreviousResultMarksStale.failed-stale-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testFailedActivityWithPreviousResultMarksStale.failed-stale-compact.png"; sourceTree = "<group>"; };
 		C0764989DE2B4FAEF1543FF5 /* CodexAppServerEventProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerEventProjection.swift; sourceTree = "<group>"; };
@@ -622,15 +641,17 @@
 		CA2BF4F63781123B8E297F7E /* ConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationView.swift; sourceTree = "<group>"; };
 		CB64B805952E5CC416C28EAF /* testCrossSessionContinuationHidesInternalAddresses.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCrossSessionContinuationHidesInternalAddresses.1.png; sourceTree = "<group>"; };
 		CC5A74E63F1B363F7C8143C1 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png"; sourceTree = "<group>"; };
+		CCBCEEF3A7D3D84A709984E8 /* ConversationMessageDeliveryReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageDeliveryReconciler.swift; sourceTree = "<group>"; };
 		CD9975BE3B6F00A870817B17 /* SessionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexStore.swift; sourceTree = "<group>"; };
 		CEB7A4F02C5EC7121D1BB6B9 /* WorktreeManagementViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeManagementViews.swift; sourceTree = "<group>"; };
 		CEE63E1F88F94DC3D0C543CF /* testComposerStatusTrayExtremelyNarrowCompactWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayExtremelyNarrowCompactWidth.1.png; sourceTree = "<group>"; };
 		D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionRuntime.swift; sourceTree = "<group>"; };
 		D231C6876074429C2374261A /* ForkOnWriterConflictProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkOnWriterConflictProtocolTests.swift; sourceTree = "<group>"; };
-		A223C002A223C002A223C002 /* CodexAppServerSessionConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionConnection.swift; sourceTree = "<group>"; };
 		D283CD0291735DA4425D91A4 /* WorkspaceRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRootView.swift; sourceTree = "<group>"; };
 		D28C291AC46CF73586F8764A /* AppExternalLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExternalLinks.swift; sourceTree = "<group>"; };
+		D2BF59E844D8092111547C64 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png"; sourceTree = "<group>"; };
 		D2F4BF550566258A06CF1F9B /* testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390-remote-url.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390-remote-url.png"; sourceTree = "<group>"; };
+		D31234CAC3FCACA63F93285D /* testSessionStateRingSemanticsAndAlignment.dark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionStateRingSemanticsAndAlignment.dark.png; sourceTree = "<group>"; };
 		D36F897C3DF848C89B87C926 /* testInlineUserInputCardMatchesApprovalChromeOnIPad.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testInlineUserInputCardMatchesApprovalChromeOnIPad.1.png; sourceTree = "<group>"; };
 		D430A72C9700460B5B2D8E3B /* SessionStoreWorkspaceRuntimePagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreWorkspaceRuntimePagination.swift; sourceTree = "<group>"; };
 		D4D9B1DC813DAB2FBDAA9084 /* testComposerStatusTrayIPadMiniSplitViewWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayIPadMiniSplitViewWidth.1.png; sourceTree = "<group>"; };
@@ -645,21 +666,25 @@
 		DD3F9E8A8ED2FD8317FB92F2 /* CodexAppServerThreadOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerThreadOwnership.swift; sourceTree = "<group>"; };
 		DE04A73144E31515A65F5830 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E033E7A8267D3C3494835305 /* SessionContextModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContextModels.swift; sourceTree = "<group>"; };
+		E0EAC4CC35379B613A901E16 /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png"; sourceTree = "<group>"; };
 		E19FB5D730EAB61A661C065D /* testSingleWindowUsesProgressBarOnCompactWidth.single-window-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleWindowUsesProgressBarOnCompactWidth.single-window-compact.png"; sourceTree = "<group>"; };
 		E269BFB984F9AAD59712F04E /* testRunningConflictCardIPhone320Dark.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testRunningConflictCardIPhone320Dark.1.png; sourceTree = "<group>"; };
 		E29969A74C4C890BB458DC64 /* TailcatExperimentRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailcatExperimentRoutingTests.swift; sourceTree = "<group>"; };
 		E322989D4007390096CA127C /* testComposerSurfaceIPadMiniIncreasedContrast.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerSurfaceIPadMiniIncreasedContrast.1.png; sourceTree = "<group>"; };
 		E4C85188C13516219753D4ED /* testComposerStatusTrayCrowdedState.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCrowdedState.1.png; sourceTree = "<group>"; };
 		E55DE1D530ABE8EE097ECB59 /* testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png; sourceTree = "<group>"; };
+		E5B963BEE564A9A53336B060 /* ManagedConnectionEntitlementStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionEntitlementStore.swift; sourceTree = "<group>"; };
 		E5D0FB9DA0913B603240372D /* WorkspaceAppearanceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceAppearanceStore.swift; sourceTree = "<group>"; };
 		E61B1FCD1B28FACE28547C86 /* FileUploadStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadStoreTests.swift; sourceTree = "<group>"; };
 		E68C2F3A2CDF72BEF743E31B /* SessionContextSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContextSidebarView.swift; sourceTree = "<group>"; };
 		E71EF316D7633A27E8BFED9C /* WorkspaceStripPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStripPresentation.swift; sourceTree = "<group>"; };
 		E80A51824E5D09051C48036F /* testIdleConflictCardIPhone390Light.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testIdleConflictCardIPhone390Light.1.png; sourceTree = "<group>"; };
+		E85CF2066687F5E5ED881FB9 /* testSessionProjectIconAndUnreadIndicatorCombinations.dark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionProjectIconAndUnreadIndicatorCombinations.dark.png; sourceTree = "<group>"; };
 		E86C009EEF7D400DE35ADBD1 /* ImageAttachmentEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentEncoder.swift; sourceTree = "<group>"; };
 		E992D8F1A54C9726692225BA /* NewSessionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionSheet.swift; sourceTree = "<group>"; };
 		E9A21AAEB96727E4907BCCB3 /* SubagentSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubagentSessionTests.swift; sourceTree = "<group>"; };
 		E9BCF1B2E13945C6F706C8BD /* WorkspaceSessionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionPresentationTests.swift; sourceTree = "<group>"; };
+		EAB411FA23971D26635E4BC8 /* ConversationMessageDeliveryUncertaintyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageDeliveryUncertaintyTests.swift; sourceTree = "<group>"; };
 		EBF24E2B6355EF529578DE9D /* testComposerStatusTrayIPadMiniPortraitWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayIPadMiniPortraitWidth.1.png; sourceTree = "<group>"; };
 		EC0864CB07EFB2FEBFFC91BA /* MimiRemotePhysicalSmokeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiRemotePhysicalSmokeUITests.swift; sourceTree = "<group>"; };
 		ECDC4F6FDDB66F610BF6FC2D /* FloatingSidebarPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingSidebarPresentation.swift; sourceTree = "<group>"; };
@@ -794,6 +819,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		191DAAA37A5A882163DF1150 /* StoreKit */ = {
+			isa = PBXGroup;
+			children = (
+				6E8F22C82C007839E2D06A90 /* ManagedConnectionStoreKitClient.swift */,
+			);
+			path = StoreKit;
+			sourceTree = "<group>";
+		};
 		2D654282DAC760A1968EF1A3 /* Logs */ = {
 			isa = PBXGroup;
 			children = (
@@ -808,6 +841,7 @@
 				DE04A73144E31515A65F5830 /* Assets.xcassets */,
 				A70AE1D612D581C90BAE9B54 /* LICENSE */,
 				6C892E2BB83F2EE5FDD6EDA4 /* Localizable.xcstrings */,
+				91BA7011F99F49B437A5ACEF /* MimiRemote.storekit */,
 				2210B237FCEF112D24D2B687 /* privacy-policy.md */,
 				11B71BA07C5D393BC0EA9FD4 /* PrivacyInfo.xcprivacy */,
 				1583E66303D9AA12C715A377 /* support.md */,
@@ -828,6 +862,17 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		438D931B8D6736E46AEE9531 /* SessionListPresentationTests */ = {
+			isa = PBXGroup;
+			children = (
+				E85CF2066687F5E5ED881FB9 /* testSessionProjectIconAndUnreadIndicatorCombinations.dark.png */,
+				9607D17E063FDB600DF0A5D8 /* testSessionProjectIconAndUnreadIndicatorCombinations.light.png */,
+				D31234CAC3FCACA63F93285D /* testSessionStateRingSemanticsAndAlignment.dark.png */,
+				3045D0EB3BA4153934CFC712 /* testSessionStateRingSemanticsAndAlignment.light.png */,
+			);
+			path = SessionListPresentationTests;
+			sourceTree = "<group>";
+		};
 		43F4D9DB96DC2682A38AC5E8 /* MimiRemoteTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -836,7 +881,7 @@
 				657215B4124C9FDDEA161D2C /* AppleVoiceStartupWatchdogTests.swift */,
 				54AAB784C642D2B0234E48BA /* CameraAttachmentTests.swift */,
 				83CFAE116262795C7501365E /* CarStatusSnapshotTests.swift */,
-				A2240002A2240002A2240002 /* CodexAppServerConnectionReliabilityTests.swift */,
+				8D05A1A4E037DC2EE90B7747 /* CodexAppServerConnectionReliabilityTests.swift */,
 				FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */,
 				B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */,
 				1254FA91BFD2E858AFBD539D /* ConversationAppServerProjectorTests.swift */,
@@ -845,13 +890,12 @@
 				81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */,
 				315746F97ABB8E16D93F98A4 /* ConversationDataFlowTests.swift */,
 				078AEE7E4BDAC1751244A05A /* ConversationDataFlowTestSupport.swift */,
-				A21400000000000000000001 /* ConversationTurnCompletionReconciliationTests.swift */,
 				3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */,
 				C0FE3675988DBD54585B3A79 /* ConversationDirectRuntimeSubscriptionTests.swift */,
 				025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */,
 				3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */,
 				F5EC542E43C2955804F35E34 /* ConversationHistoryItemEnrichmentTests.swift */,
-				A2240004A2240004A2240004 /* ConversationMessageDeliveryUncertaintyTests.swift */,
+				EAB411FA23971D26635E4BC8 /* ConversationMessageDeliveryUncertaintyTests.swift */,
 				FBF29C4EA9F4D0ECC4709B97 /* ConversationProcessGrouperTests.swift */,
 				033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */,
 				D9A1F29F52DC5CC790708ACC /* ConversationRuntimeTestSupport.swift */,
@@ -860,6 +904,7 @@
 				6C7C7C0DF7B33C596EBE5FC7 /* ConversationSnapshotTests.swift */,
 				C732DD4062EFC36827E1937A /* ConversationTimelineHistoryScrollTests.swift */,
 				F938DA83B5613E99E202281D /* ConversationTimelineReducerTests.swift */,
+				935BC4C6AC831B2EAF7CA114 /* ConversationTurnCompletionReconciliationTests.swift */,
 				13FC22D303D4E2D91D9D33EA /* ConversationTurnInterruptTests.swift */,
 				23CF7E66AAB73235912C1990 /* ConversationTurnQueueTests.swift */,
 				1F803BE24EB9F6963792C11C /* ConversationWorkspaceHistoryTests.swift */,
@@ -873,6 +918,7 @@
 				053D35545CB6F6F836EAADBA /* HostWarmSnapshotTests.swift */,
 				8AA53A2531C62C2974077C88 /* LocalizationTests.swift */,
 				A0E1C34623582EDA99D6B917 /* LogStoreTests.swift */,
+				417026D5C6353D2982527627 /* ManagedConnectionEntitlementStoreTests.swift */,
 				24B74985F9E77EEE70BC1856 /* MarkdownRenderingTests.swift */,
 				81FDFD00533B31F16F861BFB /* MimiInteractionFeedbackTests.swift */,
 				61B287032A29ABBC9D670E94 /* NewSessionPresentationSourceTests.swift */,
@@ -976,11 +1022,12 @@
 				A7F06515CE242219649D0218 /* CodexAppServerInteractionLifecycle.swift */,
 				A571C41AE73754FB6C9FD6BC /* CodexAppServerQueueSubmission.swift */,
 				469FD622125F7CE507C2607E /* CodexAppServerSessionClients.swift */,
+				049E1F8A9BBD15AF6BEE9E28 /* CodexAppServerSessionConnection.swift */,
 				D13E0CB3B7056752941144BD /* CodexAppServerSessionRuntime.swift */,
-				A223C002A223C002A223C002 /* CodexAppServerSessionConnection.swift */,
 				DD3F9E8A8ED2FD8317FB92F2 /* CodexAppServerThreadOwnership.swift */,
 				BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */,
 				5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */,
+				BFC8F89BF1B2CDD9984B85B7 /* ManagedConnectionEntitlementAPIClient.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1106,6 +1153,9 @@
 			children = (
 				59173E15ED2D45E1BDE19304 /* testConnectedStateInDarkAppearance.connected-dark.png */,
 				0CD3911F5991428A7A3D47EE /* testConnectedStateStaysQuiet.connected-compact.png */,
+				5A88B5C73E15343C1B24DD2E /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png */,
+				E0EAC4CC35379B613A901E16 /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png */,
+				D2BF59E844D8092111547C64 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png */,
 				A4AAC3D3BED6B94860B6595F /* testDisconnectedStateCarriesWarningInsideCard.disconnected-compact.png */,
 			);
 			path = SettingsConnectionCardSnapshotTests;
@@ -1115,6 +1165,7 @@
 			isa = PBXGroup;
 			children = (
 				6135FD015C001D5B5F23719E /* ConversationSnapshotTests */,
+				438D931B8D6736E46AEE9531 /* SessionListPresentationTests */,
 				13039F68B9796D4DC831B3AE /* SettingsChoiceRowSnapshotTests */,
 				78E325381D8D32F90C80FCEC /* SettingsConnectionCardSnapshotTests */,
 				5AE6D4EE1675BD04AD598F36 /* SkillModelPickerSnapshotTests */,
@@ -1238,6 +1289,7 @@
 				16A54848C6A9B1324C77E712 /* Models */,
 				6648EBB30B21EFC189EBA7DA /* Parsing */,
 				D367666DF47751B98DBA9522 /* Security */,
+				191DAAA37A5A882163DF1150 /* StoreKit */,
 				5A3C30AF38B604866E432689 /* Tailcat */,
 			);
 			path = Core;
@@ -1267,6 +1319,7 @@
 				28D9D8852662655DFC4D9FA0 /* HostInstallationSetupView.swift */,
 				4C75EB69B7DE1AAE7350B2C5 /* InitialConnectionSettingsSections.swift */,
 				B546C68F6A4EDDA47CD25FD7 /* LegalDocumentView.swift */,
+				507C31D592377CA009E2CCA9 /* ManagedConnectionSubscriptionView.swift */,
 				7D29856557B35AE9C7C9B5EA /* QRCodeScannerSheet.swift */,
 				81D105A868560CE2F66EA59C /* SettingsChoiceRow.swift */,
 				96828E6273D517310CB01F52 /* SettingsDashboardViews.swift */,
@@ -1306,9 +1359,9 @@
 				1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */,
 				332F6935AFF261FAA35F289A /* CarStatusSnapshotMapping.swift */,
 				6C6C8F9B82DA43620543124E /* ConnectionProfileModels.swift */,
-				A2250002A2250002A2250002 /* ConversationMessageDeliveryReconciler.swift */,
+				CCBCEEF3A7D3D84A709984E8 /* ConversationMessageDeliveryReconciler.swift */,
 				373EDA921B7F6B3F6B680140 /* ConversationStore.swift */,
-				C224D002C224D002C224D002 /* ConversationStoreDelivery.swift */,
+				454132341FC2CC31B453D26C /* ConversationStoreDelivery.swift */,
 				20A922D9A3D4C72236D9CFBA /* ConversationTimelineReducer.swift */,
 				D6D8E5F1F33563965409D9D4 /* DebugLaunchConfiguration.swift */,
 				52051A97BB3979091B39EB95 /* EventReducer.swift */,
@@ -1317,6 +1370,7 @@
 				80F8AA2ABA18C212AEAA34E1 /* HostStatusStore.swift */,
 				9804C07B29195A66638EE42E /* HostWarmSnapshot.swift */,
 				88A2FAA4C2526405C2DDB750 /* LogStore.swift */,
+				E5B963BEE564A9A53336B060 /* ManagedConnectionEntitlementStore.swift */,
 				B9CAFB1927C976C000C9E026 /* MessageStore.swift */,
 				AC1E5753D86397B541589878 /* RecentWorkspaceStore.swift */,
 				B923E4207A9FD4C35766E4CA /* SessionContextStore.swift */,
@@ -1528,6 +1582,9 @@
 				6DEFFD87BEBE13C2409FE183 /* testComposerSurfaceIPadMiniIncreasedContrast.1.png in Resources */,
 				795DBA9DFE88261165CC482A /* testConnectedStateInDarkAppearance.connected-dark.png in Resources */,
 				64AE3AF2F8998212338CDF8C /* testConnectedStateStaysQuiet.connected-compact.png in Resources */,
+				860DD71D11A4C4AF27322417 /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png in Resources */,
+				29EE18E5D572B779CF19F20F /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png in Resources */,
+				5FDCC383AE9448F83273EA84 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png in Resources */,
 				E7EE1A6D1A2A19F69E8F6513 /* testConversationBubbleAlignment.1.png in Resources */,
 				FF30D18FE63EA561E779924B /* testCrossSessionContinuationHidesInternalAddresses.1.png in Resources */,
 				7CD5F621C651FF6A32ACAE47 /* testDefaultDarkConversationPalette.1.png in Resources */,
@@ -1574,8 +1631,12 @@
 				76CE769D2951CF9CEBE6B3FF /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-pro-1366-dark-contrast.png in Resources */,
 				AFCB5F8D4673CA2B62400AD0 /* testSessionLibraryDensityAndAccessibilityLayouts.iphone-390-light.png in Resources */,
 				91375DEC431AD94516A09B50 /* testSessionLibraryDensityAndAccessibilityLayouts.split-375-light.png in Resources */,
+				7301810E2D669985BC4C75EC /* testSessionProjectIconAndUnreadIndicatorCombinations.dark.png in Resources */,
+				C2A5B9C8EBB21410389D102D /* testSessionProjectIconAndUnreadIndicatorCombinations.light.png in Resources */,
 				D8263551DECB2E7EBCD66E3B /* testSessionRuntimeBadgesInConversationList.1.png in Resources */,
 				1D4173EB8DAD73A39CC78A38 /* testSessionRuntimeMetadataInDarkConversationList.1.png in Resources */,
+				94EEB0914AE0A3B80C58139C /* testSessionStateRingSemanticsAndAlignment.dark.png in Resources */,
+				68CD22C1EBAF6F4B256A5CFD /* testSessionStateRingSemanticsAndAlignment.light.png in Resources */,
 				09A90025E5F3FB50D65C14A8 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-700.png in Resources */,
 				4B13DBFDB232284E99D2BE1F /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-narrow-landscape.png in Resources */,
 				69C750B399975CEDCEBC84B6 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-wide-1024.png in Resources */,
@@ -1653,7 +1714,7 @@
 				EF35A98EC4F810C40B19975F /* AppleVoiceStartupWatchdogTests.swift in Sources */,
 				03E7996441667D59DF2F9E3A /* CameraAttachmentTests.swift in Sources */,
 				101A9079E24B09BCAB8B54FF /* CarStatusSnapshotTests.swift in Sources */,
-				A2240001A2240001A2240001 /* CodexAppServerConnectionReliabilityTests.swift in Sources */,
+				EB5D0D19189AB5059993D8C9 /* CodexAppServerConnectionReliabilityTests.swift in Sources */,
 				523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */,
 				3CE709A723920DFD80FE96D0 /* ConnectionProfileRenameTests.swift in Sources */,
 				2ACE5B224FFACB3AA6391C46 /* ConversationAppServerProjectorTests.swift in Sources */,
@@ -1662,13 +1723,12 @@
 				AD2BA4EB75791D6DA68D6A46 /* ConversationConnectionRecoveryTests.swift in Sources */,
 				467ED9D49A463D5F5AF02A3C /* ConversationDataFlowTestSupport.swift in Sources */,
 				10BF43237408412ED651F5B4 /* ConversationDataFlowTests.swift in Sources */,
-				A21400000000000000000002 /* ConversationTurnCompletionReconciliationTests.swift in Sources */,
 				759158BB4175D405D74CD30A /* ConversationDirectRuntimeHistoryTests.swift in Sources */,
 				BA0F184AA3E72EE6A5A291B5 /* ConversationDirectRuntimeSubscriptionTests.swift in Sources */,
 				E790247242197F065BB1F1DE /* ConversationDirectRuntimeTests.swift in Sources */,
 				699762120516E7B19DB681E9 /* ConversationGuidanceFallbackTests.swift in Sources */,
 				696F45B5F56A3EB290292B28 /* ConversationHistoryItemEnrichmentTests.swift in Sources */,
-				A2240003A2240003A2240003 /* ConversationMessageDeliveryUncertaintyTests.swift in Sources */,
+				26B42E7402DAE746AA5841B9 /* ConversationMessageDeliveryUncertaintyTests.swift in Sources */,
 				388033847B02B31529D2BFCA /* ConversationProcessGrouperTests.swift in Sources */,
 				7813EDBB1DC23A88A94CAF56 /* ConversationRuntimeFlowTests.swift in Sources */,
 				2B372F78E1EC09D8E4B7210F /* ConversationRuntimeTestSupport.swift in Sources */,
@@ -1677,6 +1737,7 @@
 				5FD1DBDBCD89B51F6B22D679 /* ConversationSnapshotTests.swift in Sources */,
 				594989D4A8EF0493E3127965 /* ConversationTimelineHistoryScrollTests.swift in Sources */,
 				613A97BCD065B780C6162C8E /* ConversationTimelineReducerTests.swift in Sources */,
+				32A0E61668E067F6489752B3 /* ConversationTurnCompletionReconciliationTests.swift in Sources */,
 				15091B49EAC652933A3EC0AC /* ConversationTurnInterruptTests.swift in Sources */,
 				2EE9AF7AEF490C9B6832C118 /* ConversationTurnQueueTests.swift in Sources */,
 				7917AE82BBAC2F36217D9BC0 /* ConversationWorkspaceHistoryTests.swift in Sources */,
@@ -1690,6 +1751,7 @@
 				F0DC6138A242D45D79253F8B /* HostWarmSnapshotTests.swift in Sources */,
 				E4A6ECBFD5B621FB6A30299A /* LocalizationTests.swift in Sources */,
 				BDDBF10C9208B7AB95535A57 /* LogStoreTests.swift in Sources */,
+				491F23C64F7108C5B28BBD1B /* ManagedConnectionEntitlementStoreTests.swift in Sources */,
 				4DDCF6949E6DDCC9ABEBE709 /* MarkdownRenderingTests.swift in Sources */,
 				20D78099D1CE0CC7A660BFA1 /* MimiInteractionFeedbackTests.swift in Sources */,
 				B3BE80D2693D4982B46A4924 /* NewSessionPresentationSourceTests.swift in Sources */,
@@ -1758,8 +1820,8 @@
 				0DC788182243F2C8A136A742 /* CodexAppServerInteractionLifecycle.swift in Sources */,
 				293498CD48F70C646F0DD612 /* CodexAppServerQueueSubmission.swift in Sources */,
 				FAD77559CF6FDCD943849D7C /* CodexAppServerSessionClients.swift in Sources */,
+				F660CF6678E0A20AFBA5755C /* CodexAppServerSessionConnection.swift in Sources */,
 				5344C41233BA0E47A0C29FDA /* CodexAppServerSessionRuntime.swift in Sources */,
-				A223C001A223C001A223C001 /* CodexAppServerSessionConnection.swift in Sources */,
 				A9672A5CCD14CB34B13ED66A /* CodexAppServerThreadOwnership.swift in Sources */,
 				C1F8D4D973088684344C9DB6 /* CodexAppServerTransport.swift in Sources */,
 				45C1DA2766CF0D3F7DB0843C /* CodexAppServerTurnStartObservation.swift in Sources */,
@@ -1779,13 +1841,13 @@
 				CE32FFAC6FF1C8B88332FADF /* ConversationLayout.swift in Sources */,
 				C1603B73BC400064D13B6605 /* ConversationMessageAccessories.swift in Sources */,
 				69CD428419BBE636C6B397BA /* ConversationMessageBubble.swift in Sources */,
+				DAF89EB953E1D2438E4AF4E9 /* ConversationMessageDeliveryReconciler.swift in Sources */,
 				55A91A4B582F169DCE0C1197 /* ConversationMessageRow.swift in Sources */,
 				0E761373BD02FB2C656475B7 /* ConversationProcessGroupRow.swift in Sources */,
 				F996F870AD345E2888F2913B /* ConversationProcessGrouper.swift in Sources */,
 				CB8A7C0CC676C74BADF4901C /* ConversationScreenModel.swift in Sources */,
-				A2250001A2250001A2250001 /* ConversationMessageDeliveryReconciler.swift in Sources */,
 				DAAB5AD21F6B77F6D691B94F /* ConversationStore.swift in Sources */,
-				C224D001C224D001C224D001 /* ConversationStoreDelivery.swift in Sources */,
+				E8A3EE0F4BD132102FB68EAC /* ConversationStoreDelivery.swift in Sources */,
 				217C4D1F6988BDFF59701290 /* ConversationTimelineCache.swift in Sources */,
 				1158695E26ECDFF99A3B695C /* ConversationTimelineItemBuilder.swift in Sources */,
 				B30C71B98AEF44473D80C926 /* ConversationTimelineModels.swift in Sources */,
@@ -1814,6 +1876,10 @@
 				55D520C10E168BFEA7E4A619 /* LegalDocumentView.swift in Sources */,
 				78BE6068CC6C12DA79A00B6D /* LogPanelView.swift in Sources */,
 				FBF4E996E64F7B7D637E1B79 /* LogStore.swift in Sources */,
+				D57E56FF06B77F225C0F436E /* ManagedConnectionEntitlementAPIClient.swift in Sources */,
+				122264253C13D70043A627F0 /* ManagedConnectionEntitlementStore.swift in Sources */,
+				BAA573B7BCCDD95153331C04 /* ManagedConnectionStoreKitClient.swift in Sources */,
+				E02D70CAB2822FE39664F749 /* ManagedConnectionSubscriptionView.swift in Sources */,
 				9050C1E583FA7A10A4753732 /* MarkdownBlock.swift in Sources */,
 				25ED4420B6E48AB3E087E472 /* MarkdownBlockView.swift in Sources */,
 				CA5DCE5FDDA7F1DE9C0C64F7 /* MarkdownParser.swift in Sources */,

--- a/ios/MimiRemote/MimiRemote.xcodeproj/xcshareddata/xcschemes/MimiRemote.xcscheme
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/xcshareddata/xcschemes/MimiRemote.xcscheme
@@ -89,6 +89,11 @@
             ReferencedContainer = "container:MimiRemote.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <StoreKitConfigurationFileReference
+         identifier = "../../Resources/MimiRemote.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -39556,6 +39556,174 @@
         }
       }
     },
+    "ui.managed_subscription_active": {
+      "comment": "Active Mimi Managed Connection subscription status.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Subscription active" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "订阅生效中" } }
+      }
+    },
+    "ui.managed_subscription_checking": {
+      "comment": "Status shown while StoreKit and the entitlement service are checked.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Checking subscription…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在检查订阅…" } }
+      }
+    },
+    "ui.managed_subscription_expired": {
+      "comment": "Error shown when the server says the subscription expired.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This subscription has expired." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此订阅已过期。" } }
+      }
+    },
+    "ui.managed_subscription_inactive": {
+      "comment": "Error shown when the server returns an inactive entitlement state.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This subscription is not active." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此订阅当前未生效。" } }
+      }
+    },
+    "ui.managed_subscription_grace": {
+      "comment": "Subscription status during App Store billing grace period.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Billing issue — access remains available during the grace period" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "扣款出现问题，宽限期内仍可使用" } }
+      }
+    },
+    "ui.managed_subscription_network_error": {
+      "comment": "Generic network error while checking a subscription.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Couldn't verify the subscription. Check your connection and try again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法验证订阅，请检查网络后重试。" } }
+      }
+    },
+    "ui.managed_subscription_not_active": {
+      "comment": "Inactive Mimi Managed Connection subscription status.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Not subscribed" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未订阅" } }
+      }
+    },
+    "ui.managed_subscription_pending": {
+      "comment": "Status shown for an Ask to Buy or otherwise pending purchase.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Purchase pending approval" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "购买正在等待批准" } }
+      }
+    },
+    "ui.managed_subscription_plans": {
+      "comment": "Subscription plan section title.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Choose a plan" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "选择订阅方案" } }
+      }
+    },
+    "ui.managed_subscription_price_period": {
+      "comment": "Localized StoreKit price followed by its localized billing period.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "%1$@ / %2$@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "%1$@ / %2$@" } }
+      }
+    },
+    "ui.managed_subscription_product_unavailable": {
+      "comment": "Shown when StoreKit cannot load the configured products.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Subscription plans are temporarily unavailable." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "订阅方案暂时不可用。" } }
+      }
+    },
+    "ui.managed_subscription_renews_automatically": {
+      "comment": "Auto-renewal disclosure below the subscription products.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Payment is charged to your Apple Account. The subscription renews automatically unless canceled in App Store settings." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "费用将从你的 Apple 账户扣除。除非在 App Store 设置中取消，否则订阅会自动续期。" } }
+      }
+    },
+    "ui.managed_subscription_revoked": {
+      "comment": "Error shown when the server says the subscription was refunded or revoked.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This subscription was refunded or revoked." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此订阅已退款或撤销。" } }
+      }
+    },
+    "ui.managed_subscription_section": {
+      "comment": "Settings section title for the managed connection subscription.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Managed connection" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "托管连接" } }
+      }
+    },
+    "ui.managed_subscription_server_invalid": {
+      "comment": "Shown when the entitlement service response cannot be validated.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The subscription service returned an invalid response." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "订阅服务返回了无效响应。" } }
+      }
+    },
+    "ui.managed_subscription_server_rejected": {
+      "comment": "Shown when the entitlement service rejects a transaction.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The subscription could not be verified." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "订阅未能通过验证。" } }
+      }
+    },
+    "ui.managed_subscription_status": {
+      "comment": "Subscription status section title.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Status" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "订阅状态" } }
+      }
+    },
+    "ui.managed_subscription_title": {
+      "comment": "Mimi Managed Connection subscription title.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mimi Managed Connection" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Mimi 托管连接" } }
+      }
+    },
+    "ui.managed_subscription_trial_active": {
+      "comment": "Active free-trial subscription status.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Free trial active" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "免费试用中" } }
+      }
+    },
+    "ui.managed_subscription_trial_offer": {
+      "comment": "Free-trial duration returned by StoreKit.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "%@ free trial for eligible subscribers" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "符合资格的订阅者可免费试用 %@" } }
+      }
+    },
+    "ui.managed_subscription_unverified": {
+      "comment": "Shown when StoreKit or the server cannot verify Apple-signed evidence.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Apple couldn't verify this transaction." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Apple 无法验证此交易。" } }
+      }
+    },
+    "ui.managed_subscription_valid_until": {
+      "comment": "Subscription expiration date. The placeholder is a localized date.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Valid until %@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "有效期至 %@" } }
+      }
+    },
+    "ui.restore_purchases": {
+      "comment": "Explicit action to ask App Store to synchronize purchases.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Restore Purchases" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "恢复购买" } }
+      }
+    },
+    "ui.subscription_information": {
+      "comment": "Section title for subscription disclosures and legal links.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Subscription information" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "订阅信息" } }
+      }
+    },
     "·": {
       "comment": "A separator between two elements.",
       "isCommentAutoGenerated": true,

--- a/ios/MimiRemote/Resources/MimiRemote.storekit
+++ b/ios/MimiRemote/Resources/MimiRemote.storekit
@@ -1,0 +1,113 @@
+{
+  "identifier" : "B4D1E32B-2DB4-4F5D-8656-5AF0FA2B96CB",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+
+  ],
+  "settings" : {
+    "_applicationInternalID" : "6778076511",
+    "_developerTeamID" : "9HZ89R58PZ",
+    "_failTransactionsEnabled" : false,
+    "_lastSynchronizedDate" : 0,
+    "_locale" : "zh_CN",
+    "_renewalBillingIssuesEnabled" : false,
+    "_storefront" : "CHN",
+    "_storeKitErrors" : [
+
+    ]
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "AEB6B1B4-75BA-4DC7-81A4-BE8BAEA78F41",
+      "localizations" : [
+        {
+          "description" : "Mimi 托管连接订阅",
+          "displayName" : "Mimi 托管连接",
+          "locale" : "zh_CN"
+        },
+        {
+          "description" : "Mimi Managed Connection subscription",
+          "displayName" : "Mimi Managed Connection",
+          "locale" : "en_US"
+        }
+      ],
+      "name" : "Mimi Managed Connection",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "9.9",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "5B2DF4E7-41D9-45F6-BEB9-86BA345C268D",
+          "introductoryOffer" : {
+            "internalID" : "397BE225-F5EB-45D4-B24B-B8E3971103CE",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "按月使用 Mimi 托管连接",
+              "displayName" : "月度订阅",
+              "locale" : "zh_CN"
+            },
+            {
+              "description" : "Monthly access to Mimi Managed Connection",
+              "displayName" : "Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.gaixianggeng.mimi.managed.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Mimi Managed Monthly",
+          "subscriptionGroupID" : "AEB6B1B4-75BA-4DC7-81A4-BE8BAEA78F41",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "85FC2726-7535-483C-A80B-7CB043D3FE34",
+          "introductoryOffer" : {
+            "internalID" : "2CE58A47-825D-431D-A03D-36528CD57FDB",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "按年使用 Mimi 托管连接",
+              "displayName" : "年度订阅",
+              "locale" : "zh_CN"
+            },
+            {
+              "description" : "Annual access to Mimi Managed Connection",
+              "displayName" : "Annual",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.gaixianggeng.mimi.managed.annual",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Mimi Managed Annual",
+          "subscriptionGroupID" : "AEB6B1B4-75BA-4DC7-81A4-BE8BAEA78F41",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/ios/MimiRemote/Sources/Core/API/ManagedConnectionEntitlementAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/ManagedConnectionEntitlementAPIClient.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+struct ManagedConnectionEntitlement: Equatable, Sendable {
+    enum Status: String, Equatable, Sendable {
+        case trial
+        case active
+        case grace
+        case expired
+        case revoked
+    }
+
+    let id: String
+    let productID: String
+    let status: Status
+    let expiresAt: Date
+}
+
+struct ManagedConnectionEntitlementGrant: Equatable, Sendable {
+    let entitlement: ManagedConnectionEntitlement
+    let token: String
+    let tokenExpiresAt: Date
+}
+
+protocol ManagedConnectionEntitlementAPIClient: Sendable {
+    func resolve(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionEntitlementGrant
+}
+
+struct LiveManagedConnectionEntitlementAPIClient: ManagedConnectionEntitlementAPIClient {
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(
+        baseURL: URL = URL(string: "https://api.code89757.com")!,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func resolve(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionEntitlementGrant {
+        let url = baseURL.appending(path: "v1/entitlements/resolve")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 20
+        request.httpBody = try JSONEncoder().encode(
+            ResolveRequest(
+                signedAppTransaction: signedAppTransaction,
+                signedTransaction: signedTransaction
+            )
+        )
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ManagedConnectionEntitlementAPIError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let code = try? JSONDecoder().decode(ErrorResponse.self, from: data).code
+            throw ManagedConnectionEntitlementAPIError.rejected(code: code)
+        }
+
+        let payload: ResolveResponse
+        do {
+            payload = try Self.decoder.decode(ResolveResponse.self, from: data)
+        } catch {
+            throw ManagedConnectionEntitlementAPIError.invalidResponse
+        }
+        guard let status = ManagedConnectionEntitlement.Status(rawValue: payload.entitlement.status) else {
+            throw ManagedConnectionEntitlementAPIError.inactive
+        }
+        if status == .expired {
+            throw ManagedConnectionEntitlementAPIError.rejected(code: "expired")
+        }
+        if status == .revoked {
+            throw ManagedConnectionEntitlementAPIError.rejected(code: "revoked")
+        }
+        return ManagedConnectionEntitlementGrant(
+            entitlement: ManagedConnectionEntitlement(
+                id: payload.entitlement.id,
+                productID: payload.entitlement.productId,
+                status: status,
+                expiresAt: payload.entitlement.expiresAt
+            ),
+            token: payload.entitlementToken,
+            tokenExpiresAt: payload.tokenExpiresAt
+        )
+    }
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            if let date = ISO8601DateFormatter.withFractionalSeconds.date(from: value)
+                ?? ISO8601DateFormatter().date(from: value)
+            {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid RFC 3339 date"
+            )
+        }
+        return decoder
+    }()
+}
+
+private struct ResolveRequest: Encodable {
+    let signedAppTransaction: String
+    let signedTransaction: String
+}
+
+private struct ResolveResponse: Decodable {
+    struct Entitlement: Decodable {
+        let id: String
+        let productId: String
+        let status: String
+        let expiresAt: Date
+    }
+
+    let entitlement: Entitlement
+    let entitlementToken: String
+    let tokenExpiresAt: Date
+}
+
+private struct ErrorResponse: Decodable {
+    let code: String
+}
+
+enum ManagedConnectionEntitlementAPIError: LocalizedError, Equatable {
+    case invalidResponse
+    case rejected(code: String?)
+    case inactive
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return L10n.text("ui.managed_subscription_server_invalid")
+        case .inactive:
+            return L10n.text("ui.managed_subscription_inactive")
+        case .rejected(let code):
+            switch code {
+            case "expired":
+                return L10n.text("ui.managed_subscription_expired")
+            case "revoked":
+                return L10n.text("ui.managed_subscription_revoked")
+            case "unverified_transaction":
+                return L10n.text("ui.managed_subscription_unverified")
+            default:
+                return L10n.text("ui.managed_subscription_server_rejected")
+            }
+        }
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let withFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
+++ b/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
@@ -35,11 +35,16 @@ enum ManagedConnectionCurrentEntitlementOutcome: Equatable, Sendable {
     case unverified
 }
 
+enum ManagedConnectionTransactionUpdate: Equatable, Sendable {
+    case verified(ManagedConnectionTransactionEvidence)
+    case unverified
+}
+
 protocol ManagedConnectionStoreKitClient: Sendable {
     func products() async throws -> [ManagedConnectionProduct]
     func purchase(productID: String) async throws -> ManagedConnectionPurchaseOutcome
     func currentEntitlement(productID: String) async -> ManagedConnectionCurrentEntitlementOutcome
-    func transactionUpdates() -> AsyncStream<Void>
+    func transactionUpdates() -> AsyncStream<ManagedConnectionTransactionUpdate>
     func signedAppTransaction() async throws -> String
     func finish(transactionID: UInt64) async
     func syncPurchases() async throws
@@ -130,19 +135,25 @@ actor LiveManagedConnectionStoreKitClient: ManagedConnectionStoreKitClient {
         return currentOutcome(from: verification)
     }
 
-    nonisolated func transactionUpdates() -> AsyncStream<Void> {
+    nonisolated func transactionUpdates() -> AsyncStream<ManagedConnectionTransactionUpdate> {
         AsyncStream { continuation in
             let listener = Task {
                 for await verification in Transaction.updates {
-                    let transaction: Transaction
                     switch verification {
-                    case .verified(let value), .unverified(let value, _):
-                        transaction = value
+                    case .verified(let transaction):
+                        guard ManagedConnectionProductID.all.contains(transaction.productID) else {
+                            continue
+                        }
+                        await rememberUnfinished(transaction)
+                        continuation.yield(
+                            .verified(Self.evidence(from: verification, transaction: transaction))
+                        )
+                    case .unverified(let transaction, _):
+                        guard ManagedConnectionProductID.all.contains(transaction.productID) else {
+                            continue
+                        }
+                        continuation.yield(.unverified)
                     }
-                    guard ManagedConnectionProductID.all.contains(transaction.productID) else {
-                        continue
-                    }
-                    continuation.yield(())
                 }
                 continuation.finish()
             }
@@ -150,6 +161,10 @@ actor LiveManagedConnectionStoreKitClient: ManagedConnectionStoreKitClient {
                 listener.cancel()
             }
         }
+    }
+
+    private func rememberUnfinished(_ transaction: Transaction) {
+        unfinishedTransactions[transaction.id] = transaction
     }
 
     private func currentOutcome(

--- a/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
+++ b/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
@@ -1,0 +1,232 @@
+import Foundation
+import StoreKit
+
+enum ManagedConnectionProductID {
+    static let monthly = "com.gaixianggeng.mimi.managed.monthly"
+    static let annual = "com.gaixianggeng.mimi.managed.annual"
+    static let all = [monthly, annual]
+}
+
+struct ManagedConnectionProduct: Identifiable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let displayPrice: String
+    let displayPeriod: String
+    let isEligibleForTrial: Bool
+    let displayTrialPeriod: String?
+}
+
+struct ManagedConnectionTransactionEvidence: Equatable, Sendable {
+    let transactionID: UInt64
+    let productID: String
+    let signedTransaction: String
+}
+
+enum ManagedConnectionPurchaseOutcome: Equatable, Sendable {
+    case success(ManagedConnectionTransactionEvidence)
+    case pending
+    case cancelled
+    case unverified
+}
+
+enum ManagedConnectionCurrentEntitlementOutcome: Equatable, Sendable {
+    case none
+    case verified(ManagedConnectionTransactionEvidence)
+    case unverified
+}
+
+protocol ManagedConnectionStoreKitClient: Sendable {
+    func products() async throws -> [ManagedConnectionProduct]
+    func purchase(productID: String) async throws -> ManagedConnectionPurchaseOutcome
+    func currentEntitlement(productID: String) async -> ManagedConnectionCurrentEntitlementOutcome
+    func transactionUpdates() -> AsyncStream<Void>
+    func signedAppTransaction() async throws -> String
+    func finish(transactionID: UInt64) async
+    func syncPurchases() async throws
+}
+
+actor LiveManagedConnectionStoreKitClient: ManagedConnectionStoreKitClient {
+    private var productsByID: [String: Product] = [:]
+    private var unfinishedTransactions: [UInt64: Transaction] = [:]
+
+    func products() async throws -> [ManagedConnectionProduct] {
+        let products = try await Product.products(for: ManagedConnectionProductID.all)
+        productsByID = Dictionary(uniqueKeysWithValues: products.map { ($0.id, $0) })
+
+        var result: [ManagedConnectionProduct] = []
+        for product in products {
+            guard let subscription = product.subscription else { continue }
+            let eligible = await subscription.isEligibleForIntroOffer
+            let freeTrialOffer = subscription.introductoryOffer.flatMap { offer in
+                ManagedConnectionTrialEligibility.isFreeTrial(
+                    eligible: eligible,
+                    paymentMode: offer.paymentMode
+                ) ? offer : nil
+            }
+            let trialPeriod = freeTrialOffer.map {
+                Self.displayPeriod($0.period, product: product)
+            }
+            result.append(
+                ManagedConnectionProduct(
+                    id: product.id,
+                    displayName: product.displayName,
+                    displayPrice: product.displayPrice,
+                    displayPeriod: Self.displayPeriod(subscription.subscriptionPeriod, product: product),
+                    isEligibleForTrial: eligible && freeTrialOffer != nil,
+                    displayTrialPeriod: trialPeriod
+                )
+            )
+        }
+        return result.sorted { lhs, rhs in
+            ManagedConnectionProductID.all.firstIndex(of: lhs.id) ?? .max
+                < ManagedConnectionProductID.all.firstIndex(of: rhs.id) ?? .max
+        }
+    }
+
+    func purchase(productID: String) async throws -> ManagedConnectionPurchaseOutcome {
+        let product: Product
+        if let cached = productsByID[productID] {
+            product = cached
+        } else {
+            guard let loaded = try await Product.products(for: [productID]).first else {
+                throw ManagedConnectionStoreKitError.productUnavailable
+            }
+            productsByID[productID] = loaded
+            product = loaded
+        }
+
+        switch try await product.purchase() {
+        case .success(let verification):
+            guard case .verified(let transaction) = verification,
+                  transaction.revocationDate == nil,
+                  transaction.expirationDate.map({ $0 > Date() }) ?? true
+            else {
+                return .unverified
+            }
+            unfinishedTransactions[transaction.id] = transaction
+            return .success(Self.evidence(from: verification, transaction: transaction))
+        case .pending:
+            return .pending
+        case .userCancelled:
+            return .cancelled
+        @unknown default:
+            return .unverified
+        }
+    }
+
+    func currentEntitlement(productID: String) async -> ManagedConnectionCurrentEntitlementOutcome {
+        if #available(iOS 18.4, macCatalyst 18.4, *) {
+            for await verification in Transaction.currentEntitlements(for: productID) {
+                return currentOutcome(from: verification)
+            }
+            return .none
+        }
+
+        // 项目最低支持 iOS 18.0；18.4 之前没有新的 per-product 序列 API。
+        // 旧系统只查询两个固定商品之一，不遍历 App 的其他交易。
+        guard let verification = await Transaction.currentEntitlement(for: productID) else {
+            return .none
+        }
+        return currentOutcome(from: verification)
+    }
+
+    nonisolated func transactionUpdates() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            let listener = Task {
+                for await verification in Transaction.updates {
+                    let transaction: Transaction
+                    switch verification {
+                    case .verified(let value), .unverified(let value, _):
+                        transaction = value
+                    }
+                    guard ManagedConnectionProductID.all.contains(transaction.productID) else {
+                        continue
+                    }
+                    continuation.yield(())
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                listener.cancel()
+            }
+        }
+    }
+
+    private func currentOutcome(
+        from verification: VerificationResult<Transaction>
+    ) -> ManagedConnectionCurrentEntitlementOutcome {
+        guard case .verified(let transaction) = verification,
+              transaction.revocationDate == nil,
+              transaction.expirationDate.map({ $0 > Date() }) ?? true
+        else {
+            return .unverified
+        }
+        // 冷启动可能恢复到尚未 finish 的已验证交易；服务端授权后再幂等 finish。
+        unfinishedTransactions[transaction.id] = transaction
+        return .verified(Self.evidence(from: verification, transaction: transaction))
+    }
+
+    func signedAppTransaction() async throws -> String {
+        let verification = try await AppTransaction.shared
+        guard case .verified = verification else {
+            throw ManagedConnectionStoreKitError.unverifiedAppTransaction
+        }
+        return verification.jwsRepresentation
+    }
+
+    func finish(transactionID: UInt64) async {
+        guard let transaction = unfinishedTransactions.removeValue(forKey: transactionID) else { return }
+        await transaction.finish()
+    }
+
+    func syncPurchases() async throws {
+        try await StoreKit.AppStore.sync()
+    }
+
+    private static func evidence(
+        from verification: VerificationResult<Transaction>,
+        transaction: Transaction
+    ) -> ManagedConnectionTransactionEvidence {
+        ManagedConnectionTransactionEvidence(
+            transactionID: transaction.id,
+            productID: transaction.productID,
+            signedTransaction: verification.jwsRepresentation
+        )
+    }
+
+    private static func displayPeriod(
+        _ period: Product.SubscriptionPeriod,
+        product: Product
+    ) -> String {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let components = DateComponents(subscriptionPeriod: period)
+        let calendar = Calendar(identifier: .gregorian)
+        guard let end = calendar.date(byAdding: components, to: start) else {
+            return period.unit.formatted(product.subscriptionPeriodUnitFormatStyle)
+        }
+        return (start..<end).formatted(product.subscriptionPeriodFormatStyle)
+    }
+}
+
+enum ManagedConnectionTrialEligibility {
+    static func isFreeTrial(
+        eligible: Bool,
+        paymentMode: Product.SubscriptionOffer.PaymentMode?
+    ) -> Bool {
+        eligible && paymentMode == .freeTrial
+    }
+}
+
+enum ManagedConnectionStoreKitError: LocalizedError {
+    case productUnavailable
+    case unverifiedAppTransaction
+
+    var errorDescription: String? {
+        switch self {
+        case .productUnavailable:
+            return L10n.text("ui.managed_subscription_product_unavailable")
+        case .unverifiedAppTransaction:
+            return L10n.text("ui.managed_subscription_unverified")
+        }
+    }
+}

--- a/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+struct ManagedConnectionSubscriptionView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var entitlementStore: ManagedConnectionEntitlementStore
+    @EnvironmentObject private var themeStore: ThemeStore
+
+    var body: some View {
+        let tokens = themeStore.tokens(for: colorScheme)
+
+        Form {
+            statusSection
+            productsSection
+            subscriptionInformationSection
+        }
+        .listSectionSpacing(SettingsLayoutMetrics.sectionSpacing)
+        .scrollContentBackground(.hidden)
+        .settingsCanvasBackground(tokens: tokens)
+        .navigationTitle(L10n.text("ui.managed_subscription_title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .tint(tokens.accent)
+        .task {
+            if entitlementStore.products.isEmpty {
+                await entitlementStore.load()
+            }
+        }
+        .refreshable {
+            await entitlementStore.refreshEntitlement()
+        }
+        .accessibilityIdentifier("settings.managedSubscription.detail")
+    }
+
+    @ViewBuilder
+    private var statusSection: some View {
+        Section(L10n.text("ui.managed_subscription_status")) {
+            switch entitlementStore.status {
+            case .loading, .resolving:
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text(L10n.text("ui.managed_subscription_checking"))
+                }
+                .accessibilityElement(children: .combine)
+            case .available:
+                Label(
+                    L10n.text("ui.managed_subscription_not_active"),
+                    systemImage: "network"
+                )
+            case .pending:
+                Label(
+                    L10n.text("ui.managed_subscription_pending"),
+                    systemImage: "clock"
+                )
+            case .expired:
+                Label(
+                    L10n.text("ui.managed_subscription_expired"),
+                    systemImage: "calendar.badge.exclamationmark"
+                )
+                .foregroundStyle(.orange)
+            case .revoked:
+                Label(
+                    L10n.text("ui.managed_subscription_revoked"),
+                    systemImage: "xmark.shield.fill"
+                )
+                .foregroundStyle(.red)
+            case .entitled(let entitlement):
+                VStack(alignment: .leading, spacing: 6) {
+                    Label(
+                        entitlementStatusText(entitlement.status),
+                        systemImage: "checkmark.circle.fill"
+                    )
+                    .foregroundStyle(.green)
+                    Text(
+                        L10n.format(
+                            "ui.managed_subscription_valid_until",
+                            entitlement.expiresAt.formatted(date: .abbreviated, time: .omitted)
+                        )
+                    )
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                }
+            case .failed(let message):
+                VStack(alignment: .leading, spacing: 10) {
+                    Label(message, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Button(L10n.text("ui.retry")) {
+                        Task { await entitlementStore.load() }
+                    }
+                    .disabled(entitlementStore.isBusy)
+                }
+            }
+        }
+    }
+
+    private func entitlementStatusText(_ status: ManagedConnectionEntitlement.Status) -> String {
+        switch status {
+        case .trial:
+            return L10n.text("ui.managed_subscription_trial_active")
+        case .grace:
+            return L10n.text("ui.managed_subscription_grace")
+        case .active:
+            return L10n.text("ui.managed_subscription_active")
+        case .expired:
+            return L10n.text("ui.managed_subscription_expired")
+        case .revoked:
+            return L10n.text("ui.managed_subscription_revoked")
+        }
+    }
+
+    @ViewBuilder
+    private var productsSection: some View {
+        Section {
+            if entitlementStore.products.isEmpty, !entitlementStore.isBusy {
+                Text(L10n.text("ui.managed_subscription_product_unavailable"))
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(entitlementStore.products) { product in
+                    Button {
+                        Task { await entitlementStore.purchase(productID: product.id) }
+                    } label: {
+                        VStack(alignment: .leading, spacing: 5) {
+                            HStack(alignment: .firstTextBaseline) {
+                                Text(product.displayName)
+                                    .font(.headline)
+                                Spacer(minLength: 12)
+                                Text(
+                                    L10n.format(
+                                        "ui.managed_subscription_price_period",
+                                        product.displayPrice,
+                                        product.displayPeriod
+                                    )
+                                )
+                                .multilineTextAlignment(.trailing)
+                            }
+                            if product.isEligibleForTrial, let trialPeriod = product.displayTrialPeriod {
+                                Text(L10n.format("ui.managed_subscription_trial_offer", trialPeriod))
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(entitlementStore.isBusy)
+                    .accessibilityIdentifier("settings.managedSubscription.product.\(product.id)")
+                }
+            }
+        } header: {
+            Text(L10n.text("ui.managed_subscription_plans"))
+        } footer: {
+            Text(L10n.text("ui.managed_subscription_renews_automatically"))
+        }
+    }
+
+    private var subscriptionInformationSection: some View {
+        Section {
+            Button(L10n.text("ui.restore_purchases")) {
+                Task { await entitlementStore.restorePurchases() }
+            }
+            .frame(minHeight: 44)
+            .disabled(entitlementStore.isBusy)
+            .accessibilityIdentifier("settings.managedSubscription.restore")
+
+            Link(destination: AppExternalLinks.termsOfUse) {
+                Label(L10n.text("ui.terms_of_use"), systemImage: "doc.text")
+            }
+            .frame(minHeight: 44)
+
+            Link(destination: AppExternalLinks.privacyPolicy) {
+                Label(L10n.text("ui.privacy_policy"), systemImage: "hand.raised")
+            }
+            .frame(minHeight: 44)
+        } header: {
+            Text(L10n.text("ui.subscription_information"))
+        }
+    }
+}

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -300,6 +300,21 @@ struct SettingsView: View {
 
             Section {
                 NavigationLink {
+                    ManagedConnectionSubscriptionView()
+                } label: {
+                    SettingsValueLabel(
+                        title: L10n.text("ui.managed_subscription_title"),
+                        systemImage: "creditcard"
+                    )
+                }
+                .settingsStandardListRow()
+                .accessibilityIdentifier("settings.managedSubscription")
+            } header: {
+                sectionHeader(L10n.text("ui.managed_subscription_section"), tokens: tokens)
+            }
+
+            Section {
+                NavigationLink {
                     AppearanceView(profileID: appStore.activeHostScope.profileID)
                 } label: {
                     SettingsValueLabel(

--- a/ios/MimiRemote/Sources/MimiRemoteApp.swift
+++ b/ios/MimiRemote/Sources/MimiRemoteApp.swift
@@ -155,6 +155,7 @@ struct MimiRemoteApp: App {
     @StateObject private var notificationResponseAdapter: SessionNotificationResponseAdapter
     @StateObject private var hostStatusStore: HostStatusStore
     @StateObject private var tailcatExperimentController: TailcatExperimentController
+    @StateObject private var managedConnectionEntitlementStore: ManagedConnectionEntitlementStore
 
     /// 紧凑布局的会话搜索走系统 `.searchable`，而系统在 iOS 26 上给它铺的是
     /// Liquid Glass——一屏里其它 chrome 全是扁平磨砂，只有它一块玻璃。
@@ -188,6 +189,10 @@ struct MimiRemoteApp: App {
         )
         let notificationResponseAdapter = SessionNotificationResponseAdapter()
         let tailcatExperimentController = TailcatExperimentController(appStore: appStore)
+        let managedConnectionEntitlementStore = ManagedConnectionEntitlementStore(
+            storeKit: LiveManagedConnectionStoreKitClient(),
+            entitlementAPI: LiveManagedConnectionEntitlementAPIClient()
+        )
         // SessionStore 初始化会同步绑定三个缓存 Store 的 Profile namespace。
         // 必须在 SwiftUI 接管这些 ObservableObject 前完成，避免在视图更新事务内发布状态。
         let sessionStore = SessionStore(
@@ -207,6 +212,9 @@ struct MimiRemoteApp: App {
         _notificationResponseAdapter = StateObject(wrappedValue: notificationResponseAdapter)
         _hostStatusStore = StateObject(wrappedValue: HostStatusStore())
         _tailcatExperimentController = StateObject(wrappedValue: tailcatExperimentController)
+        _managedConnectionEntitlementStore = StateObject(
+            wrappedValue: managedConnectionEntitlementStore
+        )
         _sessionStore = StateObject(wrappedValue: sessionStore)
         // 尽早注册 delegate；冷启动点击会先进入 adapter 的 pendingRoute，等 RootView 消费。
         UNUserNotificationCenter.current().delegate = notificationResponseAdapter
@@ -227,6 +235,7 @@ struct MimiRemoteApp: App {
                 .environmentObject(notificationResponseAdapter)
                 .environmentObject(hostStatusStore)
                 .environmentObject(tailcatExperimentController)
+                .environmentObject(managedConnectionEntitlementStore)
                 .onOpenURL { url in
                     Task { @MainActor in
                         do {

--- a/ios/MimiRemote/Sources/RootView.swift
+++ b/ios/MimiRemote/Sources/RootView.swift
@@ -48,6 +48,10 @@ struct RootView: View {
             // 从 App 启动开始监听未完成和后续交易；任务随 RootView 生命周期取消。
             await managedConnectionEntitlementStore.observeTransactionUpdates()
         }
+        .task(id: managedConnectionEntitlementStore.currentGrant?.tokenExpiresAt) {
+            // App 长时间停留前台时，也要在短期 Token 到期前主动续期。
+            await managedConnectionEntitlementStore.maintainCurrentGrant()
+        }
         .onChange(of: appStore.connectionProfiles) { _, _ in
             // 删除重复 endpoint 后，旧数据可能刚刚变成可唯一归属；此时立即重试，
             // 不要求用户先进入工作区页面才能恢复原来的图标偏好。

--- a/ios/MimiRemote/Sources/RootView.swift
+++ b/ios/MimiRemote/Sources/RootView.swift
@@ -9,6 +9,7 @@ struct RootView: View {
     @EnvironmentObject private var notificationResponseAdapter: SessionNotificationResponseAdapter
     @EnvironmentObject private var hostStatusStore: HostStatusStore
     @EnvironmentObject private var tailcatExperimentController: TailcatExperimentController
+    @EnvironmentObject private var managedConnectionEntitlementStore: ManagedConnectionEntitlementStore
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.scenePhase) private var scenePhase
     @State private var showingLogInspector = false
@@ -36,6 +37,16 @@ struct RootView: View {
         }
         .task(id: appStore.activeHostScope) {
             migrateLegacyWorkspaceAppearance()
+        }
+        .task(id: scenePhase) {
+            guard scenePhase == .active else { return }
+            // StoreKit 当前权益是冷启动与回到前台时的本地事实入口。
+            // 只有发现 Apple 已验证的交易后，Store 才会把两份签名 JWS 发给权益服务。
+            await managedConnectionEntitlementStore.refreshEntitlement()
+        }
+        .task {
+            // 从 App 启动开始监听未完成和后续交易；任务随 RootView 生命周期取消。
+            await managedConnectionEntitlementStore.observeTransactionUpdates()
         }
         .onChange(of: appStore.connectionProfiles) { _, _ in
             // 删除重复 endpoint 后，旧数据可能刚刚变成可唯一归属；此时立即重试，

--- a/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
@@ -20,16 +20,24 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
     private let storeKit: any ManagedConnectionStoreKitClient
     private let entitlementAPI: any ManagedConnectionEntitlementAPIClient
     private let now: () -> Date
+    private let sleepUntil: @Sendable (Date) async throws -> Void
     private var operationGeneration = 0
 
     init(
         storeKit: any ManagedConnectionStoreKitClient,
         entitlementAPI: any ManagedConnectionEntitlementAPIClient,
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> Date = Date.init,
+        sleepUntil: @escaping @Sendable (Date) async throws -> Void = { date in
+            let delay = max(0, date.timeIntervalSinceNow)
+            if delay > 0 {
+                try await Task.sleep(for: .seconds(delay))
+            }
+        }
     ) {
         self.storeKit = storeKit
         self.entitlementAPI = entitlementAPI
         self.now = now
+        self.sleepUntil = sleepUntil
     }
 
     func load() async {
@@ -59,9 +67,67 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
     func observeTransactionUpdates() async {
         // Ask to Buy、另一设备购买等交易会在 App 运行期间异步完成。
         // 收到变化后仍走统一的服务端校验路径，监听器本身不直接授予权益。
-        for await _ in storeKit.transactionUpdates() {
+        for await update in storeKit.transactionUpdates() {
             guard !Task.isCancelled else { return }
+            switch update {
+            case .verified(let evidence):
+                await resolveTransactionUpdate(evidence)
+            case .unverified:
+                // 未验证事件本身不能改变权益；重新读取 Apple 当前已验证权益。
+                await refreshEntitlement()
+            }
+        }
+    }
+
+    func maintainCurrentGrant() async {
+        guard let scheduledGrant = usableCurrentGrant else { return }
+        var refreshAt = scheduledGrant.tokenExpiresAt.addingTimeInterval(-60)
+
+        while !Task.isCancelled {
+            do {
+                try await sleepUntil(max(refreshAt, now()))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled,
+                  currentGrant?.token == scheduledGrant.token,
+                  currentGrant?.tokenExpiresAt == scheduledGrant.tokenExpiresAt
+            else {
+                return
+            }
+
             await refreshEntitlement()
+
+            guard currentGrant?.token == scheduledGrant.token,
+                  currentGrant?.tokenExpiresAt == scheduledGrant.tokenExpiresAt,
+                  now() < scheduledGrant.tokenExpiresAt
+            else {
+                return
+            }
+            // 提前刷新遇到瞬时故障时，最迟在旧 Token 到期时再尝试一次。
+            refreshAt = scheduledGrant.tokenExpiresAt
+        }
+    }
+
+    private func resolveTransactionUpdate(_ evidence: ManagedConnectionTransactionEvidence) async {
+        let generation = beginOperation()
+        let previousGrant = usableCurrentGrant
+        status = .resolving
+        do {
+            let grant = try await resolve(evidence)
+            guard isLatest(generation) else { return }
+            currentGrant = grant
+            status = .entitled(grant.entitlement)
+            await storeKit.finish(transactionID: evidence.transactionID)
+        } catch is CancellationError {
+            guard isLatest(generation) else { return }
+            restore(previousGrant, otherwise: .available)
+        } catch {
+            guard isLatest(generation) else { return }
+            applyFailure(error, fallbackGrant: previousGrant)
+            if isTerminalServerDecision(error) {
+                await storeKit.finish(transactionID: evidence.transactionID)
+            }
         }
     }
 
@@ -223,6 +289,15 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         default:
             return .failed(userFacingMessage(for: error))
         }
+    }
+
+    private func isTerminalServerDecision(_ error: Error) -> Bool {
+        guard let apiError = error as? ManagedConnectionEntitlementAPIError,
+              case .rejected(let code) = apiError
+        else {
+            return false
+        }
+        return ["expired", "revoked", "no_current_entitlement"].contains(code)
     }
 
     private var usableCurrentGrant: ManagedConnectionEntitlementGrant? {

--- a/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+@MainActor
+final class ManagedConnectionEntitlementStore: ObservableObject {
+    enum Status: Equatable {
+        case loading
+        case available
+        case resolving
+        case entitled(ManagedConnectionEntitlement)
+        case pending
+        case expired
+        case revoked
+        case failed(String)
+    }
+
+    @Published private(set) var products: [ManagedConnectionProduct] = []
+    @Published private(set) var status: Status = .loading
+    @Published private(set) var currentGrant: ManagedConnectionEntitlementGrant?
+
+    private let storeKit: any ManagedConnectionStoreKitClient
+    private let entitlementAPI: any ManagedConnectionEntitlementAPIClient
+    private let now: () -> Date
+    private var operationGeneration = 0
+
+    init(
+        storeKit: any ManagedConnectionStoreKitClient,
+        entitlementAPI: any ManagedConnectionEntitlementAPIClient,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.storeKit = storeKit
+        self.entitlementAPI = entitlementAPI
+        self.now = now
+    }
+
+    func load() async {
+        let generation = beginOperation()
+        let previousGrant = usableCurrentGrant
+        let previousStatus = status
+        status = .loading
+        do {
+            let loadedProducts = try await storeKit.products()
+            guard isLatest(generation) else { return }
+            products = loadedProducts
+            await refreshEntitlement(generation: generation)
+        } catch is CancellationError {
+            guard isLatest(generation) else { return }
+            restoreAfterCancellation(previousGrant, previousStatus: previousStatus)
+        } catch {
+            guard isLatest(generation) else { return }
+            restore(previousGrant, otherwise: .failed(userFacingMessage(for: error)))
+        }
+    }
+
+    func refreshEntitlement() async {
+        let generation = beginOperation()
+        await refreshEntitlement(generation: generation)
+    }
+
+    func observeTransactionUpdates() async {
+        // Ask to Buy、另一设备购买等交易会在 App 运行期间异步完成。
+        // 收到变化后仍走统一的服务端校验路径，监听器本身不直接授予权益。
+        for await _ in storeKit.transactionUpdates() {
+            guard !Task.isCancelled else { return }
+            await refreshEntitlement()
+        }
+    }
+
+    private func refreshEntitlement(generation: Int) async {
+        let previousGrant = usableCurrentGrant
+        let previousStatus = status
+        status = .resolving
+
+        for productID in ManagedConnectionProductID.all.reversed() {
+            let outcome = await storeKit.currentEntitlement(productID: productID)
+            guard isLatest(generation) else { return }
+            switch outcome {
+            case .none:
+                continue
+            case .unverified:
+                currentGrant = nil
+                status = .failed(L10n.text("ui.managed_subscription_unverified"))
+                return
+            case .verified(let evidence):
+                do {
+                    let grant = try await resolve(evidence)
+                    guard isLatest(generation) else { return }
+                    currentGrant = grant
+                    status = .entitled(grant.entitlement)
+                    await storeKit.finish(transactionID: evidence.transactionID)
+                    return
+                } catch is CancellationError {
+                    guard isLatest(generation) else { return }
+                    restoreAfterCancellation(previousGrant, previousStatus: previousStatus)
+                    return
+                } catch {
+                    guard isLatest(generation) else { return }
+                    applyRefreshFailure(error)
+                    return
+                }
+            }
+        }
+
+        currentGrant = nil
+        status = .available
+    }
+
+    func purchase(productID: String) async {
+        guard ManagedConnectionProductID.all.contains(productID) else { return }
+        let generation = beginOperation()
+        let previousGrant = usableCurrentGrant
+        let previousStatus = status
+        status = .resolving
+        do {
+            let outcome = try await storeKit.purchase(productID: productID)
+            guard isLatest(generation) else { return }
+            switch outcome {
+            case .cancelled:
+                restore(previousGrant, otherwise: .available)
+            case .pending:
+                restore(previousGrant, otherwise: .pending)
+            case .unverified:
+                restore(
+                    previousGrant,
+                    otherwise: .failed(L10n.text("ui.managed_subscription_unverified"))
+                )
+            case .success(let evidence):
+                do {
+                    let grant = try await resolve(evidence)
+                    guard isLatest(generation) else { return }
+                    currentGrant = grant
+                    status = .entitled(grant.entitlement)
+                    // 服务端是权益事实来源。只有它接受两份 JWS 后，才结束 StoreKit 交易。
+                    await storeKit.finish(transactionID: evidence.transactionID)
+                } catch is CancellationError {
+                    guard isLatest(generation) else { return }
+                    restoreAfterCancellation(previousGrant, previousStatus: previousStatus)
+                } catch {
+                    guard isLatest(generation) else { return }
+                    applyFailure(error, fallbackGrant: previousGrant)
+                }
+            }
+        } catch is CancellationError {
+            guard isLatest(generation) else { return }
+            restoreAfterCancellation(previousGrant, previousStatus: previousStatus)
+        } catch {
+            guard isLatest(generation) else { return }
+            restore(previousGrant, otherwise: .failed(userFacingMessage(for: error)))
+        }
+    }
+
+    func restorePurchases() async {
+        let generation = beginOperation()
+        let previousGrant = usableCurrentGrant
+        let previousStatus = status
+        status = .resolving
+        do {
+            // AppStore.sync 会弹出系统鉴权，只能由用户明确点击“恢复购买”触发。
+            try await storeKit.syncPurchases()
+            guard isLatest(generation) else { return }
+            await refreshEntitlement(generation: generation)
+        } catch is CancellationError {
+            guard isLatest(generation) else { return }
+            restoreAfterCancellation(previousGrant, previousStatus: previousStatus)
+        } catch {
+            guard isLatest(generation) else { return }
+            restore(previousGrant, otherwise: .failed(userFacingMessage(for: error)))
+        }
+    }
+
+    var isBusy: Bool {
+        status == .loading || status == .resolving
+    }
+
+    private func beginOperation() -> Int {
+        operationGeneration &+= 1
+        return operationGeneration
+    }
+
+    private func isLatest(_ generation: Int) -> Bool {
+        operationGeneration == generation
+    }
+
+    private func resolve(
+        _ evidence: ManagedConnectionTransactionEvidence
+    ) async throws -> ManagedConnectionEntitlementGrant {
+        let signedAppTransaction = try await storeKit.signedAppTransaction()
+        let grant = try await entitlementAPI.resolve(
+            signedAppTransaction: signedAppTransaction,
+            signedTransaction: evidence.signedTransaction
+        )
+        guard grant.entitlement.productID == evidence.productID,
+              grant.entitlement.expiresAt > now(),
+              grant.tokenExpiresAt > now()
+        else {
+            throw ManagedConnectionEntitlementAPIError.invalidResponse
+        }
+        return grant
+    }
+
+    private func userFacingMessage(for error: Error) -> String {
+        if let localized = error as? LocalizedError,
+           let description = localized.errorDescription,
+           !description.isEmpty
+        {
+            return description
+        }
+        return L10n.text("ui.managed_subscription_network_error")
+    }
+
+    private func status(for error: Error) -> Status {
+        guard let apiError = error as? ManagedConnectionEntitlementAPIError,
+              case .rejected(let code) = apiError
+        else {
+            return .failed(userFacingMessage(for: error))
+        }
+        switch code {
+        case "expired":
+            return .expired
+        case "revoked":
+            return .revoked
+        case "no_current_entitlement":
+            return .available
+        default:
+            return .failed(userFacingMessage(for: error))
+        }
+    }
+
+    private var usableCurrentGrant: ManagedConnectionEntitlementGrant? {
+        guard let currentGrant,
+              currentGrant.entitlement.expiresAt > now(),
+              currentGrant.tokenExpiresAt > now()
+        else {
+            return nil
+        }
+        return currentGrant
+    }
+
+    private func restore(_ grant: ManagedConnectionEntitlementGrant?, otherwise status: Status) {
+        if let grant {
+            currentGrant = grant
+            self.status = .entitled(grant.entitlement)
+        } else {
+            currentGrant = nil
+            self.status = status
+        }
+    }
+
+    private func applyRefreshFailure(_ error: Error) {
+        applyFailure(error, fallbackGrant: usableCurrentGrant)
+    }
+
+    private func applyFailure(
+        _ error: Error,
+        fallbackGrant: ManagedConnectionEntitlementGrant?
+    ) {
+        let failureStatus = status(for: error)
+        switch failureStatus {
+        case .available, .expired, .revoked:
+            currentGrant = nil
+            status = failureStatus
+        case .failed:
+            if let apiError = error as? ManagedConnectionEntitlementAPIError,
+               case .rejected(let code) = apiError,
+               code == "unverified_transaction"
+            {
+                currentGrant = nil
+                status = failureStatus
+            } else {
+                restore(fallbackGrant, otherwise: failureStatus)
+            }
+        default:
+            restore(fallbackGrant, otherwise: failureStatus)
+        }
+    }
+
+    private func restoreAfterCancellation(
+        _ grant: ManagedConnectionEntitlementGrant?,
+        previousStatus: Status
+    ) {
+        if let grant {
+            restore(grant, otherwise: .available)
+            return
+        }
+        currentGrant = nil
+        switch previousStatus {
+        case .available, .pending, .expired, .revoked, .failed:
+            status = previousStatus
+        case .entitled(let entitlement) where entitlement.expiresAt > now():
+            status = .entitled(entitlement)
+        case .loading, .resolving, .entitled:
+            status = .available
+        }
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
@@ -134,7 +134,7 @@ final class ManagedConnectionEntitlementStoreTests: XCTestCase {
             productID: ManagedConnectionProductID.monthly
         )
 
-        await storeKit.sendTransactionUpdate()
+        await storeKit.sendTransactionUpdate(.verified(Self.evidence))
         for _ in 0..<100 {
             if await api.resolveCount > 0 { break }
             await Task.yield()
@@ -147,6 +147,64 @@ final class ManagedConnectionEntitlementStoreTests: XCTestCase {
         XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
         XCTAssertEqual(finishedTransactionIDs, [Self.evidence.transactionID])
         XCTAssertEqual(resolveCount, 1)
+    }
+
+    func testVerifiedRevocationUpdateSendsItsJWSAndFinishesAfterServerDecision() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(
+            result: .failure(ManagedConnectionEntitlementAPIError.rejected(code: "revoked"))
+        )
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+        let observer = Task { await store.observeTransactionUpdates() }
+
+        await storeKit.sendTransactionUpdate(.verified(Self.evidence))
+        for _ in 0..<100 {
+            if await api.resolveCount > 0 { break }
+            await Task.yield()
+        }
+
+        observer.cancel()
+        await observer.value
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        XCTAssertEqual(store.status, .revoked)
+        XCTAssertNil(store.currentGrant)
+        XCTAssertEqual(finishedTransactionIDs, [Self.evidence.transactionID])
+    }
+
+    func testGrantRefreshesBeforeTokenExpiresWhileAppRemainsActive() async {
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let firstGrant = Self.grant(now: base)
+        let renewedGrant = ManagedConnectionEntitlementGrant(
+            entitlement: firstGrant.entitlement,
+            token: "renewed-token",
+            tokenExpiresAt: base.addingTimeInterval(1_800)
+        )
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(firstGrant))
+        let sleeper = SleepUntilFake()
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: api,
+            now: { base },
+            sleepUntil: { date in try await sleeper.sleep(until: date) }
+        )
+        await store.refreshEntitlement()
+        await api.setResult(.success(renewedGrant))
+
+        let maintenance = Task { await store.maintainCurrentGrant() }
+        for _ in 0..<100 {
+            if await sleeper.hasWaiter { break }
+            await Task.yield()
+        }
+        let scheduledDate = await sleeper.scheduledDate
+        await sleeper.resume()
+        await maintenance.value
+
+        let resolveCount = await api.resolveCount
+        XCTAssertEqual(scheduledDate, firstGrant.tokenExpiresAt.addingTimeInterval(-60))
+        XCTAssertEqual(store.currentGrant, renewedGrant)
+        XCTAssertEqual(resolveCount, 2)
     }
 
     func testOlderSuccessCannotReviveGrantAfterNewerRevocation() async {
@@ -528,8 +586,8 @@ final class ManagedConnectionEntitlementAPIClientTests: XCTestCase {
 }
 
 private actor StoreKitFake: ManagedConnectionStoreKitClient {
-    nonisolated private let updates: AsyncStream<Void>
-    nonisolated private let updatesContinuation: AsyncStream<Void>.Continuation
+    nonisolated private let updates: AsyncStream<ManagedConnectionTransactionUpdate>
+    nonisolated private let updatesContinuation: AsyncStream<ManagedConnectionTransactionUpdate>.Continuation
     private var purchaseOutcome: ManagedConnectionPurchaseOutcome = .cancelled
     private var currentByProductID: [String: ManagedConnectionCurrentEntitlementOutcome] = [:]
     private(set) var finishedTransactionIDs: [UInt64] = []
@@ -539,7 +597,7 @@ private actor StoreKitFake: ManagedConnectionStoreKitClient {
     private var purchaseError: Error?
 
     init() {
-        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        let (stream, continuation) = AsyncStream<ManagedConnectionTransactionUpdate>.makeStream()
         updates = stream
         updatesContinuation = continuation
     }
@@ -578,12 +636,12 @@ private actor StoreKitFake: ManagedConnectionStoreKitClient {
         currentByProductID[productID] ?? .none
     }
 
-    nonisolated func transactionUpdates() -> AsyncStream<Void> {
+    nonisolated func transactionUpdates() -> AsyncStream<ManagedConnectionTransactionUpdate> {
         updates
     }
 
-    func sendTransactionUpdate() {
-        updatesContinuation.yield(())
+    func sendTransactionUpdate(_ update: ManagedConnectionTransactionUpdate) {
+        updatesContinuation.yield(update)
     }
 
     func signedAppTransaction() async throws -> String { "signed-app-transaction" }
@@ -595,6 +653,34 @@ private actor StoreKitFake: ManagedConnectionStoreKitClient {
     func syncPurchases() async throws {
         syncCount += 1
         if let syncError { throw syncError }
+    }
+}
+
+private actor SleepUntilFake {
+    private(set) var scheduledDate: Date?
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    var hasWaiter: Bool { continuation != nil }
+
+    func sleep(until date: Date) async throws {
+        scheduledDate = date
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+            }
+        } onCancel: {
+            Task { await self.cancel() }
+        }
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
+    }
+
+    private func cancel() {
+        continuation?.resume(throwing: CancellationError())
+        continuation = nil
     }
 }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
@@ -1,0 +1,742 @@
+import StoreKit
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class ManagedConnectionEntitlementStoreTests: XCTestCase {
+    func testVerifiedPurchaseRequiresServerGrantBeforeFinishing() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await storeKit.setPurchase(.success(Self.evidence))
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+
+        await store.purchase(productID: ManagedConnectionProductID.monthly)
+
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        let resolveCount = await api.resolveCount
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(store.currentGrant, Self.grant)
+        XCTAssertEqual(finishedTransactionIDs, [42])
+        XCTAssertEqual(resolveCount, 1)
+    }
+
+    func testServerFailureDoesNotFinishVerifiedPurchaseOrGrantAccess() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .failure(TestError.serverUnavailable))
+        await storeKit.setPurchase(.success(Self.evidence))
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+
+        await store.purchase(productID: ManagedConnectionProductID.monthly)
+
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        XCTAssertEqual(store.status, .failed("server unavailable"))
+        XCTAssertNil(store.currentGrant)
+        XCTAssertEqual(finishedTransactionIDs, [])
+    }
+
+    func testCancelledPurchaseReturnsToAvailableWithoutResolving() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await storeKit.setPurchase(.cancelled)
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+
+        await store.purchase(productID: ManagedConnectionProductID.monthly)
+
+        let resolveCount = await api.resolveCount
+        XCTAssertEqual(store.status, .available)
+        XCTAssertEqual(resolveCount, 0)
+    }
+
+    func testPendingPurchaseDoesNotGrantAccess() async {
+        let storeKit = StoreKitFake()
+        await storeKit.setPurchase(.pending)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: EntitlementAPIFake(result: .success(Self.grant))
+        )
+
+        await store.purchase(productID: ManagedConnectionProductID.monthly)
+
+        XCTAssertEqual(store.status, .pending)
+        XCTAssertNil(store.currentGrant)
+    }
+
+    func testUnverifiedPurchaseDoesNotCallServer() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await storeKit.setPurchase(.unverified)
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+
+        await store.purchase(productID: ManagedConnectionProductID.monthly)
+
+        guard case .failed = store.status else {
+            return XCTFail("unverified purchase must fail")
+        }
+        let resolveCount = await api.resolveCount
+        XCTAssertEqual(resolveCount, 0)
+    }
+
+    func testRestoreIsTheOnlyFlowThatCallsSync() async {
+        let storeKit = StoreKitFake()
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: EntitlementAPIFake(result: .success(Self.grant))
+        )
+
+        await store.refreshEntitlement()
+        let syncCountBeforeRestore = await storeKit.syncCount
+        XCTAssertEqual(syncCountBeforeRestore, 0)
+
+        await store.restorePurchases()
+        let syncCountAfterRestore = await storeKit.syncCount
+        XCTAssertEqual(syncCountAfterRestore, 1)
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+    }
+
+    func testCurrentEntitlementFinishesOnlyAfterServerGrant() async {
+        let storeKit = StoreKitFake()
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: EntitlementAPIFake(result: .success(Self.grant))
+        )
+
+        await store.refreshEntitlement()
+
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(finishedTransactionIDs, [Self.evidence.transactionID])
+    }
+
+    func testCurrentEntitlementServerFailureDoesNotFinish() async {
+        let storeKit = StoreKitFake()
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: EntitlementAPIFake(result: .failure(TestError.serverUnavailable))
+        )
+
+        await store.refreshEntitlement()
+
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        XCTAssertNil(store.currentGrant)
+        XCTAssertEqual(finishedTransactionIDs, [])
+    }
+
+    func testTransactionUpdateRefreshesAndFinishesOnlyAfterServerGrant() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+        let observer = Task { await store.observeTransactionUpdates() }
+        await storeKit.setCurrent(
+            .verified(Self.evidence),
+            productID: ManagedConnectionProductID.monthly
+        )
+
+        await storeKit.sendTransactionUpdate()
+        for _ in 0..<100 {
+            if await api.resolveCount > 0 { break }
+            await Task.yield()
+        }
+
+        observer.cancel()
+        await observer.value
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        let resolveCount = await api.resolveCount
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(finishedTransactionIDs, [Self.evidence.transactionID])
+        XCTAssertEqual(resolveCount, 1)
+    }
+
+    func testOlderSuccessCannotReviveGrantAfterNewerRevocation() async {
+        let storeKit = StoreKitFake()
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let api = DelayedEntitlementAPIFake()
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+
+        let olderRefresh = Task { await store.refreshEntitlement() }
+        while !(await api.hasStartedFirstRequest) {
+            await Task.yield()
+        }
+        await store.refreshEntitlement()
+        await api.completeFirstRequest(with: Self.grant)
+        await olderRefresh.value
+
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        XCTAssertEqual(store.status, .revoked)
+        XCTAssertNil(store.currentGrant)
+        XCTAssertEqual(finishedTransactionIDs, [])
+    }
+
+    func testCancellingOrPendingPlanChangeKeepsExistingGrant() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+        await store.refreshEntitlement()
+
+        await storeKit.setPurchase(.cancelled)
+        await store.purchase(productID: ManagedConnectionProductID.annual)
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(store.currentGrant, Self.grant)
+
+        await storeKit.setPurchase(.pending)
+        await store.purchase(productID: ManagedConnectionProductID.annual)
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(store.currentGrant, Self.grant)
+    }
+
+    func testRestoreSyncFailureKeepsExistingGrant() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+        await store.refreshEntitlement()
+        await storeKit.setSyncError(TestError.serverUnavailable)
+
+        await store.restorePurchases()
+
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(store.currentGrant, Self.grant)
+    }
+
+    func testExplicitPurchaseRejectionClearsExistingGrant() async {
+        for code in ["expired", "revoked", "unverified_transaction"] {
+            let storeKit = StoreKitFake()
+            let api = EntitlementAPIFake(result: .success(Self.grant))
+            await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+            await storeKit.setPurchase(.success(Self.evidence))
+            let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+            await store.refreshEntitlement()
+            await api.setResult(.failure(ManagedConnectionEntitlementAPIError.rejected(code: code)))
+
+            await store.purchase(productID: ManagedConnectionProductID.annual)
+
+            XCTAssertNil(store.currentGrant, "server rejection must clear grant: \(code)")
+            if code == "expired" {
+                XCTAssertEqual(store.status, .expired)
+            } else if code == "revoked" {
+                XCTAssertEqual(store.status, .revoked)
+            } else {
+                guard case .failed = store.status else {
+                    return XCTFail("unverified transaction must fail")
+                }
+            }
+        }
+    }
+
+    func testNoCurrentEntitlementClearsExistingGrantDuringRefreshAndPurchase() async {
+        for operation in ["refresh", "purchase"] {
+            let storeKit = StoreKitFake()
+            let api = EntitlementAPIFake(result: .success(Self.grant))
+            await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+            await storeKit.setPurchase(.success(Self.evidence))
+            let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+            await store.refreshEntitlement()
+            await api.setResult(
+                .failure(ManagedConnectionEntitlementAPIError.rejected(code: "no_current_entitlement"))
+            )
+
+            if operation == "refresh" {
+                await store.refreshEntitlement()
+            } else {
+                await store.purchase(productID: ManagedConnectionProductID.annual)
+            }
+
+            XCTAssertNil(store.currentGrant, operation)
+            XCTAssertEqual(store.status, .available, operation)
+        }
+    }
+
+    func testProductLoadFailureKeepsExistingGrant() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+        await store.refreshEntitlement()
+        await storeKit.setProductsError(TestError.serverUnavailable)
+
+        await store.load()
+
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(store.currentGrant, Self.grant)
+    }
+
+    func testCancellationNeverLeavesStoreBusy() async {
+        let loadStoreKit = StoreKitFake()
+        await loadStoreKit.setProductsError(CancellationError())
+        let loadStore = ManagedConnectionEntitlementStore(
+            storeKit: loadStoreKit,
+            entitlementAPI: EntitlementAPIFake(result: .success(Self.grant))
+        )
+        await loadStore.load()
+        XCTAssertEqual(loadStore.status, .available)
+
+        let refreshStoreKit = StoreKitFake()
+        await refreshStoreKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let refreshStore = ManagedConnectionEntitlementStore(
+            storeKit: refreshStoreKit,
+            entitlementAPI: EntitlementAPIFake(result: .failure(CancellationError()))
+        )
+        await refreshStore.refreshEntitlement()
+        XCTAssertEqual(refreshStore.status, .available)
+
+        let purchaseStoreKit = StoreKitFake()
+        await purchaseStoreKit.setPurchaseError(CancellationError())
+        let purchaseStore = ManagedConnectionEntitlementStore(
+            storeKit: purchaseStoreKit,
+            entitlementAPI: EntitlementAPIFake(result: .success(Self.grant))
+        )
+        await purchaseStore.purchase(productID: ManagedConnectionProductID.monthly)
+        XCTAssertEqual(purchaseStore.status, .available)
+
+        let restoreStoreKit = StoreKitFake()
+        await restoreStoreKit.setSyncError(CancellationError())
+        let restoreStore = ManagedConnectionEntitlementStore(
+            storeKit: restoreStoreKit,
+            entitlementAPI: EntitlementAPIFake(result: .success(Self.grant))
+        )
+        await restoreStore.restorePurchases()
+        XCTAssertEqual(restoreStore.status, .available)
+    }
+
+    func testTransientRefreshFailureKeepsGrantWhileTokenIsValid() async {
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(storeKit: storeKit, entitlementAPI: api)
+        await store.refreshEntitlement()
+        await api.setResult(.failure(TestError.serverUnavailable))
+
+        await store.refreshEntitlement()
+
+        XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(store.currentGrant, Self.grant)
+    }
+
+    func testTransientRefreshFailureClearsExpiredToken() async {
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        var now = base
+        let grant = Self.grant(now: base)
+        let storeKit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(grant))
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: api,
+            now: { now }
+        )
+        await store.refreshEntitlement()
+        now = base.addingTimeInterval(901)
+        await api.setResult(.failure(TestError.serverUnavailable))
+
+        await store.refreshEntitlement()
+
+        XCTAssertNil(store.currentGrant)
+        XCTAssertEqual(store.status, .failed("server unavailable"))
+    }
+
+    func testExpiredServerDecisionProducesExpiredState() async {
+        let storeKit = StoreKitFake()
+        await storeKit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: EntitlementAPIFake(
+                result: .failure(ManagedConnectionEntitlementAPIError.rejected(code: "expired"))
+            )
+        )
+
+        await store.refreshEntitlement()
+
+        XCTAssertEqual(store.status, .expired)
+        XCTAssertNil(store.currentGrant)
+    }
+
+    func testRevokedServerDecisionProducesRevokedState() async {
+        let storeKit = StoreKitFake()
+        await storeKit.setPurchase(.success(Self.evidence))
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: EntitlementAPIFake(
+                result: .failure(ManagedConnectionEntitlementAPIError.rejected(code: "revoked"))
+            )
+        )
+
+        await store.purchase(productID: ManagedConnectionProductID.monthly)
+
+        let finishedTransactionIDs = await storeKit.finishedTransactionIDs
+        XCTAssertEqual(store.status, .revoked)
+        XCTAssertNil(store.currentGrant)
+        XCTAssertEqual(finishedTransactionIDs, [])
+    }
+
+    func testOnlyFreeTrialOfferIsPresentedAsTrial() {
+        XCTAssertTrue(
+            ManagedConnectionTrialEligibility.isFreeTrial(
+                eligible: true,
+                paymentMode: .freeTrial
+            )
+        )
+        XCTAssertFalse(
+            ManagedConnectionTrialEligibility.isFreeTrial(
+                eligible: true,
+                paymentMode: .payAsYouGo
+            )
+        )
+        XCTAssertFalse(
+            ManagedConnectionTrialEligibility.isFreeTrial(
+                eligible: true,
+                paymentMode: .payUpFront
+            )
+        )
+        XCTAssertFalse(
+            ManagedConnectionTrialEligibility.isFreeTrial(
+                eligible: false,
+                paymentMode: .freeTrial
+            )
+        )
+    }
+
+    private static let evidence = ManagedConnectionTransactionEvidence(
+        transactionID: 42,
+        productID: ManagedConnectionProductID.monthly,
+        signedTransaction: "signed-transaction"
+    )
+
+    private static let grant = ManagedConnectionEntitlementGrant(
+        entitlement: ManagedConnectionEntitlement(
+            id: "entitlement-id",
+            productID: ManagedConnectionProductID.monthly,
+            status: .active,
+            expiresAt: Date(timeIntervalSinceNow: 3_600)
+        ),
+        token: "in-memory-token",
+        tokenExpiresAt: Date(timeIntervalSinceNow: 900)
+    )
+
+    private static func grant(now: Date) -> ManagedConnectionEntitlementGrant {
+        ManagedConnectionEntitlementGrant(
+            entitlement: ManagedConnectionEntitlement(
+                id: "entitlement-id",
+                productID: ManagedConnectionProductID.monthly,
+                status: .active,
+                expiresAt: now.addingTimeInterval(3_600)
+            ),
+            token: "in-memory-token",
+            tokenExpiresAt: now.addingTimeInterval(900)
+        )
+    }
+}
+
+final class ManagedConnectionEntitlementAPIClientTests: XCTestCase {
+    override func tearDown() {
+        ManagedConnectionEntitlementURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testResolvePostsBothAppleJWSValuesAndParsesGrant() async throws {
+        ManagedConnectionEntitlementURLProtocol.respond(
+            statusCode: 200,
+            body: #"""
+            {
+                "entitlement": {
+                    "id": "entitlement-id",
+                    "productId": "com.gaixianggeng.mimi.managed.monthly",
+                    "status": "trial",
+                    "expiresAt": "2026-09-11T00:00:00.000Z"
+                },
+                "entitlementToken": "short-lived-token",
+                "tokenExpiresAt": "2026-09-04T00:15:00Z"
+            }
+            """#
+        )
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let client = LiveManagedConnectionEntitlementAPIClient(
+            baseURL: URL(string: "https://api.code89757.com")!,
+            session: session
+        )
+
+        let grant = try await client.resolve(
+            signedAppTransaction: "signed-app-transaction",
+            signedTransaction: "signed-transaction"
+        )
+
+        let request = try XCTUnwrap(ManagedConnectionEntitlementURLProtocol.capturedRequest())
+        XCTAssertEqual(request.url?.absoluteString, "https://api.code89757.com/v1/entitlements/resolve")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        let body = try XCTUnwrap(ManagedConnectionEntitlementURLProtocol.capturedBody())
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(json["signedAppTransaction"], "signed-app-transaction")
+        XCTAssertEqual(json["signedTransaction"], "signed-transaction")
+        XCTAssertEqual(grant.entitlement.id, "entitlement-id")
+        XCTAssertEqual(grant.entitlement.status, .trial)
+        XCTAssertEqual(grant.entitlement.productID, ManagedConnectionProductID.monthly)
+        XCTAssertEqual(grant.token, "short-lived-token")
+    }
+
+    func testResolvePreservesServerRejectionCode() async throws {
+        ManagedConnectionEntitlementURLProtocol.respond(
+            statusCode: 403,
+            body: #"{"code":"no_current_entitlement"}"#
+        )
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let client = LiveManagedConnectionEntitlementAPIClient(session: session)
+
+        do {
+            _ = try await client.resolve(
+                signedAppTransaction: "signed-app-transaction",
+                signedTransaction: "signed-transaction"
+            )
+            XCTFail("server rejection must not grant access")
+        } catch {
+            XCTAssertEqual(
+                error as? ManagedConnectionEntitlementAPIError,
+                .rejected(code: "no_current_entitlement")
+            )
+        }
+    }
+
+    func testResolveRejectsMalformedSuccessPayload() async throws {
+        ManagedConnectionEntitlementURLProtocol.respond(
+            statusCode: 200,
+            body: #"{"entitlement":{"id":"missing-fields"}}"#
+        )
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let client = LiveManagedConnectionEntitlementAPIClient(session: session)
+
+        do {
+            _ = try await client.resolve(
+                signedAppTransaction: "signed-app-transaction",
+                signedTransaction: "signed-transaction"
+            )
+            XCTFail("malformed response must not grant access")
+        } catch {
+            XCTAssertEqual(error as? ManagedConnectionEntitlementAPIError, .invalidResponse)
+        }
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ManagedConnectionEntitlementURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private actor StoreKitFake: ManagedConnectionStoreKitClient {
+    nonisolated private let updates: AsyncStream<Void>
+    nonisolated private let updatesContinuation: AsyncStream<Void>.Continuation
+    private var purchaseOutcome: ManagedConnectionPurchaseOutcome = .cancelled
+    private var currentByProductID: [String: ManagedConnectionCurrentEntitlementOutcome] = [:]
+    private(set) var finishedTransactionIDs: [UInt64] = []
+    private(set) var syncCount = 0
+    private var syncError: Error?
+    private var productsError: Error?
+    private var purchaseError: Error?
+
+    init() {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        updates = stream
+        updatesContinuation = continuation
+    }
+
+    func setPurchase(_ outcome: ManagedConnectionPurchaseOutcome) {
+        purchaseOutcome = outcome
+    }
+
+    func setCurrent(_ outcome: ManagedConnectionCurrentEntitlementOutcome, productID: String) {
+        currentByProductID[productID] = outcome
+    }
+
+    func setSyncError(_ error: Error?) {
+        syncError = error
+    }
+
+    func setProductsError(_ error: Error?) {
+        productsError = error
+    }
+
+    func setPurchaseError(_ error: Error?) {
+        purchaseError = error
+    }
+
+    func products() async throws -> [ManagedConnectionProduct] {
+        if let productsError { throw productsError }
+        return []
+    }
+
+    func purchase(productID: String) async throws -> ManagedConnectionPurchaseOutcome {
+        if let purchaseError { throw purchaseError }
+        return purchaseOutcome
+    }
+
+    func currentEntitlement(productID: String) async -> ManagedConnectionCurrentEntitlementOutcome {
+        currentByProductID[productID] ?? .none
+    }
+
+    nonisolated func transactionUpdates() -> AsyncStream<Void> {
+        updates
+    }
+
+    func sendTransactionUpdate() {
+        updatesContinuation.yield(())
+    }
+
+    func signedAppTransaction() async throws -> String { "signed-app-transaction" }
+
+    func finish(transactionID: UInt64) async {
+        finishedTransactionIDs.append(transactionID)
+    }
+
+    func syncPurchases() async throws {
+        syncCount += 1
+        if let syncError { throw syncError }
+    }
+}
+
+private actor EntitlementAPIFake: ManagedConnectionEntitlementAPIClient {
+    private var result: Result<ManagedConnectionEntitlementGrant, Error>
+    private(set) var resolveCount = 0
+
+    init(result: Result<ManagedConnectionEntitlementGrant, Error>) {
+        self.result = result
+    }
+
+    func setResult(_ result: Result<ManagedConnectionEntitlementGrant, Error>) {
+        self.result = result
+    }
+
+    func resolve(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionEntitlementGrant {
+        resolveCount += 1
+        return try result.get()
+    }
+}
+
+private actor DelayedEntitlementAPIFake: ManagedConnectionEntitlementAPIClient {
+    private var requestCount = 0
+    private var firstContinuation: CheckedContinuation<ManagedConnectionEntitlementGrant, Error>?
+
+    var hasStartedFirstRequest: Bool { firstContinuation != nil }
+
+    func resolve(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionEntitlementGrant {
+        requestCount += 1
+        if requestCount == 1 {
+            return try await withCheckedThrowingContinuation { continuation in
+                firstContinuation = continuation
+            }
+        }
+        throw ManagedConnectionEntitlementAPIError.rejected(code: "revoked")
+    }
+
+    func completeFirstRequest(with grant: ManagedConnectionEntitlementGrant) {
+        firstContinuation?.resume(returning: grant)
+        firstContinuation = nil
+    }
+}
+
+private enum TestError: LocalizedError {
+    case serverUnavailable
+
+    var errorDescription: String? { "server unavailable" }
+}
+
+private final class ManagedConnectionEntitlementURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var statusCode = 500
+    private static var responseBody = Data()
+    private static var lastRequest: URLRequest?
+    private static var lastBody: Data?
+
+    static func respond(statusCode: Int, body: String) {
+        lock.lock()
+        self.statusCode = statusCode
+        responseBody = Data(body.utf8)
+        lastRequest = nil
+        lastBody = nil
+        lock.unlock()
+    }
+
+    static func capturedRequest() -> URLRequest? {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastRequest
+    }
+
+    static func capturedBody() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastBody
+    }
+
+    static func reset() {
+        lock.lock()
+        statusCode = 500
+        responseBody = Data()
+        lastRequest = nil
+        lastBody = nil
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        var requestBody = request.httpBody
+        if requestBody == nil, let stream = request.httpBodyStream {
+            requestBody = Self.readAll(from: stream)
+        }
+
+        Self.lock.lock()
+        Self.lastRequest = request
+        Self.lastBody = requestBody
+        let statusCode = Self.statusCode
+        let responseBody = Self.responseBody
+        Self.lock.unlock()
+
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+              )
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: responseBody)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readAll(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4 * 1024)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -20,6 +20,8 @@ packages:
   swift-markdown:
     url: https://github.com/swiftlang/swift-markdown
     from: "0.8.0"
+fileGroups:
+  - Resources/MimiRemote.storekit
 targets:
   MimiRemote:
     type: application
@@ -211,6 +213,8 @@ schemes:
         MimiRemote: all
         MimiRemoteTests:
           - test
+    run:
+      storeKitConfiguration: Resources/MimiRemote.storekit
     test:
       language: zh-Hans
       targets:


### PR DESCRIPTION
## 结果
- 接入月付和年付 StoreKit 2 商品、7 天试用资格与本地化价格
- 增加购买、Pending、取消、未验证、过期、退款/撤销和恢复购买状态
- 使用 AppTransaction 与 Transaction JWS 向匿名权益服务换取短期内存 Token
- 仅在服务端确认权益后 finish 交易，并从 App 启动监听 Transaction.updates
- 设置页增加 Mimi 托管连接订阅入口；本地 StoreKit Configuration 只挂到 Run Scheme

## 验证
- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/ManagedConnectionEntitlementStoreTests -only-testing:MimiRemoteTests/ManagedConnectionEntitlementAPIClientTests`：24/24 通过
- `bash ./scripts/ios-dev.sh build-for-testing`：通过
- `bash ./scripts/check-source-size.sh`：通过
- `bash ./scripts/check-ios-localization.sh`：通过
- `bash ./scripts/check-app-store-metadata.sh`：通过
- `bash ./scripts/check-ios-privacy-manifest.sh`：通过
- `bash ./scripts/check-critical-regressions.sh`：通过

## 后续
真实 App Store Sandbox JWS 与云端联合验证按发布波次执行，不阻塞本 PR 的代码与本地 StoreKit 闭环。