### PR TITLE
MIM-251 让 Claude 的 thread/turns/list 真正分页

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
@@ -18,6 +18,9 @@ use thiserror::Error;
 use tokio::io::AsyncReadExt;
 use uuid::Uuid;
 
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
 use alleycat_codex_proto as p;
 
 use crate::handlers::model::{normalize_claude_model, normalize_claude_model_id};
@@ -723,35 +726,96 @@ pub async fn handle_thread_read(
 // thread/turns/list
 // ============================================================================
 
+/// Turn 游标：turns 是一次性物化的有序向量，用 turn id 作位置锚点即可，
+/// 不依赖 `started_at`（它允许为 None，用时间戳会在补写的历史上产生歧义）。
+/// 编码方式与 thread 列表游标保持一致：base64url(JSON)。
+fn encode_turn_cursor(turn_id: &str) -> String {
+    let json = serde_json::json!({ "turnId": turn_id }).to_string();
+    URL_SAFE_NO_PAD.encode(json)
+}
+
+fn decode_turn_cursor(raw: &str) -> Option<String> {
+    let bytes = URL_SAFE_NO_PAD.decode(raw).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    value
+        .get("turnId")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
 pub async fn handle_thread_turns_list(
     state: &Arc<ConnectionState>,
     params: p::ThreadTurnsListParams,
 ) -> Result<p::ThreadTurnsListResponse, ThreadError> {
-    if params.cursor.as_deref().is_some_and(|c| !c.is_empty()) {
-        return Ok(p::ThreadTurnsListResponse::default());
-    }
     let entry = state
         .thread_index()
         .lookup(&params.thread_id)
         .await
         .ok_or_else(|| ThreadError::NotFound(params.thread_id.clone()))?;
-    let mut turns = cached_thread_turns(state, &entry).await?;
-    if matches!(
-        params.sort_direction.unwrap_or(p::SortDirection::Desc),
-        p::SortDirection::Desc
-    ) {
+    let turns = cached_thread_turns(state, &entry).await?;
+    Ok(paginate_turns(
+        turns,
+        params.cursor.as_deref(),
+        params.limit,
+        matches!(
+            params.sort_direction.unwrap_or(p::SortDirection::Desc),
+            p::SortDirection::Desc
+        ),
+    ))
+}
+
+/// turns 的游标分页。抽成纯函数便于覆盖跨页边界，handler 只负责取数据。
+fn paginate_turns(
+    mut turns: Vec<p::Turn>,
+    cursor: Option<&str>,
+    limit: Option<u32>,
+    descending: bool,
+) -> p::ThreadTurnsListResponse {
+    if descending {
         turns.reverse();
     }
-    if let Some(limit) = params.limit
-        && (limit as usize) < turns.len()
-    {
-        turns.truncate(limit as usize);
+
+    // 游标定位到锚点之后一位。锚点不在本次结果里（turn 被截断或 id 变了）时返回
+    // 空页且不再给 next_cursor，让调用方干净收敛，而不是从头重发导致重复。
+    let start = match cursor.filter(|c| !c.is_empty()) {
+        Some(raw) => {
+            let Some(anchor) = decode_turn_cursor(raw) else {
+                return p::ThreadTurnsListResponse::default();
+            };
+            match turns.iter().position(|turn| turn.id == anchor) {
+                Some(index) => index + 1,
+                None => return p::ThreadTurnsListResponse::default(),
+            }
+        }
+        None => 0,
+    };
+    if start >= turns.len() {
+        return p::ThreadTurnsListResponse::default();
     }
-    Ok(p::ThreadTurnsListResponse {
-        data: turns,
-        next_cursor: None,
-        backwards_cursor: None,
-    })
+
+    // limit 只决定单页大小；它过去被当成"只保留最新 N 轮"，早期历史因此永远取不到。
+    let limit = alleycat_bridge_core::resolve_list_limit(limit) as usize;
+    let end = turns.len().min(start + limit);
+    let has_more = end < turns.len();
+    let page: Vec<p::Turn> = turns[start..end].to_vec();
+
+    let next_cursor = if has_more {
+        page.last().map(|turn| encode_turn_cursor(&turn.id))
+    } else {
+        None
+    };
+    // backwards_cursor 指向本页第一条：调用方带着它反向请求可以回到上一页边界。
+    let backwards_cursor = if start > 0 {
+        page.first().map(|turn| encode_turn_cursor(&turn.id))
+    } else {
+        None
+    };
+
+    p::ThreadTurnsListResponse {
+        data: page,
+        next_cursor,
+        backwards_cursor,
+    }
 }
 
 // ============================================================================
@@ -1072,6 +1136,109 @@ fn notification_frame(notif: p::ServerNotification) -> p::JsonRpcMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn turn(id: &str) -> p::Turn {
+        p::Turn {
+            id: id.to_string(),
+            items: Vec::new(),
+            items_view: p::default_items_view(),
+            status: p::TurnStatus::Completed,
+            error: None,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
+        }
+    }
+
+    fn turns(count: usize) -> Vec<p::Turn> {
+        (0..count).map(|i| turn(&format!("turn-{i}"))).collect()
+    }
+
+    fn ids(response: &p::ThreadTurnsListResponse) -> Vec<String> {
+        response.data.iter().map(|t| t.id.clone()).collect()
+    }
+
+    /// MIM-251：limit 只是单页大小。回归前它等价于"只保留最新 N 轮"，
+    /// 早期历史因此永远取不到。
+    #[test]
+    fn paginate_turns_walks_every_turn_without_gaps_or_repeats() {
+        let all = turns(23);
+        let mut seen: Vec<String> = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..10 {
+            let page = paginate_turns(all.clone(), cursor.as_deref(), Some(5), true);
+            assert!(!page.data.is_empty(), "分页不得在走完之前返回空页");
+            seen.extend(ids(&page));
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        // 倒序：最新的 turn-22 在最前，一路翻到最早的 turn-0
+        let expected: Vec<String> = (0..23).rev().map(|i| format!("turn-{i}")).collect();
+        assert_eq!(seen, expected, "必须无重复无跳段地覆盖全部 23 轮");
+    }
+
+    #[test]
+    fn paginate_turns_reports_cursors_at_page_boundaries() {
+        let all = turns(7);
+        let first = paginate_turns(all.clone(), None, Some(3), true);
+        assert_eq!(ids(&first), ["turn-6", "turn-5", "turn-4"]);
+        assert!(first.next_cursor.is_some(), "还有更多时必须给 next_cursor");
+        assert!(
+            first.backwards_cursor.is_none(),
+            "首页没有上一页，不应给 backwards_cursor"
+        );
+
+        let second = paginate_turns(all.clone(), first.next_cursor.as_deref(), Some(3), true);
+        assert_eq!(ids(&second), ["turn-3", "turn-2", "turn-1"]);
+        assert!(
+            second.backwards_cursor.is_some(),
+            "非首页必须给 backwards_cursor 以便回翻"
+        );
+
+        let last = paginate_turns(all, second.next_cursor.as_deref(), Some(3), true);
+        assert_eq!(ids(&last), ["turn-0"]);
+        assert!(
+            last.next_cursor.is_none(),
+            "走到最早一轮后不得再给 next_cursor"
+        );
+    }
+
+    #[test]
+    fn paginate_turns_respects_ascending_order() {
+        let page = paginate_turns(turns(4), None, Some(2), false);
+        assert_eq!(ids(&page), ["turn-0", "turn-1"]);
+    }
+
+    #[test]
+    fn paginate_turns_terminates_on_unknown_or_invalid_cursor() {
+        // 锚点已不在结果里（历史被截断/重写）时必须干净收敛，不能从头重发造成重复。
+        let stale = encode_turn_cursor("turn-does-not-exist");
+        let page = paginate_turns(turns(3), Some(&stale), Some(2), true);
+        assert!(page.data.is_empty());
+        assert!(page.next_cursor.is_none());
+
+        let garbage = paginate_turns(turns(3), Some("!!!not-base64!!!"), Some(2), true);
+        assert!(garbage.data.is_empty());
+        assert!(garbage.next_cursor.is_none());
+    }
+
+    #[test]
+    fn paginate_turns_handles_empty_thread() {
+        let page = paginate_turns(Vec::new(), None, Some(5), true);
+        assert!(page.data.is_empty());
+        assert!(page.next_cursor.is_none());
+        assert!(page.backwards_cursor.is_none());
+    }
+
+    #[test]
+    fn turn_cursor_round_trips() {
+        assert_eq!(
+            decode_turn_cursor(&encode_turn_cursor("turn-42")).as_deref(),
+            Some("turn-42")
+        );
+    }
 
     #[test]
     fn encode_cwd_strips_slashes() {


### PR DESCRIPTION
超过一页的 Claude 会话，早期历史**根本取不到** —— 这不是显示问题，是数据够不着。

## 根因

`handle_thread_turns_list`（`bridges/claude/crates/claude-bridge/src/handlers/thread.rs`）从来没有实现分页：

- 带非空 `cursor` 直接返回空页
- `next_cursor` 与 `backwards_cursor` 恒为 `None`
- `limit` 被当成「只保留最新 N 轮」（`turns.truncate(limit)`），而不是单页大小

同文件里的 `thread/list` 是有真游标分页的，所以这不是协议不支持，纯粹是这个 handler 没写。

## 改动

以 **turn id 作锚点**的游标分页。没有用 `started_at`：它允许为 `None`，在补写过的历史上会产生歧义，而 turns 是一次性物化的有序向量，用 id 定位既稳定又不依赖时钟。

- `limit` 恢复成单页大小语义，走完最后一页才停止给 `next_cursor`
- 非首页给出 `backwards_cursor`，供调用方回翻
- **锚点不在当前结果里**（历史被截断或重写）时返回空页且不给 `next_cursor`，让调用方干净收敛，而不是从头重发造成重复
- 分页逻辑抽成纯函数 `paginate_turns`，handler 只负责取数据

`thread/turns/list` 本来就在 `appServerClaudeAllowedMethods` 白名单里，所以这个改动合并后即端到端生效，不需要配套的 gateway 改动。

## 测试

新增 6 个用例：

- 23 轮会话逐页走完，断言**无重复无跳段**地覆盖全部 turn（这条直接对应回归前「早期历史取不到」）
- 页边界的 `next_cursor` / `backwards_cursor` 语义（首页无 backwards、末页无 next）
- 升序方向
- 失效锚点与非法 base64 游标都干净终止
- 空会话
- 游标编解码往返

验证：`cargo test` 全量 **219 passed / 0 failed**；`cargo fmt --check`、`cargo clippy --all-targets` 干净；`scripts/check-source-size.sh` 通过。

## 不在本 PR 范围

`.full` 模式仍会降级到 economy，因为 `thread/items/list` 与 `items_view` 在 bridge 侧尚未实现、也不在 Claude 白名单里。那需要新增一个协议方法 + item 级投影 + iOS 解除降级，体量与本修复不在一个量级，已拆为 MIM-265 单独跟进。

本 PR 只解决 turn 级分页，可独立验收：历史翻得动了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
