### PR TITLE
MIM-261 将 Tailcat 产品化为 Mimi 托管连接

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		55D520C10E168BFEA7E4A619 /* LegalDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B546C68F6A4EDDA47CD25FD7 /* LegalDocumentView.swift */; };
 		594989D4A8EF0493E3127965 /* ConversationTimelineHistoryScrollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C732DD4062EFC36827E1937A /* ConversationTimelineHistoryScrollTests.swift */; };
 		599CFC31A5F3C5F8390CB71F /* testDisconnectedStateCarriesWarningInsideCard.disconnected-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = A4AAC3D3BED6B94860B6595F /* testDisconnectedStateCarriesWarningInsideCard.disconnected-compact.png */; };
+		5AF7E7C9B96CC4CD99F4E8FC /* ConnectionProfileRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE89BC4D75B4E7289493DDF /* ConnectionProfileRouteTests.swift */; };
 		5B092289C5F40E2A9B3622B9 /* SessionStoreLifecycleWorkspaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78D8C49C36228C60EF5D096 /* SessionStoreLifecycleWorkspaces.swift */; };
 		5B378569754B50364C872318 /* WorkspaceSessionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BCF1B2E13945C6F706C8BD /* WorkspaceSessionPresentationTests.swift */; };
 		5CC1C792F93F291FDD49FF09 /* ConnectionSpeedTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C3E59C8D5983AB7784558F /* ConnectionSpeedTestView.swift */; };
@@ -132,6 +133,7 @@
 		5FDCC383AE9448F83273EA84 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png in Resources */ = {isa = PBXBuildFile; fileRef = D2BF59E844D8092111547C64 /* testConnectionDiagnosticsNetworkPathWrapsLongEnglishDirectSummary.diagnostics-network-path-english-direct-wrap.png */; };
 		613A97BCD065B780C6162C8E /* ConversationTimelineReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F938DA83B5613E99E202281D /* ConversationTimelineReducerTests.swift */; };
 		61FC963CFB3ED09059EDA70C /* testNoTerminalTurnUsesAccessibleLayeredLayout.1.png in Resources */ = {isa = PBXBuildFile; fileRef = A8E14D359CDA20CBF7E78DD1 /* testNoTerminalTurnUsesAccessibleLayeredLayout.1.png */; };
+		6242237BF55EAA0D2945AC77 /* ManagedConnectionEventAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828DECD2F01CFABB9CB3E1F1 /* ManagedConnectionEventAPIClientTests.swift */; };
 		626E053AFAE30F345EEFC01D /* WorkspaceVisualSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327AF69020E348B4AE9F7BBE /* WorkspaceVisualSnapshotTests.swift */; platformFilters = (ios, ); };
 		6329757B930F1A8506FACF90 /* SessionAPIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C046A065EC50889673C918 /* SessionAPIModels.swift */; };
 		63843BD119A590E1B9399BF3 /* testLongEnglishFailureRemainsInline.1.png in Resources */ = {isa = PBXBuildFile; fileRef = FDD0D38CA5BBBF1F1D8A5F2B /* testLongEnglishFailureRemainsInline.1.png */; };
@@ -210,6 +212,7 @@
 		9DB7FDC4C6AB0FBB1DE2DC8D /* testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5F6590638B16083675339655 /* testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png */; };
 		9F08EDD6695137214ECF7A7B /* testSkillInvocationCardLightAppearance.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 8AE76E723980EA82E7BBD4A8 /* testSkillInvocationCardLightAppearance.1.png */; };
 		9F4EA8644B1E67A1F3CC863C /* testCompactModelGridLightFastModeOff.1.png in Resources */ = {isa = PBXBuildFile; fileRef = C4E6AEA3E96B661F7473D460 /* testCompactModelGridLightFastModeOff.1.png */; };
+		9F7D54E83E01704400E0545E /* ManagedConnectionEventAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F61AFF194ED42377F56DF80 /* ManagedConnectionEventAPIClient.swift */; };
 		9FCCC7A13E2113887C18513F /* AgentEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5330D382730C4473E4D9EC92 /* AgentEvent.swift */; };
 		A3621619C40A5F0CFB0C4F10 /* WorkspaceAppearanceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4A66767462028B863816B7 /* WorkspaceAppearanceStoreTests.swift */; };
 		A3D2577AA6E9A37E62C67FDC /* SessionContextStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B923E4207A9FD4C35766E4CA /* SessionContextStore.swift */; };
@@ -406,6 +409,7 @@
 		089CDD9B409CEDE6D600DA58 /* UnifiedWorkbenchShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedWorkbenchShell.swift; sourceTree = "<group>"; };
 		0A0A765F253BE3908F1A65AE /* ConnectionBenchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionBenchmark.swift; sourceTree = "<group>"; };
 		0CD3911F5991428A7A3D47EE /* testConnectedStateStaysQuiet.connected-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testConnectedStateStaysQuiet.connected-compact.png"; sourceTree = "<group>"; };
+		0F61AFF194ED42377F56DF80 /* ManagedConnectionEventAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionEventAPIClient.swift; sourceTree = "<group>"; };
 		0FC920B8D7FE7F76E2C18FD7 /* testConversationBubbleAlignment.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testConversationBubbleAlignment.1.png; sourceTree = "<group>"; };
 		0FEBDFE8C8CBDEA57661CEE4 /* ManagedConnectionMobileIdentityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionMobileIdentityStore.swift; sourceTree = "<group>"; };
 		1154D73506BE309E6A2ED0EC /* CarStatusSnapshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshotCoordinator.swift; sourceTree = "<group>"; };
@@ -558,6 +562,7 @@
 		81BCB17BD7BC9E4109AC1F8A /* ConversationConnectionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationConnectionRecoveryTests.swift; sourceTree = "<group>"; };
 		81D105A868560CE2F66EA59C /* SettingsChoiceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsChoiceRow.swift; sourceTree = "<group>"; };
 		81FDFD00533B31F16F861BFB /* MimiInteractionFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimiInteractionFeedbackTests.swift; sourceTree = "<group>"; };
+		828DECD2F01CFABB9CB3E1F1 /* ManagedConnectionEventAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionEventAPIClientTests.swift; sourceTree = "<group>"; };
 		82A5884CEA865140A301E6AC /* SessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStore.swift; sourceTree = "<group>"; };
 		83CFAE116262795C7501365E /* CarStatusSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarStatusSnapshotTests.swift; sourceTree = "<group>"; };
 		85879EDF3D64609C3C6BA873 /* WorkspaceGitSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGitSummaryTests.swift; sourceTree = "<group>"; };
@@ -654,6 +659,7 @@
 		C896DA13C5A44DA224A17CAB /* WorkspaceSessionLoadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionLoadingTests.swift; sourceTree = "<group>"; };
 		C8ADED105ABC10EFC2E93B69 /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-pro-1366-ax3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSessionLibraryDensityAndAccessibilityLayouts.ipad-pro-1366-ax3.png"; sourceTree = "<group>"; };
 		CA2BF4F63781123B8E297F7E /* ConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationView.swift; sourceTree = "<group>"; };
+		CAE89BC4D75B4E7289493DDF /* ConnectionProfileRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionProfileRouteTests.swift; sourceTree = "<group>"; };
 		CB64B805952E5CC416C28EAF /* testCrossSessionContinuationHidesInternalAddresses.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testCrossSessionContinuationHidesInternalAddresses.1.png; sourceTree = "<group>"; };
 		CC5A74E63F1B363F7C8143C1 /* testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testModelPickerAdaptiveWidthAndAccessibilityLayouts.ipad-split-375.png"; sourceTree = "<group>"; };
 		CCBCEEF3A7D3D84A709984E8 /* ConversationMessageDeliveryReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageDeliveryReconciler.swift; sourceTree = "<group>"; };
@@ -903,6 +909,7 @@
 				FA34FDB7E26D6307E81C07CC /* CodexAppServerProtocolTests.swift */,
 				B210B3D471597B46216C352B /* ConnectionBenchmarkTests.swift */,
 				B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */,
+				CAE89BC4D75B4E7289493DDF /* ConnectionProfileRouteTests.swift */,
 				1254FA91BFD2E858AFBD539D /* ConversationAppServerProjectorTests.swift */,
 				86B6C2FC1CE749D7A8268F85 /* ConversationComposerHistoryTests.swift */,
 				18F186EFB2A8BEC6E258B00D /* ConversationComposerSubmissionAndPendingInputTests.swift */,
@@ -940,6 +947,7 @@
 				72FF3738D9EAED4C04AF0B69 /* ManagedConnectionDeviceAPIClientTests.swift */,
 				04DF31C6F06A2786DE678E4A /* ManagedConnectionDeviceStoreTests.swift */,
 				417026D5C6353D2982527627 /* ManagedConnectionEntitlementStoreTests.swift */,
+				828DECD2F01CFABB9CB3E1F1 /* ManagedConnectionEventAPIClientTests.swift */,
 				4CAF352234E74EEAF7B023AE /* ManagedPairingContractTests.swift */,
 				24B74985F9E77EEE70BC1856 /* MarkdownRenderingTests.swift */,
 				81FDFD00533B31F16F861BFB /* MimiInteractionFeedbackTests.swift */,
@@ -1051,6 +1059,7 @@
 				5399A4FAF6DD4671B317B47E /* CodexAppServerTurnStartObservation.swift */,
 				FD7E14A8B39BFA1C4D7C4D88 /* ManagedConnectionDeviceAPIClient.swift */,
 				BFC8F89BF1B2CDD9984B85B7 /* ManagedConnectionEntitlementAPIClient.swift */,
+				0F61AFF194ED42377F56DF80 /* ManagedConnectionEventAPIClient.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1745,6 +1754,7 @@
 				523D4FE3642B0D171DB1647E /* CodexAppServerProtocolTests.swift in Sources */,
 				D2CAE650EFDE114FBA986987 /* ConnectionBenchmarkTests.swift in Sources */,
 				3CE709A723920DFD80FE96D0 /* ConnectionProfileRenameTests.swift in Sources */,
+				5AF7E7C9B96CC4CD99F4E8FC /* ConnectionProfileRouteTests.swift in Sources */,
 				2ACE5B224FFACB3AA6391C46 /* ConversationAppServerProjectorTests.swift in Sources */,
 				042B8AE52871708DD3606659 /* ConversationComposerHistoryTests.swift in Sources */,
 				77E8FB23786675B2947013E9 /* ConversationComposerSubmissionAndPendingInputTests.swift in Sources */,
@@ -1782,6 +1792,7 @@
 				419537AC5582400C687118ED /* ManagedConnectionDeviceAPIClientTests.swift in Sources */,
 				70625989072AA4231FE732EA /* ManagedConnectionDeviceStoreTests.swift in Sources */,
 				491F23C64F7108C5B28BBD1B /* ManagedConnectionEntitlementStoreTests.swift in Sources */,
+				6242237BF55EAA0D2945AC77 /* ManagedConnectionEventAPIClientTests.swift in Sources */,
 				7FCF7AE789CFBC4E2148BCD3 /* ManagedPairingContractTests.swift in Sources */,
 				4DDCF6949E6DDCC9ABEBE709 /* MarkdownRenderingTests.swift in Sources */,
 				20D78099D1CE0CC7A660BFA1 /* MimiInteractionFeedbackTests.swift in Sources */,
@@ -1912,6 +1923,7 @@
 				A925DD0C63B39984BA807415 /* ManagedConnectionDeviceStore.swift in Sources */,
 				D57E56FF06B77F225C0F436E /* ManagedConnectionEntitlementAPIClient.swift in Sources */,
 				122264253C13D70043A627F0 /* ManagedConnectionEntitlementStore.swift in Sources */,
+				9F7D54E83E01704400E0545E /* ManagedConnectionEventAPIClient.swift in Sources */,
 				E4E5828D292B014505EE19DA /* ManagedConnectionMobileIdentityStore.swift in Sources */,
 				BAA573B7BCCDD95153331C04 /* ManagedConnectionStoreKitClient.swift in Sources */,
 				E02D70CAB2822FE39664F749 /* ManagedConnectionSubscriptionView.swift in Sources */,

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -39381,10 +39381,10 @@
       }
     },
     "ui.tailcat_experiment": {
-      "comment": "Name of the opt-in Tailcat transport experiment.",
+      "comment": "Generic Tailcat route name retained for compatibility.",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Tailcat experiment" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Tailcat 实验" } }
+        "en": { "stringUnit": { "state": "translated", "value": "Tailcat" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Tailcat" } }
       }
     },
     "ui.tailcat_experiment_enabled": {
@@ -39418,8 +39418,8 @@
     "ui.tailcat_pairing_help": {
       "comment": "Explains the Tailcat QR pairing flow.",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Generate a Tailcat QR code in Mimi on your Mac, then scan it from Mac Connection. A successful scan enables this experiment automatically." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "先在 Mac 版 Mimi 中生成 Tailcat 二维码，再从“Mac 连接”扫码。配对成功后会自动开启本实验。" } }
+        "en": { "stringUnit": { "state": "translated", "value": "Generate a Tailcat QR code in Mimi on your Mac, then scan it from Mac Connection. A successful scan selects this route automatically." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "先在 Mac 版 Mimi 中生成 Tailcat 二维码，再从“Mac 连接”扫码。配对成功后会自动选择此线路。" } }
       }
     },
     "ui.tailcat_pairing_address_missing": {
@@ -40002,6 +40002,104 @@
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "Valid until %@" } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "有效期至 %@" } }
+      }
+    },
+    "ui.custom_tailcat": {
+      "comment": "Name of the free user-managed Tailcat connection type.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Self-hosted Tailcat" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "自建 Tailcat" } }
+      }
+    },
+    "ui.enable_custom_tailcat": {
+      "comment": "Toggle label for the free user-managed Tailcat route.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Use self-hosted Tailcat" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "使用自建 Tailcat" } }
+      }
+    },
+    "ui.custom_tailcat_summary": {
+      "comment": "Explains the self-hosted Tailcat route.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This free option uses the Tailcat address and relay service you manage. Turning it off keeps the saved address and uses the saved direct route." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此免费方式使用你自行管理的 Tailcat 地址和中转服务。关闭后仍保留地址，并改用已保存的直连线路。" } }
+      }
+    },
+    "ui.custom_tailcat_safety_note": {
+      "comment": "Security responsibility notice for self-hosted Tailcat.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "You are responsible for relay access control, availability, and updates. The Tailcat private key remains in this device's Keychain." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "你需要自行负责中转准入、可用性和升级。Tailcat 私钥只保存在本设备的 Keychain 中。" } }
+      }
+    },
+    "ui.local_network": {
+      "comment": "LAN connection type name.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Local network" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "局域网" } }
+      }
+    },
+    "ui.managed_connection_recommended_title": {
+      "comment": "Section title that prioritizes managed connection during first setup.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Recommended" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "推荐" } }
+      }
+    },
+    "ui.managed_connection_recommended_value": {
+      "comment": "Short value for the managed connection setup entry.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No relay setup" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "免配置中转" } }
+      }
+    },
+    "ui.managed_connection_recommended_summary": {
+      "comment": "First-setup explanation for the managed connection product.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Subscribe with your Apple Account and scan each Mac. LAN, Tailscale, and self-hosted Tailcat remain free below." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "使用 Apple 账户订阅后扫描每台 Mac。局域网、Tailscale 和自建 Tailcat 仍可在下方免费使用。" } }
+      }
+    },
+    "ui.managed_connection_route_status": {
+      "comment": "Section title for the active managed connection route.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Connection route" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "连接线路" } }
+      }
+    },
+    "ui.managed_connection_retry": {
+      "comment": "Action to retry the managed Tailcat route.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Retry Managed Connection" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "重试托管连接" } }
+      }
+    },
+    "ui.managed_connection_use_tailscale_once": {
+      "comment": "Action to use a saved Tailscale route without changing the default.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Use Tailscale This Time" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "本次使用 Tailscale" } }
+      }
+    },
+    "ui.managed_connection_use_lan_once": {
+      "comment": "Action to use a saved LAN route without changing the default.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Use Local Network This Time" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "本次使用局域网" } }
+      }
+    },
+    "ui.managed_connection_using_temporary_route": {
+      "comment": "Status when the user temporarily selected a free route. Placeholder is the route name.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Using %@ for this session" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "本次正在使用 %@" } }
+      }
+    },
+    "ui.managed_connection_fallback_notice": {
+      "comment": "Explains that temporary fallback is explicit and only saved routes are available.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Only a route already saved for this Mac can be selected. This choice does not change the default or delete any configuration." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "只能选择这台 Mac 已保存的线路。本次选择不会修改默认线路，也不会删除任何配置。" } }
       }
     },
     "ui.restore_purchases": {

--- a/ios/MimiRemote/Sources/Core/API/ManagedConnectionEventAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/ManagedConnectionEventAPIClient.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+enum ManagedConnectionEventPath: String, Codable, Equatable, Sendable {
+    case direct
+    case peerRelay = "peer_relay"
+    case derp
+    case unknown
+
+    init(tailcatPath: String) {
+        switch tailcatPath.lowercased() {
+        case "direct": self = .direct
+        case "peer-relay", "peer_relay": self = .peerRelay
+        case "derp": self = .derp
+        default: self = .unknown
+        }
+    }
+}
+
+enum ManagedConnectionEventDurationBucket: String, Codable, Equatable, Sendable {
+    case underOneSecond = "under_1s"
+    case oneToThreeSeconds = "1s_to_3s"
+    case threeToEightSeconds = "3s_to_8s"
+    case eightToTenSeconds = "8s_to_10s"
+    case overTenSeconds = "over_10s"
+
+    init(milliseconds: Int) {
+        switch max(0, milliseconds) {
+        case ..<1_000: self = .underOneSecond
+        case ..<3_000: self = .oneToThreeSeconds
+        case ..<8_000: self = .threeToEightSeconds
+        case ..<10_000: self = .eightToTenSeconds
+        default: self = .overTenSeconds
+        }
+    }
+}
+
+enum ManagedConnectionEventErrorCategory: String, Codable, Equatable, Sendable {
+    case none
+    case network
+    case timeout
+    case authentication
+    case policy
+    case unknown
+
+    init(error: Error?) {
+        guard let error else {
+            self = .none
+            return
+        }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut:
+                self = .timeout
+            case .userAuthenticationRequired, .userCancelledAuthentication:
+                self = .authentication
+            case .appTransportSecurityRequiresSecureConnection:
+                self = .policy
+            case .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
+                 .internationalRoamingOff, .networkConnectionLost, .notConnectedToInternet:
+                self = .network
+            default:
+                self = .unknown
+            }
+            return
+        }
+        self = .unknown
+    }
+}
+
+struct ManagedConnectionEvent: Encodable, Equatable, Sendable {
+    let id: UUID
+    let path: ManagedConnectionEventPath
+    let succeeded: Bool
+    let durationBucket: ManagedConnectionEventDurationBucket
+    let errorCategory: ManagedConnectionEventErrorCategory
+    let regionCode: String?
+    let appVersion: String
+
+    init(
+        id: UUID = UUID(),
+        path: ManagedConnectionEventPath,
+        succeeded: Bool,
+        durationMillis: Int,
+        errorCategory: ManagedConnectionEventErrorCategory,
+        regionCode: String?,
+        appVersion: String
+    ) {
+        self.id = id
+        self.path = path
+        self.succeeded = succeeded
+        durationBucket = ManagedConnectionEventDurationBucket(milliseconds: durationMillis)
+        self.errorCategory = succeeded
+            ? .none
+            : (errorCategory == .none ? .unknown : errorCategory)
+        self.regionCode = path == .derp
+            ? Self.normalizedRegionCode(regionCode)
+            : nil
+        self.appVersion = appVersion.isEmpty ? "unknown" : appVersion
+    }
+
+    private static func normalizedRegionCode(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard (2...12).contains(value.count),
+              value.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") })
+        else { return nil }
+        return value
+    }
+}
+
+protocol ManagedConnectionEventAPIClient: Sendable {
+    func send(_ event: ManagedConnectionEvent, deviceToken: String) async throws
+}
+
+struct LiveManagedConnectionEventAPIClient: ManagedConnectionEventAPIClient {
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(
+        baseURL: URL = URL(string: "https://api.code89757.com")!,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func send(_ event: ManagedConnectionEvent, deviceToken: String) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "v1/connection-events"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(deviceToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        request.httpBody = try JSONEncoder().encode(event)
+
+        let (_, response) = try await session.data(for: request)
+        guard let response = response as? HTTPURLResponse,
+              (200..<300).contains(response.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+    }
+}
+
+@MainActor
+protocol ManagedConnectionEventReporting: AnyObject {
+    func report(_ event: ManagedConnectionEvent) async
+}
+
+@MainActor
+final class ManagedConnectionEventReporter: ManagedConnectionEventReporting {
+    private let api: any ManagedConnectionEventAPIClient
+    private let identityStore: any ManagedConnectionMobileIdentityStoring
+
+    init(
+        api: any ManagedConnectionEventAPIClient = LiveManagedConnectionEventAPIClient(),
+        identityStore: any ManagedConnectionMobileIdentityStoring
+    ) {
+        self.api = api
+        self.identityStore = identityStore
+    }
+
+    func report(_ event: ManagedConnectionEvent) async {
+        guard let identity = try? identityStore.loadOrCreate(),
+              identity.registeredDeviceID != nil else {
+            return
+        }
+        // 遥测永远不影响连接结果，也不把服务端响应或设备凭据写入本地日志。
+        try? await api.send(event, deviceToken: identity.deviceToken)
+    }
+}

--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -270,7 +270,9 @@ struct InitialConnectionSettingsSections: View {
                         } label: {
                             SettingsValueLabel(
                                 title: L10n.text("ui.connection_speed_test"),
-                                value: tailcatController.isEnabled ? "Tailcat" : "Tailscale",
+                                value: tailcatController.isEnabled
+                                    ? (appStore.activeConnectionProfile?.connectionRoute.title ?? "Tailcat")
+                                    : (appStore.savedFallbackConnectionRoute?.title ?? "Tailscale"),
                                 systemImage: "gauge.with.dots.needle.67percent"
                             )
                         }
@@ -285,13 +287,13 @@ struct InitialConnectionSettingsSections: View {
             if appStore.isConfigured {
                 Section {
                     NavigationLink {
-                        TailcatExperimentSettingsView()
+                        tailcatSettingsDestination
                     } label: {
                         SettingsValueLabel(
-                            title: L10n.text("ui.tailcat_experiment"),
+                            title: tailcatConnectionTitle,
                             value: tailcatController.isEnabled
-                                ? L10n.text("ui.tailcat_experiment_enabled")
-                                : L10n.text("ui.tailcat_experiment_disabled"),
+                                ? L10n.text("ui.connected")
+                                : L10n.text("ui.deactivated"),
                             systemImage: "point.3.connected.trianglepath.dotted"
                         )
                     }
@@ -658,7 +660,7 @@ struct InitialConnectionSettingsSections: View {
     }
 
     private func connectionProfileRouteDetail(_ item: ConnectionProfileSettingsItem) -> String {
-        var details: [String] = []
+        var details: [String] = [item.profile.connectionRoute.title]
         if let dnsName = item.profile.tailscaleDNSName {
             details.append("MagicDNS \(dnsName)")
         }
@@ -668,6 +670,21 @@ struct InitialConnectionSettingsSections: View {
             details.append("\(L10n.text("ui.current_connection")) \(appStore.connectionEndpoint)")
         }
         return details.joined(separator: " · ")
+    }
+
+    private var tailcatConnectionTitle: String {
+        appStore.activeConnectionProfile?.connectionRoute.isManaged == true
+            ? L10n.text("ui.managed_subscription_title")
+            : L10n.text("ui.custom_tailcat")
+    }
+
+    @ViewBuilder
+    private var tailcatSettingsDestination: some View {
+        if appStore.activeConnectionProfile?.connectionRoute.isManaged == true {
+            ManagedConnectionSubscriptionView()
+        } else {
+            TailcatExperimentSettingsView()
+        }
     }
 
     private var endpointTransportAssessment: EndpointTransportAssessment {

--- a/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
@@ -6,17 +6,23 @@ struct ManagedConnectionSubscriptionView: View {
     @EnvironmentObject private var sessionStore: SessionStore
     @EnvironmentObject private var entitlementStore: ManagedConnectionEntitlementStore
     @EnvironmentObject private var deviceStore: ManagedConnectionDeviceStore
+    @EnvironmentObject private var tailcatController: TailcatExperimentController
     @EnvironmentObject private var qrScannerPresentation: ConnectionQRCodeScannerPresentation
     @EnvironmentObject private var themeStore: ThemeStore
     @State private var pendingRemoval: ManagedConnectionDevice?
     @State private var localError: String?
     @State private var isConnectingMac = false
+    @State private var isChangingRoute = false
+    @State private var managedRouteError: String?
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         Form {
             statusSection
+            if appStore.activeConnectionProfile?.connectionRoute.isManaged == true {
+                managedRouteSection
+            }
             if isEntitled {
                 connectionSection
                 devicesSection
@@ -181,6 +187,131 @@ struct ManagedConnectionSubscriptionView: View {
             Text(L10n.text("ui.managed_devices_connection"))
         } footer: {
             Text(L10n.text("ui.managed_devices_rescan_notice"))
+        }
+    }
+
+    private var managedRouteSection: some View {
+        Section {
+            Label(managedRouteStatusText, systemImage: managedRouteStatusImage)
+                .foregroundStyle(managedRouteStatusColor)
+
+            if let diagnostic = tailcatController.lastDiagnostic {
+                Label(diagnostic.summary, systemImage: "point.3.connected.trianglepath.dotted")
+                if let requestSummary = diagnostic.requestSummary {
+                    Label(requestSummary, systemImage: "stopwatch")
+                }
+            }
+
+            if showsManagedRecoveryActions {
+                Button {
+                    performRouteChange { await sessionStore.retryManagedConnection() }
+                } label: {
+                    Label(L10n.text("ui.managed_connection_retry"), systemImage: "arrow.clockwise")
+                        .frame(minHeight: 44)
+                }
+                .disabled(isChangingRoute)
+                .accessibilityIdentifier("settings.managedConnection.retry")
+
+                Button {
+                    performRouteChange { await sessionStore.useSavedConnectionRouteOnce(.tailscale) }
+                } label: {
+                    Label(L10n.text("ui.managed_connection_use_tailscale_once"), systemImage: "network")
+                        .frame(minHeight: 44)
+                }
+                .disabled(isChangingRoute || !appStore.canUseSavedFallback(.tailscale))
+                .accessibilityIdentifier("settings.managedConnection.useTailscaleOnce")
+
+                Button {
+                    performRouteChange { await sessionStore.useSavedConnectionRouteOnce(.lan) }
+                } label: {
+                    Label(L10n.text("ui.managed_connection_use_lan_once"), systemImage: "wifi.router")
+                        .frame(minHeight: 44)
+                }
+                .disabled(isChangingRoute || !appStore.canUseSavedFallback(.lan))
+                .accessibilityIdentifier("settings.managedConnection.useLANOnce")
+            }
+
+            if isChangingRoute {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text(L10n.text("ui.connecting"))
+                }
+                .accessibilityElement(children: .combine)
+            }
+
+            if let managedRouteError {
+                Label(managedRouteError, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+            }
+        } header: {
+            Text(L10n.text("ui.managed_connection_route_status"))
+        } footer: {
+            if showsManagedRecoveryActions {
+                Text(L10n.text("ui.managed_connection_fallback_notice"))
+            }
+        }
+    }
+
+    private var showsManagedRecoveryActions: Bool {
+        if case .usingTemporaryRoute = tailcatController.state { return true }
+        if case .failed = tailcatController.state { return true }
+        if case .failed = appStore.connectionStatus { return true }
+        return false
+    }
+
+    private var managedRouteStatusText: String {
+        switch tailcatController.state {
+        case .disabled, .needsAddress:
+            return L10n.text("ui.tailcat_needs_address")
+        case .starting:
+            return L10n.text("ui.connecting")
+        case .connected:
+            return L10n.text("ui.connected")
+        case .usingTemporaryRoute(let route):
+            return L10n.format("ui.managed_connection_using_temporary_route", route.title)
+        case .failed(let message):
+            return L10n.format("ui.tailcat_connection_failed_value", message)
+        case .unavailable:
+            return L10n.text("ui.tailcat_framework_unavailable")
+        }
+    }
+
+    private var managedRouteStatusImage: String {
+        switch tailcatController.state {
+        case .connected:
+            return "checkmark.circle.fill"
+        case .usingTemporaryRoute:
+            return "arrow.triangle.branch"
+        case .failed, .unavailable:
+            return "exclamationmark.triangle.fill"
+        case .starting:
+            return "arrow.trianglehead.2.clockwise.rotate.90"
+        case .disabled, .needsAddress:
+            return "circle.dashed"
+        }
+    }
+
+    private var managedRouteStatusColor: Color {
+        switch tailcatController.state {
+        case .connected:
+            return .green
+        case .failed, .unavailable:
+            return .orange
+        case .disabled, .needsAddress, .starting, .usingTemporaryRoute:
+            return .secondary
+        }
+    }
+
+    private func performRouteChange(_ operation: @escaping @MainActor () async -> Bool) {
+        guard !isChangingRoute else { return }
+        isChangingRoute = true
+        managedRouteError = nil
+        Task { @MainActor in
+            let succeeded = await operation()
+            if !succeeded {
+                managedRouteError = appStore.lastError ?? L10n.text("ui.managed_devices_network_error")
+            }
+            isChangingRoute = false
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
@@ -10,6 +10,24 @@ struct InitialPairingView: View {
         let tokens = themeStore.tokens(for: colorScheme)
 
         Form {
+            Section {
+                NavigationLink {
+                    ManagedConnectionSubscriptionView()
+                } label: {
+                    SettingsValueLabel(
+                        title: L10n.text("ui.managed_subscription_title"),
+                        value: L10n.text("ui.managed_connection_recommended_value"),
+                        systemImage: "network.badge.shield.half.filled"
+                    )
+                }
+                .settingsStandardListRow()
+                .accessibilityIdentifier("settings.initial.managedConnection")
+            } header: {
+                Text(L10n.text("ui.managed_connection_recommended_title"))
+            } footer: {
+                Text(L10n.text("ui.managed_connection_recommended_summary"))
+            }
+
             InitialConnectionSettingsSections(
                 qrScannerPresentation: qrScannerPresentation,
                 onRequestProfileRename: onRequestProfileRename

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDetailViews.swift
@@ -1436,8 +1436,8 @@ struct TailcatExperimentSettingsView: View {
             Section {
                 Toggle(isOn: enabledBinding) {
                     SettingsValueLabel(
-                        title: L10n.text("ui.enable_tailcat_experiment"),
-                        systemImage: "flask"
+                        title: L10n.text("ui.enable_custom_tailcat"),
+                        systemImage: "point.3.connected.trianglepath.dotted"
                     )
                 }
                 // 曾用实验版开启过时，即使当前构建没有框架，也必须允许用户关闭该偏好。
@@ -1448,7 +1448,7 @@ struct TailcatExperimentSettingsView: View {
                     .foregroundStyle(statusColor)
                     .accessibilityIdentifier("settings.experimentalFeatures.status")
             } footer: {
-                Text(L10n.text("ui.tailcat_experiment_summary"))
+                Text(L10n.text("ui.custom_tailcat_summary"))
             }
 
             Section {
@@ -1493,12 +1493,12 @@ struct TailcatExperimentSettingsView: View {
             }
 
             Section {
-                Label(L10n.text("ui.tailcat_safety_note"), systemImage: "exclamationmark.shield")
+                Label(L10n.text("ui.custom_tailcat_safety_note"), systemImage: "exclamationmark.shield")
                     .foregroundStyle(tokens.secondaryText)
             }
         }
         .themedSettingsForm(tokens: tokens)
-        .navigationTitle(L10n.text("ui.tailcat_experiment"))
+        .navigationTitle(L10n.text("ui.custom_tailcat"))
         .navigationBarTitleDisplayMode(.inline)
         .accessibilityIdentifier("settings.experimentalFeatures.detail")
     }
@@ -1526,7 +1526,9 @@ struct TailcatExperimentSettingsView: View {
         case .starting:
             return L10n.text("ui.connecting")
         case .connected:
-            return L10n.text("ui.tailcat_experiment_enabled")
+            return L10n.text("ui.connected")
+        case .usingTemporaryRoute(let route):
+            return L10n.format("ui.managed_connection_using_temporary_route", route.title)
         case .failed(let message):
             return L10n.format("ui.tailcat_connection_failed_value", message)
         case .unavailable:
@@ -1536,7 +1538,7 @@ struct TailcatExperimentSettingsView: View {
 
     private var statusSystemImage: String {
         switch controller.state {
-        case .connected:
+        case .connected, .usingTemporaryRoute:
             return "checkmark.circle.fill"
         case .failed, .unavailable:
             return "exclamationmark.triangle.fill"
@@ -1549,7 +1551,7 @@ struct TailcatExperimentSettingsView: View {
 
     private var statusColor: Color {
         switch controller.state {
-        case .connected:
+        case .connected, .usingTemporaryRoute:
             return .green
         case .failed, .unavailable:
             return .orange

--- a/ios/MimiRemote/Sources/MimiRemoteApp.swift
+++ b/ios/MimiRemote/Sources/MimiRemoteApp.swift
@@ -193,12 +193,18 @@ struct MimiRemoteApp: App {
             storeKit: LiveManagedConnectionStoreKitClient(),
             entitlementAPI: LiveManagedConnectionEntitlementAPIClient()
         )
+        let managedConnectionIdentityStore = ManagedConnectionMobileIdentityStore()
         let managedConnectionDeviceStore = ManagedConnectionDeviceStore(
-            entitlementStore: managedConnectionEntitlementStore
+            entitlementStore: managedConnectionEntitlementStore,
+            identityStore: managedConnectionIdentityStore
+        )
+        let managedConnectionEventReporter = ManagedConnectionEventReporter(
+            identityStore: managedConnectionIdentityStore
         )
         let tailcatExperimentController = TailcatExperimentController(
             appStore: appStore,
-            managedPairingAuthorizer: managedConnectionDeviceStore
+            managedPairingAuthorizer: managedConnectionDeviceStore,
+            managedConnectionEventReporter: managedConnectionEventReporter
         )
         // SessionStore 初始化会同步绑定三个缓存 Store 的 Profile namespace。
         // 必须在 SwiftUI 接管这些 ObservableObject 前完成，避免在视图更新事务内发布状态。

--- a/ios/MimiRemote/Sources/State/AppStore.swift
+++ b/ios/MimiRemote/Sources/State/AppStore.swift
@@ -783,7 +783,7 @@ final class AppStore: ObservableObject {
         connectionTermination = nil
         // 每次提交都开启新的连接代次。即使地址没变，旧异步结果也必须失效。
         connectionGeneration += 1
-        if case .tailcat = prepared.route {
+        if prepared.route.usesTailcat {
             isTailcatExperimentModeEnabled = true
             tailcatExperimentEndpoint = normalizedActiveEndpoint
             activeRouteEndpoint = normalizedActiveEndpoint
@@ -1181,7 +1181,10 @@ final class AppStore: ObservableObject {
 
     /// 用已保存的连接信息做轻量真实链路探测，让设置页不必等用户手动点“测试连接”才显示状态。
     @discardableResult
-    func preflightConnection(force: Bool = false) async -> Bool {
+    func preflightConnection(
+        force: Bool = false,
+        preferredProfileRoute: ConnectionProfileRoute? = nil
+    ) async -> Bool {
 #if DEBUG
         if debugLaunchConfiguration.applyStoreScreenshotConnectionState(status: &connectionStatus, lastError: &lastError) { return true }
 #endif
@@ -1192,7 +1195,10 @@ final class AppStore: ObservableObject {
             lastError = error.localizedDescription
             return false
         }
-        let localAvailable = usesTailcatExperiment ? false : await detectLocalAgent(force: force)
+        let shouldProbeLocal = preferredProfileRoute == nil || preferredProfileRoute == .lan
+        let localAvailable = usesTailcatExperiment || !shouldProbeLocal
+            ? false
+            : await detectLocalAgent(force: force)
         if !force, case .connected = connectionStatus {
             return true
         }
@@ -1248,12 +1254,14 @@ final class AppStore: ObservableObject {
             ))
         }
         let configuredEndpoints: [String]
+        let matchesPreferredRoute = preferredProfileRoute.map(canUseSavedFallback) ?? true
         if !usesTailcatExperiment, let profile = activeConnectionProfile,
            AgentAPIClient.normalizedEndpoint(profile.endpoint) ==
-            AgentAPIClient.normalizedEndpoint(normalizedEndpoint) {
+            AgentAPIClient.normalizedEndpoint(normalizedEndpoint),
+           matchesPreferredRoute {
             configuredEndpoints = profile.connectionCandidates
         } else {
-            configuredEndpoints = [normalizedEndpoint]
+            configuredEndpoints = preferredProfileRoute == nil ? [normalizedEndpoint] : []
         }
         for configuredEndpoint in configuredEndpoints {
             let route: ActiveConnectionRoute = usesTailcatExperiment

--- a/ios/MimiRemote/Sources/State/AppStoreRouting.swift
+++ b/ios/MimiRemote/Sources/State/AppStoreRouting.swift
@@ -40,6 +40,7 @@ extension AppStore {
         endpoint: String,
         activeEndpoint: String,
         tailcatAddress: String,
+        managed: Bool = false,
         token: String,
         profileTarget: PreparedConnectionProfileTarget
     ) async throws -> PreparedConnectionSettings {
@@ -52,7 +53,9 @@ extension AppStore {
         return PreparedConnectionSettings(
             endpoint: canonicalEndpoint,
             activeEndpoint: routed.activeEndpoint,
-            route: .tailcat(address: tailcatAddress),
+            route: managed
+                ? .managedTailcat(address: tailcatAddress)
+                : .customTailcat(address: tailcatAddress),
             token: routed.token,
             profileTarget: routed.profileTarget,
             validatedAt: routed.validatedAt,
@@ -68,7 +71,8 @@ extension AppStore {
     func prepareConnectionProfileSwitch(
         id: String,
         activeEndpoint: String,
-        tailcatAddress: String
+        tailcatAddress: String,
+        managed: Bool
     ) async throws -> PreparedConnectionSettings {
         guard let profile = connectionProfiles.first(where: { $0.id == id }) else {
             throw ConnectionProfileError.notFound
@@ -81,6 +85,7 @@ extension AppStore {
             endpoint: profile.endpoint,
             activeEndpoint: activeEndpoint,
             tailcatAddress: tailcatAddress,
+            managed: managed,
             token: profileToken,
             profileTarget: .existingProfile(id: id)
         )
@@ -102,6 +107,19 @@ extension AppStore {
 
     var isUsingLocalConnection: Bool {
         activeConnectionRoute == .local
+    }
+
+    var savedFallbackConnectionRoute: ConnectionProfileRoute? {
+        guard let profile = activeConnectionProfile else { return nil }
+        return .configuredValue(
+            endpoint: profile.endpoint,
+            tailscaleDNSName: profile.tailscaleDNSName
+        )
+    }
+
+    func canUseSavedFallback(_ route: ConnectionProfileRoute) -> Bool {
+        guard route == .tailscale || route == .lan || route == .https else { return false }
+        return savedFallbackConnectionRoute == route
     }
 
     /// 通知路由优先使用持久化 profile ID；legacy/debug 单连接才退回规范 endpoint 的 SHA-256。

--- a/ios/MimiRemote/Sources/State/ConnectionProfileModels.swift
+++ b/ios/MimiRemote/Sources/State/ConnectionProfileModels.swift
@@ -71,8 +71,74 @@ enum HostPlatformIconKind: Equatable {
 }
 
 enum ConnectionProfileRoute: String, Codable, Equatable {
-    case configured
-    case tailcat
+    case managedTailcat
+    case customTailcat
+    case tailscale
+    case lan
+    case https
+
+    var usesTailcat: Bool {
+        self == .managedTailcat || self == .customTailcat
+    }
+
+    var isManaged: Bool { self == .managedTailcat }
+
+    var title: String {
+        switch self {
+        case .managedTailcat:
+            return L10n.text("ui.managed_subscription_title")
+        case .customTailcat:
+            return L10n.text("ui.custom_tailcat")
+        case .tailscale:
+            return "Tailscale"
+        case .lan:
+            return L10n.text("ui.local_network")
+        case .https:
+            return "HTTPS"
+        }
+    }
+
+    /// 旧版本只区分 configured/tailcat。升级时把旧 Tailcat 明确归入免费自建线路，
+    /// configured 则根据已经保存的地址保守分类，避免把现有用户静默转成付费托管。
+    static func persistedValue(
+        _ rawValue: String?,
+        endpoint: String,
+        tailscaleDNSName: String?
+    ) -> ConnectionProfileRoute {
+        switch rawValue {
+        case managedTailcat.rawValue:
+            return .managedTailcat
+        case customTailcat.rawValue, "tailcat":
+            return .customTailcat
+        case tailscale.rawValue:
+            return .tailscale
+        case lan.rawValue:
+            return .lan
+        case https.rawValue:
+            return .https
+        case "configured", nil:
+            return configuredValue(endpoint: endpoint, tailscaleDNSName: tailscaleDNSName)
+        default:
+            return configuredValue(endpoint: endpoint, tailscaleDNSName: tailscaleDNSName)
+        }
+    }
+
+    static func configuredValue(
+        endpoint: String,
+        tailscaleDNSName: String? = nil
+    ) -> ConnectionProfileRoute {
+        if ConnectionProfile.isTailscaleIPEndpoint(endpoint) || tailscaleDNSName != nil {
+            return .tailscale
+        }
+        if URLComponents(string: endpoint)?.scheme?.lowercased() == "https" {
+            return .https
+        }
+        return .lan
+    }
+
+    // 只保留给旧测试和调用点的源码兼容别名；新版持久化永远写入明确类型。
+    static var configured: ConnectionProfileRoute { .tailscale }
+    static var tailcat: ConnectionProfileRoute { .customTailcat }
 }
 
 /// 一台已保存电脑的本地连接档案。
@@ -116,7 +182,7 @@ struct ConnectionProfile: Codable, Identifiable, Equatable {
         lastSuccessfulAt: Date?,
         installationID: String? = nil,
         hostPlatform: HostPlatform = .unknown,
-        connectionRoute: ConnectionProfileRoute = .configured,
+        connectionRoute: ConnectionProfileRoute? = nil,
         revision: UInt64 = 0
     ) {
         self.id = id
@@ -143,7 +209,10 @@ struct ConnectionProfile: Codable, Identifiable, Equatable {
         self.lastSuccessfulAt = lastSuccessfulAt
         self.installationID = installationID
         self.hostPlatform = hostPlatform
-        self.connectionRoute = connectionRoute
+        self.connectionRoute = connectionRoute ?? ConnectionProfileRoute.configuredValue(
+            endpoint: endpoint,
+            tailscaleDNSName: normalizedDNSName
+        )
         self.revision = revision
     }
 
@@ -179,7 +248,11 @@ struct ConnectionProfile: Codable, Identifiable, Equatable {
         lastSuccessfulAt = try container.decodeIfPresent(Date.self, forKey: .lastSuccessfulAt)
         installationID = try container.decodeIfPresent(String.self, forKey: .installationID)
         hostPlatform = try container.decodeIfPresent(HostPlatform.self, forKey: .hostPlatform) ?? .unknown
-        connectionRoute = try container.decodeIfPresent(ConnectionProfileRoute.self, forKey: .connectionRoute) ?? .configured
+        connectionRoute = ConnectionProfileRoute.persistedValue(
+            try container.decodeIfPresent(String.self, forKey: .connectionRoute),
+            endpoint: endpoint,
+            tailscaleDNSName: tailscaleDNSName
+        )
         revision = try container.decodeIfPresent(UInt64.self, forKey: .revision) ?? 0
     }
 
@@ -471,14 +544,54 @@ enum PreparedConnectionProfileTarget: Equatable {
 }
 
 enum PreparedConnectionRoute: Equatable {
-    case configured
-    case tailcat(address: String)
+    case tailscale
+    case lan
+    case https
+    case customTailcat(address: String)
+    case managedTailcat(address: String)
 
     var profileRoute: ConnectionProfileRoute {
         switch self {
-        case .configured: return .configured
-        case .tailcat: return .tailcat
+        case .tailscale: return .tailscale
+        case .lan: return .lan
+        case .https: return .https
+        case .customTailcat: return .customTailcat
+        case .managedTailcat: return .managedTailcat
         }
+    }
+
+    var usesTailcat: Bool { profileRoute.usesTailcat }
+
+    var tailcatAddress: String? {
+        switch self {
+        case .customTailcat(let address), .managedTailcat(let address):
+            return address
+        case .tailscale, .lan, .https:
+            return nil
+        }
+    }
+
+    static func configured(
+        endpoint: String,
+        tailscaleDNSName: String? = nil
+    ) -> PreparedConnectionRoute {
+        switch ConnectionProfileRoute.configuredValue(
+            endpoint: endpoint,
+            tailscaleDNSName: tailscaleDNSName
+        ) {
+        case .tailscale:
+            return .tailscale
+        case .lan:
+            return .lan
+        case .https:
+            return .https
+        case .managedTailcat, .customTailcat:
+            return .lan
+        }
+    }
+
+    static func tailcat(address: String) -> PreparedConnectionRoute {
+        .customTailcat(address: address)
     }
 }
 
@@ -502,7 +615,7 @@ struct PreparedConnectionSettings: Equatable {
     init(
         endpoint: String,
         activeEndpoint: String? = nil,
-        route: PreparedConnectionRoute = .configured,
+        route: PreparedConnectionRoute? = nil,
         token: String,
         profileTarget: PreparedConnectionProfileTarget = .currentOrNew(displayName: nil),
         validatedAt: Date = Date(),
@@ -515,7 +628,10 @@ struct PreparedConnectionSettings: Equatable {
     ) {
         self.endpoint = endpoint
         self.activeEndpoint = activeEndpoint ?? endpoint
-        self.route = route
+        self.route = route ?? .configured(
+            endpoint: endpoint,
+            tailscaleDNSName: tailscaleDNSName
+        )
         self.token = token
         self.profileTarget = profileTarget
         self.validatedAt = validatedAt

--- a/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHostSwitching.swift
@@ -26,6 +26,26 @@ extension SessionStore {
     }
 
     @discardableResult
+    func retryManagedConnection() async -> Bool {
+        guard let tailcatExperimentController else { return false }
+        resetConnectionForSettingsChange()
+        guard await tailcatExperimentController.retryManagedConnection(appStore: appStore) else {
+            return false
+        }
+        return await refreshAfterConnectionCommit(maxWait: 10)
+    }
+
+    @discardableResult
+    func useSavedConnectionRouteOnce(_ route: ConnectionProfileRoute) async -> Bool {
+        guard let tailcatExperimentController else { return false }
+        resetConnectionForSettingsChange()
+        guard await tailcatExperimentController.useSavedRouteOnce(route, appStore: appStore) else {
+            return false
+        }
+        return await refreshAfterConnectionCommit(maxWait: 10)
+    }
+
+    @discardableResult
     func applyConnectionSettings(
         endpoint: String,
         token: String

--- a/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
+++ b/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
@@ -5,6 +5,7 @@ enum TailcatExperimentState: Equatable {
     case needsAddress
     case starting
     case connected(endpoint: String)
+    case usingTemporaryRoute(ConnectionProfileRoute)
     case failed(message: String)
     case unavailable
 }
@@ -172,6 +173,7 @@ final class TailcatExperimentController: ObservableObject {
     private struct PendingPairing {
         let stableAddress: String
         let localEndpoint: String
+        let connectionStartedAt: Date
         let previousEnabled: Bool
         let previousAddress: String
         let previousLegacyAddress: String?
@@ -189,6 +191,9 @@ final class TailcatExperimentController: ObservableObject {
     private let runtime: any TailcatExperimentRuntimeProtocol
     private let bridge: TailcatExperimentBridgeAdapter
     private let managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)?
+    private let managedConnectionEventReporter: (any ManagedConnectionEventReporting)?
+    private let now: () -> Date
+    private let appVersion: () -> String
     private var generation: UInt64 = 0
     private var preparationTask: RoutePreparation?
     private var pendingPairing: PendingPairing?
@@ -199,7 +204,13 @@ final class TailcatExperimentController: ObservableObject {
         tokenStore: TokenStore = TokenStore(),
         runtime: any TailcatExperimentRuntimeProtocol = TailcatExperimentRuntime(),
         bridge: TailcatExperimentBridgeAdapter = .live,
-        managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)? = nil
+        managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)? = nil,
+        managedConnectionEventReporter: (any ManagedConnectionEventReporting)? = nil,
+        now: @escaping () -> Date = Date.init,
+        appVersion: @escaping () -> String = {
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+                ?? "unknown"
+        }
     ) {
         let available = bridge.isAvailable
         let savedEnabled = defaults.bool(forKey: Self.enabledKey)
@@ -214,7 +225,7 @@ final class TailcatExperimentController: ObservableObject {
         }
         defaults.removeObject(forKey: Self.legacyAddressKey)
         var savedAddress = legacyAddress
-        var profileRoute = appStore.activeConnectionProfile?.connectionRoute ?? .configured
+        var profileRoute = appStore.activeConnectionProfile?.connectionRoute ?? .tailscale
         if let profileID = appStore.activeConnectionProfileID {
             let profileAddress = (try? tokenStore.loadTailcatAddress(profileID: profileID)) ?? ""
             var profileAddressReady = !profileAddress.isEmpty
@@ -231,8 +242,8 @@ final class TailcatExperimentController: ObservableObject {
                 } catch {}
             }
             if savedEnabled, profileAddressReady, !savedAddress.isEmpty {
-                try? appStore.setActiveConnectionProfileRoute(.tailcat)
-                profileRoute = .tailcat
+                try? appStore.setActiveConnectionProfileRoute(.customTailcat)
+                profileRoute = .customTailcat
             }
             if profileAddressReady, appStore.connectionProfiles.count == 1 {
                 try? tokenStore.deleteTailcatExperimentAddress()
@@ -241,12 +252,15 @@ final class TailcatExperimentController: ObservableObject {
         }
         let initialEnabled = (appStore.activeConnectionProfileID == nil
             ? savedEnabled
-            : profileRoute == .tailcat) && available
+            : profileRoute.usesTailcat) && available
         self.defaults = defaults
         self.tokenStore = tokenStore
         self.runtime = runtime
         self.bridge = bridge
         self.managedPairingAuthorizer = managedPairingAuthorizer
+        self.managedConnectionEventReporter = managedConnectionEventReporter
+        self.now = now
+        self.appVersion = appVersion
         address = savedAddress
         diagnostics = Self.loadDiagnostics(defaults: defaults)
         isEnabled = initialEnabled
@@ -300,7 +314,14 @@ final class TailcatExperimentController: ObservableObject {
                 defaults.set(false, forKey: Self.enabledKey)
             } else {
                 defaults.removeObject(forKey: Self.enabledKey)
-                try? appStore.setActiveConnectionProfileRoute(.configured)
+                if let profile = appStore.activeConnectionProfile {
+                    try? appStore.setActiveConnectionProfileRoute(
+                        .configuredValue(
+                            endpoint: profile.endpoint,
+                            tailscaleDNSName: profile.tailscaleDNSName
+                        )
+                    )
+                }
             }
             pendingPairing = nil
             preparationTask?.task.cancel()
@@ -330,9 +351,52 @@ final class TailcatExperimentController: ObservableObject {
         }
         let ready = await prepareRoute(appStore: appStore)
         if ready {
-            try? appStore.setActiveConnectionProfileRoute(.tailcat)
+            try? appStore.setActiveConnectionProfileRoute(.customTailcat)
         }
         return ready
+    }
+
+    /// 用户明确选择后只修改本次进程内的活动线路。Profile 的托管默认值保持不变，
+    /// 下次启动或用户点击重试时仍回到 Mimi 托管连接。
+    @discardableResult
+    func useSavedRouteOnce(
+        _ route: ConnectionProfileRoute,
+        appStore: AppStore
+    ) async -> Bool {
+        guard appStore.activeConnectionProfile?.connectionRoute.isManaged == true,
+              appStore.canUseSavedFallback(route) else {
+            return false
+        }
+        generation &+= 1
+        preparationTask?.task.cancel()
+        preparationTask = nil
+        pendingPairing = nil
+        try? await runtime.stop()
+        appStore.setTailcatExperimentModeEnabled(false)
+        let connected = await appStore.preflightConnection(
+            force: true,
+            preferredProfileRoute: route
+        )
+        state = connected
+            ? .usingTemporaryRoute(route)
+            : .failed(message: appStore.lastError ?? URLError(.cannotConnectToHost).localizedDescription)
+        return connected
+    }
+
+    @discardableResult
+    func retryManagedConnection(appStore: AppStore) async -> Bool {
+        guard appStore.activeConnectionProfile?.connectionRoute.isManaged == true else {
+            return false
+        }
+        let routeReady = await prepareRoute(appStore: appStore)
+        guard routeReady else { return false }
+        let connected = await appStore.preflightConnection(force: true)
+        if !connected {
+            state = .failed(
+                message: appStore.lastError ?? URLError(.cannotConnectToHost).localizedDescription
+            )
+        }
+        return connected
     }
 
     @discardableResult
@@ -374,6 +438,8 @@ final class TailcatExperimentController: ObservableObject {
         forceRestart: Bool,
         refreshPathDiagnosticAfterPreparation: Bool
     ) async -> Bool {
+        let connectionStartedAt = now()
+        let reportsManagedConnection = appStore.activeConnectionProfile?.connectionRoute.isManaged == true
         appStore.setTailcatExperimentModeEnabled(isEnabled)
         guard isAvailable else {
             state = .unavailable
@@ -434,7 +500,13 @@ final class TailcatExperimentController: ObservableObject {
             appStore.setTailcatExperimentEndpoint(endpoint)
             state = .connected(endpoint: endpoint)
             if refreshPathDiagnosticAfterPreparation {
-                Task { await refreshPathDiagnostic(appStore: appStore) }
+                Task {
+                    await refreshPathDiagnostic(
+                        appStore: appStore,
+                        reportManagedConnectionEvent: reportsManagedConnection,
+                        connectionStartedAt: connectionStartedAt
+                    )
+                }
             }
             return true
         } catch {
@@ -444,6 +516,14 @@ final class TailcatExperimentController: ObservableObject {
             guard !Task.isCancelled, capturedGeneration == generation else { return false }
             appStore.setTailcatExperimentEndpoint(nil)
             state = .failed(message: error.localizedDescription)
+            await reportManagedConnectionAttempt(
+                enabled: reportsManagedConnection,
+                path: .unknown,
+                succeeded: false,
+                startedAt: connectionStartedAt,
+                error: error,
+                regionCode: nil
+            )
             return false
         }
     }
@@ -454,6 +534,7 @@ final class TailcatExperimentController: ObservableObject {
         profileTarget: PreparedConnectionProfileTarget,
         requiresManagedAuthorization: Bool = false
     ) async throws -> PreparedConnectionSettings {
+        let connectionStartedAt = now()
         guard let link = try TailcatPairingLink.parse(url) else {
             throw PairingLinkError.unsupportedURL
         }
@@ -536,12 +617,14 @@ final class TailcatExperimentController: ObservableObject {
                 endpoint: canonicalEndpoint,
                 activeEndpoint: stableEndpoint,
                 tailcatAddress: stableAddress,
+                managed: requiresManagedAuthorization,
                 token: response.token,
                 profileTarget: resolvedProfileTarget
             )
             pendingPairing = PendingPairing(
                 stableAddress: stableAddress,
                 localEndpoint: stableEndpoint,
+                connectionStartedAt: connectionStartedAt,
                 previousEnabled: previousEnabled,
                 previousAddress: previousAddress,
                 previousLegacyAddress: previousLegacyAddress,
@@ -559,6 +642,14 @@ final class TailcatExperimentController: ObservableObject {
                 previousLegacyAddress: previousLegacyAddress,
                 appStore: appStore
             )
+            await reportManagedConnectionAttempt(
+                enabled: requiresManagedAuthorization,
+                path: .unknown,
+                succeeded: false,
+                startedAt: connectionStartedAt,
+                error: error,
+                regionCode: nil
+            )
             throw error
         }
     }
@@ -570,7 +661,7 @@ final class TailcatExperimentController: ObservableObject {
         guard let profile = appStore.connectionProfiles.first(where: { $0.id == id }) else {
             throw ConnectionProfileError.notFound
         }
-        guard profile.connectionRoute == .tailcat else {
+        guard profile.connectionRoute.usesTailcat else {
             return try await appStore.prepareConnectionProfileSwitch(id: id)
         }
         let targetAddress = try tokenStore.loadTailcatAddress(profileID: id)
@@ -592,11 +683,13 @@ final class TailcatExperimentController: ObservableObject {
             let prepared = try await appStore.prepareConnectionProfileSwitch(
                 id: id,
                 activeEndpoint: endpoint,
-                tailcatAddress: targetAddress
+                tailcatAddress: targetAddress,
+                managed: profile.connectionRoute.isManaged
             )
             pendingPairing = PendingPairing(
                 stableAddress: targetAddress,
                 localEndpoint: endpoint,
+                connectionStartedAt: now(),
                 previousEnabled: previousEnabled,
                 previousAddress: previousAddress,
                 previousLegacyAddress: nil,
@@ -619,7 +712,7 @@ final class TailcatExperimentController: ObservableObject {
     }
 
     func stagePreparedRouteIfNeeded(_ prepared: PreparedConnectionSettings, appStore: AppStore) async throws {
-        guard case .tailcat = prepared.route,
+        guard prepared.route.usesTailcat,
               var pendingPairing,
               AgentAPIClient.normalizedEndpoint(pendingPairing.localEndpoint) ==
                 AgentAPIClient.normalizedEndpoint(prepared.activeEndpoint)
@@ -653,7 +746,7 @@ final class TailcatExperimentController: ObservableObject {
     }
 
     func commitPreparedRouteIfNeeded(_ prepared: PreparedConnectionSettings, appStore: AppStore) async {
-        guard case .tailcat = prepared.route else {
+        guard prepared.route.usesTailcat else {
             pendingPairing = nil
             generation &+= 1
             try? await runtime.stop()
@@ -691,7 +784,13 @@ final class TailcatExperimentController: ObservableObject {
         appStore.setTailcatExperimentEndpoint(pendingPairing.localEndpoint)
         appStore.setTailcatExperimentModeEnabled(true)
         state = .connected(endpoint: pendingPairing.localEndpoint)
-        Task { await refreshPathDiagnostic(appStore: appStore) }
+        Task {
+            await refreshPathDiagnostic(
+                appStore: appStore,
+                reportManagedConnectionEvent: prepared.route.profileRoute.isManaged,
+                connectionStartedAt: pendingPairing.connectionStartedAt
+            )
+        }
     }
 
     func discardPreparedRouteIfNeeded(_ prepared: PreparedConnectionSettings?, appStore: AppStore) async {
@@ -719,19 +818,27 @@ final class TailcatExperimentController: ObservableObject {
         try tokenStore.deleteTailcatAddress(profileID: profileID)
     }
 
-    func refreshPathDiagnostic(appStore: AppStore? = nil) async {
-        guard isEnabled else { return }
+    @discardableResult
+    func refreshPathDiagnostic(
+        appStore: AppStore? = nil,
+        reportManagedConnectionEvent: Bool = false,
+        connectionStartedAt: Date? = nil
+    ) async -> TailcatPathDiagnostic? {
+        guard isEnabled else { return nil }
         var path = "failed"
         var latencyMillis: Int?
         var derpRegionCode: String?
         var pathSucceeded = false
+        var connectionError: Error?
         do {
             let result = try await runtime.discoPing()
             path = result.path
             latencyMillis = result.latencyMillis
             derpRegionCode = result.derpRegionCode
             pathSucceeded = true
-        } catch {}
+        } catch {
+            connectionError = error
+        }
 
         var requestLatencyMillis: Int?
         var requestSucceeded: Bool?
@@ -746,6 +853,7 @@ final class TailcatExperimentController: ObservableObject {
                 requestSucceeded = true
             } catch {
                 requestSucceeded = false
+                connectionError = error
             }
         }
         let diagnostic = TailcatPathDiagnostic(
@@ -763,6 +871,19 @@ final class TailcatExperimentController: ObservableObject {
         if let encoded = try? JSONEncoder().encode(diagnostics) {
             defaults.set(encoded, forKey: Self.diagnosticsKey)
         }
+        if reportManagedConnectionEvent,
+           appStore?.activeConnectionProfile?.connectionRoute.isManaged == true {
+            let succeeded = pathSucceeded && requestSucceeded == true
+            await reportManagedConnectionAttempt(
+                enabled: true,
+                path: ManagedConnectionEventPath(tailcatPath: path),
+                succeeded: succeeded,
+                startedAt: connectionStartedAt ?? diagnostic.checkedAt,
+                error: succeeded ? nil : connectionError,
+                regionCode: derpRegionCode
+            )
+        }
+        return diagnostic
     }
 
     var redactedDiagnosticsText: String {
@@ -807,6 +928,28 @@ final class TailcatExperimentController: ObservableObject {
         let privateKey = try bridge.generatePrivateKey()
         try tokenStore.saveTailcatExperimentPrivateKey(privateKey)
         return privateKey
+    }
+
+    private func reportManagedConnectionAttempt(
+        enabled: Bool,
+        path: ManagedConnectionEventPath,
+        succeeded: Bool,
+        startedAt: Date,
+        error: Error?,
+        regionCode: String?
+    ) async {
+        guard enabled, let managedConnectionEventReporter else { return }
+        let durationMillis = max(0, Int((now().timeIntervalSince(startedAt) * 1_000).rounded()))
+        await managedConnectionEventReporter.report(
+            ManagedConnectionEvent(
+                path: path,
+                succeeded: succeeded,
+                durationMillis: durationMillis,
+                errorCategory: ManagedConnectionEventErrorCategory(error: error),
+                regionCode: regionCode,
+                appVersion: appVersion()
+            )
+        )
     }
 
     private func restoreProfileAddress(_ address: String, profileID: String) throws {

--- a/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
+++ b/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
@@ -417,6 +417,10 @@ final class TailcatExperimentController: ObservableObject {
     ) async -> Bool {
         guard !Task.isCancelled else { return false }
         guard isEnabled else { return true }
+        if case .usingTemporaryRoute = state {
+            // “仅本次使用”覆盖整个当前进程。前后台切换不应被当成用户主动重试。
+            return true
+        }
         if let inFlightPreparation = preparationTask {
             _ = await inFlightPreparation.task.value
             if preparationTask?.id == inFlightPreparation.id {
@@ -464,6 +468,7 @@ final class TailcatExperimentController: ObservableObject {
         let capturedGeneration = generation
         state = .starting
         var preparationID: UUID?
+        var ownsPreparation = false
         do {
             let privateKey = try loadOrCreatePrivateKey()
             publicKey = try bridge.publicKey(privateKey)
@@ -471,6 +476,7 @@ final class TailcatExperimentController: ObservableObject {
             if let preparationTask {
                 preparation = preparationTask
             } else {
+                ownsPreparation = true
                 let task = Task<Result<String, Error>, Never> {
                     do {
                         return .success(try await runtime.start(
@@ -499,7 +505,7 @@ final class TailcatExperimentController: ObservableObject {
             }
             appStore.setTailcatExperimentEndpoint(endpoint)
             state = .connected(endpoint: endpoint)
-            if refreshPathDiagnosticAfterPreparation {
+            if refreshPathDiagnosticAfterPreparation, ownsPreparation {
                 Task {
                     await refreshPathDiagnostic(
                         appStore: appStore,
@@ -516,14 +522,16 @@ final class TailcatExperimentController: ObservableObject {
             guard !Task.isCancelled, capturedGeneration == generation else { return false }
             appStore.setTailcatExperimentEndpoint(nil)
             state = .failed(message: error.localizedDescription)
-            await reportManagedConnectionAttempt(
-                enabled: reportsManagedConnection,
-                path: .unknown,
-                succeeded: false,
-                startedAt: connectionStartedAt,
-                error: error,
-                regionCode: nil
-            )
+            if ownsPreparation {
+                enqueueManagedConnectionAttempt(
+                    enabled: reportsManagedConnection,
+                    path: .unknown,
+                    succeeded: false,
+                    startedAt: connectionStartedAt,
+                    error: error,
+                    regionCode: nil
+                )
+            }
             return false
         }
     }
@@ -642,7 +650,7 @@ final class TailcatExperimentController: ObservableObject {
                 previousLegacyAddress: previousLegacyAddress,
                 appStore: appStore
             )
-            await reportManagedConnectionAttempt(
+            enqueueManagedConnectionAttempt(
                 enabled: requiresManagedAuthorization,
                 path: .unknown,
                 succeeded: false,
@@ -950,6 +958,28 @@ final class TailcatExperimentController: ObservableObject {
                 appVersion: appVersion()
             )
         )
+    }
+
+    private func enqueueManagedConnectionAttempt(
+        enabled: Bool,
+        path: ManagedConnectionEventPath,
+        succeeded: Bool,
+        startedAt: Date,
+        error: Error?,
+        regionCode: String?
+    ) {
+        guard enabled, managedConnectionEventReporter != nil else { return }
+        // 遥测是旁路能力。网络故障时不能让它延迟失败状态和恢复按钮。
+        Task { [weak self] in
+            await self?.reportManagedConnectionAttempt(
+                enabled: true,
+                path: path,
+                succeeded: succeeded,
+                startedAt: startedAt,
+                error: error,
+                regionCode: regionCode
+            )
+        }
     }
 
     private func restoreProfileAddress(_ address: String, profileID: String) throws {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConnectionProfileRouteTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConnectionProfileRouteTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class ConnectionProfileRouteTests: XCTestCase {
+    func testLegacyTailcatMigratesToFreeCustomRoute() throws {
+        let profile = try decodeLegacyProfile(
+            endpoint: "http://100.64.0.10:8787",
+            route: "tailcat"
+        )
+        XCTAssertEqual(profile.connectionRoute, .customTailcat)
+    }
+
+    func testLegacyConfiguredRouteUsesSavedEndpointWithoutChangingIt() throws {
+        let tailscale = try decodeLegacyProfile(
+            endpoint: "http://100.64.0.10:8787",
+            route: "configured"
+        )
+        let lan = try decodeLegacyProfile(
+            endpoint: "http://192.168.1.20:8787",
+            route: "configured"
+        )
+        let https = try decodeLegacyProfile(
+            endpoint: "https://mac.example.com",
+            route: "configured"
+        )
+
+        XCTAssertEqual(tailscale.connectionRoute, .tailscale)
+        XCTAssertEqual(lan.connectionRoute, .lan)
+        XCTAssertEqual(https.connectionRoute, .https)
+        XCTAssertEqual(tailscale.endpoint, "http://100.64.0.10:8787")
+        XCTAssertEqual(lan.endpoint, "http://192.168.1.20:8787")
+        XCTAssertEqual(https.endpoint, "https://mac.example.com")
+    }
+
+    func testManagedAndCustomPairingProduceDifferentPersistentTypes() async throws {
+        let suiteName = "ConnectionProfileRouteTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: TokenStore(keychain: TestKeychainOperations()),
+            prefersLocalConnection: false,
+            routeProbe: { _, _, _ in }
+        )
+
+        let managed = try await store.prepareRoutedConnectionSettings(
+            endpoint: "http://100.64.0.10:8787",
+            activeEndpoint: "http://127.0.0.1:49152",
+            tailcatAddress: "tailcat:managed",
+            managed: true,
+            token: "token",
+            profileTarget: .newProfile(id: "managed", displayName: "Managed")
+        )
+        let custom = try await store.prepareRoutedConnectionSettings(
+            endpoint: "http://100.64.0.20:8787",
+            activeEndpoint: "http://127.0.0.1:49153",
+            tailcatAddress: "tailcat:custom",
+            token: "token",
+            profileTarget: .newProfile(id: "custom", displayName: "Custom")
+        )
+
+        XCTAssertEqual(managed.route.profileRoute, .managedTailcat)
+        XCTAssertEqual(custom.route.profileRoute, .customTailcat)
+    }
+
+    func testTemporaryFallbackProbeDoesNotChangeManagedDefault() async throws {
+        let suiteName = "ConnectionProfileRouteTests.Fallback.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let tokenStore = TokenStore(keychain: TestKeychainOperations())
+        let profile = ConnectionProfile(
+            id: "managed-mac",
+            displayName: "Managed Mac",
+            endpoint: "http://100.64.0.10:8787",
+            lastSuccessfulAt: nil,
+            installationID: "10000000-0000-4000-8000-000000000001",
+            connectionRoute: .managedTailcat
+        )
+        defaults.set(try JSONEncoder().encode([profile]), forKey: "agentd.connectionProfiles.v2")
+        defaults.set(profile.id, forKey: "agentd.activeConnectionProfileID.v1")
+        try tokenStore.save("token", profileID: profile.id)
+        let store = AppStore(
+            defaults: defaults,
+            tokenStore: tokenStore,
+            prefersLocalConnection: false,
+            routeProbe: { _, _, _ in }
+        )
+
+        let connected = await store.preflightConnection(
+            force: true,
+            preferredProfileRoute: .tailscale
+        )
+
+        XCTAssertTrue(connected)
+        XCTAssertEqual(store.activeConnectionProfile?.connectionRoute, .managedTailcat)
+        XCTAssertEqual(store.savedFallbackConnectionRoute, .tailscale)
+    }
+
+    private func decodeLegacyProfile(endpoint: String, route: String) throws -> ConnectionProfile {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "id": "legacy",
+            "displayName": "Legacy Mac",
+            "endpoint": endpoint,
+            "connectionRoute": route,
+            "revision": 0,
+        ])
+        return try JSONDecoder().decode(ConnectionProfile.self, from: data)
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LocalizationTests.swift
@@ -99,8 +99,9 @@ final class LocalizationTests: XCTestCase {
             ("ui.my_preferences", "My Preferences", "我的偏好设置"),
             ("ui.more", "More", "更多"),
             ("ui.experimental_features", "Experimental Features", "实验功能"),
-            ("ui.tailcat_experiment", "Tailcat experiment", "Tailcat 实验"),
-            ("ui.enable_tailcat_experiment", "Use Tailcat experimental mode", "使用 Tailcat 实验模式"),
+            ("ui.tailcat_experiment", "Tailcat", "Tailcat"),
+            ("ui.managed_subscription_title", "Mimi Managed Connection", "Mimi 托管连接"),
+            ("ui.custom_tailcat", "Self-hosted Tailcat", "自建 Tailcat"),
             ("ui.personalization", "Appearance & Personalization", "外观与个性化"),
             ("ui.advanced_and_development", "Advanced & Development", "高级与开发"),
             ("ui.about_and_legal", "About & Legal", "关于与法律")

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEventAPIClientTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEventAPIClientTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import XCTest
+@testable import MimiRemote
+
+final class ManagedConnectionEventAPIClientTests: XCTestCase {
+    override func tearDown() {
+        MIM261EventURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testEventRequestContainsOnlyApprovedCoarseFields() async throws {
+        MIM261EventURLProtocol.statusCode = 202
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let client = LiveManagedConnectionEventAPIClient(session: session)
+        let event = ManagedConnectionEvent(
+            id: UUID(uuidString: "10000000-0000-4000-8000-000000000001")!,
+            path: .derp,
+            succeeded: true,
+            durationMillis: 3_200,
+            errorCategory: .network,
+            regionCode: " tok ",
+            appVersion: "1.2.1"
+        )
+
+        try await client.send(event, deviceToken: Self.deviceToken)
+
+        let request = try XCTUnwrap(MIM261EventURLProtocol.capturedRequest)
+        let body = try XCTUnwrap(MIM261EventURLProtocol.capturedBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(request.url?.path, "/v1/connection-events")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(Self.deviceToken)")
+        XCTAssertEqual(
+            Set(json.keys),
+            Set(["id", "path", "succeeded", "durationBucket", "errorCategory", "regionCode", "appVersion"])
+        )
+        XCTAssertEqual(json["path"] as? String, "derp")
+        XCTAssertEqual(json["durationBucket"] as? String, "3s_to_8s")
+        XCTAssertEqual(json["errorCategory"] as? String, "none")
+        XCTAssertEqual(json["regionCode"] as? String, "TOK")
+        XCTAssertNil(json["ip"])
+        XCTAssertNil(json["deviceName"])
+        XCTAssertNil(json["address"])
+        XCTAssertNil(json["token"])
+        XCTAssertNil(json["content"])
+    }
+
+    func testNonDERPEventDropsRegionAndClassifiesTimeout() throws {
+        let data = try JSONEncoder().encode(
+            ManagedConnectionEvent(
+                path: .direct,
+                succeeded: false,
+                durationMillis: 10_000,
+                errorCategory: ManagedConnectionEventErrorCategory(error: URLError(.timedOut)),
+                regionCode: "TOK",
+                appVersion: "1.2.1"
+            )
+        )
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["durationBucket"] as? String, "over_10s")
+        XCTAssertEqual(json["errorCategory"] as? String, "timeout")
+        XCTAssertNil(json["regionCode"])
+    }
+
+    func testFailedEventWithoutSystemErrorUsesUnknownCategory() throws {
+        let data = try JSONEncoder().encode(
+            ManagedConnectionEvent(
+                path: .unknown,
+                succeeded: false,
+                durationMillis: 500,
+                errorCategory: .none,
+                regionCode: nil,
+                appVersion: "1.2.1"
+            )
+        )
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["errorCategory"] as? String, "unknown")
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MIM261EventURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private static let deviceToken = Data(repeating: 7, count: 32).base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+private final class MIM261EventURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    static var statusCode = 500
+    private(set) static var capturedRequest: URLRequest?
+    private(set) static var capturedBody: Data?
+
+    static func reset() {
+        lock.lock()
+        statusCode = 500
+        capturedRequest = nil
+        capturedBody = nil
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        var body = request.httpBody
+        if body == nil, let stream = request.httpBodyStream {
+            body = Self.readAll(from: stream)
+        }
+        Self.lock.lock()
+        Self.capturedRequest = request
+        Self.capturedBody = body
+        let statusCode = Self.statusCode
+        Self.lock.unlock()
+
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: statusCode,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: ["Content-Type": "application/json"]
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readAll(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4 * 1_024)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
@@ -136,7 +136,108 @@ private final class ManagedPairingAuthorizerStub: ManagedConnectionPairingAuthor
 }
 
 @MainActor
+private final class ManagedConnectionEventReporterStub: ManagedConnectionEventReporting {
+    private(set) var events: [ManagedConnectionEvent] = []
+    var onReport: (() -> Void)?
+    var blocksReports = false
+    private var blockedContinuation: CheckedContinuation<Void, Never>?
+
+    func report(_ event: ManagedConnectionEvent) async {
+        events.append(event)
+        onReport?()
+        if blocksReports {
+            await withCheckedContinuation { continuation in
+                blockedContinuation = continuation
+            }
+        }
+    }
+
+    func releaseBlockedReport() {
+        blockedContinuation?.resume()
+        blockedContinuation = nil
+    }
+}
+
+@MainActor
 final class TailcatExperimentRoutingTests: XCTestCase {
+    func testForegroundRecoveryPreservesTemporaryManagedFallback() async throws {
+        let fixture = try makeControllerFixture(
+            startResults: [.success("http://127.0.0.1:49152")],
+            managedProfile: true
+        )
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let prepared = await fixture.controller.prepareRoute(appStore: fixture.store)
+        let usedFallback = await fixture.controller.useSavedRouteOnce(.tailscale, appStore: fixture.store)
+        let recovered = await fixture.controller.recoverRouteFromForeground(appStore: fixture.store)
+        let startCallCount = await fixture.runtime.startCallCount()
+
+        XCTAssertTrue(prepared)
+        XCTAssertTrue(usedFallback)
+        XCTAssertTrue(recovered)
+        XCTAssertEqual(startCallCount, 1)
+        XCTAssertEqual(fixture.controller.state, .usingTemporaryRoute(.tailscale))
+        XCTAssertFalse(fixture.store.isTailcatExperimentModeEnabled)
+        XCTAssertEqual(fixture.store.activeConnectionProfile?.connectionRoute, .managedTailcat)
+    }
+
+    func testManagedFailureTelemetryDoesNotDelayFailureResult() async throws {
+        let reporter = ManagedConnectionEventReporterStub()
+        reporter.blocksReports = true
+        let reportStarted = expectation(description: "telemetry started")
+        reporter.onReport = { reportStarted.fulfill() }
+        let routeFinished = expectation(description: "route failure returned")
+        let fixture = try makeControllerFixture(
+            startResults: [.failure(.startFailed)],
+            managedProfile: true,
+            managedConnectionEventReporter: reporter
+        )
+        defer {
+            reporter.releaseBlockedReport()
+            fixture.defaults.removePersistentDomain(forName: fixture.suiteName)
+        }
+
+        Task { @MainActor in
+            let ready = await fixture.controller.prepareRoute(appStore: fixture.store)
+            XCTAssertFalse(ready)
+            routeFinished.fulfill()
+        }
+
+        await fulfillment(of: [routeFinished, reportStarted], timeout: 1)
+        guard case .failed = fixture.controller.state else {
+            return XCTFail("线路失败必须先于旁路遥测返回")
+        }
+    }
+
+    func testConcurrentManagedPreparationEmitsOneConnectionEvent() async throws {
+        let reporter = ManagedConnectionEventReporterStub()
+        let reported = expectation(description: "one managed event")
+        reporter.onReport = { reported.fulfill() }
+        let fixture = try makeControllerFixture(
+            startResults: [.success("http://127.0.0.1:49152")],
+            blockedStartCall: 1,
+            managedProfile: true,
+            managedConnectionEventReporter: reporter
+        )
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let first = Task { await fixture.controller.prepareRoute(appStore: fixture.store) }
+        await fixture.runtime.waitForBlockedStart()
+        let second = Task { await fixture.controller.prepareRoute(appStore: fixture.store) }
+        await Task.yield()
+        await fixture.runtime.releaseBlockedStart()
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+        await fulfillment(of: [reported], timeout: 1)
+        for _ in 0..<5 { await Task.yield() }
+        let startCallCount = await fixture.runtime.startCallCount()
+        XCTAssertTrue(firstResult)
+        XCTAssertTrue(secondResult)
+        XCTAssertEqual(reporter.events.count, 1)
+        XCTAssertEqual(startCallCount, 1)
+    }
+
     func testManagedPairingRequiresManagedQRCodeBeforeStartingRuntime() async throws {
         let authorizer = ManagedPairingAuthorizerStub()
         let fixture = try makeControllerFixture(
@@ -729,7 +830,9 @@ final class TailcatExperimentRoutingTests: XCTestCase {
     private func makeControllerFixture(
         startResults: [Result<String, TailcatRuntimeStubError>],
         blockedStartCall: Int? = nil,
-        managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)? = nil
+        managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)? = nil,
+        managedProfile: Bool = false,
+        managedConnectionEventReporter: (any ManagedConnectionEventReporting)? = nil
     ) throws -> (
         controller: TailcatExperimentController,
         runtime: TailcatExperimentRuntimeStub,
@@ -751,10 +854,24 @@ final class TailcatExperimentRoutingTests: XCTestCase {
         )
         let keychain = TestKeychainOperations()
         let tokenStore = TokenStore(keychain: keychain)
+        if managedProfile {
+            let profile = ConnectionProfile(
+                id: "managed-mac",
+                displayName: "Managed Mac",
+                endpoint: "http://100.64.0.10:8787",
+                lastSuccessfulAt: nil,
+                connectionRoute: .managedTailcat
+            )
+            defaults.set(try JSONEncoder().encode([profile]), forKey: "agentd.connectionProfiles.v2")
+            defaults.set(profile.id, forKey: "agentd.activeConnectionProfileID.v1")
+            try tokenStore.save("managed-token", profileID: profile.id)
+            try tokenStore.saveTailcatAddress("tailcat:managed-mac", profileID: profile.id)
+        }
         let store = AppStore(
             defaults: defaults,
             tokenStore: tokenStore,
-            prefersLocalConnection: false
+            prefersLocalConnection: false,
+            routeProbe: { _, _, _ in }
         )
         let controller = TailcatExperimentController(
             appStore: store,
@@ -762,7 +879,8 @@ final class TailcatExperimentRoutingTests: XCTestCase {
             tokenStore: tokenStore,
             runtime: runtime,
             bridge: bridge,
-            managedPairingAuthorizer: managedPairingAuthorizer
+            managedPairingAuthorizer: managedPairingAuthorizer,
+            managedConnectionEventReporter: managedConnectionEventReporter
         )
         return (controller, runtime, store, defaults, suiteName)
     }


### PR DESCRIPTION
## 结果

- 将连接档案拆分为 managedTailcat、customTailcat、tailscale、lan 和 https，旧 Tailcat 档案迁移为免费自建线路
- 新用户首屏优先展示 Mimi 托管连接，现有用户默认线路保持不变
- 托管连接失败时提供重试、仅本次使用已保存 Tailscale、仅本次使用已保存局域网
- 仅为托管连接上报固定枚举的路径、结果、耗时桶、错误分类、DERP 区域和版本

## 验证

- bash ./scripts/ios-dev.sh test 指定 ConnectionProfileRouteTests、ManagedConnectionEventAPIClientTests、TailcatExperimentRoutingTests、LocalizationTests：48 项通过
- bash ./scripts/check-source-size.sh：通过
- git diff --check：通过
- jq empty ios/MimiRemote/Resources/Localizable.xcstrings：通过

本地测试完成后已删除 979 MB 可重新生成的 ios/MimiRemote/build 缓存。