### PR TITLE
MIM-260 在 iOS 中管理托管设备并完成多 Mac 配对

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		26F460F34C7BA2C10839F2CA /* testComposerStatusTrayCrowdedCompactWidth.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */; };
 		26FD0EEAC5360C26BD0CF2D0 /* SessionListLifecycleCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347A38B609AE9F5CCBD52029 /* SessionListLifecycleCoordinatorTests.swift */; };
 		279E8E85742A39CBD64F8C36 /* CarStatusSnapshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */; };
+		27DEAE1F21FC391A124F6332 /* ConnectionBenchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0A765F253BE3908F1A65AE /* ConnectionBenchmark.swift */; };
 		293498CD48F70C646F0DD612 /* CodexAppServerQueueSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = A571C41AE73754FB6C9FD6BC /* CodexAppServerQueueSubmission.swift */; };
 		2988A74079D67A66B14DFF98 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92342D7DF3BBF2BC0BF24FC /* SettingsView.swift */; };
 		29EE18E5D572B779CF19F20F /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png in Resources */ = {isa = PBXBuildFile; fileRef = E0EAC4CC35379B613A901E16 /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-single-line.png */; };
@@ -90,12 +91,12 @@
 		3B7C6F8101AC352585369923 /* SettingsChoiceRowSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADF7C1BCDC8114BB0CC589D /* SettingsChoiceRowSnapshotTests.swift */; platformFilters = (ios, ); };
 		3C66496C0EC02D59EC54C711 /* testLoadedActivityInDarkAppearance.loaded-compact-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = 405D5433F81D4DFCDCD6008B /* testLoadedActivityInDarkAppearance.loaded-compact-dark.png */; };
 		3CE709A723920DFD80FE96D0 /* ConnectionProfileRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */; };
-		C0B244000000000000000003 /* ConnectionBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B244000000000000000004 /* ConnectionBenchmarkTests.swift */; };
 		3E93414CD3560843DC67433E /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png in Resources */ = {isa = PBXBuildFile; fileRef = 9143CBABCA38B2E316A221BB /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png */; };
 		3F150075A258BDF73AFB8ED6 /* WorktreeManagementViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7A4F02C5EC7121D1BB6B9 /* WorktreeManagementViews.swift */; };
 		41032E4AF4E356EA802FEBDD /* AppStoreRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF3FE084B65924E2014463C /* AppStoreRouting.swift */; };
 		410ECA3E93AE577686A636C0 /* MediaWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4E57C95034C12853D10303 /* MediaWorker.swift */; };
 		4133C316969607C72DFE1168 /* SkillModelPickerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476737709E01875A7992BABB /* SkillModelPickerSnapshotTests.swift */; platformFilters = (ios, ); };
+		419537AC5582400C687118ED /* ManagedConnectionDeviceAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FF3738D9EAED4C04AF0B69 /* ManagedConnectionDeviceAPIClientTests.swift */; };
 		41B2009F6B92E4B407CFDB72 /* ModelReasoningGridPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A4A2B3A4B718F54CB4F8AE /* ModelReasoningGridPicker.swift */; };
 		420F5F2A694B0E491DBD45B0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7348A6FCD28C7489CC7097AD /* ThemeStoreTests.swift */; };
 		439355570F5ED69354673D07 /* testAppearancePreview.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 190DA6E3F95C3577B94AB67C /* testAppearancePreview.1.png */; };
@@ -126,7 +127,6 @@
 		5B092289C5F40E2A9B3622B9 /* SessionStoreLifecycleWorkspaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78D8C49C36228C60EF5D096 /* SessionStoreLifecycleWorkspaces.swift */; };
 		5B378569754B50364C872318 /* WorkspaceSessionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BCF1B2E13945C6F706C8BD /* WorkspaceSessionPresentationTests.swift */; };
 		5CC1C792F93F291FDD49FF09 /* ConnectionSpeedTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C3E59C8D5983AB7784558F /* ConnectionSpeedTestView.swift */; };
-		C0B244000000000000000001 /* ConnectionBenchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B244000000000000000002 /* ConnectionBenchmark.swift */; };
 		5CD51AE13B5D23F8FBE444C5 /* SessionStoreSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */; };
 		5FD1DBDBCD89B51F6B22D679 /* ConversationSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7C7C0DF7B33C596EBE5FC7 /* ConversationSnapshotTests.swift */; platformFilters = (ios, ); };
 		5FDCC383AE9448F83273EA84 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png in Resources */ = {isa = PBXBuildFile; fileRef = D2BF59E844D8092111547C64 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png */; };
@@ -152,6 +152,7 @@
 		6DEFFD87BEBE13C2409FE183 /* testComposerSurfaceIPadMiniIncreasedContrast.1.png in Resources */ = {isa = PBXBuildFile; fileRef = E322989D4007390096CA127C /* testComposerSurfaceIPadMiniIncreasedContrast.1.png */; };
 		6EE0372C42829D55A92DA504 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FAD5B8DE8A8FD7FC216867 /* L10n.swift */; };
 		705F1646646DBB454684A718 /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163EC3A1080DFD2A3BB8F098 /* ComposerView.swift */; };
+		70625989072AA4231FE732EA /* ManagedConnectionDeviceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DF31C6F06A2786DE678E4A /* ManagedConnectionDeviceStoreTests.swift */; };
 		717992D232DA806812FB7A81 /* testFailedActivityWithoutPreviousResult.failed-empty-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = 36A4616D85FD81D7258E0C6B /* testFailedActivityWithoutPreviousResult.failed-empty-compact.png */; };
 		7301810E2D669985BC4C75EC /* testSessionProjectIconAndUnreadIndicatorCombinations.dark.png in Resources */ = {isa = PBXBuildFile; fileRef = E85CF2066687F5E5ED881FB9 /* testSessionProjectIconAndUnreadIndicatorCombinations.dark.png */; };
 		7380C6ED244A91FE8786269B /* QRCodeScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D29856557B35AE9C7C9B5EA /* QRCodeScannerSheet.swift */; };
@@ -173,6 +174,7 @@
 		7CD5F621C651FF6A32ACAE47 /* testDefaultDarkConversationPalette.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 8E5FA820000C5AD8FB8E1300 /* testDefaultDarkConversationPalette.1.png */; };
 		7D7B8E54D821EA6FD3240307 /* testCollapsedWorkGroupRendering.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 760E3B9BE51D633691ED9C56 /* testCollapsedWorkGroupRendering.1.png */; };
 		7EC0BC9D0E04B06658CC2EFC /* privacy-policy.md in Resources */ = {isa = PBXBuildFile; fileRef = 2210B237FCEF112D24D2B687 /* privacy-policy.md */; };
+		7FCF7AE789CFBC4E2148BCD3 /* ManagedPairingContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CAF352234E74EEAF7B023AE /* ManagedPairingContractTests.swift */; };
 		84F5B773E0438B85B671B2F3 /* AgentAPIClientRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC88F25CEBA6C13050A2B4F /* AgentAPIClientRequestTests.swift */; };
 		8579BB85C852E3DD247FF7EE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A3BB200E07DB4CD95503B8F7 /* InfoPlist.strings */; };
 		860DD71D11A4C4AF27322417 /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png in Resources */ = {isa = PBXBuildFile; fileRef = 5A88B5C73E15343C1B24DD2E /* testConnectionDiagnosticsNetworkPathKeepsIntrinsicHeightInsideExpandedForm.diagnostics-network-path-intrinsic-height.png */; };
@@ -181,7 +183,6 @@
 		879CC5740352620BC5E9CA37 /* DataURLImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C87937DA9D34D00853E635B /* DataURLImageDecoder.swift */; };
 		893B4B1CA4413EA016239631 /* testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png in Resources */ = {isa = PBXBuildFile; fileRef = E55DE1D530ABE8EE097ECB59 /* testExpandedGoalTrayDarkMaterialSeparatesBackdropContent.1.png */; };
 		89DCEF26CCF404A369DFDE80 /* PairingLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EABFF317C695883ECE910D0 /* PairingLinkTests.swift */; };
-		A12590000000000000000002 /* ManagedPairingContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12590000000000000000001 /* ManagedPairingContractTests.swift */; };
 		8B704ED612394635B98E9D56 /* SubagentHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3359185FAA3E42EA9C7A5392 /* SubagentHistoryTests.swift */; };
 		8C027A403C453281A5BD7812 /* WorkspaceRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D283CD0291735DA4425D91A4 /* WorkspaceRootView.swift */; };
 		8CF275290562942710A21717 /* SessionListPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5219F30FB1F37F4EE868FF /* SessionListPresentationTests.swift */; };
@@ -213,6 +214,7 @@
 		A3621619C40A5F0CFB0C4F10 /* WorkspaceAppearanceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4A66767462028B863816B7 /* WorkspaceAppearanceStoreTests.swift */; };
 		A3D2577AA6E9A37E62C67FDC /* SessionContextStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B923E4207A9FD4C35766E4CA /* SessionContextStore.swift */; };
 		A3EA0AAF74B1FDF1F1BDE5F4 /* testSingleWindowUsesProgressBarOnCompactWidth.single-window-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = E19FB5D730EAB61A661C065D /* testSingleWindowUsesProgressBarOnCompactWidth.single-window-compact.png */; };
+		A427DDF4E4F31E31EDFD1D17 /* WorkspaceWorkbenchRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F400F53D43F0F11A84B46D20 /* WorkspaceWorkbenchRootView.swift */; };
 		A44C4B01562D78D25968ABFF /* AppStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9DB99DDCE7CA778B616657 /* AppStore.swift */; };
 		A4DBF3E94C42D2C505267C1E /* SessionListPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5441F059E674EFBF21A880EA /* SessionListPresentation.swift */; };
 		A59938EA3EE1686DFBC9B0C5 /* TailcatExperimentRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29969A74C4C890BB458DC64 /* TailcatExperimentRoutingTests.swift */; };
@@ -222,7 +224,7 @@
 		A7BFE2529FB2612C5B111B56 /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-mini-744-light.png in Resources */ = {isa = PBXBuildFile; fileRef = AA3FAE227E24D21CD42E3761 /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-mini-744-light.png */; };
 		A7CF7C20E5D854D900452377 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-390-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = 1F4C7F055E8F17853BC7CB04 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-390-dark.png */; };
 		A88F2FBBEE8A6F5F5C0283F5 /* UnifiedWorkbenchShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089CDD9B409CEDE6D600DA58 /* UnifiedWorkbenchShell.swift */; };
-		317000000000000000000002 /* WorkspaceWorkbenchRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317000000000000000000001 /* WorkspaceWorkbenchRootView.swift */; };
+		A925DD0C63B39984BA807415 /* ManagedConnectionDeviceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F496EBE1E6484F4DF9EC8186 /* ManagedConnectionDeviceStore.swift */; };
 		A9672A5CCD14CB34B13ED66A /* CodexAppServerThreadOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3F9E8A8ED2FD8317FB92F2 /* CodexAppServerThreadOwnership.swift */; };
 		AADCBC7617C842DC51799171 /* MimiInteractionFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C746BA73EAA9E0C19B0C0E4 /* MimiInteractionFeedback.swift */; };
 		AD2BA4EB75791D6DA68D6A46 /* ConversationConnectionRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */; };
@@ -278,10 +280,12 @@
 		CDA816193B812C35A0C9C2DA /* ApprovalCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AD0073053D927F8328CC9C /* ApprovalCardView.swift */; };
 		CE32FFAC6FF1C8B88332FADF /* ConversationLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E9BE6E1D3AD3BE0B2C111B /* ConversationLayout.swift */; };
 		CE3EFDEF26263DA09CB31B0F /* SessionActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA890B38E5262F0E985B6D6 /* SessionActions.swift */; };
+		CE6FB08301D58D92C1B77ECC /* ManagedConnectionDeviceAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7E14A8B39BFA1C4D7C4D88 /* ManagedConnectionDeviceAPIClient.swift */; };
 		CE8D6606331D38D9A5FF738B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE04A73144E31515A65F5830 /* Assets.xcassets */; };
 		D06839D753295D8BCF05B585 /* SessionListLifecycleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073C831970D1BA4EBC3FD572 /* SessionListLifecycleCoordinator.swift */; };
 		D07503C7468E7547ABA072EE /* testCompactModelGridDarkFastModeOn.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 7C6A770A18111A38D48BF68F /* testCompactModelGridDarkFastModeOn.1.png */; };
 		D277DCC60CB55D50D1C0731A /* DebugLaunchConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D8E5F1F33563965409D9D4 /* DebugLaunchConfiguration.swift */; };
+		D2CAE650EFDE114FBA986987 /* ConnectionBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B210B3D471597B46216C352B /* ConnectionBenchmarkTests.swift */; };
 		D3F4D53A1BACAEA7FF62CA1F /* WorkspaceSessionRuntimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFC45E69D906A49E9EB6310 /* WorkspaceSessionRuntimePicker.swift */; };
 		D4B700AC9DF628887258F469 /* SessionStoreTurns.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38A8CE5A8F1D7EE3889F078 /* SessionStoreTurns.swift */; };
 		D502C332F16B48F95CAAA518 /* HostInstallationSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D9D8852662655DFC4D9FA0 /* HostInstallationSetupView.swift */; };
@@ -306,6 +310,7 @@
 		E371BD850B9F36B47EC3BB3D /* MimiTailcatBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB374BAC8444A29B353D6C9 /* MimiTailcatBridge.m */; };
 		E4A6ECBFD5B621FB6A30299A /* LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA53A2531C62C2974077C88 /* LocalizationTests.swift */; };
 		E4C5AB826686611C3468FAB8 /* ComposerAttachmentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF511A69E274B12E5E2AE265 /* ComposerAttachmentViews.swift */; };
+		E4E5828D292B014505EE19DA /* ManagedConnectionMobileIdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FEBDFE8C8CBDEA57661CEE4 /* ManagedConnectionMobileIdentityStore.swift */; };
 		E52FF51E6A66678EBAEF7F9E /* testComposerModelTriggerFastIndicator.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 608F5B2621676207DEE92BA8 /* testComposerModelTriggerFastIndicator.1.png */; };
 		E790247242197F065BB1F1DE /* ConversationDirectRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */; };
 		E7EE1A6D1A2A19F69E8F6513 /* testConversationBubbleAlignment.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 0FC920B8D7FE7F76E2C18FD7 /* testConversationBubbleAlignment.1.png */; };
@@ -391,6 +396,7 @@
 		033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationRuntimeFlowTests.swift; sourceTree = "<group>"; };
 		04740AD795D6AEEF87C98B35 /* ConversationMessageAccessories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageAccessories.swift; sourceTree = "<group>"; };
 		049E1F8A9BBD15AF6BEE9E28 /* CodexAppServerSessionConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionConnection.swift; sourceTree = "<group>"; };
+		04DF31C6F06A2786DE678E4A /* ManagedConnectionDeviceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionDeviceStoreTests.swift; sourceTree = "<group>"; };
 		053D35545CB6F6F836EAADBA /* HostWarmSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostWarmSnapshotTests.swift; sourceTree = "<group>"; };
 		073C831970D1BA4EBC3FD572 /* SessionListLifecycleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListLifecycleCoordinator.swift; sourceTree = "<group>"; };
 		075FEFC74C482609AAAEEA39 /* TailcatExperimentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailcatExperimentController.swift; sourceTree = "<group>"; };
@@ -398,9 +404,10 @@
 		07BAA9DB4A44577D0DBAC730 /* SkillInterfaceViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillInterfaceViews.swift; sourceTree = "<group>"; };
 		08549513F9D308C94B5C1938 /* WorkbenchSidebarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkbenchSidebarComponents.swift; sourceTree = "<group>"; };
 		089CDD9B409CEDE6D600DA58 /* UnifiedWorkbenchShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedWorkbenchShell.swift; sourceTree = "<group>"; };
-		317000000000000000000001 /* WorkspaceWorkbenchRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceWorkbenchRootView.swift; sourceTree = "<group>"; };
+		0A0A765F253BE3908F1A65AE /* ConnectionBenchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionBenchmark.swift; sourceTree = "<group>"; };
 		0CD3911F5991428A7A3D47EE /* testConnectedStateStaysQuiet.connected-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testConnectedStateStaysQuiet.connected-compact.png"; sourceTree = "<group>"; };
 		0FC920B8D7FE7F76E2C18FD7 /* testConversationBubbleAlignment.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testConversationBubbleAlignment.1.png; sourceTree = "<group>"; };
+		0FEBDFE8C8CBDEA57661CEE4 /* ManagedConnectionMobileIdentityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionMobileIdentityStore.swift; sourceTree = "<group>"; };
 		1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshotCoordinator.swift; sourceTree = "<group>"; };
 		11B71BA07C5D393BC0EA9FD4 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		121E340DD237BE03706546CA /* ConversationSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSessionStoreTests.swift; sourceTree = "<group>"; };
@@ -482,6 +489,7 @@
 		4B840A5598C49D381F9BF4D5 /* testExpandedProcessGroupRendering.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testExpandedProcessGroupRendering.1.png; sourceTree = "<group>"; };
 		4C75EB69B7DE1AAE7350B2C5 /* InitialConnectionSettingsSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialConnectionSettingsSections.swift; sourceTree = "<group>"; };
 		4C86A8DFF7254C2458488075 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
+		4CAF352234E74EEAF7B023AE /* ManagedPairingContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedPairingContractTests.swift; sourceTree = "<group>"; };
 		4F93698AE10EA771676747F8 /* testCompactWorkspaceRuntimeMenuOnPhoneWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCompactWorkspaceRuntimeMenuOnPhoneWidth.1.png; sourceTree = "<group>"; };
 		4FC2FBFEBA275A5869FC350D /* CameraAttachmentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAttachmentViews.swift; sourceTree = "<group>"; };
 		4FCDE6ACD44D941797C6186A /* testEmptyConversationShowsCurrentDirectoryAcrossAppearances.iphone-long-path-light.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testEmptyConversationShowsCurrentDirectoryAcrossAppearances.iphone-long-path-light.png"; sourceTree = "<group>"; };
@@ -529,6 +537,7 @@
 		6E8F22C82C007839E2D06A90 /* ManagedConnectionStoreKitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionStoreKitClient.swift; sourceTree = "<group>"; };
 		6F194D291F4AC7CA28CE52FD /* CarStatusSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshot.swift; sourceTree = "<group>"; };
 		712B1CDEF343C4D9D338DDDC /* testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testUnavailableUserImageGalleryRemainsLegibleInLightTheme.1.png; sourceTree = "<group>"; };
+		72FF3738D9EAED4C04AF0B69 /* ManagedConnectionDeviceAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionDeviceAPIClientTests.swift; sourceTree = "<group>"; };
 		730CE8CD91CC2F2DFB5E6FBA /* ConversationTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTimelineView.swift; sourceTree = "<group>"; };
 		7348A6FCD28C7489CC7097AD /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		73B98B7856DBCB29BD8FA4BB /* testPermissionOptionPageShowsEveryDetail.permission-page-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testPermissionOptionPageShowsEveryDetail.permission-page-compact.png"; sourceTree = "<group>"; };
@@ -556,8 +565,6 @@
 		85D6ABA1F92A0E715AA179A7 /* WriterConflictCardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterConflictCardSnapshotTests.swift; sourceTree = "<group>"; };
 		86B6C2FC1CE749D7A8268F85 /* ConversationComposerHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationComposerHistoryTests.swift; sourceTree = "<group>"; };
 		87C3E59C8D5983AB7784558F /* ConnectionSpeedTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionSpeedTestView.swift; sourceTree = "<group>"; };
-		C0B244000000000000000002 /* ConnectionBenchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionBenchmark.swift; sourceTree = "<group>"; };
-		C0B244000000000000000004 /* ConnectionBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionBenchmarkTests.swift; sourceTree = "<group>"; };
 		88052679070049ECC40BAE19 /* testRunningConflictCardCompactDark.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testRunningConflictCardCompactDark.1.png; sourceTree = "<group>"; };
 		88A2FAA4C2526405C2DDB750 /* LogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStore.swift; sourceTree = "<group>"; };
 		8AA53A2531C62C2974077C88 /* LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
@@ -570,7 +577,6 @@
 		8D23870E31FFF787AC7C14C0 /* WorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; };
 		8E5FA820000C5AD8FB8E1300 /* testDefaultDarkConversationPalette.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testDefaultDarkConversationPalette.1.png; sourceTree = "<group>"; };
 		8EABFF317C695883ECE910D0 /* PairingLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingLinkTests.swift; sourceTree = "<group>"; };
-		A12590000000000000000001 /* ManagedPairingContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedPairingContractTests.swift; sourceTree = "<group>"; };
 		90B47F5F094477F8E0CDC100 /* testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleImageMediaCardAlignmentAcrossLayouts.iphone-390.png"; sourceTree = "<group>"; };
 		9143CBABCA38B2E316A221BB /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testModelPickerAdaptiveWidthAndAccessibilityLayouts.accessibility3.png; sourceTree = "<group>"; };
 		9145366BE7345CD146DFA0AE /* AnsiCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnsiCleaner.swift; sourceTree = "<group>"; };
@@ -610,6 +616,7 @@
 		ACF46F57503EB4138315D9E4 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-landscape-compact-height.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testModelPickerAdaptiveWidthAndAccessibilityLayouts.iphone-landscape-compact-height.png"; sourceTree = "<group>"; };
 		AF511A69E274B12E5E2AE265 /* ComposerAttachmentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerAttachmentViews.swift; sourceTree = "<group>"; };
 		AFDEF6C57E7FE342A5411C7B /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-claude-popover-420-dark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-claude-popover-420-dark.png"; sourceTree = "<group>"; };
+		B210B3D471597B46216C352B /* ConnectionBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionBenchmarkTests.swift; sourceTree = "<group>"; };
 		B337007E06BFD01501A0C9BD /* MimiRemoteApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiRemoteApp.swift; sourceTree = "<group>"; };
 		B4C046A065EC50889673C918 /* SessionAPIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAPIModels.swift; sourceTree = "<group>"; };
 		B546C68F6A4EDDA47CD25FD7 /* LegalDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalDocumentView.swift; sourceTree = "<group>"; };
@@ -705,6 +712,8 @@
 		F28670A6714AE711F3E93218 /* testIdleConflictCardWideLight.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testIdleConflictCardWideLight.1.png; sourceTree = "<group>"; };
 		F394E738574CBD9914E54047 /* SettingsConnectionCardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsConnectionCardSnapshotTests.swift; sourceTree = "<group>"; };
 		F3D83CF837D1EE07A541F820 /* testSessionRuntimeMetadataInDarkConversationList.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionRuntimeMetadataInDarkConversationList.1.png; sourceTree = "<group>"; };
+		F400F53D43F0F11A84B46D20 /* WorkspaceWorkbenchRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceWorkbenchRootView.swift; sourceTree = "<group>"; };
+		F496EBE1E6484F4DF9EC8186 /* ManagedConnectionDeviceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionDeviceStore.swift; sourceTree = "<group>"; };
 		F55F20982430C816BB70A7F5 /* FileAttachmentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAttachmentModelsTests.swift; sourceTree = "<group>"; };
 		F5EC542E43C2955804F35E34 /* ConversationHistoryItemEnrichmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationHistoryItemEnrichmentTests.swift; sourceTree = "<group>"; };
 		F5EF45DF782D873112FB24F1 /* MimiRemoteUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MimiRemoteUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -717,6 +726,7 @@
 		FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerProtocolTests.swift; sourceTree = "<group>"; };
 		FBF29C4EA9F4D0ECC4709B97 /* ConversationProcessGrouperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationProcessGrouperTests.swift; sourceTree = "<group>"; };
 		FD791172EDEEA29731488D73 /* MimiTailcatBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MimiTailcatBridge.h; sourceTree = "<group>"; };
+		FD7E14A8B39BFA1C4D7C4D88 /* ManagedConnectionDeviceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionDeviceAPIClient.swift; sourceTree = "<group>"; };
 		FD8EF812560A139C665A9D46 /* ConversationSessionArchiveMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSessionArchiveMutationTests.swift; sourceTree = "<group>"; };
 		FDBE622C5ED274C1DA9803DB /* ComposerInputExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerInputExtensions.swift; sourceTree = "<group>"; };
 		FDD0D38CA5BBBF1F1D8A5F2B /* testLongEnglishFailureRemainsInline.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testLongEnglishFailureRemainsInline.1.png; sourceTree = "<group>"; };
@@ -891,7 +901,7 @@
 				83CFAE116262795C7501365E /* CarStatusSnapshotTests.swift */,
 				8D05A1A4E037DC2EE90B7747 /* CodexAppServerConnectionReliabilityTests.swift */,
 				FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */,
-				C0B244000000000000000004 /* ConnectionBenchmarkTests.swift */,
+				B210B3D471597B46216C352B /* ConnectionBenchmarkTests.swift */,
 				B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */,
 				1254FA91BFD2E858AFBD539D /* ConversationAppServerProjectorTests.swift */,
 				86B6C2FC1CE749D7A8268F85 /* ConversationComposerHistoryTests.swift */,
@@ -927,8 +937,10 @@
 				053D35545CB6F6F836EAADBA /* HostWarmSnapshotTests.swift */,
 				8AA53A2531C62C2974077C88 /* LocalizationTests.swift */,
 				A0E1C34623582EDA99D6B917 /* LogStoreTests.swift */,
+				72FF3738D9EAED4C04AF0B69 /* ManagedConnectionDeviceAPIClientTests.swift */,
+				04DF31C6F06A2786DE678E4A /* ManagedConnectionDeviceStoreTests.swift */,
 				417026D5C6353D2982527627 /* ManagedConnectionEntitlementStoreTests.swift */,
-				A12590000000000000000001 /* ManagedPairingContractTests.swift */,
+				4CAF352234E74EEAF7B023AE /* ManagedPairingContractTests.swift */,
 				24B74985F9E77EEE70BC1856 /* MarkdownRenderingTests.swift */,
 				81FDFD00533B31F16F861BFB /* MimiInteractionFeedbackTests.swift */,
 				61B287032A29ABBC9D670E94 /* NewSessionPresentationSourceTests.swift */,
@@ -1037,6 +1049,7 @@
 				DD3F9E8A8ED2FD8317FB92F2 /* CodexAppServerThreadOwnership.swift */,
 				BBA6E082051A620B6BDFFED5 /* CodexAppServerTransport.swift */,
 				5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */,
+				FD7E14A8B39BFA1C4D7C4D88 /* ManagedConnectionDeviceAPIClient.swift */,
 				BFC8F89BF1B2CDD9984B85B7 /* ManagedConnectionEntitlementAPIClient.swift */,
 			);
 			path = API;
@@ -1282,8 +1295,8 @@
 				B7E83526E3C22DF48B2DD911 /* NewSessionPresentationSource.swift */,
 				E992D8F1A54C9726692225BA /* NewSessionSheet.swift */,
 				089CDD9B409CEDE6D600DA58 /* UnifiedWorkbenchShell.swift */,
-				317000000000000000000001 /* WorkspaceWorkbenchRootView.swift */,
 				08549513F9D308C94B5C1938 /* WorkbenchSidebarComponents.swift */,
+				F400F53D43F0F11A84B46D20 /* WorkspaceWorkbenchRootView.swift */,
 			);
 			path = Shell;
 			sourceTree = "<group>";
@@ -1309,6 +1322,7 @@
 		D367666DF47751B98DBA9522 /* Security */ = {
 			isa = PBXGroup;
 			children = (
+				0FEBDFE8C8CBDEA57661CEE4 /* ManagedConnectionMobileIdentityStore.swift */,
 				A30F059863E0778E0B00065D /* TokenStore.swift */,
 			);
 			path = Security;
@@ -1369,8 +1383,8 @@
 				6DF3FE084B65924E2014463C /* AppStoreRouting.swift */,
 				1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */,
 				332F6935AFF261FAA35F289A /* CarStatusSnapshotMapping.swift */,
+				0A0A765F253BE3908F1A65AE /* ConnectionBenchmark.swift */,
 				6C6C8F9B82DA43620543124E /* ConnectionProfileModels.swift */,
-				C0B244000000000000000002 /* ConnectionBenchmark.swift */,
 				CCBCEEF3A7D3D84A709984E8 /* ConversationMessageDeliveryReconciler.swift */,
 				373EDA921B7F6B3F6B680140 /* ConversationStore.swift */,
 				454132341FC2CC31B453D26C /* ConversationStoreDelivery.swift */,
@@ -1382,6 +1396,7 @@
 				80F8AA2ABA18C212AEAA34E1 /* HostStatusStore.swift */,
 				9804C07B29195A66638EE42E /* HostWarmSnapshot.swift */,
 				88A2FAA4C2526405C2DDB750 /* LogStore.swift */,
+				F496EBE1E6484F4DF9EC8186 /* ManagedConnectionDeviceStore.swift */,
 				E5B963BEE564A9A53336B060 /* ManagedConnectionEntitlementStore.swift */,
 				B9CAFB1927C976C000C9E026 /* MessageStore.swift */,
 				AC1E5753D86397B541589878 /* RecentWorkspaceStore.swift */,
@@ -1728,7 +1743,7 @@
 				101A9079E24B09BCAB8B54FF /* CarStatusSnapshotTests.swift in Sources */,
 				EB5D0D19189AB5059993D8C9 /* CodexAppServerConnectionReliabilityTests.swift in Sources */,
 				523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */,
-				C0B244000000000000000003 /* ConnectionBenchmarkTests.swift in Sources */,
+				D2CAE650EFDE114FBA986987 /* ConnectionBenchmarkTests.swift in Sources */,
 				3CE709A723920DFD80FE96D0 /* ConnectionProfileRenameTests.swift in Sources */,
 				2ACE5B224FFACB3AA6391C46 /* ConversationAppServerProjectorTests.swift in Sources */,
 				042B8AE52871708DD3606659 /* ConversationComposerHistoryTests.swift in Sources */,
@@ -1764,8 +1779,10 @@
 				F0DC6138A242D45D79253F8B /* HostWarmSnapshotTests.swift in Sources */,
 				E4A6ECBFD5B621FB6A30299A /* LocalizationTests.swift in Sources */,
 				BDDBF10C9208B7AB95535A57 /* LogStoreTests.swift in Sources */,
+				419537AC5582400C687118ED /* ManagedConnectionDeviceAPIClientTests.swift in Sources */,
+				70625989072AA4231FE732EA /* ManagedConnectionDeviceStoreTests.swift in Sources */,
 				491F23C64F7108C5B28BBD1B /* ManagedConnectionEntitlementStoreTests.swift in Sources */,
-				A12590000000000000000002 /* ManagedPairingContractTests.swift in Sources */,
+				7FCF7AE789CFBC4E2148BCD3 /* ManagedPairingContractTests.swift in Sources */,
 				4DDCF6949E6DDCC9ABEBE709 /* MarkdownRenderingTests.swift in Sources */,
 				20D78099D1CE0CC7A660BFA1 /* MimiInteractionFeedbackTests.swift in Sources */,
 				B3BE80D2693D4982B46A4924 /* NewSessionPresentationSourceTests.swift in Sources */,
@@ -1848,8 +1865,8 @@
 				BC8B20DA0FE42207D5D2CA8C /* ComposerTextEditor.swift in Sources */,
 				705F1646646DBB454684A718 /* ComposerView.swift in Sources */,
 				FE70F3C6CDFB5DCD60874B4B /* ComposerVoiceSupport.swift in Sources */,
+				27DEAE1F21FC391A124F6332 /* ConnectionBenchmark.swift in Sources */,
 				DC2F420929F4E30D3B6AC6DE /* ConnectionProfileModels.swift in Sources */,
-				C0B244000000000000000001 /* ConnectionBenchmark.swift in Sources */,
 				5CC1C792F93F291FDD49FF09 /* ConnectionSpeedTestView.swift in Sources */,
 				332D0CF7E81E796945EFD9F0 /* ConversationActivityRows.swift in Sources */,
 				A6ECF6598F5FF2DC733E8E56 /* ConversationCommentaryRow.swift in Sources */,
@@ -1891,8 +1908,11 @@
 				55D520C10E168BFEA7E4A619 /* LegalDocumentView.swift in Sources */,
 				78BE6068CC6C12DA79A00B6D /* LogPanelView.swift in Sources */,
 				FBF4E996E64F7B7D637E1B79 /* LogStore.swift in Sources */,
+				CE6FB08301D58D92C1B77ECC /* ManagedConnectionDeviceAPIClient.swift in Sources */,
+				A925DD0C63B39984BA807415 /* ManagedConnectionDeviceStore.swift in Sources */,
 				D57E56FF06B77F225C0F436E /* ManagedConnectionEntitlementAPIClient.swift in Sources */,
 				122264253C13D70043A627F0 /* ManagedConnectionEntitlementStore.swift in Sources */,
+				E4E5828D292B014505EE19DA /* ManagedConnectionMobileIdentityStore.swift in Sources */,
 				BAA573B7BCCDD95153331C04 /* ManagedConnectionStoreKitClient.swift in Sources */,
 				E02D70CAB2822FE39664F749 /* ManagedConnectionSubscriptionView.swift in Sources */,
 				9050C1E583FA7A10A4753732 /* MarkdownBlock.swift in Sources */,
@@ -1949,7 +1969,6 @@
 				8793E07E19375B78629AC0F3 /* TokenActivityView.swift in Sources */,
 				958AE82A3087284FEE63DBB8 /* TokenStore.swift in Sources */,
 				A88F2FBBEE8A6F5F5C0283F5 /* UnifiedWorkbenchShell.swift in Sources */,
-				317000000000000000000002 /* WorkspaceWorkbenchRootView.swift in Sources */,
 				B5BAC2CFD69E8F6E30996369 /* VoiceInputPreferences.swift in Sources */,
 				26187C1CD9C32B84B41153D0 /* WorkbenchChrome.swift in Sources */,
 				94E3CCCEB33D4DB58965C7DB /* WorkbenchSidebarComponents.swift in Sources */,
@@ -1961,6 +1980,7 @@
 				D3F4D53A1BACAEA7FF62CA1F /* WorkspaceSessionRuntimePicker.swift in Sources */,
 				305ECB04E77553124786333E /* WorkspaceStripPresentation.swift in Sources */,
 				0E20F441A1A1B56E39868A44 /* WorkspaceView.swift in Sources */,
+				A427DDF4E4F31E31EDFD1D17 /* WorkspaceWorkbenchRootView.swift in Sources */,
 				3F150075A258BDF73AFB8ED6 /* WorktreeManagementViews.swift in Sources */,
 				C7E776F8B05E9EB508767C6D /* WriterConflictCard.swift in Sources */,
 			);

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -39668,6 +39668,188 @@
         }
       }
     },
+    "ui.managed_devices_added_detail": {
+      "comment": "Managed device registration date and non-secret ID suffix.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Added %1$@ · ID %2$@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "%1$@ 添加 · ID %2$@" } }
+      }
+    },
+    "ui.managed_devices_authorization_expired": {
+      "comment": "Shown when a managed connection device credential expired or was revoked.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Device authorization expired. Check the subscription and try again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "设备授权已失效，请检查订阅后重试。" } }
+      }
+    },
+    "ui.managed_devices_connect_mac": {
+      "comment": "Action to scan a Mac QR code and create a managed connection.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Scan a Mac QR Code" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "扫描 Mac 二维码" } }
+      }
+    },
+    "ui.managed_devices_connecting": {
+      "comment": "Progress shown while managed pairing is being authorized and completed.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Authorizing this Mac…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在授权这台 Mac…" } }
+      }
+    },
+    "ui.managed_devices_connection": {
+      "comment": "Section title for adding a Mac through Mimi Managed Connection.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Connect a Mac" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "连接 Mac" } }
+      }
+    },
+    "ui.managed_devices_credential_conflict": {
+      "comment": "Shown when the local managed device credential conflicts with the server record.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This installation already uses another device credential. Remove the old device and try again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "本次安装已登记其他设备凭证，请移除旧设备后重试。" } }
+      }
+    },
+    "ui.managed_devices_empty": {
+      "comment": "Empty state for the managed device list.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No devices are using this subscription yet." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此订阅尚未登记设备。" } }
+      }
+    },
+    "ui.managed_devices_limit_reached": {
+      "comment": "Managed device quota error. First value is device type and second is limit.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "%1$@ limit reached (%2$@). Remove an old device and try again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "%1$@名额已满（最多 %2$@ 台），请移除旧设备后重试。" } }
+      }
+    },
+    "ui.managed_devices_loading": {
+      "comment": "Progress shown while loading managed devices.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Loading devices…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在加载设备…" } }
+      }
+    },
+    "ui.managed_devices_mac": {
+      "comment": "Mac device type in managed device quota and list.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mac" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Mac" } }
+      }
+    },
+    "ui.managed_devices_mobile": {
+      "comment": "iPhone and iPad device type in managed device quota and list.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "iPhone & iPad" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "iPhone 与 iPad" } }
+      }
+    },
+    "ui.managed_devices_network_error": {
+      "comment": "Generic network error while managing devices.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Couldn't update devices. Check your connection and try again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法更新设备，请检查网络后重试。" } }
+      }
+    },
+    "ui.managed_devices_not_found": {
+      "comment": "Shown when a managed device was already removed.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This device was already removed. Refresh the list and try again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此设备已被移除，请刷新列表后重试。" } }
+      }
+    },
+    "ui.managed_devices_pairing_conflict": {
+      "comment": "Shown when the managed pairing request conflicts with an earlier request.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The pairing request conflicts with an earlier request. Scan the Mac code again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "配对请求与之前的请求冲突，请重新扫描 Mac 二维码。" } }
+      }
+    },
+    "ui.managed_devices_privacy_notice": {
+      "comment": "Privacy disclosure below managed devices.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mimi stores only random installation identifiers and credential hashes. It doesn't upload device names, Tailcat addresses, agentd tokens, or private keys." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Mimi 只保存随机安装标识和凭证哈希，不上传设备名称、Tailcat 地址、agentd Token 或私钥。" } }
+      }
+    },
+    "ui.managed_devices_qr_required": {
+      "comment": "Shown when managed pairing receives a QR code without managed host metadata.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Use the current Mimi agentd to generate a Tailcat pairing QR code on your Mac." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "请在 Mac 上使用当前版本的 Mimi agentd 生成 Tailcat 配对二维码。" } }
+      }
+    },
+    "ui.managed_devices_remove_action": {
+      "comment": "Action to remove a managed device.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Remove Device" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "移除设备" } }
+      }
+    },
+    "ui.managed_devices_remove_message": {
+      "comment": "Confirmation message before revoking a managed device.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The device will immediately lose managed access. To use it again, register it and rescan each Mac." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "该设备会立即失去托管访问权限。再次使用时，需要重新登记并扫描每台 Mac。" } }
+      }
+    },
+    "ui.managed_devices_remove_title": {
+      "comment": "Confirmation title before revoking a managed device.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Remove this device?" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "移除此设备？" } }
+      }
+    },
+    "ui.managed_devices_rescan_notice": {
+      "comment": "Explains that restored purchases don't copy host credentials.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Restoring a subscription doesn't copy Mac credentials. On a new iPhone or iPad, scan every Mac you want to use." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "恢复订阅不会同步 Mac 凭证。更换 iPhone 或 iPad 后，需要重新扫描每台要访问的 Mac。" } }
+      }
+    },
+    "ui.managed_devices_server_invalid": {
+      "comment": "Shown when the managed device service returns malformed data.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The managed device service returned an invalid response." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "托管设备服务返回了无效响应。" } }
+      }
+    },
+    "ui.managed_devices_server_rejected": {
+      "comment": "Generic managed device service rejection.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The managed device request was rejected." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "托管设备请求被拒绝。" } }
+      }
+    },
+    "ui.managed_devices_subscription_required": {
+      "comment": "Shown when managed pairing is attempted without an active verified subscription.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "An active Mimi Managed Connection subscription is required." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "需要有效的 Mimi 托管连接订阅。" } }
+      }
+    },
+    "ui.managed_devices_this_device": {
+      "comment": "Marks the current iPhone or iPad in the managed device list.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This device" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "本设备" } }
+      }
+    },
+    "ui.managed_devices_title": {
+      "comment": "Managed device quota and list section title.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Device slots" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "设备名额" } }
+      }
+    },
+    "ui.managed_devices_usage": {
+      "comment": "Managed device quota usage. First value is used count and second is limit.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "%1$@ of %2$@ used" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已用 %1$@ / %2$@" } }
+      }
+    },
     "ui.managed_subscription_active": {
       "comment": "Active Mimi Managed Connection subscription status.",
       "localizations": {

--- a/ios/MimiRemote/Sources/Core/API/ManagedConnectionDeviceAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/ManagedConnectionDeviceAPIClient.swift
@@ -1,0 +1,337 @@
+import Foundation
+
+enum ManagedConnectionDeviceType: String, Codable, Equatable, Sendable {
+    case mac
+    case mobile
+}
+
+struct ManagedConnectionDevice: Identifiable, Equatable, Sendable {
+    let id: String
+    let deviceType: ManagedConnectionDeviceType
+    let createdAt: Date
+}
+
+struct ManagedConnectionDeviceRegistration: Equatable, Sendable {
+    let device: ManagedConnectionDevice
+    let created: Bool
+}
+
+struct ManagedConnectionManagementSession: Equatable, Sendable {
+    let token: String
+    let expiresAt: Date
+}
+
+struct ManagedConnectionPairingSession: Equatable, Sendable {
+    enum MacSlot: String, Equatable, Sendable {
+        case reserved
+        case existing
+    }
+
+    let id: String
+    let expiresAt: Date
+    let macSlot: MacSlot
+    let created: Bool
+}
+
+protocol ManagedConnectionDeviceAPIClient: Sendable {
+    func registerMobileDevice(
+        entitlementToken: String,
+        installationID: String,
+        deviceToken: String
+    ) async throws -> ManagedConnectionDeviceRegistration
+
+    func authorizePairing(
+        deviceToken: String,
+        requestID: String,
+        macInstallationID: String,
+        mobileTailcatPublicKey: String,
+        macTailcatPublicKey: String,
+        managedPairingGrant: String
+    ) async throws -> ManagedConnectionPairingSession
+
+    func createManagementSession(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionManagementSession
+
+    func listDevices(managementToken: String) async throws -> [ManagedConnectionDevice]
+    func removeDevice(id: String, managementToken: String) async throws
+}
+
+struct LiveManagedConnectionDeviceAPIClient: ManagedConnectionDeviceAPIClient {
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(
+        baseURL: URL = URL(string: "https://api.code89757.com")!,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func registerMobileDevice(
+        entitlementToken: String,
+        installationID: String,
+        deviceToken: String
+    ) async throws -> ManagedConnectionDeviceRegistration {
+        var request = jsonRequest(path: "v1/devices", method: "POST", bearerToken: entitlementToken)
+        request.httpBody = try JSONEncoder().encode(
+            RegisterDeviceRequest(
+                installationId: installationID,
+                deviceType: ManagedConnectionDeviceType.mobile.rawValue,
+                deviceToken: deviceToken
+            )
+        )
+        let payload: RegisterDeviceResponse = try await decodedResponse(for: request)
+        return ManagedConnectionDeviceRegistration(
+            device: try payload.device.model(),
+            created: payload.created
+        )
+    }
+
+    func authorizePairing(
+        deviceToken: String,
+        requestID: String,
+        macInstallationID: String,
+        mobileTailcatPublicKey: String,
+        macTailcatPublicKey: String,
+        managedPairingGrant: String
+    ) async throws -> ManagedConnectionPairingSession {
+        var request = jsonRequest(
+            path: "v1/pairing-sessions/authorize",
+            method: "POST",
+            bearerToken: deviceToken
+        )
+        request.httpBody = try JSONEncoder().encode(
+            AuthorizePairingRequest(
+                requestId: requestID,
+                macInstallationId: macInstallationID,
+                mobileTailcatPublicKey: mobileTailcatPublicKey,
+                macTailcatPublicKey: macTailcatPublicKey,
+                managedPairingGrant: managedPairingGrant
+            )
+        )
+        let payload: AuthorizePairingResponse = try await decodedResponse(for: request)
+        guard let macSlot = ManagedConnectionPairingSession.MacSlot(
+            rawValue: payload.pairingSession.macSlot
+        ) else {
+            throw ManagedConnectionDeviceAPIError.invalidResponse
+        }
+        return ManagedConnectionPairingSession(
+            id: payload.pairingSession.id,
+            expiresAt: payload.pairingSession.expiresAt,
+            macSlot: macSlot,
+            created: payload.created
+        )
+    }
+
+    func createManagementSession(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionManagementSession {
+        var request = jsonRequest(path: "v1/device-management-sessions", method: "POST")
+        request.httpBody = try JSONEncoder().encode(
+            ManagementSessionRequest(
+                signedAppTransaction: signedAppTransaction,
+                signedTransaction: signedTransaction
+            )
+        )
+        let payload: ManagementSessionResponse = try await decodedResponse(for: request)
+        guard payload.scope == "device:manage" else {
+            throw ManagedConnectionDeviceAPIError.invalidResponse
+        }
+        return ManagedConnectionManagementSession(
+            token: payload.managementToken,
+            expiresAt: payload.expiresAt
+        )
+    }
+
+    func listDevices(managementToken: String) async throws -> [ManagedConnectionDevice] {
+        let request = jsonRequest(path: "v1/devices", method: "GET", bearerToken: managementToken)
+        let payload: DeviceListResponse = try await decodedResponse(for: request)
+        return try payload.devices.map { try $0.model() }
+    }
+
+    func removeDevice(id: String, managementToken: String) async throws {
+        let request = jsonRequest(
+            path: "v1/devices/\(id)",
+            method: "DELETE",
+            bearerToken: managementToken
+        )
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ManagedConnectionDeviceAPIError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw Self.rejection(from: data)
+        }
+    }
+
+    private func jsonRequest(
+        path: String,
+        method: String,
+        bearerToken: String? = nil
+    ) -> URLRequest {
+        var request = URLRequest(url: baseURL.appending(path: path))
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if method == "POST" {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        if let bearerToken {
+            request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        }
+        request.timeoutInterval = 20
+        return request
+    }
+
+    private func decodedResponse<Response: Decodable>(for request: URLRequest) async throws -> Response {
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ManagedConnectionDeviceAPIError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw Self.rejection(from: data)
+        }
+        do {
+            return try Self.decoder.decode(Response.self, from: data)
+        } catch {
+            throw ManagedConnectionDeviceAPIError.invalidResponse
+        }
+    }
+
+    private static func rejection(from data: Data) -> ManagedConnectionDeviceAPIError {
+        let payload = try? JSONDecoder().decode(DeviceErrorResponse.self, from: data)
+        return .rejected(
+            code: payload?.code,
+            deviceType: payload?.deviceType.flatMap(ManagedConnectionDeviceType.init(rawValue:)),
+            limit: payload?.limit
+        )
+    }
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            if let date = ISO8601DateFormatter.deviceAPIWithFractionalSeconds.date(from: value)
+                ?? ISO8601DateFormatter().date(from: value)
+            {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid RFC 3339 date"
+            )
+        }
+        return decoder
+    }()
+}
+
+enum ManagedConnectionDeviceAPIError: LocalizedError, Equatable {
+    case invalidResponse
+    case rejected(code: String?, deviceType: ManagedConnectionDeviceType?, limit: Int?)
+
+    var rejectionCode: String? {
+        guard case .rejected(let code, _, _) = self else { return nil }
+        return code
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return L10n.text("ui.managed_devices_server_invalid")
+        case .rejected(let code, let deviceType, let limit):
+            switch code {
+            case "device_limit_reached":
+                let name = deviceType == .mac
+                    ? L10n.text("ui.managed_devices_mac")
+                    : L10n.text("ui.managed_devices_mobile")
+                return L10n.format("ui.managed_devices_limit_reached", name, limit ?? 0)
+            case "unauthorized":
+                return L10n.text("ui.managed_devices_authorization_expired")
+            case "device_token_conflict":
+                return L10n.text("ui.managed_devices_credential_conflict")
+            case "installation_id_conflict", "pairing_request_conflict", "pairing_grant_conflict":
+                return L10n.text("ui.managed_devices_pairing_conflict")
+            case "device_not_found":
+                return L10n.text("ui.managed_devices_not_found")
+            default:
+                return L10n.text("ui.managed_devices_server_rejected")
+            }
+        }
+    }
+}
+
+private struct RegisterDeviceRequest: Encodable {
+    let installationId: String
+    let deviceType: String
+    let deviceToken: String
+}
+
+private struct RegisterDeviceResponse: Decodable {
+    let device: DeviceResponse
+    let created: Bool
+}
+
+private struct AuthorizePairingRequest: Encodable {
+    let requestId: String
+    let macInstallationId: String
+    let mobileTailcatPublicKey: String
+    let macTailcatPublicKey: String
+    let managedPairingGrant: String
+}
+
+private struct AuthorizePairingResponse: Decodable {
+    struct PairingSession: Decodable {
+        let id: String
+        let expiresAt: Date
+        let macSlot: String
+    }
+
+    let pairingSession: PairingSession
+    let created: Bool
+}
+
+private struct ManagementSessionRequest: Encodable {
+    let signedAppTransaction: String
+    let signedTransaction: String
+}
+
+private struct ManagementSessionResponse: Decodable {
+    let managementToken: String
+    let scope: String
+    let expiresAt: Date
+}
+
+private struct DeviceListResponse: Decodable {
+    let devices: [DeviceResponse]
+}
+
+private struct DeviceResponse: Decodable {
+    let id: String
+    let deviceType: String
+    let createdAt: Date
+
+    func model() throws -> ManagedConnectionDevice {
+        guard let type = ManagedConnectionDeviceType(rawValue: deviceType) else {
+            throw ManagedConnectionDeviceAPIError.invalidResponse
+        }
+        return ManagedConnectionDevice(id: id, deviceType: type, createdAt: createdAt)
+    }
+}
+
+private struct DeviceErrorResponse: Decodable {
+    let code: String
+    let deviceType: String?
+    let limit: Int?
+}
+
+private extension ISO8601DateFormatter {
+    static let deviceAPIWithFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/ios/MimiRemote/Sources/Core/Security/ManagedConnectionMobileIdentityStore.swift
+++ b/ios/MimiRemote/Sources/Core/Security/ManagedConnectionMobileIdentityStore.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Security
+
+struct ManagedConnectionMobileIdentity: Equatable, Sendable {
+    let installationID: String
+    let deviceToken: String
+    let registeredDeviceID: String?
+}
+
+@MainActor
+protocol ManagedConnectionMobileIdentityStoring: AnyObject {
+    func loadOrCreate() throws -> ManagedConnectionMobileIdentity
+    func rememberRegisteredDeviceID(_ id: String)
+    func rotateCredentialAfterRevocation(deviceID: String) throws
+}
+
+enum ManagedConnectionSecretGenerator {
+    static func token() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw TokenStoreError.saveFailed(status)
+        }
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+@MainActor
+final class ManagedConnectionMobileIdentityStore: ManagedConnectionMobileIdentityStoring {
+    private static let installationIDKey = "managedConnection.mobileInstallationID.v1"
+    private static let registeredDeviceIDKey = "managedConnection.mobileDeviceID.v1"
+
+    private let defaults: UserDefaults
+    private let tokenStore: TokenStore
+    private let makeUUID: () -> UUID
+    private let makeToken: () throws -> String
+
+    init(
+        defaults: UserDefaults = .standard,
+        tokenStore: TokenStore = TokenStore(),
+        makeUUID: @escaping () -> UUID = UUID.init,
+        makeToken: @escaping () throws -> String = ManagedConnectionSecretGenerator.token
+    ) {
+        self.defaults = defaults
+        self.tokenStore = tokenStore
+        self.makeUUID = makeUUID
+        self.makeToken = makeToken
+    }
+
+    func loadOrCreate() throws -> ManagedConnectionMobileIdentity {
+        let installationID = validInstallationID(defaults.string(forKey: Self.installationIDKey))
+            ?? createInstallationID()
+        var deviceToken = try tokenStore.loadManagedMobileDeviceToken(installationID: installationID)
+        if !Self.isCanonicalDeviceToken(deviceToken) {
+            deviceToken = try makeToken()
+            guard Self.isCanonicalDeviceToken(deviceToken) else {
+                throw ManagedConnectionDeviceAPIError.invalidResponse
+            }
+            try tokenStore.saveManagedMobileDeviceToken(deviceToken, installationID: installationID)
+        }
+        return ManagedConnectionMobileIdentity(
+            installationID: installationID,
+            deviceToken: deviceToken,
+            registeredDeviceID: defaults.string(forKey: Self.registeredDeviceIDKey)
+        )
+    }
+
+    func rememberRegisteredDeviceID(_ id: String) {
+        defaults.set(id, forKey: Self.registeredDeviceIDKey)
+    }
+
+    func rotateCredentialAfterRevocation(deviceID: String) throws {
+        guard defaults.string(forKey: Self.registeredDeviceIDKey) == deviceID,
+              let installationID = validInstallationID(
+                  defaults.string(forKey: Self.installationIDKey)
+              ) else {
+            return
+        }
+        // 服务端明确禁止复用已撤销 Token。安装 ID 保持稳定，下一次登记生成新 Token。
+        try tokenStore.deleteManagedMobileDeviceToken(installationID: installationID)
+        defaults.removeObject(forKey: Self.registeredDeviceIDKey)
+    }
+
+    private func createInstallationID() -> String {
+        var value = makeUUID().uuidString.lowercased()
+        while !Self.isUUIDv4(value) {
+            value = UUID().uuidString.lowercased()
+        }
+        defaults.set(value, forKey: Self.installationIDKey)
+        defaults.removeObject(forKey: Self.registeredDeviceIDKey)
+        return value
+    }
+
+    private func validInstallationID(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value.lowercased()
+        return Self.isUUIDv4(normalized) ? normalized : nil
+    }
+
+    private static func isUUIDv4(_ value: String) -> Bool {
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard UUID(uuidString: value) != nil,
+              parts.count == 5,
+              parts[2].first == "4",
+              let variant = parts[3].first?.lowercased()
+        else {
+            return false
+        }
+        return ["8", "9", "a", "b"].contains(variant)
+    }
+
+    private static func isCanonicalDeviceToken(_ value: String) -> Bool {
+        guard value.count == 43,
+              !value.contains("="),
+              value.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
+        else {
+            return false
+        }
+        var base64 = value.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64.append("=")
+        guard let data = Data(base64Encoded: base64), data.count == 32 else { return false }
+        return data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "") == value
+    }
+}

--- a/ios/MimiRemote/Sources/Core/Security/TokenStore.swift
+++ b/ios/MimiRemote/Sources/Core/Security/TokenStore.swift
@@ -57,6 +57,7 @@ struct TokenStore {
     private let tailcatExperimentAccount = "tailcat-experiment-client-key.v1"
     private let tailcatExperimentAddressAccount = "tailcat-experiment-address.v1"
     private let tailcatProfileAddressAccountPrefix = "tailcat-profile-address.v1."
+    private let managedMobileDeviceTokenAccountPrefix = "managed-mobile-device-token.v1."
     private let keychain: any KeychainOperating
 
     init(keychain: any KeychainOperating = SystemKeychainOperations()) {
@@ -81,6 +82,10 @@ struct TokenStore {
 
     func loadTailcatAddress(profileID: String) throws -> String {
         try load(account: tailcatProfileAddressAccountPrefix + profileID)
+    }
+
+    func loadManagedMobileDeviceToken(installationID: String) throws -> String {
+        try load(account: managedMobileDeviceTokenAccountPrefix + installationID.lowercased())
     }
 
     private func load(account: String) throws -> String {
@@ -122,12 +127,23 @@ struct TokenStore {
         try save(address, account: tailcatProfileAddressAccountPrefix + profileID)
     }
 
+    func saveManagedMobileDeviceToken(_ token: String, installationID: String) throws {
+        try save(token, account: managedMobileDeviceTokenAccountPrefix + installationID.lowercased())
+    }
+
     func deleteTailcatExperimentAddress(allowMissing: Bool = true) throws {
         try delete(account: tailcatExperimentAddressAccount, allowMissing: allowMissing)
     }
 
     func deleteTailcatAddress(profileID: String, allowMissing: Bool = true) throws {
         try delete(account: tailcatProfileAddressAccountPrefix + profileID, allowMissing: allowMissing)
+    }
+
+    func deleteManagedMobileDeviceToken(installationID: String, allowMissing: Bool = true) throws {
+        try delete(
+            account: managedMobileDeviceTokenAccountPrefix + installationID.lowercased(),
+            allowMissing: allowMissing
+        )
     }
 
     private func save(_ token: String, account: String) throws {

--- a/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
@@ -2,14 +2,25 @@ import SwiftUI
 
 struct ManagedConnectionSubscriptionView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var appStore: AppStore
+    @EnvironmentObject private var sessionStore: SessionStore
     @EnvironmentObject private var entitlementStore: ManagedConnectionEntitlementStore
+    @EnvironmentObject private var deviceStore: ManagedConnectionDeviceStore
+    @EnvironmentObject private var qrScannerPresentation: ConnectionQRCodeScannerPresentation
     @EnvironmentObject private var themeStore: ThemeStore
+    @State private var pendingRemoval: ManagedConnectionDevice?
+    @State private var localError: String?
+    @State private var isConnectingMac = false
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         Form {
             statusSection
+            if isEntitled {
+                connectionSection
+                devicesSection
+            }
             productsSection
             subscriptionInformationSection
         }
@@ -24,10 +35,42 @@ struct ManagedConnectionSubscriptionView: View {
                 await entitlementStore.load()
             }
         }
+        .task(id: entitlementStore.currentGrant?.entitlement.id) {
+            guard isEntitled else { return }
+            await deviceStore.refreshDevices()
+        }
+        .onAppear(perform: configureManagedScanner)
         .refreshable {
             await entitlementStore.refreshEntitlement()
+            if isEntitled {
+                await deviceStore.refreshDevices()
+            }
+        }
+        .confirmationDialog(
+            L10n.text("ui.managed_devices_remove_title"),
+            isPresented: Binding(
+                get: { pendingRemoval != nil },
+                set: { if !$0 { pendingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button(L10n.text("ui.managed_devices_remove_action"), role: .destructive) {
+                guard let device = pendingRemoval else { return }
+                pendingRemoval = nil
+                Task { await deviceStore.removeDevice(device) }
+            }
+            Button(L10n.text("ui.cancel"), role: .cancel) {
+                pendingRemoval = nil
+            }
+        } message: {
+            Text(L10n.text("ui.managed_devices_remove_message"))
         }
         .accessibilityIdentifier("settings.managedSubscription.detail")
+    }
+
+    private var isEntitled: Bool {
+        guard case .entitled = entitlementStore.status else { return false }
+        return true
     }
 
     @ViewBuilder
@@ -103,6 +146,214 @@ struct ManagedConnectionSubscriptionView: View {
             return L10n.text("ui.managed_subscription_expired")
         case .revoked:
             return L10n.text("ui.managed_subscription_revoked")
+        }
+    }
+
+    private var connectionSection: some View {
+        Section {
+            Button {
+                localError = nil
+                qrScannerPresentation.request(
+                    appStore.activeConnectionProfile == nil
+                        ? .initialConnection
+                        : .addConnectionProfile
+                )
+            } label: {
+                Label(L10n.text("ui.managed_devices_connect_mac"), systemImage: "qrcode.viewfinder")
+                    .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            }
+            .disabled(isConnectingMac || entitlementStore.isBusy)
+            .accessibilityIdentifier("settings.managedSubscription.connectMac")
+
+            if isConnectingMac {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text(L10n.text("ui.managed_devices_connecting"))
+                }
+                .accessibilityElement(children: .combine)
+            }
+
+            if let localError {
+                Label(localError, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+            }
+        } header: {
+            Text(L10n.text("ui.managed_devices_connection"))
+        } footer: {
+            Text(L10n.text("ui.managed_devices_rescan_notice"))
+        }
+    }
+
+    private var devicesSection: some View {
+        Section {
+            HStack(spacing: 16) {
+                deviceUsageLabel(
+                    title: L10n.text("ui.managed_devices_mac"),
+                    systemImage: "laptopcomputer",
+                    count: deviceStore.macCount,
+                    limit: ManagedConnectionDeviceStore.macLimit
+                )
+                Spacer(minLength: 8)
+                deviceUsageLabel(
+                    title: L10n.text("ui.managed_devices_mobile"),
+                    systemImage: "iphone.and.arrow.forward",
+                    count: deviceStore.mobileCount,
+                    limit: ManagedConnectionDeviceStore.mobileLimit
+                )
+            }
+            .accessibilityElement(children: .contain)
+
+            if deviceStore.isRefreshing, deviceStore.devices.isEmpty {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text(L10n.text("ui.managed_devices_loading"))
+                }
+                .accessibilityElement(children: .combine)
+            } else if deviceStore.devices.isEmpty {
+                Text(L10n.text("ui.managed_devices_empty"))
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(deviceStore.devices) { device in
+                    deviceRow(device)
+                }
+            }
+
+            if let message = deviceStore.errorMessage {
+                VStack(alignment: .leading, spacing: 10) {
+                    Label(message, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Button(L10n.text("ui.retry")) {
+                        Task { await deviceStore.refreshDevices() }
+                    }
+                    .disabled(deviceStore.isRefreshing)
+                }
+            }
+        } header: {
+            Text(L10n.text("ui.managed_devices_title"))
+        } footer: {
+            Text(L10n.text("ui.managed_devices_privacy_notice"))
+        }
+    }
+
+    private func deviceUsageLabel(
+        title: String,
+        systemImage: String,
+        count: Int,
+        limit: Int
+    ) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline)
+                Text(L10n.format("ui.managed_devices_usage", count, limit))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+        } icon: {
+            Image(systemName: systemImage)
+        }
+    }
+
+    private func deviceRow(_ device: ManagedConnectionDevice) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: device.deviceType == .mac ? "laptopcomputer" : "iphone")
+                .frame(width: 24)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(device.deviceType == .mac
+                        ? L10n.text("ui.managed_devices_mac")
+                        : L10n.text("ui.managed_devices_mobile"))
+                    if device.id == deviceStore.currentDeviceID {
+                        Text(L10n.text("ui.managed_devices_this_device"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text(
+                    L10n.format(
+                        "ui.managed_devices_added_detail",
+                        device.createdAt.formatted(date: .abbreviated, time: .shortened),
+                        String(device.id.suffix(4)).uppercased()
+                    )
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            if deviceStore.removingDeviceID == device.id {
+                ProgressView()
+            } else {
+                Button(role: .destructive) {
+                    pendingRemoval = device
+                } label: {
+                    Image(systemName: "trash")
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(L10n.text("ui.managed_devices_remove_action"))
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func configureManagedScanner() {
+        qrScannerPresentation.configure(
+            onSubmit: { rawValue, intent in
+                await applyManagedPairing(rawValue, intent: intent)
+            },
+            onChooseManualConnection: { _ in
+                localError = L10n.text("ui.managed_devices_qr_required")
+            },
+            onDismiss: {}
+        )
+    }
+
+    private func applyManagedPairing(
+        _ rawValue: String,
+        intent: ConnectionQRCodeScanIntent
+    ) async -> QRCodeScannerSubmissionResult {
+        isConnectingMac = true
+        defer { isConnectingMac = false }
+        do {
+            guard isEntitled else {
+                throw ManagedConnectionDeviceStoreError.subscriptionRequired
+            }
+            let raw = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let url = URL(string: raw),
+                  let link = try TailcatPairingLink.parse(url),
+                  link.managedMacInstallationID != nil,
+                  link.managedMacTailcatPublicKey != nil else {
+                throw ManagedConnectionDeviceStoreError.managedQRCodeRequired
+            }
+            let wasConfigured = appStore.isConfigured
+            if appStore.activeConnectionProfile == nil {
+                _ = try await sessionStore.applyManagedPairingURL(url)
+            } else {
+                _ = try await sessionStore.addManagedConnectionProfile(
+                    pairingURL: url,
+                    displayName: ""
+                )
+            }
+            localError = nil
+            Task { @MainActor in
+                _ = await sessionStore.refreshAfterConnectionCommit(
+                    maxWait: wasConfigured ? 10 : 45
+                )
+            }
+            return .accepted(
+                intent.addsConnectionProfile
+                    ? L10n.text("ui.added_and_switched_to_this_mac")
+                    : L10n.text("ui.this_mac_is_connected")
+            )
+        } catch is CancellationError {
+            return .rejected(L10n.text("ui.the_code_scan_has_been_cancelled_please_scan"))
+        } catch {
+            let message = error.localizedDescription
+            localError = message
+            return .rejected(message)
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -165,6 +165,7 @@ struct SettingsView: View {
         // 顶部再来一个同名大标题只是白占一屏高度。
         .navigationTitle(isInitialSetup ? L10n.text("ui.connect_your_mac") : "")
         .navigationBarTitleDisplayMode(isInitialSetup ? initialNavigationTitleDisplayMode : .inline)
+        .environmentObject(qrScannerPresentation)
         .navigationDestination(isPresented: $showsConnectionManagement) {
             ConnectionManagementView(
                 qrScannerPresentation: qrScannerPresentation,

--- a/ios/MimiRemote/Sources/MimiRemoteApp.swift
+++ b/ios/MimiRemote/Sources/MimiRemoteApp.swift
@@ -156,6 +156,7 @@ struct MimiRemoteApp: App {
     @StateObject private var hostStatusStore: HostStatusStore
     @StateObject private var tailcatExperimentController: TailcatExperimentController
     @StateObject private var managedConnectionEntitlementStore: ManagedConnectionEntitlementStore
+    @StateObject private var managedConnectionDeviceStore: ManagedConnectionDeviceStore
 
     /// 紧凑布局的会话搜索走系统 `.searchable`，而系统在 iOS 26 上给它铺的是
     /// Liquid Glass——一屏里其它 chrome 全是扁平磨砂，只有它一块玻璃。
@@ -188,10 +189,16 @@ struct MimiRemoteApp: App {
             profiles: appStore.connectionProfiles
         )
         let notificationResponseAdapter = SessionNotificationResponseAdapter()
-        let tailcatExperimentController = TailcatExperimentController(appStore: appStore)
         let managedConnectionEntitlementStore = ManagedConnectionEntitlementStore(
             storeKit: LiveManagedConnectionStoreKitClient(),
             entitlementAPI: LiveManagedConnectionEntitlementAPIClient()
+        )
+        let managedConnectionDeviceStore = ManagedConnectionDeviceStore(
+            entitlementStore: managedConnectionEntitlementStore
+        )
+        let tailcatExperimentController = TailcatExperimentController(
+            appStore: appStore,
+            managedPairingAuthorizer: managedConnectionDeviceStore
         )
         // SessionStore 初始化会同步绑定三个缓存 Store 的 Profile namespace。
         // 必须在 SwiftUI 接管这些 ObservableObject 前完成，避免在视图更新事务内发布状态。
@@ -215,6 +222,9 @@ struct MimiRemoteApp: App {
         _managedConnectionEntitlementStore = StateObject(
             wrappedValue: managedConnectionEntitlementStore
         )
+        _managedConnectionDeviceStore = StateObject(
+            wrappedValue: managedConnectionDeviceStore
+        )
         _sessionStore = StateObject(wrappedValue: sessionStore)
         // 尽早注册 delegate；冷启动点击会先进入 adapter 的 pendingRoute，等 RootView 消费。
         UNUserNotificationCenter.current().delegate = notificationResponseAdapter
@@ -236,6 +246,7 @@ struct MimiRemoteApp: App {
                 .environmentObject(hostStatusStore)
                 .environmentObject(tailcatExperimentController)
                 .environmentObject(managedConnectionEntitlementStore)
+                .environmentObject(managedConnectionDeviceStore)
                 .onOpenURL { url in
                     Task { @MainActor in
                         do {

--- a/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+struct ManagedConnectionPairingAuthorization: Equatable, Sendable {
+    let sessionID: String
+    let grant: String
+}
+
+@MainActor
+protocol ManagedConnectionPairingAuthorizing: AnyObject {
+    func authorizeManagedPairing(
+        macInstallationID: String,
+        macTailcatPublicKey: String,
+        mobileTailcatPublicKey: String
+    ) async throws -> ManagedConnectionPairingAuthorization
+
+    func didCompleteManagedPairing(_ authorization: ManagedConnectionPairingAuthorization)
+}
+
+@MainActor
+final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPairingAuthorizing {
+    static let macLimit = 3
+    static let mobileLimit = 5
+
+    @Published private(set) var devices: [ManagedConnectionDevice] = []
+    @Published private(set) var isRefreshing = false
+    @Published private(set) var removingDeviceID: String?
+    @Published private(set) var errorMessage: String?
+
+    private struct PendingPairingAuthorization {
+        let macInstallationID: String
+        let mobileTailcatPublicKey: String
+        let requestID: String
+        let grant: String
+        var session: ManagedConnectionPairingSession?
+        let localExpiresAt: Date
+    }
+
+    private let entitlementStore: ManagedConnectionEntitlementStore
+    private let api: any ManagedConnectionDeviceAPIClient
+    private let identityStore: any ManagedConnectionMobileIdentityStoring
+    private let now: () -> Date
+    private let makeUUID: () -> UUID
+    private let makeToken: () throws -> String
+    private var managementSession: ManagedConnectionManagementSession?
+    private var pendingPairing: PendingPairingAuthorization?
+
+    init(
+        entitlementStore: ManagedConnectionEntitlementStore,
+        api: any ManagedConnectionDeviceAPIClient = LiveManagedConnectionDeviceAPIClient(),
+        identityStore: (any ManagedConnectionMobileIdentityStoring)? = nil,
+        now: @escaping () -> Date = Date.init,
+        makeUUID: @escaping () -> UUID = UUID.init,
+        makeToken: @escaping () throws -> String = ManagedConnectionSecretGenerator.token
+    ) {
+        self.entitlementStore = entitlementStore
+        self.api = api
+        if let identityStore {
+            self.identityStore = identityStore
+        } else {
+            self.identityStore = ManagedConnectionMobileIdentityStore()
+        }
+        self.now = now
+        self.makeUUID = makeUUID
+        self.makeToken = makeToken
+    }
+
+    var macCount: Int { devices.lazy.filter { $0.deviceType == .mac }.count }
+    var mobileCount: Int { devices.lazy.filter { $0.deviceType == .mobile }.count }
+
+    var currentDeviceID: String? {
+        try? identityStore.loadOrCreate().registeredDeviceID
+    }
+
+    func refreshDevices() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        do {
+            let token = try await validManagementToken()
+            devices = try await api.listDevices(managementToken: token)
+                .sorted { $0.createdAt > $1.createdAt }
+            errorMessage = nil
+        } catch {
+            errorMessage = userFacingMessage(for: error)
+        }
+    }
+
+    func removeDevice(_ device: ManagedConnectionDevice) async {
+        guard removingDeviceID == nil else { return }
+        removingDeviceID = device.id
+        defer { removingDeviceID = nil }
+        do {
+            let token = try await validManagementToken()
+            try await api.removeDevice(id: device.id, managementToken: token)
+            try identityStore.rotateCredentialAfterRevocation(deviceID: device.id)
+            if currentDeviceID == nil {
+                pendingPairing = nil
+            }
+            devices.removeAll { $0.id == device.id }
+            errorMessage = nil
+        } catch {
+            errorMessage = userFacingMessage(for: error)
+        }
+    }
+
+    func authorizeManagedPairing(
+        macInstallationID: String,
+        macTailcatPublicKey: String,
+        mobileTailcatPublicKey: String
+    ) async throws -> ManagedConnectionPairingAuthorization {
+        let identity = try await ensureMobileDeviceRegistered()
+        let pending = try reusableOrNewPendingPairing(
+            macInstallationID: macInstallationID,
+            mobileTailcatPublicKey: mobileTailcatPublicKey
+        )
+        if let session = pending.session, session.expiresAt > now() {
+            return ManagedConnectionPairingAuthorization(sessionID: session.id, grant: pending.grant)
+        }
+
+        let session = try await api.authorizePairing(
+            deviceToken: identity.deviceToken,
+            requestID: pending.requestID,
+            macInstallationID: macInstallationID,
+            mobileTailcatPublicKey: mobileTailcatPublicKey,
+            macTailcatPublicKey: macTailcatPublicKey,
+            managedPairingGrant: pending.grant
+        )
+        pendingPairing?.session = session
+        return ManagedConnectionPairingAuthorization(sessionID: session.id, grant: pending.grant)
+    }
+
+    func didCompleteManagedPairing(_ authorization: ManagedConnectionPairingAuthorization) {
+        guard pendingPairing?.grant == authorization.grant else { return }
+        pendingPairing = nil
+        Task { await refreshDevices() }
+    }
+
+    private func ensureMobileDeviceRegistered() async throws -> ManagedConnectionMobileIdentity {
+        let identity = try identityStore.loadOrCreate()
+        let grant = try await validEntitlementGrant()
+        do {
+            let result = try await api.registerMobileDevice(
+                entitlementToken: grant.token,
+                installationID: identity.installationID,
+                deviceToken: identity.deviceToken
+            )
+            identityStore.rememberRegisteredDeviceID(result.device.id)
+            return ManagedConnectionMobileIdentity(
+                installationID: identity.installationID,
+                deviceToken: identity.deviceToken,
+                registeredDeviceID: result.device.id
+            )
+        } catch let error as ManagedConnectionDeviceAPIError where error.rejectionCode == "unauthorized" {
+            await entitlementStore.refreshEntitlement()
+            let refreshedGrant = try await validEntitlementGrant(refreshIfMissing: false)
+            let result = try await api.registerMobileDevice(
+                entitlementToken: refreshedGrant.token,
+                installationID: identity.installationID,
+                deviceToken: identity.deviceToken
+            )
+            identityStore.rememberRegisteredDeviceID(result.device.id)
+            return ManagedConnectionMobileIdentity(
+                installationID: identity.installationID,
+                deviceToken: identity.deviceToken,
+                registeredDeviceID: result.device.id
+            )
+        }
+    }
+
+    private func validEntitlementGrant(
+        refreshIfMissing: Bool = true
+    ) async throws -> ManagedConnectionEntitlementGrant {
+        if let grant = entitlementStore.currentGrant,
+           grant.entitlement.expiresAt > now(),
+           grant.tokenExpiresAt > now()
+        {
+            return grant
+        }
+        if refreshIfMissing {
+            await entitlementStore.refreshEntitlement()
+            if let grant = entitlementStore.currentGrant,
+               grant.entitlement.expiresAt > now(),
+               grant.tokenExpiresAt > now()
+            {
+                return grant
+            }
+        }
+        throw ManagedConnectionDeviceStoreError.subscriptionRequired
+    }
+
+    private func validManagementToken() async throws -> String {
+        if let managementSession,
+           managementSession.expiresAt.timeIntervalSince(now()) > 5
+        {
+            return managementSession.token
+        }
+        let evidence = try await entitlementStore.managementPurchaseEvidence()
+        let session = try await api.createManagementSession(
+            signedAppTransaction: evidence.signedAppTransaction,
+            signedTransaction: evidence.signedTransaction
+        )
+        managementSession = session
+        return session.token
+    }
+
+    private func reusableOrNewPendingPairing(
+        macInstallationID: String,
+        mobileTailcatPublicKey: String
+    ) throws -> PendingPairingAuthorization {
+        if let pendingPairing,
+           pendingPairing.macInstallationID == macInstallationID,
+           pendingPairing.mobileTailcatPublicKey == mobileTailcatPublicKey,
+           pendingPairing.localExpiresAt > now()
+        {
+            return pendingPairing
+        }
+        let pending = PendingPairingAuthorization(
+            macInstallationID: macInstallationID,
+            mobileTailcatPublicKey: mobileTailcatPublicKey,
+            requestID: makeUUID().uuidString.lowercased(),
+            grant: try makeToken(),
+            session: nil,
+            localExpiresAt: now().addingTimeInterval(600)
+        )
+        pendingPairing = pending
+        return pending
+    }
+
+    private func userFacingMessage(for error: Error) -> String {
+        if let localized = error as? LocalizedError,
+           let description = localized.errorDescription,
+           !description.isEmpty
+        {
+            return description
+        }
+        return L10n.text("ui.managed_devices_network_error")
+    }
+}
+
+enum ManagedConnectionDeviceStoreError: LocalizedError, Equatable {
+    case subscriptionRequired
+    case managedQRCodeRequired
+
+    var errorDescription: String? {
+        switch self {
+        case .subscriptionRequired:
+            return L10n.text("ui.managed_devices_subscription_required")
+        case .managedQRCodeRequired:
+            return L10n.text("ui.managed_devices_qr_required")
+        }
+    }
+}

--- a/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
@@ -28,11 +28,18 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
 
     private struct PendingPairingAuthorization {
         let macInstallationID: String
+        let macTailcatPublicKey: String
         let mobileTailcatPublicKey: String
         let requestID: String
         let grant: String
         var session: ManagedConnectionPairingSession?
         let localExpiresAt: Date
+    }
+
+    private struct CachedManagementSession {
+        let session: ManagedConnectionManagementSession
+        let transactionID: UInt64
+        let productID: String
     }
 
     private let entitlementStore: ManagedConnectionEntitlementStore
@@ -41,7 +48,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
     private let now: () -> Date
     private let makeUUID: () -> UUID
     private let makeToken: () throws -> String
-    private var managementSession: ManagedConnectionManagementSession?
+    private var managementSession: CachedManagementSession?
     private var pendingPairing: PendingPairingAuthorization?
 
     init(
@@ -77,8 +84,10 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         defer { isRefreshing = false }
         do {
             let token = try await validManagementToken()
-            devices = try await api.listDevices(managementToken: token)
+            let refreshedDevices = try await api.listDevices(managementToken: token)
                 .sorted { $0.createdAt > $1.createdAt }
+            devices = refreshedDevices
+            try reconcileCurrentDeviceAfterRemoteRevocation(refreshedDevices)
             errorMessage = nil
         } catch {
             errorMessage = userFacingMessage(for: error)
@@ -91,7 +100,12 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         defer { removingDeviceID = nil }
         do {
             let token = try await validManagementToken()
-            try await api.removeDevice(id: device.id, managementToken: token)
+            do {
+                try await api.removeDevice(id: device.id, managementToken: token)
+            } catch let error as ManagedConnectionDeviceAPIError
+                where error.rejectionCode == "device_not_found" {
+                // 服务端删除已完成但客户端未收到响应时，重试仍要完成本地凭证轮换。
+            }
             try identityStore.rotateCredentialAfterRevocation(deviceID: device.id)
             if currentDeviceID == nil {
                 pendingPairing = nil
@@ -111,6 +125,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         let identity = try await ensureMobileDeviceRegistered()
         let pending = try reusableOrNewPendingPairing(
             macInstallationID: macInstallationID,
+            macTailcatPublicKey: macTailcatPublicKey,
             mobileTailcatPublicKey: mobileTailcatPublicKey
         )
         if let session = pending.session, session.expiresAt > now() {
@@ -189,26 +204,34 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
     }
 
     private func validManagementToken() async throws -> String {
-        if let managementSession,
-           managementSession.expiresAt.timeIntervalSince(now()) > 5
-        {
-            return managementSession.token
-        }
         let evidence = try await entitlementStore.managementPurchaseEvidence()
+        if let managementSession,
+           managementSession.transactionID == evidence.transactionID,
+           managementSession.productID == evidence.productID,
+           managementSession.session.expiresAt.timeIntervalSince(now()) > 5
+        {
+            return managementSession.session.token
+        }
         let session = try await api.createManagementSession(
             signedAppTransaction: evidence.signedAppTransaction,
             signedTransaction: evidence.signedTransaction
         )
-        managementSession = session
+        managementSession = CachedManagementSession(
+            session: session,
+            transactionID: evidence.transactionID,
+            productID: evidence.productID
+        )
         return session.token
     }
 
     private func reusableOrNewPendingPairing(
         macInstallationID: String,
+        macTailcatPublicKey: String,
         mobileTailcatPublicKey: String
     ) throws -> PendingPairingAuthorization {
         if let pendingPairing,
            pendingPairing.macInstallationID == macInstallationID,
+           pendingPairing.macTailcatPublicKey == macTailcatPublicKey,
            pendingPairing.mobileTailcatPublicKey == mobileTailcatPublicKey,
            pendingPairing.localExpiresAt > now()
         {
@@ -216,6 +239,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         }
         let pending = PendingPairingAuthorization(
             macInstallationID: macInstallationID,
+            macTailcatPublicKey: macTailcatPublicKey,
             mobileTailcatPublicKey: mobileTailcatPublicKey,
             requestID: makeUUID().uuidString.lowercased(),
             grant: try makeToken(),
@@ -224,6 +248,18 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         )
         pendingPairing = pending
         return pending
+    }
+
+    private func reconcileCurrentDeviceAfterRemoteRevocation(
+        _ refreshedDevices: [ManagedConnectionDevice]
+    ) throws {
+        guard let currentDeviceID,
+              !refreshedDevices.contains(where: { $0.id == currentDeviceID }) else {
+            return
+        }
+        // DELETE 成功后的进程中断或 Keychain 失败会留下旧本地凭证；每次刷新都重试收敛。
+        try identityStore.rotateCredentialAfterRevocation(deviceID: currentDeviceID)
+        pendingPairing = nil
     }
 
     private func userFacingMessage(for error: Error) -> String {

--- a/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct ManagedConnectionPurchaseEvidence: Equatable, Sendable {
+    let signedAppTransaction: String
+    let signedTransaction: String
+}
+
 @MainActor
 final class ManagedConnectionEntitlementStore: ObservableObject {
     enum Status: Equatable {
@@ -16,6 +21,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
     @Published private(set) var products: [ManagedConnectionProduct] = []
     @Published private(set) var status: Status = .loading
     @Published private(set) var currentGrant: ManagedConnectionEntitlementGrant?
+    private(set) var currentEvidence: ManagedConnectionTransactionEvidence?
 
     private let storeKit: any ManagedConnectionStoreKitClient
     private let entitlementAPI: any ManagedConnectionEntitlementAPIClient
@@ -117,6 +123,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
             let grant = try await resolve(evidence)
             guard isLatest(generation) else { return }
             currentGrant = grant
+            currentEvidence = evidence
             status = .entitled(grant.entitlement)
             await storeKit.finish(transactionID: evidence.transactionID)
         } catch is CancellationError {
@@ -144,6 +151,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                 continue
             case .unverified:
                 currentGrant = nil
+                currentEvidence = nil
                 status = .failed(L10n.text("ui.managed_subscription_unverified"))
                 return
             case .verified(let evidence):
@@ -151,6 +159,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                     let grant = try await resolve(evidence)
                     guard isLatest(generation) else { return }
                     currentGrant = grant
+                    currentEvidence = evidence
                     status = .entitled(grant.entitlement)
                     await storeKit.finish(transactionID: evidence.transactionID)
                     return
@@ -167,6 +176,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         }
 
         currentGrant = nil
+        currentEvidence = nil
         status = .available
     }
 
@@ -194,6 +204,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                     let grant = try await resolve(evidence)
                     guard isLatest(generation) else { return }
                     currentGrant = grant
+                    currentEvidence = evidence
                     status = .entitled(grant.entitlement)
                     // 服务端是权益事实来源。只有它接受两份 JWS 后，才结束 StoreKit 交易。
                     await storeKit.finish(transactionID: evidence.transactionID)
@@ -235,6 +246,19 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
 
     var isBusy: Bool {
         status == .loading || status == .resolving
+    }
+
+    func managementPurchaseEvidence() async throws -> ManagedConnectionPurchaseEvidence {
+        guard let currentGrant = usableCurrentGrant,
+              let currentEvidence,
+              currentEvidence.productID == currentGrant.entitlement.productID
+        else {
+            throw ManagedConnectionDeviceStoreError.subscriptionRequired
+        }
+        return ManagedConnectionPurchaseEvidence(
+            signedAppTransaction: try await storeKit.signedAppTransaction(),
+            signedTransaction: currentEvidence.signedTransaction
+        )
     }
 
     private func beginOperation() -> Int {
@@ -332,6 +356,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         switch failureStatus {
         case .available, .expired, .revoked:
             currentGrant = nil
+            currentEvidence = nil
             status = failureStatus
         case .failed:
             if let apiError = error as? ManagedConnectionEntitlementAPIError,
@@ -339,6 +364,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                code == "unverified_transaction"
             {
                 currentGrant = nil
+                currentEvidence = nil
                 status = failureStatus
             } else {
                 restore(fallbackGrant, otherwise: failureStatus)

--- a/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 struct ManagedConnectionPurchaseEvidence: Equatable, Sendable {
+    let transactionID: UInt64
+    let productID: String
     let signedAppTransaction: String
     let signedTransaction: String
 }
@@ -256,6 +258,8 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
             throw ManagedConnectionDeviceStoreError.subscriptionRequired
         }
         return ManagedConnectionPurchaseEvidence(
+            transactionID: currentEvidence.transactionID,
+            productID: currentEvidence.productID,
             signedAppTransaction: try await storeKit.signedAppTransaction(),
             signedTransaction: currentEvidence.signedTransaction
         )

--- a/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
@@ -129,6 +129,22 @@ extension SessionStore {
     }
 
     @discardableResult
+    func applyManagedPairingURL(_ url: URL) async throws -> Bool {
+        try await performPreparedConnectionChange {
+            guard let controller = self.tailcatExperimentController,
+                  try TailcatPairingLink.parse(url) != nil else {
+                throw ManagedConnectionDeviceStoreError.managedQRCodeRequired
+            }
+            return try await controller.preparePairingURL(
+                url,
+                appStore: self.appStore,
+                profileTarget: .currentOrNew(displayName: nil),
+                requiresManagedAuthorization: true
+            )
+        }
+    }
+
+    @discardableResult
     func addConnectionProfile(pairingURL url: URL, displayName: String) async throws -> Bool {
         try await performPreparedConnectionChange {
             if let controller = self.tailcatExperimentController,
@@ -143,6 +159,22 @@ extension SessionStore {
                 )
             }
             return try await self.appStore.prepareNewPairingURL(url, displayName: displayName)
+        }
+    }
+
+    @discardableResult
+    func addManagedConnectionProfile(pairingURL url: URL, displayName: String) async throws -> Bool {
+        try await performPreparedConnectionChange {
+            guard let controller = self.tailcatExperimentController,
+                  try TailcatPairingLink.parse(url) != nil else {
+                throw ManagedConnectionDeviceStoreError.managedQRCodeRequired
+            }
+            return try await controller.preparePairingURL(
+                url,
+                appStore: self.appStore,
+                profileTarget: .newProfile(id: UUID().uuidString, displayName: displayName),
+                requiresManagedAuthorization: true
+            )
         }
     }
 

--- a/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
+++ b/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
@@ -188,6 +188,7 @@ final class TailcatExperimentController: ObservableObject {
     private let tokenStore: TokenStore
     private let runtime: any TailcatExperimentRuntimeProtocol
     private let bridge: TailcatExperimentBridgeAdapter
+    private let managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)?
     private var generation: UInt64 = 0
     private var preparationTask: RoutePreparation?
     private var pendingPairing: PendingPairing?
@@ -197,7 +198,8 @@ final class TailcatExperimentController: ObservableObject {
         defaults: UserDefaults = .standard,
         tokenStore: TokenStore = TokenStore(),
         runtime: any TailcatExperimentRuntimeProtocol = TailcatExperimentRuntime(),
-        bridge: TailcatExperimentBridgeAdapter = .live
+        bridge: TailcatExperimentBridgeAdapter = .live,
+        managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)? = nil
     ) {
         let available = bridge.isAvailable
         let savedEnabled = defaults.bool(forKey: Self.enabledKey)
@@ -244,6 +246,7 @@ final class TailcatExperimentController: ObservableObject {
         self.tokenStore = tokenStore
         self.runtime = runtime
         self.bridge = bridge
+        self.managedPairingAuthorizer = managedPairingAuthorizer
         address = savedAddress
         diagnostics = Self.loadDiagnostics(defaults: defaults)
         isEnabled = initialEnabled
@@ -448,7 +451,8 @@ final class TailcatExperimentController: ObservableObject {
     func preparePairingURL(
         _ url: URL,
         appStore: AppStore,
-        profileTarget: PreparedConnectionProfileTarget
+        profileTarget: PreparedConnectionProfileTarget,
+        requiresManagedAuthorization: Bool = false
     ) async throws -> PreparedConnectionSettings {
         guard let link = try TailcatPairingLink.parse(url) else {
             throw PairingLinkError.unsupportedURL
@@ -473,14 +477,43 @@ final class TailcatExperimentController: ObservableObject {
             let privateKey = try loadOrCreatePrivateKey()
             let clientKey = try bridge.publicKey(privateKey)
             publicKey = clientKey
+            let managedAuthorization: ManagedConnectionPairingAuthorization?
+            if requiresManagedAuthorization {
+                guard let macInstallationID = link.managedMacInstallationID,
+                      let macTailcatPublicKey = link.managedMacTailcatPublicKey,
+                      let managedPairingAuthorizer
+                else {
+                    throw ManagedConnectionDeviceStoreError.managedQRCodeRequired
+                }
+                managedAuthorization = try await managedPairingAuthorizer.authorizeManagedPairing(
+                    macInstallationID: macInstallationID,
+                    macTailcatPublicKey: macTailcatPublicKey,
+                    mobileTailcatPublicKey: clientKey
+                )
+            } else {
+                managedAuthorization = nil
+            }
             let pairingEndpoint = try await runtime.prepare(
                 address: link.pairAddress,
                 privateKey: privateKey
             )
             let response: PairingClaimResponse
             do {
+                let claimRequest: PairingClaimRequest
+                if let managedAuthorization {
+                    claimRequest = link.ticket.managedClaimRequest(
+                        tailcatClientKey: clientKey,
+                        pairingSessionID: managedAuthorization.sessionID,
+                        managedPairingGrant: managedAuthorization.grant
+                    )
+                } else {
+                    claimRequest = link.ticket.claimRequest(tailcatClientKey: clientKey)
+                }
                 response = try await AgentAPIClient(endpoint: pairingEndpoint, token: "")
-                    .claimPairing(link.ticket.claimRequest(tailcatClientKey: clientKey))
+                    .claimPairing(claimRequest)
+                if let managedAuthorization {
+                    managedPairingAuthorizer?.didCompleteManagedPairing(managedAuthorization)
+                }
             } catch {
                 try? await runtime.discardPrepared(endpoint: pairingEndpoint)
                 throw error

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceAPIClientTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceAPIClientTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import XCTest
+@testable import MimiRemote
+
+final class ManagedConnectionDeviceAPIClientTests: XCTestCase {
+    override func tearDown() {
+        MIM260DeviceURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testRegisterMobileSendsOnlyRandomIdentityAndDeviceToken() async throws {
+        MIM260DeviceURLProtocol.respond(
+            statusCode: 201,
+            body: #"{"device":{"id":"device-id","deviceType":"mobile","createdAt":"2026-09-04T00:00:00.000Z"},"created":true}"#
+        )
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let client = LiveManagedConnectionDeviceAPIClient(session: session)
+
+        let result = try await client.registerMobileDevice(
+            entitlementToken: "entitlement-token-that-is-long-enough",
+            installationID: "10000000-0000-4000-8000-000000000001",
+            deviceToken: Self.token(byte: 1)
+        )
+
+        let request = try XCTUnwrap(MIM260DeviceURLProtocol.capturedRequest())
+        let body = try XCTUnwrap(MIM260DeviceURLProtocol.capturedBody())
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(request.url?.path, "/v1/devices")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer entitlement-token-that-is-long-enough"
+        )
+        XCTAssertEqual(json["deviceType"], "mobile")
+        XCTAssertEqual(json["installationId"], "10000000-0000-4000-8000-000000000001")
+        XCTAssertEqual(json["deviceToken"], Self.token(byte: 1))
+        XCTAssertEqual(Set(json.keys), Set(["deviceType", "installationId", "deviceToken"]))
+        XCTAssertTrue(result.created)
+        XCTAssertEqual(result.device.deviceType, .mobile)
+    }
+
+    func testAuthorizePairingKeepsGrantInRequestAndParsesReservedSlot() async throws {
+        MIM260DeviceURLProtocol.respond(
+            statusCode: 201,
+            body: #"{"pairingSession":{"id":"30000000-0000-4000-8000-000000000001","expiresAt":"2026-09-04T00:10:00Z","macSlot":"reserved"},"created":true}"#
+        )
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let client = LiveManagedConnectionDeviceAPIClient(session: session)
+        let grant = Self.token(byte: 2)
+
+        let result = try await client.authorizePairing(
+            deviceToken: Self.token(byte: 3),
+            requestID: "30000000-0000-4000-8000-000000000002",
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            mobileTailcatPublicKey: "nodekey:mobile",
+            macTailcatPublicKey: "nodekey:mac",
+            managedPairingGrant: grant
+        )
+
+        let body = try XCTUnwrap(MIM260DeviceURLProtocol.capturedBody())
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(json["requestId"], "30000000-0000-4000-8000-000000000002")
+        XCTAssertEqual(json["macInstallationId"], "20000000-0000-4000-8000-000000000001")
+        XCTAssertEqual(json["mobileTailcatPublicKey"], "nodekey:mobile")
+        XCTAssertEqual(json["macTailcatPublicKey"], "nodekey:mac")
+        XCTAssertEqual(json["managedPairingGrant"], grant)
+        XCTAssertEqual(result.macSlot, .reserved)
+    }
+
+    func testDeviceLimitErrorPreservesTypeAndLimit() async throws {
+        MIM260DeviceURLProtocol.respond(
+            statusCode: 409,
+            body: #"{"code":"device_limit_reached","deviceType":"mac","limit":3}"#
+        )
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let client = LiveManagedConnectionDeviceAPIClient(session: session)
+
+        do {
+            _ = try await client.registerMobileDevice(
+                entitlementToken: "entitlement-token-that-is-long-enough",
+                installationID: "10000000-0000-4000-8000-000000000001",
+                deviceToken: Self.token(byte: 1)
+            )
+            XCTFail("quota rejection must be surfaced")
+        } catch {
+            XCTAssertEqual(
+                error as? ManagedConnectionDeviceAPIError,
+                .rejected(code: "device_limit_reached", deviceType: .mac, limit: 3)
+            )
+        }
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MIM260DeviceURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private static func token(byte: UInt8) -> String {
+        Data(repeating: byte, count: 32).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private final class MIM260DeviceURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var statusCode = 500
+    private static var responseBody = Data()
+    private static var lastRequest: URLRequest?
+    private static var lastBody: Data?
+
+    static func respond(statusCode: Int, body: String) {
+        lock.lock()
+        self.statusCode = statusCode
+        responseBody = Data(body.utf8)
+        lastRequest = nil
+        lastBody = nil
+        lock.unlock()
+    }
+
+    static func capturedRequest() -> URLRequest? {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastRequest
+    }
+
+    static func capturedBody() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastBody
+    }
+
+    static func reset() {
+        lock.lock()
+        statusCode = 500
+        responseBody = Data()
+        lastRequest = nil
+        lastBody = nil
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        var requestBody = request.httpBody
+        if requestBody == nil, let stream = request.httpBodyStream {
+            requestBody = Self.readAll(from: stream)
+        }
+
+        Self.lock.lock()
+        Self.lastRequest = request
+        Self.lastBody = requestBody
+        let statusCode = Self.statusCode
+        let responseBody = Self.responseBody
+        Self.lock.unlock()
+
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: statusCode,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: ["Content-Type": "application/json"]
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: responseBody)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readAll(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4 * 1024)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
@@ -1,0 +1,356 @@
+import Foundation
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class ManagedConnectionDeviceStoreTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testMobileIdentityPersistsAcrossLaunchAndRotatesOnlyAfterThisDeviceIsRevoked() throws {
+        let suiteName = "ManagedConnectionDeviceStoreTests.Identity.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let tokenStore = TokenStore(keychain: TestKeychainOperations())
+        let tokens = TokenSequence([Self.token(byte: 1), Self.token(byte: 2)])
+        let installationID = UUID(uuidString: "10000000-0000-4000-8000-000000000001")!
+        let store = ManagedConnectionMobileIdentityStore(
+            defaults: defaults,
+            tokenStore: tokenStore,
+            makeUUID: { installationID },
+            makeToken: { try tokens.next() }
+        )
+
+        let first = try store.loadOrCreate()
+        store.rememberRegisteredDeviceID("mobile-device-id")
+        let relaunched = ManagedConnectionMobileIdentityStore(
+            defaults: defaults,
+            tokenStore: tokenStore,
+            makeToken: { try tokens.next() }
+        )
+        let restored = try relaunched.loadOrCreate()
+        try relaunched.rotateCredentialAfterRevocation(deviceID: "another-device")
+        let unchanged = try relaunched.loadOrCreate()
+        try relaunched.rotateCredentialAfterRevocation(deviceID: "mobile-device-id")
+        let rotated = try relaunched.loadOrCreate()
+
+        XCTAssertEqual(first.installationID, installationID.uuidString.lowercased())
+        XCTAssertEqual(restored.installationID, first.installationID)
+        XCTAssertEqual(restored.deviceToken, first.deviceToken)
+        XCTAssertEqual(restored.registeredDeviceID, "mobile-device-id")
+        XCTAssertEqual(unchanged.deviceToken, first.deviceToken)
+        XCTAssertEqual(rotated.installationID, first.installationID)
+        XCTAssertNotEqual(rotated.deviceToken, first.deviceToken)
+        XCTAssertNil(rotated.registeredDeviceID)
+    }
+
+    func testManagedPairingRegistersMobileAndReusesAuthorizationDuringRetry() async throws {
+        let fixture = await makeFixture()
+
+        let first = try await fixture.store.authorizeManagedPairing(
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            macTailcatPublicKey: "nodekey:mac",
+            mobileTailcatPublicKey: "nodekey:mobile"
+        )
+        let retry = try await fixture.store.authorizeManagedPairing(
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            macTailcatPublicKey: "nodekey:mac",
+            mobileTailcatPublicKey: "nodekey:mobile"
+        )
+
+        let registrationCount = await fixture.api.registrationCount
+        let authorizationCount = await fixture.api.authorizationCount
+        let authorizedRequest = await fixture.api.lastAuthorizedRequest
+        XCTAssertEqual(first, retry)
+        XCTAssertEqual(first.sessionID, "30000000-0000-4000-8000-000000000001")
+        XCTAssertEqual(registrationCount, 2, "登记接口本身幂等，每次配对都重新确认设备仍有效")
+        XCTAssertEqual(authorizationCount, 1, "响应丢失后的同一逻辑配对应复用授权")
+        XCTAssertEqual(authorizedRequest?.mobileKey, "nodekey:mobile")
+        XCTAssertEqual(authorizedRequest?.macKey, "nodekey:mac")
+        XCTAssertEqual(fixture.identity.registeredDeviceID, "mobile-device-id")
+    }
+
+    func testMobileQuotaFailureStopsBeforePairingAuthorization() async {
+        let fixture = await makeFixture()
+        await fixture.api.setRegistrationFailure(
+            .rejected(code: "device_limit_reached", deviceType: .mobile, limit: 5)
+        )
+
+        do {
+            _ = try await fixture.store.authorizeManagedPairing(
+                macInstallationID: "20000000-0000-4000-8000-000000000001",
+                macTailcatPublicKey: "nodekey:mac",
+                mobileTailcatPublicKey: "nodekey:mobile"
+            )
+            XCTFail("第六台移动设备必须被名额门禁拒绝")
+        } catch let error as ManagedConnectionDeviceAPIError {
+            XCTAssertEqual(
+                error,
+                .rejected(code: "device_limit_reached", deviceType: .mobile, limit: 5)
+            )
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        let authorizationCount = await fixture.api.authorizationCount
+        XCTAssertEqual(authorizationCount, 0)
+    }
+
+    func testDeviceManagementUsesStoreKitEvidenceAndRevokingCurrentDeviceRotatesToken() async {
+        let fixture = await makeFixture()
+        let current = ManagedConnectionDevice(
+            id: "mobile-device-id",
+            deviceType: .mobile,
+            createdAt: now.addingTimeInterval(-60)
+        )
+        fixture.identity.rememberRegisteredDeviceID(current.id)
+        await fixture.api.setDevices([
+            current,
+            ManagedConnectionDevice(
+                id: "mac-device-id",
+                deviceType: .mac,
+                createdAt: now.addingTimeInterval(-120)
+            )
+        ])
+
+        await fixture.store.refreshDevices()
+        await fixture.store.removeDevice(current)
+
+        let evidence = await fixture.api.lastManagementEvidence
+        let removed = await fixture.api.removedDeviceIDs
+        XCTAssertEqual(evidence?.app, "signed-app-transaction")
+        XCTAssertEqual(evidence?.transaction, "signed-transaction")
+        XCTAssertEqual(removed, ["mobile-device-id"])
+        XCTAssertEqual(fixture.identity.rotatedDeviceIDs, ["mobile-device-id"])
+        XCTAssertEqual(fixture.store.macCount, 1)
+        XCTAssertEqual(fixture.store.mobileCount, 0)
+    }
+
+    private func makeFixture() async -> (
+        store: ManagedConnectionDeviceStore,
+        api: MIM260DeviceAPIFake,
+        identity: MIM260IdentityFake
+    ) {
+        let storeKit = MIM260StoreKitFake(evidence: Self.evidence)
+        let entitlementAPI = MIM260EntitlementAPIFake(grant: grant)
+        let entitlementStore = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: entitlementAPI,
+            now: { self.now }
+        )
+        await entitlementStore.refreshEntitlement()
+        let api = MIM260DeviceAPIFake(now: now)
+        let identity = MIM260IdentityFake(
+            identity: ManagedConnectionMobileIdentity(
+                installationID: "10000000-0000-4000-8000-000000000001",
+                deviceToken: Self.token(byte: 3),
+                registeredDeviceID: nil
+            )
+        )
+        let store = ManagedConnectionDeviceStore(
+            entitlementStore: entitlementStore,
+            api: api,
+            identityStore: identity,
+            now: { self.now },
+            makeUUID: {
+                UUID(uuidString: "30000000-0000-4000-8000-000000000002")!
+            },
+            makeToken: { Self.token(byte: 4) }
+        )
+        return (store, api, identity)
+    }
+
+    private var grant: ManagedConnectionEntitlementGrant {
+        ManagedConnectionEntitlementGrant(
+            entitlement: ManagedConnectionEntitlement(
+                id: "entitlement-id",
+                productID: ManagedConnectionProductID.monthly,
+                status: .active,
+                expiresAt: now.addingTimeInterval(3_600)
+            ),
+            token: "entitlement-token-that-is-long-enough",
+            tokenExpiresAt: now.addingTimeInterval(900)
+        )
+    }
+
+    private static let evidence = ManagedConnectionTransactionEvidence(
+        transactionID: 42,
+        productID: ManagedConnectionProductID.monthly,
+        signedTransaction: "signed-transaction"
+    )
+
+    fileprivate static func token(byte: UInt8) -> String {
+        Data(repeating: byte, count: 32).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private final class TokenSequence {
+    private var tokens: [String]
+
+    init(_ tokens: [String]) {
+        self.tokens = tokens
+    }
+
+    func next() throws -> String {
+        guard !tokens.isEmpty else { throw URLError(.unknown) }
+        return tokens.removeFirst()
+    }
+}
+
+private actor MIM260StoreKitFake: ManagedConnectionStoreKitClient {
+    let evidence: ManagedConnectionTransactionEvidence
+
+    init(evidence: ManagedConnectionTransactionEvidence) {
+        self.evidence = evidence
+    }
+
+    func products() async throws -> [ManagedConnectionProduct] { [] }
+    func purchase(productID: String) async throws -> ManagedConnectionPurchaseOutcome { .cancelled }
+    func currentEntitlement(productID: String) async -> ManagedConnectionCurrentEntitlementOutcome {
+        productID == evidence.productID ? .verified(evidence) : .none
+    }
+    nonisolated func transactionUpdates() -> AsyncStream<ManagedConnectionTransactionUpdate> {
+        AsyncStream { $0.finish() }
+    }
+    func signedAppTransaction() async throws -> String { "signed-app-transaction" }
+    func finish(transactionID: UInt64) async {}
+    func syncPurchases() async throws {}
+}
+
+private actor MIM260EntitlementAPIFake: ManagedConnectionEntitlementAPIClient {
+    let grant: ManagedConnectionEntitlementGrant
+
+    init(grant: ManagedConnectionEntitlementGrant) {
+        self.grant = grant
+    }
+
+    func resolve(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionEntitlementGrant {
+        grant
+    }
+}
+
+@MainActor
+private final class MIM260IdentityFake: ManagedConnectionMobileIdentityStoring {
+    private var identity: ManagedConnectionMobileIdentity
+    private(set) var rotatedDeviceIDs: [String] = []
+
+    var registeredDeviceID: String? { identity.registeredDeviceID }
+
+    init(identity: ManagedConnectionMobileIdentity) {
+        self.identity = identity
+    }
+
+    func loadOrCreate() throws -> ManagedConnectionMobileIdentity { identity }
+
+    func rememberRegisteredDeviceID(_ id: String) {
+        identity = ManagedConnectionMobileIdentity(
+            installationID: identity.installationID,
+            deviceToken: identity.deviceToken,
+            registeredDeviceID: id
+        )
+    }
+
+    func rotateCredentialAfterRevocation(deviceID: String) throws {
+        guard identity.registeredDeviceID == deviceID else { return }
+        rotatedDeviceIDs.append(deviceID)
+        identity = ManagedConnectionMobileIdentity(
+            installationID: identity.installationID,
+            deviceToken: ManagedConnectionDeviceStoreTests.token(byte: 9),
+            registeredDeviceID: nil
+        )
+    }
+}
+
+private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
+    struct AuthorizedRequest: Equatable, Sendable {
+        let requestID: String
+        let mobileKey: String
+        let macKey: String
+        let grant: String
+    }
+
+    let now: Date
+    private(set) var registrationCount = 0
+    private(set) var authorizationCount = 0
+    private(set) var lastAuthorizedRequest: AuthorizedRequest?
+    private(set) var lastManagementEvidence: (app: String, transaction: String)?
+    private(set) var removedDeviceIDs: [String] = []
+    private var registrationFailure: ManagedConnectionDeviceAPIError?
+    private var devices: [ManagedConnectionDevice] = []
+
+    init(now: Date) {
+        self.now = now
+    }
+
+    func setRegistrationFailure(_ error: ManagedConnectionDeviceAPIError) {
+        registrationFailure = error
+    }
+
+    func setDevices(_ devices: [ManagedConnectionDevice]) {
+        self.devices = devices
+    }
+
+    func registerMobileDevice(
+        entitlementToken: String,
+        installationID: String,
+        deviceToken: String
+    ) async throws -> ManagedConnectionDeviceRegistration {
+        registrationCount += 1
+        if let registrationFailure { throw registrationFailure }
+        return ManagedConnectionDeviceRegistration(
+            device: ManagedConnectionDevice(
+                id: "mobile-device-id",
+                deviceType: .mobile,
+                createdAt: now
+            ),
+            created: registrationCount == 1
+        )
+    }
+
+    func authorizePairing(
+        deviceToken: String,
+        requestID: String,
+        macInstallationID: String,
+        mobileTailcatPublicKey: String,
+        macTailcatPublicKey: String,
+        managedPairingGrant: String
+    ) async throws -> ManagedConnectionPairingSession {
+        authorizationCount += 1
+        lastAuthorizedRequest = AuthorizedRequest(
+            requestID: requestID,
+            mobileKey: mobileTailcatPublicKey,
+            macKey: macTailcatPublicKey,
+            grant: managedPairingGrant
+        )
+        return ManagedConnectionPairingSession(
+            id: "30000000-0000-4000-8000-000000000001",
+            expiresAt: now.addingTimeInterval(600),
+            macSlot: .reserved,
+            created: true
+        )
+    }
+
+    func createManagementSession(
+        signedAppTransaction: String,
+        signedTransaction: String
+    ) async throws -> ManagedConnectionManagementSession {
+        lastManagementEvidence = (signedAppTransaction, signedTransaction)
+        return ManagedConnectionManagementSession(
+            token: "management-token-that-is-long-enough",
+            expiresAt: now.addingTimeInterval(600)
+        )
+    }
+
+    func listDevices(managementToken: String) async throws -> [ManagedConnectionDevice] {
+        devices
+    }
+
+    func removeDevice(id: String, managementToken: String) async throws {
+        removedDeviceIDs.append(id)
+        devices.removeAll { $0.id == id }
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
@@ -69,6 +69,26 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         XCTAssertEqual(fixture.identity.registeredDeviceID, "mobile-device-id")
     }
 
+    func testMacKeyRotationDoesNotReusePairingAuthorization() async throws {
+        let fixture = await makeFixture()
+
+        _ = try await fixture.store.authorizeManagedPairing(
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            macTailcatPublicKey: "nodekey:mac-old",
+            mobileTailcatPublicKey: "nodekey:mobile"
+        )
+        _ = try await fixture.store.authorizeManagedPairing(
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            macTailcatPublicKey: "nodekey:mac-new",
+            mobileTailcatPublicKey: "nodekey:mobile"
+        )
+
+        let authorizationCount = await fixture.api.authorizationCount
+        let authorizedRequest = await fixture.api.lastAuthorizedRequest
+        XCTAssertEqual(authorizationCount, 2)
+        XCTAssertEqual(authorizedRequest?.macKey, "nodekey:mac-new")
+    }
+
     func testMobileQuotaFailureStopsBeforePairingAuthorization() async {
         let fixture = await makeFixture()
         await fixture.api.setRegistrationFailure(
@@ -124,10 +144,75 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         XCTAssertEqual(fixture.store.mobileCount, 0)
     }
 
+    func testManagementSessionIsRecreatedWhenVerifiedTransactionChanges() async {
+        let fixture = await makeFixture()
+
+        await fixture.store.refreshDevices()
+        await fixture.store.refreshDevices()
+        await fixture.storeKit.setEvidence(
+            ManagedConnectionTransactionEvidence(
+                transactionID: 43,
+                productID: ManagedConnectionProductID.monthly,
+                signedTransaction: "signed-transaction-new-account"
+            )
+        )
+        await fixture.entitlementStore.refreshEntitlement()
+        await fixture.store.refreshDevices()
+
+        let sessionCount = await fixture.api.managementSessionCount
+        let evidence = await fixture.api.lastManagementEvidence
+        XCTAssertEqual(sessionCount, 2, "同一交易复用会话，交易身份变化后必须重新创建")
+        XCTAssertEqual(evidence?.transaction, "signed-transaction-new-account")
+    }
+
+    func testRevocationReconcilesAfterLocalCredentialRotationInitiallyFails() async {
+        let fixture = await makeFixture()
+        let current = ManagedConnectionDevice(
+            id: "mobile-device-id",
+            deviceType: .mobile,
+            createdAt: now
+        )
+        fixture.identity.rememberRegisteredDeviceID(current.id)
+        fixture.identity.failNextCredentialRotations()
+        await fixture.api.setDevices([current])
+
+        await fixture.store.refreshDevices()
+        await fixture.store.removeDevice(current)
+        XCTAssertEqual(fixture.identity.registeredDeviceID, current.id)
+
+        await fixture.store.refreshDevices()
+
+        XCTAssertNil(fixture.identity.registeredDeviceID)
+        XCTAssertEqual(fixture.identity.rotatedDeviceIDs, [current.id])
+        XCTAssertTrue(fixture.store.devices.isEmpty)
+        XCTAssertNil(fixture.store.errorMessage)
+    }
+
+    func testAlreadyMissingRemoteDeviceStillRotatesLocalCredential() async {
+        let fixture = await makeFixture()
+        let current = ManagedConnectionDevice(
+            id: "mobile-device-id",
+            deviceType: .mobile,
+            createdAt: now
+        )
+        fixture.identity.rememberRegisteredDeviceID(current.id)
+        await fixture.api.setRemovalFailure(
+            .rejected(code: "device_not_found", deviceType: nil, limit: nil)
+        )
+
+        await fixture.store.removeDevice(current)
+
+        XCTAssertNil(fixture.identity.registeredDeviceID)
+        XCTAssertEqual(fixture.identity.rotatedDeviceIDs, [current.id])
+        XCTAssertNil(fixture.store.errorMessage)
+    }
+
     private func makeFixture() async -> (
         store: ManagedConnectionDeviceStore,
         api: MIM260DeviceAPIFake,
-        identity: MIM260IdentityFake
+        identity: MIM260IdentityFake,
+        entitlementStore: ManagedConnectionEntitlementStore,
+        storeKit: MIM260StoreKitFake
     ) {
         let storeKit = MIM260StoreKitFake(evidence: Self.evidence)
         let entitlementAPI = MIM260EntitlementAPIFake(grant: grant)
@@ -155,7 +240,7 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
             },
             makeToken: { Self.token(byte: 4) }
         )
-        return (store, api, identity)
+        return (store, api, identity, entitlementStore, storeKit)
     }
 
     private var grant: ManagedConnectionEntitlementGrant {
@@ -199,9 +284,13 @@ private final class TokenSequence {
 }
 
 private actor MIM260StoreKitFake: ManagedConnectionStoreKitClient {
-    let evidence: ManagedConnectionTransactionEvidence
+    private var evidence: ManagedConnectionTransactionEvidence
 
     init(evidence: ManagedConnectionTransactionEvidence) {
+        self.evidence = evidence
+    }
+
+    func setEvidence(_ evidence: ManagedConnectionTransactionEvidence) {
         self.evidence = evidence
     }
 
@@ -237,6 +326,7 @@ private actor MIM260EntitlementAPIFake: ManagedConnectionEntitlementAPIClient {
 private final class MIM260IdentityFake: ManagedConnectionMobileIdentityStoring {
     private var identity: ManagedConnectionMobileIdentity
     private(set) var rotatedDeviceIDs: [String] = []
+    private var remainingRotationFailures = 0
 
     var registeredDeviceID: String? { identity.registeredDeviceID }
 
@@ -254,8 +344,16 @@ private final class MIM260IdentityFake: ManagedConnectionMobileIdentityStoring {
         )
     }
 
+    func failNextCredentialRotations(_ count: Int = 1) {
+        remainingRotationFailures = count
+    }
+
     func rotateCredentialAfterRevocation(deviceID: String) throws {
         guard identity.registeredDeviceID == deviceID else { return }
+        if remainingRotationFailures > 0 {
+            remainingRotationFailures -= 1
+            throw URLError(.cannotWriteToFile)
+        }
         rotatedDeviceIDs.append(deviceID)
         identity = ManagedConnectionMobileIdentity(
             installationID: identity.installationID,
@@ -279,7 +377,9 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
     private(set) var lastAuthorizedRequest: AuthorizedRequest?
     private(set) var lastManagementEvidence: (app: String, transaction: String)?
     private(set) var removedDeviceIDs: [String] = []
+    private(set) var managementSessionCount = 0
     private var registrationFailure: ManagedConnectionDeviceAPIError?
+    private var removalFailure: ManagedConnectionDeviceAPIError?
     private var devices: [ManagedConnectionDevice] = []
 
     init(now: Date) {
@@ -292,6 +392,10 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
 
     func setDevices(_ devices: [ManagedConnectionDevice]) {
         self.devices = devices
+    }
+
+    func setRemovalFailure(_ error: ManagedConnectionDeviceAPIError?) {
+        removalFailure = error
     }
 
     func registerMobileDevice(
@@ -338,9 +442,10 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
         signedAppTransaction: String,
         signedTransaction: String
     ) async throws -> ManagedConnectionManagementSession {
+        managementSessionCount += 1
         lastManagementEvidence = (signedAppTransaction, signedTransaction)
         return ManagedConnectionManagementSession(
-            token: "management-token-that-is-long-enough",
+            token: "management-token-\(managementSessionCount)-that-is-long-enough",
             expiresAt: now.addingTimeInterval(600)
         )
     }
@@ -350,6 +455,7 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
     }
 
     func removeDevice(id: String, managementToken: String) async throws {
+        if let removalFailure { throw removalFailure }
         removedDeviceIDs.append(id)
         devices.removeAll { $0.id == id }
     }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
@@ -117,7 +117,98 @@ private actor TailcatExperimentRuntimeStub: TailcatExperimentRuntimeProtocol {
 }
 
 @MainActor
+private final class ManagedPairingAuthorizerStub: ManagedConnectionPairingAuthorizing {
+    private(set) var requests: [(macInstallationID: String, macKey: String, mobileKey: String)] = []
+    private(set) var completions: [ManagedConnectionPairingAuthorization] = []
+
+    func authorizeManagedPairing(
+        macInstallationID: String,
+        macTailcatPublicKey: String,
+        mobileTailcatPublicKey: String
+    ) async throws -> ManagedConnectionPairingAuthorization {
+        requests.append((macInstallationID, macTailcatPublicKey, mobileTailcatPublicKey))
+        return ManagedConnectionPairingAuthorization(sessionID: "managed-session", grant: "managed-grant")
+    }
+
+    func didCompleteManagedPairing(_ authorization: ManagedConnectionPairingAuthorization) {
+        completions.append(authorization)
+    }
+}
+
+@MainActor
 final class TailcatExperimentRoutingTests: XCTestCase {
+    func testManagedPairingRequiresManagedQRCodeBeforeStartingRuntime() async throws {
+        let authorizer = ManagedPairingAuthorizerStub()
+        let fixture = try makeControllerFixture(
+            startResults: [.failure(.startFailed)],
+            managedPairingAuthorizer: authorizer
+        )
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let url = try XCTUnwrap(URL(string: Self.freeTailcatPairingURL))
+
+        await XCTAssertThrowsErrorAsync(
+            try await fixture.controller.preparePairingURL(
+                url,
+                appStore: fixture.store,
+                profileTarget: .currentOrNew(displayName: nil),
+                requiresManagedAuthorization: true
+            )
+        )
+
+        let startCallCount = await fixture.runtime.startCallCount()
+        XCTAssertTrue(authorizer.requests.isEmpty)
+        XCTAssertEqual(startCallCount, 0)
+    }
+
+    func testManagedPairingAuthorizesBeforePreparingTailcatRoute() async throws {
+        let authorizer = ManagedPairingAuthorizerStub()
+        let fixture = try makeControllerFixture(
+            startResults: [.failure(.startFailed)],
+            managedPairingAuthorizer: authorizer
+        )
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let url = try XCTUnwrap(URL(string: Self.managedTailcatPairingURL))
+
+        await XCTAssertThrowsErrorAsync(
+            try await fixture.controller.preparePairingURL(
+                url,
+                appStore: fixture.store,
+                profileTarget: .currentOrNew(displayName: nil),
+                requiresManagedAuthorization: true
+            )
+        )
+
+        XCTAssertEqual(authorizer.requests.count, 1)
+        XCTAssertEqual(authorizer.requests.first?.macInstallationID, "20000000-0000-4000-8000-000000000001")
+        XCTAssertEqual(authorizer.requests.first?.macKey, "nodekey:mac-public")
+        XCTAssertEqual(authorizer.requests.first?.mobileKey, "nodekey:public-key")
+        let startCallCount = await fixture.runtime.startCallCount()
+        XCTAssertEqual(startCallCount, 1)
+        XCTAssertTrue(authorizer.completions.isEmpty)
+    }
+
+    func testFreeTailcatPairingDoesNotRequestManagedAuthorization() async throws {
+        let authorizer = ManagedPairingAuthorizerStub()
+        let fixture = try makeControllerFixture(
+            startResults: [.failure(.startFailed)],
+            managedPairingAuthorizer: authorizer
+        )
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let url = try XCTUnwrap(URL(string: Self.managedTailcatPairingURL))
+
+        await XCTAssertThrowsErrorAsync(
+            try await fixture.controller.preparePairingURL(
+                url,
+                appStore: fixture.store,
+                profileTarget: .currentOrNew(displayName: nil)
+            )
+        )
+
+        let startCallCount = await fixture.runtime.startCallCount()
+        XCTAssertTrue(authorizer.requests.isEmpty)
+        XCTAssertEqual(startCallCount, 1)
+    }
+
     func testConnectedPrepareRouteDoesNotRestartProxy() async throws {
         let fixture = try makeControllerFixture(startResults: [
             .success("http://127.0.0.1:49152"),
@@ -637,7 +728,8 @@ final class TailcatExperimentRoutingTests: XCTestCase {
 
     private func makeControllerFixture(
         startResults: [Result<String, TailcatRuntimeStubError>],
-        blockedStartCall: Int? = nil
+        blockedStartCall: Int? = nil,
+        managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)? = nil
     ) throws -> (
         controller: TailcatExperimentController,
         runtime: TailcatExperimentRuntimeStub,
@@ -669,8 +761,16 @@ final class TailcatExperimentRoutingTests: XCTestCase {
             defaults: defaults,
             tokenStore: tokenStore,
             runtime: runtime,
-            bridge: bridge
+            bridge: bridge,
+            managedPairingAuthorizer: managedPairingAuthorizer
         )
         return (controller, runtime, store, defaults, suiteName)
     }
+
+    private static let freeTailcatPairingURL =
+        "mimiremote://pair?endpoint=http%3A%2F%2F127.0.0.1%3A8787&issued_at=2026-09-01T00%3A00%3A00Z&expires_at=4102444800&pair_sig=abcdef&transport=tailcat&tailcat_pair_address=tc%3Atest-address"
+
+    private static let managedTailcatPairingURL = freeTailcatPairingURL
+        + "&managed_mac_installation_id=20000000-0000-4000-8000-000000000001"
+        + "&managed_mac_tailcat_public_key=nodekey%3Amac-public"
 }


### PR DESCRIPTION
## 结果

- 为 iOS 增加匿名移动设备身份：随机 UUID v4 安装 ID 与 Keychain 里的 256 位设备 Token。
- 接入移动设备登记、10 分钟托管配对授权、短期设备管理凭证、设备列表与撤销 API。
- 在订阅页增加托管扫码、3 台 Mac / 5 台移动设备用量、移除设备与名额满恢复入口。
- 托管扫码通过显式入口启用授权；原有免费自建 Tailcat 扫码继续走旧流程。
- 配对成功后继续复用 ConnectionProfile 独立 Tailcat 地址事务，不上传 Tailcat 地址、agentd Token 或私钥。

## 验证

- 源码体积检查：通过。
- iOS 本地化检查：通过，1896 个 key，String Catalog 编译通过。
- 统一 iOS build：通过。
- MIM-260 定向测试共 24 项：23 项首轮通过；剩余 1 项修正测试夹具后单独重跑通过。
- 完整 iOS 测试运行 1544 项：本次新增失败已修正；其余 19 项为既有历史分页时序与快照基线失败，不在本 Issue 范围。
- git diff 检查：通过。

## 缓存

每轮构建和测试后已删除该 Worktree 的 DerivedData；仅保留可复用的 Tailcat XCFramework。