### PR TITLE
MIM-246/MIM-248 让 Claude 会话在「会话」tab 可见可搜索，并补齐下行授权

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
@@ -662,11 +662,22 @@ pub async fn handle_thread_list(
         .into_iter()
         .filter(|id| !id.starts_with("utility_"))
         .collect();
+    // git_info 每条要 fork 三个 git 子进程。全局列表一页 50 条会产生 150 个进程、
+    // 实测约 3 秒；同一页里的 thread 通常只落在少数几个 cwd 上，按 cwd 去重后
+    // 降到个位数。
+    let mut git_info_by_cwd: std::collections::HashMap<
+        String,
+        Option<alleycat_codex_proto::GitInfo>,
+    > = std::collections::HashMap::new();
     let data = page
         .data
         .into_iter()
         .map(|entry| {
-            let mut t = thread_from_entry(&entry);
+            let git_info = git_info_by_cwd
+                .entry(entry.cwd.clone())
+                .or_insert_with(|| alleycat_bridge_core::git_info_for_cwd(&entry.cwd))
+                .clone();
+            let mut t = crate::index::entry_to_thread_with_git_info(&entry, Some(git_info));
             let is_loaded = loaded.contains(&t.id);
             apply_live_thread_status(&mut t, is_loaded);
             t

--- a/bridges/claude/crates/claude-bridge/src/index/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/mod.rs
@@ -77,6 +77,16 @@ pub fn entry_from_claude(info: &ClaudeSessionInfo) -> IndexEntry {
 
 /// Render an index row as a wire `Thread`.
 pub fn entry_to_thread(entry: &IndexEntry) -> Thread {
+    entry_to_thread_with_git_info(entry, None)
+}
+
+/// 列表路径专用：git_info 每次调用会 fork 三个 git 子进程（rev-parse / branch /
+/// config）。一页 50 条会产生 150 个进程、约 3 秒，而同一页里的 thread 往往共享
+/// 少数几个 cwd。调用方按 cwd 去重后把结果传进来，避免重复计算。
+pub fn entry_to_thread_with_git_info(
+    entry: &IndexEntry,
+    git_info: Option<Option<alleycat_codex_proto::GitInfo>>,
+) -> Thread {
     Thread {
         id: entry.thread_id.clone(),
         session_id: entry.metadata.claude_session_id.clone(),
@@ -100,7 +110,7 @@ pub fn entry_to_thread(entry: &IndexEntry) -> Thread {
         thread_source: None,
         agent_nickname: None,
         agent_role: None,
-        git_info: alleycat_bridge_core::git_info_for_cwd(&entry.cwd),
+        git_info: git_info.unwrap_or_else(|| alleycat_bridge_core::git_info_for_cwd(&entry.cwd)),
         name: entry.name.clone(),
         turns: Vec::new(),
     }

--- a/internal/httpapi/appserver_gateway_inbound_policy_test.go
+++ b/internal/httpapi/appserver_gateway_inbound_policy_test.go
@@ -12,6 +12,32 @@ import (
 	"github.com/gaixianggeng/mimi-remote/internal/projects"
 )
 
+func newInboundPolicyForTest(t *testing.T, runtimeID string) (*appServerGatewayPolicy, string) {
+	t.Helper()
+	projectDir := t.TempDir()
+	registry, err := projects.NewRegistry([]config.ProjectConfig{{
+		ID: "project", Name: "Project", Path: projectDir,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := &Router{
+		cfg: config.Config{}, projects: registry,
+		gatewayThreads: map[string]appServerGatewayAllowedThread{},
+	}
+	policy := &appServerGatewayPolicy{
+		router:                router,
+		runtimeID:             runtimeID,
+		pendingThreads:        map[string]appServerGatewayPendingThreadRequest{},
+		allowedThreads:        map[string]appServerGatewayAllowedThread{},
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	policy.allowThread(appServerGatewayAllowedThread{
+		id: "allowed", runtimeID: runtimeID, cwd: projectDir, scopeID: "project",
+	})
+	return policy, projectDir
+}
+
 func newCodexInboundPolicyForTest(t *testing.T) (*appServerGatewayPolicy, string) {
 	t.Helper()
 	projectDir := t.TempDir()
@@ -283,5 +309,35 @@ func TestClaudeGatewayFiltersReplayEnvelopeByThreadAuthorization(t *testing.T) {
 	dropID := json.RawMessage(`"drop"`)
 	if _, ok := policy.consumePendingServerRequest(&dropID); ok {
 		t.Fatal("被裁掉的重放请求不应登记 pending")
+	}
+}
+
+// MIM-246：受控全局发现要经过完整的 validateClientFrame 入口才算数。
+// 只测 observeUpstreamFrame / validateThreadCapability 会漏掉更早的 scope 校验
+// （appserver_gateway_scope.go 的 allowsControlledGlobalList），那一层曾经只放行
+// codex，导致 Claude 的无 cwd thread/list 在到达能力校验之前就被拒。
+func TestGatewayAllowsControlledGlobalThreadListWithoutCWDForBothRuntimes(t *testing.T) {
+	globalList := []byte(`{"id":1,"method":"thread/list","params":{"limit":50,"sortKey":"updated_at","sortDirection":"desc","archived":false}}`)
+
+	for _, runtimeID := range []string{"codex", "claude"} {
+		t.Run(runtimeID, func(t *testing.T) {
+			policy, _ := newInboundPolicyForTest(t, runtimeID)
+			if _, err := policy.validateClientFrame(websocket.TextMessage, globalList); err != nil {
+				t.Fatalf("%s 的无 cwd 全局发现必须放行：%v", runtimeID, err)
+			}
+		})
+	}
+}
+
+func TestGatewayStillRequiresCWDForNonGlobalListMethods(t *testing.T) {
+	// 例外只针对 thread/list：其余需要 cwd 的方法不得被顺带放开。
+	start := []byte(`{"id":2,"method":"thread/start","params":{"input":"hi"}}`)
+	for _, runtimeID := range []string{"codex", "claude"} {
+		t.Run(runtimeID, func(t *testing.T) {
+			policy, _ := newInboundPolicyForTest(t, runtimeID)
+			if _, err := policy.validateClientFrame(websocket.TextMessage, start); err == nil {
+				t.Fatalf("%s 的无 cwd thread/start 必须被拒", runtimeID)
+			}
+		})
 	}
 }

--- a/internal/httpapi/appserver_gateway_inbound_policy_test.go
+++ b/internal/httpapi/appserver_gateway_inbound_policy_test.go
@@ -167,3 +167,121 @@ func quoteJSON(value string) string {
 	raw, _ := json.Marshal(value)
 	return string(raw)
 }
+
+// MIM-248：Claude 路径的下行门禁。独立 fixture，不复用 Codex 的用例，
+// 因为两条链路的全局通知集合与 replay 语义并不相同。
+func newClaudeInboundPolicyForTest(t *testing.T) (*appServerGatewayPolicy, string) {
+	t.Helper()
+	projectDir := t.TempDir()
+	registry, err := projects.NewRegistry([]config.ProjectConfig{{
+		ID: "project", Name: "Project", Path: projectDir,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := &Router{
+		cfg: config.Config{}, projects: registry,
+		gatewayThreads: map[string]appServerGatewayAllowedThread{},
+	}
+	policy := &appServerGatewayPolicy{
+		router:                router,
+		runtimeID:             "claude",
+		pendingThreads:        map[string]appServerGatewayPendingThreadRequest{},
+		allowedThreads:        map[string]appServerGatewayAllowedThread{},
+		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+	}
+	policy.allowThread(appServerGatewayAllowedThread{
+		id: "allowed", runtimeID: "claude", cwd: projectDir, scopeID: "project",
+	})
+	return policy, projectDir
+}
+
+func TestClaudeGatewayAuthorizesInboundNotificationsByThread(t *testing.T) {
+	policy, _ := newClaudeInboundPolicyForTest(t)
+
+	cases := []struct {
+		name    string
+		payload string
+		forward bool
+	}{
+		{
+			name:    "已授权 thread 的通知放行",
+			payload: `{"method":"turn/completed","params":{"threadId":"allowed","turnId":"turn-1"}}`,
+			forward: true,
+		},
+		{
+			name:    "未授权 thread 的通知丢弃",
+			payload: `{"method":"turn/completed","params":{"threadId":"intruder","turnId":"turn-1"}}`,
+			forward: false,
+		},
+		{
+			name:    "Claude 实际会发的无 thread 全局通知放行",
+			payload: `{"method":"account/rateLimits/updated","params":{"rateLimits":{}}}`,
+			forward: true,
+		},
+		{
+			name:    "未登记的无 thread 通知丢弃",
+			payload: `{"method":"account/somethingNew/updated","params":{}}`,
+			forward: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, []byte(tc.payload))
+			if policyErr != nil {
+				t.Fatalf("通知不应产生策略错误：%+v", policyErr)
+			}
+			if forward != tc.forward {
+				t.Fatalf("转发判定不符：want=%t got=%t payload=%s", tc.forward, forward, tc.payload)
+			}
+		})
+	}
+}
+
+func TestClaudeGatewayRequiresAuthorizedThreadForReverseRequests(t *testing.T) {
+	policy, _ := newClaudeInboundPolicyForTest(t)
+
+	allowed := []byte(`{"id":"req-1","method":"item/tool/requestUserInput","params":{"threadId":"allowed","itemId":"toolu_1"}}`)
+	if _, forward, err := policy.observeUpstreamFrame(websocket.TextMessage, allowed); err != nil || !forward {
+		t.Fatalf("已授权 thread 的反向请求应转发：forward=%t err=%+v", forward, err)
+	}
+
+	intruder := []byte(`{"id":"req-2","method":"item/tool/requestUserInput","params":{"threadId":"intruder","itemId":"toolu_2"}}`)
+	if _, forward, err := policy.observeUpstreamFrame(websocket.TextMessage, intruder); err != nil || forward {
+		t.Fatalf("未授权 thread 的反向请求必须丢弃：forward=%t err=%+v", forward, err)
+	}
+	// 丢弃的请求不得登记 pending，否则客户端后续可以用它的 id 回一个从未展示过的答复。
+	intruderID := json.RawMessage(`"req-2"`)
+	if _, ok := policy.consumePendingServerRequest(&intruderID); ok {
+		t.Fatal("被丢弃的反向请求不应登记 pending")
+	}
+}
+
+// replay 信封是 Claude 重连恢复挂起卡片的唯一通道：整帧丢掉会让用户永远等不到
+// 那张卡，整帧放行又会泄露未授权 thread 的挂起请求，所以必须按条目裁剪。
+func TestClaudeGatewayFiltersReplayEnvelopeByThreadAuthorization(t *testing.T) {
+	policy, _ := newClaudeInboundPolicyForTest(t)
+
+	replay := []byte(`{"jsonrpc":"2.0","method":"serverRequest/replay","params":{"outstanding":[` +
+		`{"id":"keep","method":"item/tool/requestUserInput","params":{"threadId":"allowed","itemId":"toolu_ok"}},` +
+		`{"id":"drop","method":"item/tool/requestUserInput","params":{"threadId":"intruder","itemId":"toolu_bad"}}]}}`)
+	got, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, replay)
+	if policyErr != nil || !forward {
+		t.Fatalf("replay 信封必须转发：forward=%t err=%+v", forward, policyErr)
+	}
+	if !bytes.Contains(got, []byte(`"keep"`)) {
+		t.Fatalf("已授权 thread 的挂起请求必须保留，否则重连恢复不了：%s", got)
+	}
+	if bytes.Contains(got, []byte(`"drop"`)) || bytes.Contains(got, []byte("toolu_bad")) {
+		t.Fatalf("未授权 thread 的挂起请求不应下发：%s", got)
+	}
+
+	keepID := json.RawMessage(`"keep"`)
+	if _, ok := policy.consumePendingServerRequest(&keepID); !ok {
+		t.Fatal("保留下来的重放请求应登记 pending，否则客户端答不了")
+	}
+	dropID := json.RawMessage(`"drop"`)
+	if _, ok := policy.consumePendingServerRequest(&dropID); ok {
+		t.Fatal("被裁掉的重放请求不应登记 pending")
+	}
+}

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -108,9 +108,10 @@ func (p *appServerGatewayPolicy) validateThreadCapability(frame *appServerGatewa
 				return err
 			}
 			if !validated.hasCWD {
-				if normalizeAppServerRuntimeID(p.runtimeID) != "codex" {
-					return fmt.Errorf("thread/list.cwd 不能为空")
-				}
+				// 受控全局发现只依赖 cwd → 项目 / browse-root / git common-dir 的映射
+				// （见 sanitizeThreadListResponse），与 runtime 无关：Claude 的 thread
+				// 载荷同样带 cwd 与 gitInfo，裁剪逻辑逐字适用。此前限定 codex 是保守
+				// 起见，代价是 Claude 会话在「会话」tab 完全不可见，只能逐目录去翻。
 				if err := p.resolveGlobalListCursor(params); err != nil {
 					return err
 				}
@@ -889,7 +890,9 @@ func sanitizedGatewayThreadTurnsListParams(params map[string]any) map[string]any
 func sanitizedGatewayThreadListParams(runtimeID string, params map[string]any) map[string]any {
 	keys := []string{"cwd", "limit", "cursor", "sortKey", "sortDirection", "sourceKinds", "archived", "useStateDbOnly"}
 	if normalizeAppServerRuntimeID(runtimeID) == "claude" {
-		keys = append(keys, "refreshHistory")
+		// Claude bridge 没有独立的 thread/search，搜索走 thread/list 的 searchTerm。
+		// Codex 有 thread/search，这里不放行以免同一能力出现两条语义不同的入口。
+		keys = append(keys, "refreshHistory", "searchTerm")
 	}
 	return copyGatewayParams(params, keys...)
 }
@@ -1084,6 +1087,16 @@ func validateGatewayThreadListParams(params map[string]any) error {
 	if value, ok := params["useStateDbOnly"]; ok && value != nil {
 		if _, ok := value.(bool); !ok {
 			return fmt.Errorf("thread/list.useStateDbOnly 必须是布尔值")
+		}
+	}
+	if value, ok := params["searchTerm"]; ok && value != nil {
+		// 与 thread/search 共用同一套上限，避免两条搜索入口的边界不一致。
+		text, ok := value.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return fmt.Errorf("thread/list.searchTerm 必须是非空字符串")
+		}
+		if len(strings.TrimSpace(text)) > appServerGatewayThreadSearchTermMaxBytes {
+			return fmt.Errorf("thread/list.searchTerm 不能超过 %d bytes", appServerGatewayThreadSearchTermMaxBytes)
 		}
 	}
 	refreshHistory := false

--- a/internal/httpapi/appserver_gateway_policy_test.go
+++ b/internal/httpapi/appserver_gateway_policy_test.go
@@ -1760,14 +1760,26 @@ func TestAppServerGatewayRegistersReplayedServerRequests(t *testing.T) {
 	policy := &appServerGatewayPolicy{
 		runtimeID:             "claude",
 		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thr_1": {id: "thr_1", runtimeID: "claude", cwd: "/repo", scopeID: "repo"},
+		},
 	}
 	replay := []byte(`{"jsonrpc":"2.0","method":"serverRequest/replay","params":{"outstanding":[` +
 		`{"id":"req-abc","method":"item/commandExecution/requestApproval","params":{"threadId":"thr_1"}},` +
 		`{"id":7,"method":"item/tool/requestUserInput","params":{"threadId":"thr_1"}},` +
 		`{"id":"req-nope","method":"account/chatgptAuthTokens/refresh","params":{}}]}}`)
 	got, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, replay)
-	if policyErr != nil || !forward || !bytes.Equal(got, replay) {
-		t.Fatalf("replay 通知应原样转发 forward=%v err=%+v got=%s", forward, policyErr, got)
+	if policyErr != nil || !forward {
+		t.Fatalf("replay 信封必须转发，否则重连恢复不了挂起卡片 forward=%v err=%+v", forward, policyErr)
+	}
+	// 已授权 thread 的条目原样保留。
+	if !bytes.Contains(got, []byte(`"req-abc"`)) || !bytes.Contains(got, []byte(`"item/tool/requestUserInput"`)) {
+		t.Fatalf("已授权 thread 的重放条目不应被剥掉：%s", got)
+	}
+	// 移动端渲染不了、也拿不到 thread 归属的条目不再下发（MIM-248）：
+	// 转发它只会让客户端看到一条永远不会被回答的挂起请求。
+	if bytes.Contains(got, []byte(`"req-nope"`)) {
+		t.Fatalf("未授权条目不应下发给客户端：%s", got)
 	}
 
 	for _, expected := range []struct {
@@ -2244,6 +2256,9 @@ func TestClaudeGatewayPassesThroughServerRequestResolvedAfterDecision(t *testing
 	policy := &appServerGatewayPolicy{
 		runtimeID:             "claude",
 		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-1": {id: "thread-1", runtimeID: "claude", cwd: "/repo", scopeID: "repo"},
+		},
 	}
 	request := []byte(`{"id":"claude-approval-1","method":"item/fileChange/requestApproval","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1","path":"README.md"}}`)
 	forwarded, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, request)
@@ -2707,10 +2722,9 @@ func TestAppServerGatewayNotificationRedactsInlineImagesForCodexAndClaude(t *tes
 		t.Run(runtimeID, func(t *testing.T) {
 			router := &Router{historyMedia: newAppServerHistoryMediaStore()}
 			policy := &appServerGatewayPolicy{router: router, runtimeID: runtimeID}
-			if runtimeID == "codex" {
-				policy.allowedThreads = map[string]appServerGatewayAllowedThread{
-					"thread-media": {id: "thread-media", runtimeID: "codex", cwd: "/repo", scopeID: "repo"},
-				}
+			// 两条 runtime 现在都受 thread 授权门禁（MIM-248），fixture 必须各自授权。
+			policy.allowedThreads = map[string]appServerGatewayAllowedThread{
+				"thread-media": {id: "thread-media", runtimeID: runtimeID, cwd: "/repo", scopeID: "repo"},
 			}
 			forwarded, forward, policyErr := policy.observeUpstreamFrame(websocket.TextMessage, notification)
 			if policyErr != nil || !forward {

--- a/internal/httpapi/appserver_gateway_scope.go
+++ b/internal/httpapi/appserver_gateway_scope.go
@@ -151,10 +151,12 @@ func (r *Router) validateGatewayPolicyParams(runtimeID string, method string, pa
 		validated.cwdScopeOK = true
 		validated.pendingManagedWorktreePath = pendingManagedPath
 	}
-	// Codex 的无 cwd thread/list 仅用于受控全局发现。它的响应必须在
+	// 无 cwd 的 thread/list 仅用于受控全局发现。它的响应必须在
 	// observeUpstreamFrame 中逐条完成路径、仓库身份和 capability 裁剪，
-	// 不能作为普通“省略 cwd”透传。Claude bridge 没有这条合同，仍要求 cwd。
-	allowsControlledGlobalList := method == "thread/list" && runtimeID == "codex"
+	// 不能作为普通“省略 cwd”透传。裁剪只依赖 cwd → 项目 / browse-root /
+	// git common-dir 的映射，与 runtime 无关，因此 Codex 与 Claude 同等适用。
+	allowsControlledGlobalList := method == "thread/list" &&
+		(runtimeID == "codex" || runtimeID == "claude")
 	if requiresGatewayCWD(method) && !allowsControlledGlobalList {
 		if !validated.hasCWD {
 			return validated, fmt.Errorf("%s.cwd 必须来自 projects allowlist 或 browse_roots", method)

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -141,7 +141,7 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 			// 能力的 owner；保持沉默，由其他订阅入口处理，不向上游代替拒绝。
 			return payload, false, nil
 		}
-		if normalizeAppServerRuntimeID(p.runtimeID) == "codex" && !p.codexServerRequestAllowed(frame.Params) {
+		if p.enforcesInboundThreadAuthorization() && !p.inboundServerRequestAllowed(frame.Params) {
 			return payload, false, nil
 		}
 		if err := p.rememberPendingServerRequest(frame.ID, frame.Method, frame.Params); err != nil {
@@ -153,10 +153,14 @@ func (p *appServerGatewayPolicy) observeUpstreamFrame(messageType int, payload [
 		if p.runtimeID == "codex" && p.router.isAutoThreadTitleNotification(frame.Params) {
 			return payload, false, nil
 		}
-		if normalizeAppServerRuntimeID(p.runtimeID) == "codex" && !p.codexNotificationAllowed(&frame) {
+		if p.enforcesInboundThreadAuthorization() && !p.inboundNotificationAllowed(&frame) {
 			return payload, false, nil
 		}
 		p.clearPendingServerRequestsForNotification(&frame)
+		if filtered, changed := p.sanitizeReplayedServerRequests(payload, &frame); changed {
+			payload = filtered
+			_ = json.Unmarshal(payload, &frame)
+		}
 		p.rememberReplayedServerRequests(&frame)
 		if appServerRuntimeRedactsInlineImages(p.runtimeID) && appServerMediaRedactNotificationsEnabled() {
 			if redacted, changed := p.router.redactInlineHistoryImagesInGatewayResponse(payload); changed {
@@ -319,29 +323,51 @@ func sanitizeThreadForkResponse(payload []byte) ([]byte, json.RawMessage, error)
 	return rewritten, resultRaw, nil
 }
 
-var codexGlobalNotificationMethods = map[string]struct{}{
+// 下行门禁适用于我们自己拥有的两条 runtime。未知 runtime 保持既有透传语义
+// （见 TestAppServerGatewayNotificationRedactsInlineImagesForCodexAndClaude 的
+// unknown-runtime-passthrough 子用例）：那是一个独立的产品决定，新接入 runtime 时
+// 应当显式纳入这里，而不是靠这个函数悄悄改变语义。
+func (p *appServerGatewayPolicy) enforcesInboundThreadAuthorization() bool {
+	switch normalizeAppServerRuntimeID(p.runtimeID) {
+	case "codex", "claude":
+		return true
+	default:
+		return false
+	}
+}
+
+// 无 thread 归属、因而无法按 thread 授权的全局通知。Codex 与 Claude 共用这一份：
+// Claude bridge 目前只发其中的 account/rateLimits/updated，多出的两条它不会发，
+// 放在这里不扩大暴露面。新增任何全局通知都必须显式登记，否则会被静默丢弃。
+var inboundGlobalNotificationMethods = map[string]struct{}{
 	"account/rateLimits/updated":      {},
 	"mcpServer/startupStatus/updated": {},
 	"deprecationNotice":               {},
 }
 
-func (p *appServerGatewayPolicy) codexServerRequestAllowed(rawParams json.RawMessage) bool {
+func (p *appServerGatewayPolicy) inboundServerRequestAllowed(rawParams json.RawMessage) bool {
 	threadID, _, _ := appServerGatewayServerRequestScope(rawParams)
 	_, ok := p.allowedThread(threadID)
 	return ok
 }
 
-func (p *appServerGatewayPolicy) codexNotificationAllowed(frame *appServerGatewayFrame) bool {
+func (p *appServerGatewayPolicy) inboundNotificationAllowed(frame *appServerGatewayFrame) bool {
 	method := strings.TrimSpace(frame.Method)
-	if _, ok := codexGlobalNotificationMethods[method]; ok {
+	if _, ok := inboundGlobalNotificationMethods[method]; ok {
+		return true
+	}
+	// serverRequest/replay 是 Claude 重连时的挂起请求信封，顶层没有 threadId：
+	// 授权必须按 outstanding 条目逐个判定（见 sanitizeReplayedServerRequests）。
+	// 整帧丢弃会打断重连恢复，整帧放行又会泄露未授权 thread 的挂起请求。
+	if method == claudeBridgeServerRequestReplayMethod {
 		return true
 	}
 	if method == "serverRequest/resolved" {
-		return p.codexResolvedNotificationAllowed(frame.Params)
+		return p.inboundResolvedNotificationAllowed(frame.Params)
 	}
 	threadID := appServerGatewayThreadIDFromParams(frame.Params)
 	if method == "thread/started" {
-		return p.allowCodexStartedThread(frame.Params, threadID)
+		return p.allowInboundStartedThread(frame.Params, threadID)
 	}
 	_, ok := p.allowedThread(threadID)
 	return ok
@@ -367,7 +393,7 @@ func appServerGatewayThreadIDFromParams(rawParams json.RawMessage) string {
 	return ""
 }
 
-func (p *appServerGatewayPolicy) allowCodexStartedThread(rawParams json.RawMessage, threadID string) bool {
+func (p *appServerGatewayPolicy) allowInboundStartedThread(rawParams json.RawMessage, threadID string) bool {
 	params, err := decodeGatewayParams(rawParams)
 	if err != nil || threadID == "" || p.router == nil {
 		return false
@@ -398,7 +424,7 @@ func (p *appServerGatewayPolicy) allowCodexStartedThread(rawParams json.RawMessa
 	return true
 }
 
-func (p *appServerGatewayPolicy) codexResolvedNotificationAllowed(rawParams json.RawMessage) bool {
+func (p *appServerGatewayPolicy) inboundResolvedNotificationAllowed(rawParams json.RawMessage) bool {
 	threadID, _, _ := appServerGatewayServerRequestScope(rawParams)
 	if _, ok := p.allowedThread(threadID); ok {
 		return true
@@ -945,6 +971,64 @@ func (p *appServerGatewayPolicy) prunePendingClientRequestsLocked(now time.Time)
 // registered and `validateClientResponse` rejected the user's answer as "not
 // issued by app-server" — the prompt would come back after a reconnect and
 // then refuse to be answered.
+// sanitizeReplayedServerRequests 把 serverRequest/replay 的 outstanding 裁剪到
+// 当前连接已授权的 thread。信封本身要保留：它是 Claude 重连恢复挂起审批与补充
+// 信息卡的唯一通道，整帧丢掉会让用户重连后永远等不到那张卡。
+func (p *appServerGatewayPolicy) sanitizeReplayedServerRequests(payload []byte, frame *appServerGatewayFrame) ([]byte, bool) {
+	if !p.enforcesInboundThreadAuthorization() ||
+		strings.TrimSpace(frame.Method) != claudeBridgeServerRequestReplayMethod ||
+		len(frame.Params) == 0 {
+		return payload, false
+	}
+	var params map[string]json.RawMessage
+	if json.Unmarshal(frame.Params, &params) != nil {
+		return payload, false
+	}
+	rawOutstanding, ok := params["outstanding"]
+	if !ok {
+		return payload, false
+	}
+	var entries []json.RawMessage
+	if json.Unmarshal(rawOutstanding, &entries) != nil {
+		return payload, false
+	}
+	kept := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		var scoped struct {
+			Params json.RawMessage `json:"params"`
+		}
+		if json.Unmarshal(entry, &scoped) != nil {
+			continue
+		}
+		if !p.inboundServerRequestAllowed(scoped.Params) {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	if len(kept) == len(entries) {
+		return payload, false
+	}
+	rewrittenOutstanding, err := json.Marshal(kept)
+	if err != nil {
+		return payload, false
+	}
+	params["outstanding"] = rewrittenOutstanding
+	rewrittenParams, err := json.Marshal(params)
+	if err != nil {
+		return payload, false
+	}
+	var envelope map[string]json.RawMessage
+	if json.Unmarshal(payload, &envelope) != nil {
+		return payload, false
+	}
+	envelope["params"] = rewrittenParams
+	rewritten, err := json.Marshal(envelope)
+	if err != nil {
+		return payload, false
+	}
+	return rewritten, true
+}
+
 func (p *appServerGatewayPolicy) rememberReplayedServerRequests(frame *appServerGatewayFrame) {
 	if strings.TrimSpace(frame.Method) != claudeBridgeServerRequestReplayMethod || len(frame.Params) == 0 {
 		return
@@ -967,6 +1051,9 @@ func (p *appServerGatewayPolicy) rememberReplayedServerRequests(frame *appServer
 		if !appServerServerRequestAllowed(p.runtimeID, entry.Method) {
 			// The client cannot render it, so it will never answer it; leaving
 			// it unregistered keeps the pending table honest.
+			continue
+		}
+		if p.enforcesInboundThreadAuthorization() && !p.inboundServerRequestAllowed(entry.Params) {
 			continue
 		}
 		if err := p.rememberPendingServerRequest(entry.ID, entry.Method, entry.Params); err != nil {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
@@ -535,11 +535,34 @@ final class CodexAppServerRuntimeRoutingSessionAPIClient: SessionStoreAPIClient 
         return page
     }
 
+    /// 搜索的分页由 Codex 的 thread/search 独占驱动：只有首页会额外查一次 Claude，
+    /// 并把结果拼在后面。Claude 没有 thread/search，它走 thread/list + searchTerm，
+    /// 按单页返回。这样既让 Claude 会话可搜到，也不需要把两条游标流编进一个复合
+    /// cursor（那会重新引入跨 Runtime 的分页状态机）。
+    ///
+    /// 代价说明：Claude 的搜索结果限于首页 limit 条。搜索场景下用户通常继续收窄
+    /// 关键词而不是翻页；真出现「Claude 结果翻不动」再升级为按 runtime 分段。
     func searchSessions(query: String, cursor: String?, limit: Int?) async throws -> ThreadSearchPage {
-        // Codex 的 thread/search 是独立能力；Claude channel 目前没有同构接口，避免为搜索额外发双路请求。
-        let page = try await codexClient.searchSessions(query: query, cursor: cursor, limit: limit)
-        bundle.routes.remember(page.sessions)
-        return page
+        let codexPage = try await codexClient.searchSessions(query: query, cursor: cursor, limit: limit)
+        bundle.routes.remember(codexPage.sessions)
+        guard cursor == nil else {
+            return codexPage
+        }
+        // Claude 搜索是增强项：bridge 未启用或不健康时不能连带让 Codex 搜索失败。
+        guard let claudePage = try? await bundle.claude.globalThreadListSearchPage(
+            query: query,
+            limit: limit
+        ), !claudePage.results.isEmpty else {
+            return codexPage
+        }
+        bundle.routes.remember(claudePage.sessions)
+        let existingIDs = Set(codexPage.results.map(\.session.id))
+        let merged = codexPage.results + claudePage.results.filter { !existingIDs.contains($0.session.id) }
+        return ThreadSearchPage(
+            results: merged,
+            nextCursor: codexPage.nextCursor,
+            backwardsCursor: codexPage.backwardsCursor
+        )
     }
 
     func session(id: String, afterSeq: EventSequence?) async throws -> SessionResponse {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionClients.swift
@@ -518,8 +518,19 @@ final class CodexAppServerRuntimeRoutingSessionAPIClient: SessionStoreAPIClient 
     }
 
     func controlledGlobalSessionsPage(cursor: String?, limit: Int?) async throws -> SessionsPage {
-        // 受控全局发现是 Codex App Server 能力；Claude bridge 没有同构的无 cwd 合同。
-        let page = try await codexClient.controlledGlobalSessionsPage(cursor: cursor, limit: limit)
+        try await controlledGlobalSessionsPage(runtimeProvider: "codex", cursor: cursor, limit: limit)
+    }
+
+    /// 受控全局发现按 runtime 分头遍历：两条 opaque cursor 流各自独立推进，
+    /// 从不交织成一条，调用方把两趟结果并进同一份 canonical sessions。
+    /// 这样既让 Claude 会话在「会话」tab 可见，也不引入跨 Runtime 排序状态机。
+    func controlledGlobalSessionsPage(
+        runtimeProvider: String,
+        cursor: String?,
+        limit: Int?
+    ) async throws -> SessionsPage {
+        let page = try await bundle.runtime(for: runtimeProvider)
+            .controlledGlobalSessionsPage(cursor: cursor, limit: limit)
         bundle.routes.remember(page.sessions)
         return page
     }

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -534,6 +534,40 @@ actor CodexAppServerSessionRuntime {
         return page
     }
 
+    /// 面向没有 thread/search 的 runtime（Claude）的搜索：走 thread/list + searchTerm。
+    /// 结果按单页返回且不给 nextCursor —— 翻页由 Codex 的 thread/search 驱动。
+    /// bridge 的 thread/list 不返回命中片段，因此用会话 preview 兜底当 snippet；
+    /// 为空时上层会自动不渲染片段行，不会留下空白。
+    func globalThreadListSearchPage(query: String, limit: Int?) async throws -> ThreadSearchPage {
+        let searchTerm = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !searchTerm.isEmpty else {
+            return ThreadSearchPage(results: [])
+        }
+        let config = try await ensureConfig()
+        guard config.policy.allowedMethods.contains("thread/list") else {
+            throw CodexAppServerSessionRuntimeError.threadSearchUnavailable
+        }
+        let projects = config.projects
+        let result = try await sendRecoveringFromStaleInitialization(
+            CodexAppServerRequestBuilder(allowlistedProjects: projects)
+                .searchThreadListGlobally(query: searchTerm, limit: limit),
+            timeout: longRunningRequestTimeout
+        )
+        let page = threadListPage(from: result, projects: projects, fallbackProject: nil)
+        for session in page.sessions {
+            contextsBySessionID[session.id] = CodexAppServerSessionContext(
+                session: session,
+                cwd: session.dir,
+                activeTurnID: session.activeTurnID
+            )
+        }
+        return ThreadSearchPage(
+            results: page.sessions.map {
+                ThreadSearchResult(session: $0, snippet: $0.preview ?? "")
+            }
+        )
+    }
+
     func resolveWorkspace(path: String) async throws -> AgentWorkspace {
         // resolve 是 agentd 控制面的 REST 接口（非 app-server JSON-RPC），用 runtime 自己的 endpoint/token 直接请求。
         try await AgentAPIClient(endpoint: endpoint, token: token).resolveWorkspace(path: path)

--- a/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
@@ -407,6 +407,23 @@ struct CodexAppServerRequestBuilder {
 
     /// 无 cwd 列表只用于 agentd 的受控全局发现。客户端不携带项目过滤器，也不
     /// 依赖 experimental parent/ancestor API；路径与仓库身份裁剪完全由 gateway 完成。
+    /// Claude bridge 没有 thread/search，搜索走 thread/list 的 searchTerm
+    /// （bridge 早已支持，gateway 也已放行）。这里不带 cursor：搜索按单页返回，
+    /// 翻页仍由 Codex 的 thread/search 驱动，避免引入跨 Runtime 的分页状态机。
+    func searchThreadListGlobally(
+        query: String,
+        limit: Int? = 50
+    ) -> CodexAppServerRequestSpec {
+        CodexAppServerRequestSpec(method: "thread/list", params: CodexAppServerJSONValue.objectValue([
+            "limit": limit.map { .int(Int64($0)) },
+            "searchTerm": .string(query),
+            "sortKey": .string("updated_at"),
+            "sortDirection": .string("desc"),
+            "archived": .bool(false),
+            "useStateDbOnly": .bool(false)
+        ]))
+    }
+
     func controlledGlobalThreadList(
         limit: Int? = 50,
         cursor: String? = nil

--- a/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreNetworking.swift
@@ -139,6 +139,7 @@ protocol SessionStoreAPIClient {
     func sessionsPage(projectID: String?, runtimeProvider: String, cursor: String?, limit: Int?, consistency: SessionListConsistency) async throws -> SessionsPage
     func sessionsPage(workspace: AgentWorkspace, runtimeProvider: String, cursor: String?, limit: Int?, consistency: SessionListConsistency) async throws -> SessionsPage
     func controlledGlobalSessionsPage(cursor: String?, limit: Int?) async throws -> SessionsPage
+    func controlledGlobalSessionsPage(runtimeProvider: String, cursor: String?, limit: Int?) async throws -> SessionsPage
     func searchSessions(query: String, cursor: String?, limit: Int?) async throws -> ThreadSearchPage
     func session(id: String, afterSeq: EventSequence?) async throws -> SessionResponse
     func threadGoal(threadID: String) async throws -> ThreadGoal?
@@ -211,6 +212,16 @@ extension SessionStoreAPIClient {
 
     func controlledGlobalSessionsPage(cursor: String?, limit: Int?) async throws -> SessionsPage {
         SessionsPage(sessions: [])
+    }
+
+    /// 默认忽略 runtime 维度，回落到单一 runtime 的实现：既有 mock 与只服务 Codex
+    /// 的客户端无需改动。真正按 runtime 分头请求的是路由 facade。
+    func controlledGlobalSessionsPage(
+        runtimeProvider: String,
+        cursor: String?,
+        limit: Int?
+    ) async throws -> SessionsPage {
+        try await controlledGlobalSessionsPage(cursor: cursor, limit: limit)
     }
 
     func runtimeChannelAvailable(runtimeProvider: String) async throws -> Bool {

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -1661,7 +1661,11 @@ extension SessionStore {
         if !controlledGlobalDiscoveryUnavailable {
             let controlledIDsBeforeTraversal = controlledGlobalSessionIDs
             var discoveredSessionIDs: Set<SessionID> = []
-            var reachedTraversalEnd = true
+            // 撤权按 runtime 独立结算：Claude bridge 未启用或不健康是常态，
+            // 不能因为它那趟没走完，就让已经完整遍历的 Codex 永远撤不掉
+            // 已删除的会话（反之亦然）。
+            var discoveredByRuntime: [String: Set<SessionID>] = [:]
+            var completedRuntimes: Set<String> = []
             for runtimeProvider in ["codex", "claude"] {
                 var cursor: String?
                 var runtimeReachedEnd = false
@@ -1678,6 +1682,7 @@ extension SessionStore {
                         recordCarStatusHostObservation(at: sessionListNow())
                         let pageSessionIDs = Set(page.sessions.map(\.id))
                         discoveredSessionIDs.formUnion(pageSessionIDs)
+                        discoveredByRuntime[runtimeProvider, default: []].formUnion(pageSessionIDs)
                         // 先发布授权 ID 再合并 Session；这样首次发现的外部 Worktree 在同一轮
                         // sessions 更新里即可进入根侧栏补充集，不依赖后续精确 cwd 刷新。
                         let expandedControlledIDs = controlledGlobalSessionIDs.union(pageSessionIDs)
@@ -1719,15 +1724,30 @@ extension SessionStore {
                         break
                     }
                 }
-                reachedTraversalEnd = reachedTraversalEnd && runtimeReachedEnd
+                if runtimeReachedEnd {
+                    completedRuntimes.insert(runtimeProvider)
+                }
             }
             guard appStore.activeHostScope == hostScope,
                   appStore.connectionGeneration == generation,
                   !Task.isCancelled else { return }
-            if reachedTraversalEnd {
+            if !completedRuntimes.isEmpty {
                 // 完整遍历是删除旧授权 ID 的唯一证据；分页上限、重复 cursor 或错误时
                 // 只合并本次已见项，避免把尚未扫到的外部 Worktree 从列表误删。
-                let revokedSessionIDs = controlledIDsBeforeTraversal.subtracting(discoveredSessionIDs)
+                //
+                // 归属未知的旧 ID（会话已不在 store 里，无从判断 runtime）保守保留：
+                // 宁可多留一条，也不要因为归属判断不了而误删别的 runtime 的会话。
+                let runtimeBySessionID = Dictionary(
+                    sessions.map { ($0.id, Self.normalizedRuntimeProvider($0.runtimeProvider)) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                let revokedSessionIDs = controlledIDsBeforeTraversal.filter { sessionID in
+                    guard let runtime = runtimeBySessionID[sessionID],
+                          completedRuntimes.contains(runtime) else {
+                        return false
+                    }
+                    return !(discoveredByRuntime[runtime]?.contains(sessionID) ?? false)
+                }
                 if !revokedSessionIDs.isEmpty {
                     let retainedSessions = sessions.filter { !revokedSessionIDs.contains($0.id) }
                     if retainedSessions != sessions {
@@ -1747,8 +1767,11 @@ extension SessionStore {
                         remoteSessionSearchSnippetByID.removeValue(forKey: sessionID)
                     }
                 }
-                if controlledGlobalSessionIDs != discoveredSessionIDs {
-                    controlledGlobalSessionIDs = discoveredSessionIDs
+                let retainedFromUnsettledRuntimes = controlledIDsBeforeTraversal
+                    .subtracting(revokedSessionIDs)
+                let settledIDs = discoveredSessionIDs.union(retainedFromUnsettledRuntimes)
+                if controlledGlobalSessionIDs != settledIDs {
+                    controlledGlobalSessionIDs = settledIDs
                 }
             } else {
                 let expandedControlledIDs = controlledGlobalSessionIDs.union(discoveredSessionIDs)

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -1650,61 +1650,76 @@ extension SessionStore {
             return
         }
 
-        // 先用最多 4 页、每页 50 条的有界全局发现补齐 Codex 外部 Worktree。
+        // 先用最多 4 页、每页 50 条的有界全局发现补齐外部 Worktree。
         // agentd 返回的每一项都已经过项目、browse_root 与 git common-dir 裁剪；
         // iOS 只消费 opaque cursor，不接触上游全局 cursor。
+        //
+        // 两条 runtime 各跑一趟独立遍历：cursor 流互不交织，结果并进同一份
+        // discoveredSessionIDs 由 canonical sessions 统一归并，因此不需要跨 Runtime
+        // 的排序状态机。撤权只在**两趟都完整走完**时才允许——否则 Codex 那趟会把
+        // Claude 刚发现的会话当成"已不存在"删掉。
         if !controlledGlobalDiscoveryUnavailable {
             let controlledIDsBeforeTraversal = controlledGlobalSessionIDs
-            var cursor: String?
             var discoveredSessionIDs: Set<SessionID> = []
-            var reachedTraversalEnd = false
-            for pageIndex in 0..<4 {
-                guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
-                let hostRequestStartedAt = sessionListNow()
-                do {
-                    let page = try await client.controlledGlobalSessionsPage(cursor: cursor, limit: 50)
-                    guard appStore.connectionGeneration == generation else { return }
-                    recordCarStatusHostObservation(at: sessionListNow())
-                    let pageSessionIDs = Set(page.sessions.map(\.id))
-                    discoveredSessionIDs.formUnion(pageSessionIDs)
-                    // 先发布授权 ID 再合并 Session；这样首次发现的外部 Worktree 在同一轮
-                    // sessions 更新里即可进入根侧栏补充集，不依赖后续精确 cwd 刷新。
-                    let expandedControlledIDs = controlledGlobalSessionIDs.union(pageSessionIDs)
-                    if expandedControlledIDs != controlledGlobalSessionIDs {
-                        controlledGlobalSessionIDs = expandedControlledIDs
-                    }
-                    // 全局发现只携带根项目归属；进入 canonical sessions 前先沿用 Store
-                    // 已知的 workspace identity（已有同 ID 会话或 dir 命中 recent workspace）。
-                    // 否则同一 session.id 的全局响应会把稳定的 workspace projectID 覆盖回
-                    // root projectID，导致侧栏分组和会话头像命名空间在两种身份之间来回跳变。
-                    // 未命中的外部 worktree 仍返回原始 session，保留既有受控发现行为。
-                    mergeSessionPage(page.sessions.map(alignSessionToKnownWorkspace))
-                    guard page.hasMore,
-                          let nextCursor = page.nextCursor,
-                          nextCursor != cursor else {
-                        reachedTraversalEnd = !page.hasMore
+            var reachedTraversalEnd = true
+            for runtimeProvider in ["codex", "claude"] {
+                var cursor: String?
+                var runtimeReachedEnd = false
+                for pageIndex in 0..<4 {
+                    guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
+                    let hostRequestStartedAt = sessionListNow()
+                    do {
+                        let page = try await client.controlledGlobalSessionsPage(
+                            runtimeProvider: runtimeProvider,
+                            cursor: cursor,
+                            limit: 50
+                        )
+                        guard appStore.connectionGeneration == generation else { return }
+                        recordCarStatusHostObservation(at: sessionListNow())
+                        let pageSessionIDs = Set(page.sessions.map(\.id))
+                        discoveredSessionIDs.formUnion(pageSessionIDs)
+                        // 先发布授权 ID 再合并 Session；这样首次发现的外部 Worktree 在同一轮
+                        // sessions 更新里即可进入根侧栏补充集，不依赖后续精确 cwd 刷新。
+                        let expandedControlledIDs = controlledGlobalSessionIDs.union(pageSessionIDs)
+                        if expandedControlledIDs != controlledGlobalSessionIDs {
+                            controlledGlobalSessionIDs = expandedControlledIDs
+                        }
+                        // 全局发现只携带根项目归属；进入 canonical sessions 前先沿用 Store
+                        // 已知的 workspace identity（已有同 ID 会话或 dir 命中 recent workspace）。
+                        // 否则同一 session.id 的全局响应会把稳定的 workspace projectID 覆盖回
+                        // root projectID，导致侧栏分组和会话头像命名空间在两种身份之间来回跳变。
+                        // 未命中的外部 worktree 仍返回原始 session，保留既有受控发现行为。
+                        mergeSessionPage(page.sessions.map(alignSessionToKnownWorkspace))
+                        guard page.hasMore,
+                              let nextCursor = page.nextCursor,
+                              nextCursor != cursor else {
+                            runtimeReachedEnd = !page.hasMore
+                            break
+                        }
+                        cursor = nextCursor
+                    } catch {
+                        guard appStore.activeHostScope == hostScope,
+                              appStore.connectionGeneration == generation,
+                              !Task.isCancelled else {
+                            // Host 已切换或任务已取消：旧 Host 的迟到错误不得污染新 Host 证据。
+                            return
+                        }
+                        // 只有 Codex 报不可用才整体停掉受控发现：Claude bridge 未启用或
+                        // 不健康是常态，不能因此让 Codex 的外部 Worktree 也发现不到。
+                        if pageIndex == 0, runtimeProvider == "codex", isControlledGlobalDiscoveryUnavailable(error) {
+                            controlledGlobalDiscoveryUnavailable = true
+                        }
+                        if !isCancellationError(error) {
+                            if Self.carStatusHostDidRespond(to: error) {
+                                recordCarStatusHostObservation(at: sessionListNow())
+                            } else {
+                                invalidateCarStatusHostObservation(ifNotNewerThan: hostRequestStartedAt)
+                            }
+                        }
                         break
                     }
-                    cursor = nextCursor
-                } catch {
-                    guard appStore.activeHostScope == hostScope,
-                          appStore.connectionGeneration == generation,
-                          !Task.isCancelled else {
-                        // Host 已切换或任务已取消：旧 Host 的迟到错误不得污染新 Host 证据。
-                        return
-                    }
-                    if pageIndex == 0, isControlledGlobalDiscoveryUnavailable(error) {
-                        controlledGlobalDiscoveryUnavailable = true
-                    }
-                    if !isCancellationError(error) {
-                        if Self.carStatusHostDidRespond(to: error) {
-                            recordCarStatusHostObservation(at: sessionListNow())
-                        } else {
-                            invalidateCarStatusHostObservation(ifNotNewerThan: hostRequestStartedAt)
-                        }
-                    }
-                    break
                 }
+                reachedTraversalEnd = reachedTraversalEnd && runtimeReachedEnd
             }
             guard appStore.activeHostScope == hostScope,
                   appStore.connectionGeneration == generation,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -520,6 +520,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     let rateLimitsByRuntime: [String: RateLimitSummary]
     let rateLimitHandler: ((String) async throws -> RateLimitSummary?)?
     let controlledGlobalSessionsHandler: ((String?, Int?) async throws -> SessionsPage)?
+    let controlledGlobalSessionsByRuntimeHandler: ((String, String?, Int?) async throws -> SessionsPage)?
     let accountTokenUsageHandler: (() async throws -> AccountTokenUsageSnapshot?)?
     /// 需要区分 unsupported / failed 时用这个；它优先于 snapshot 便捷 handler。
     let accountTokenUsageFetchHandler: (() async throws -> AccountTokenUsageFetch)?
@@ -550,6 +551,10 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         requestLogLock.withLock { requestedControlledGlobalCursorsStorage }
     }
     private var requestedControlledGlobalCursorsStorage: [String?] = []
+    var requestedControlledGlobalRuntimes: [String] {
+        requestLogLock.withLock { requestedControlledGlobalRuntimesStorage }
+    }
+    private var requestedControlledGlobalRuntimesStorage: [String] = []
     var requestedCapabilityPaths: [String?] = []
     var requestedCapabilityForceReloads: [Bool] = []
     var requestedResolvePaths: [String] = []
@@ -643,6 +648,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         rateLimitsByRuntime: [String: RateLimitSummary] = [:],
         rateLimitHandler: ((String) async throws -> RateLimitSummary?)? = nil,
         controlledGlobalSessionsHandler: ((String?, Int?) async throws -> SessionsPage)? = nil,
+        controlledGlobalSessionsByRuntimeHandler: ((String, String?, Int?) async throws -> SessionsPage)? = nil,
         accountTokenUsageHandler: (() async throws -> AccountTokenUsageSnapshot?)? = nil,
         accountTokenUsageFetchHandler: (() async throws -> AccountTokenUsageFetch)? = nil,
         threadSearchHandler: ((String, String?, Int?) async throws -> ThreadSearchPage)? = nil,
@@ -703,6 +709,7 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
         self.rateLimitsByRuntime = rateLimitsByRuntime
         self.rateLimitHandler = rateLimitHandler
         self.controlledGlobalSessionsHandler = controlledGlobalSessionsHandler
+        self.controlledGlobalSessionsByRuntimeHandler = controlledGlobalSessionsByRuntimeHandler
         self.accountTokenUsageHandler = accountTokenUsageHandler
         self.accountTokenUsageFetchHandler = accountTokenUsageFetchHandler
         self.threadSearchHandler = threadSearchHandler
@@ -1071,10 +1078,27 @@ final class MockSessionStoreClient: SessionStoreAPIClient {
     }
 
     func controlledGlobalSessionsPage(cursor: String?, limit: Int?) async throws -> SessionsPage {
+        try await controlledGlobalSessionsPage(runtimeProvider: "codex", cursor: cursor, limit: limit)
+    }
+
+    /// 受控全局发现现在按 runtime 各跑一趟。默认只有 codex 走既有 handler，
+    /// claude 返回空页，这样只关心 Codex 的既有用例语义保持不变；需要断言双
+    /// runtime 行为的用例传 controlledGlobalSessionsByRuntimeHandler。
+    func controlledGlobalSessionsPage(
+        runtimeProvider: String,
+        cursor: String?,
+        limit: Int?
+    ) async throws -> SessionsPage {
         requestLogLock.withLock {
-            requestedControlledGlobalCursorsStorage.append(cursor)
+            requestedControlledGlobalRuntimesStorage.append(runtimeProvider)
+            if runtimeProvider == "codex" {
+                requestedControlledGlobalCursorsStorage.append(cursor)
+            }
         }
-        guard let controlledGlobalSessionsHandler else {
+        if let controlledGlobalSessionsByRuntimeHandler {
+            return try await controlledGlobalSessionsByRuntimeHandler(runtimeProvider, cursor, limit)
+        }
+        guard runtimeProvider == "codex", let controlledGlobalSessionsHandler else {
             return SessionsPage(sessions: [])
         }
         return try await controlledGlobalSessionsHandler(cursor, limit)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeTests.swift
@@ -2544,3 +2544,129 @@ extension ConversationDataFlowTests {
     }
 
 }
+
+// MARK: - MIM-246 全局搜索按 runtime 分头请求
+
+extension ConversationDataFlowTests {
+    private func makeSearchRoutingClient() -> (
+        client: CodexAppServerRuntimeRoutingSessionAPIClient,
+        codexTransport: FakeCodexAppServerTransport,
+        claudeTransport: FakeCodexAppServerTransport
+    ) {
+        let project = AgentProject(id: "proj_search", name: "Search", path: "/tmp/search")
+        let config = makeDirectAppServerConfig(
+            project: project,
+            allowedMethods: ["initialize", "initialized", "thread/list", "thread/search"],
+            channels: [makeClaudeChannelMetadata()]
+        )
+        let codexTransport = FakeCodexAppServerTransport()
+        let claudeTransport = FakeCodexAppServerTransport()
+        let codex = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787", token: "t",
+            runtimeProvider: "codex",
+            transportFactory: { codexTransport },
+            configProvider: { config }
+        )
+        let claude = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787", token: "t",
+            runtimeProvider: "claude",
+            transportFactory: { claudeTransport },
+            configProvider: { config }
+        )
+        return (
+            CodexAppServerRuntimeRoutingSessionAPIClient(codexRuntime: codex, claudeRuntime: claude),
+            codexTransport,
+            claudeTransport
+        )
+    }
+
+    private func completeInitialize(_ transport: FakeCodexAppServerTransport) async throws {
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake","platformFamily":"macos"}"#
+        )
+    }
+
+    /// 首页搜索必须同时命中两条 runtime：Claude 没有 thread/search，走 thread/list
+    /// + searchTerm。回归前 searchSessions 硬编码只查 Codex，Claude 会话搜不到。
+    func testGlobalSearchFirstPageMergesClaudeResultsBehindCodex() async throws {
+        let (client, codexTransport, claudeTransport) = makeSearchRoutingClient()
+
+        let searchTask = Task { try await client.searchSessions(query: "游标", cursor: nil, limit: 50) }
+
+        try await completeInitialize(codexTransport)
+        let search = try await waitForFakeAppServerRequest(codexTransport, method: "thread/search", after: 1)
+        transportResponse(
+            codexTransport,
+            id: search.id,
+            result: #"{"data":[{"thread":{"id":"codex-hit","cwd":"/tmp/search"},"snippet":"codex 片段"}],"nextCursor":"codex_more"}"#
+        )
+
+        try await completeInitialize(claudeTransport)
+        let list = try await waitForFakeAppServerRequest(claudeTransport, method: "thread/list", after: 1)
+        XCTAssertEqual(
+            list.params?.objectValue?["searchTerm"]?.stringValue,
+            "游标",
+            "Claude 搜索必须把关键词放进 thread/list 的 searchTerm"
+        )
+        XCTAssertNil(
+            list.params?.objectValue?["cwd"],
+            "全局搜索不带 cwd，否则又退回逐目录检索"
+        )
+        transportResponse(
+            claudeTransport,
+            id: list.id,
+            result: #"{"data":[{"id":"claude-hit","cwd":"/tmp/search","preview":"claude 预览"}]}"#
+        )
+
+        let page = try await searchTask.value
+        XCTAssertEqual(
+            page.results.map(\.session.id),
+            ["codex-hit", "claude-hit"],
+            "Codex 结果在前，Claude 结果拼在后面"
+        )
+        XCTAssertEqual(page.results.last?.snippet, "claude 预览", "无命中片段时用会话 preview 兜底")
+        XCTAssertEqual(
+            page.nextCursor,
+            "codex_more",
+            "翻页游标只来自 Codex，不引入跨 Runtime 的复合游标"
+        )
+    }
+
+    /// 翻页只推进 Codex：带 cursor 时不得再打扰 Claude。
+    func testGlobalSearchPaginationDoesNotQueryClaude() async throws {
+        let (client, codexTransport, claudeTransport) = makeSearchRoutingClient()
+
+        let searchTask = Task { try await client.searchSessions(query: "游标", cursor: "codex_more", limit: 50) }
+        try await completeInitialize(codexTransport)
+        let search = try await waitForFakeAppServerRequest(codexTransport, method: "thread/search", after: 1)
+        transportResponse(codexTransport, id: search.id, result: #"{"data":[]}"#)
+
+        _ = try await searchTask.value
+        let claudeMessages = await claudeTransport.sentMessages()
+        XCTAssertTrue(claudeMessages.isEmpty, "翻页阶段不应向 Claude 发任何请求")
+    }
+
+    /// Claude 搜索是增强项：bridge 不可用时不能连带让 Codex 搜索失败。
+    func testGlobalSearchKeepsCodexResultsWhenClaudeFails() async throws {
+        let (client, codexTransport, claudeTransport) = makeSearchRoutingClient()
+
+        let searchTask = Task { try await client.searchSessions(query: "游标", cursor: nil, limit: 50) }
+        try await completeInitialize(codexTransport)
+        let search = try await waitForFakeAppServerRequest(codexTransport, method: "thread/search", after: 1)
+        transportResponse(
+            codexTransport,
+            id: search.id,
+            result: #"{"data":[{"thread":{"id":"codex-hit","cwd":"/tmp/search"},"snippet":"codex 片段"}]}"#
+        )
+
+        try await completeInitialize(claudeTransport)
+        let list = try await waitForFakeAppServerRequest(claudeTransport, method: "thread/list", after: 1)
+        transportErrorResponse(claudeTransport, id: list.id, code: -32000, message: "claude bridge unavailable")
+
+        let page = try await searchTask.value
+        XCTAssertEqual(page.results.map(\.session.id), ["codex-hit"], "Claude 失败不得清空 Codex 结果")
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -295,6 +295,64 @@ extension ConversationDataFlowTests {
         )
     }
 
+    /// MIM-248 评审提出的 P2：撤权必须按 runtime 独立结算。
+    /// Claude bridge 未启用或不健康是常态，若因此卡住 Codex 的撤权，
+    /// 已删除的 Codex 会话会永远留在列表里。
+    func testControlledGlobalDiscoveryRevokesCodexEvenWhenClaudeTraversalFails() async {
+        let project = makeProject(id: "proj_revoke")
+        let staleCodex = makeSession(
+            id: "codex-stale",
+            projectID: project.id,
+            title: "已删除的 Codex 会话",
+            status: "history",
+            source: "codex",
+            resumeID: "codex-stale"
+        )
+        let liveCodex = makeSession(
+            id: "codex-live",
+            projectID: project.id,
+            title: "仍在的 Codex 会话",
+            status: "history",
+            source: "codex",
+            resumeID: "codex-live"
+        )
+        var claudeShouldFail = false
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            controlledGlobalSessionsByRuntimeHandler: { runtimeProvider, _, _ in
+                switch runtimeProvider {
+                case "codex":
+                    return SessionsPage(sessions: claudeShouldFail ? [liveCodex] : [staleCodex, liveCodex])
+                default:
+                    if claudeShouldFail {
+                        throw MockError.unimplemented
+                    }
+                    return SessionsPage(sessions: [])
+                }
+            }
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        await store.refreshSessionLibraryIndex(authoritative: true)
+        XCTAssertTrue(store.sessions.contains { $0.id == "codex-stale" }, "首轮应发现两条 Codex 会话")
+
+        // 第二轮：Codex 完整遍历且不再返回 codex-stale，Claude 那趟失败。
+        claudeShouldFail = true
+        await store.refreshSessionLibraryIndex(authoritative: true)
+
+        XCTAssertFalse(
+            store.sessions.contains { $0.id == "codex-stale" },
+            "Codex 完整遍历后必须撤销已消失的会话，不能被 Claude 的失败卡住"
+        )
+        XCTAssertTrue(store.sessions.contains { $0.id == "codex-live" }, "仍被发现的会话必须保留")
+    }
+
     func testControlledGlobalDerivedReadOnlySessionsReceiveBoundedStableRecentHistoryVisibility() async {
         let project = makeProject(id: "proj_derived_visibility")
         var newestStructuralChild = makeSession(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationSessionStoreTests.swift
@@ -197,6 +197,104 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(store.sessions.allSatisfy { !$0.allowsDirectInput })
     }
 
+    /// MIM-246：受控全局发现必须对 Codex 与 Claude 各跑一趟独立遍历。
+    /// 回归前 Claude 那趟根本不发，Claude 会话在「会话」tab 完全不出现。
+    func testControlledGlobalDiscoveryTraversesBothRuntimesAndMergesSessions() async {
+        let project = makeProject(id: "proj_dual")
+        let codexSession = makeSession(
+            id: "codex-global",
+            projectID: project.id,
+            title: "Codex 会话",
+            status: "history",
+            source: "codex",
+            resumeID: "codex-global"
+        )
+        let claudeSession = makeSession(
+            id: "claude-global",
+            projectID: project.id,
+            title: "Claude 会话",
+            status: "history",
+            source: "claude",
+            resumeID: "claude-global"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            controlledGlobalSessionsByRuntimeHandler: { runtimeProvider, cursor, limit in
+                XCTAssertEqual(limit, 50)
+                XCTAssertNil(cursor, "两条 runtime 的游标流互不交织，各自从头开始")
+                switch runtimeProvider {
+                case "codex":
+                    return SessionsPage(sessions: [codexSession])
+                case "claude":
+                    return SessionsPage(sessions: [claudeSession])
+                default:
+                    XCTFail("不应请求未知 runtime：\(runtimeProvider)")
+                    return SessionsPage(sessions: [])
+                }
+            }
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        await store.refreshSessionLibraryIndex(authoritative: true)
+
+        XCTAssertEqual(
+            client.requestedControlledGlobalRuntimes,
+            ["codex", "claude"],
+            "两条 runtime 都要遍历，且顺序稳定"
+        )
+        XCTAssertEqual(
+            Set(store.sessions.map(\.id)),
+            ["codex-global", "claude-global"],
+            "两趟结果并进同一份 canonical sessions"
+        )
+    }
+
+    /// 撤权只在两趟都完整走完时才允许。否则先跑的 Codex 那趟会把 Claude 刚发现的
+    /// 会话当成「已不存在」删掉 —— 这是加第二条 runtime 时最容易引入的回归。
+    func testControlledGlobalDiscoveryKeepsSessionsWhenOneRuntimeTraversalIsIncomplete() async {
+        let project = makeProject(id: "proj_partial")
+        let claudeSession = makeSession(
+            id: "claude-partial",
+            projectID: project.id,
+            title: "Claude 会话",
+            status: "history",
+            source: "claude",
+            resumeID: "claude-partial"
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            controlledGlobalSessionsByRuntimeHandler: { runtimeProvider, _, _ in
+                switch runtimeProvider {
+                case "codex":
+                    // Codex 这趟没走到底（还有下一页），因此本轮不具备撤权证据。
+                    return SessionsPage(sessions: [], nextCursor: "codex_more", hasMore: true)
+                default:
+                    return SessionsPage(sessions: [claudeSession])
+                }
+            }
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+
+        await store.refreshSessionLibraryIndex(authoritative: true)
+
+        XCTAssertTrue(
+            store.sessions.contains { $0.id == "claude-partial" },
+            "Codex 遍历未走完时不得撤销 Claude 发现的会话"
+        )
+    }
+
     func testControlledGlobalDerivedReadOnlySessionsReceiveBoundedStableRecentHistoryVisibility() async {
         let project = makeProject(id: "proj_derived_visibility")
         var newestStructuralChild = makeSession(


### PR DESCRIPTION
Claude 会话此前**在「会话」标签页里一个都不出现**，只能进工作区一个目录一个目录翻；搜索也搜不到。同时 MIM-222 给 Codex 加的下行授权门禁一直没覆盖 Claude，两条链路的授权是不对称的。放开可见性和补齐授权必须同期落地，否则等于先扩大暴露面再补门。

## MIM-246 可见 + 可搜索

**gateway**
- `thread/list` 去掉「非 codex runtime 必须带 cwd」的限制。受控全局发现只依赖 `cwd → 项目 / browse-root / git common-dir` 的映射（见 `sanitizeThreadListResponse`），与 runtime 无关；Claude 的 thread 载荷同样带 `cwd` 与 `gitInfo`，裁剪逻辑逐字适用。此前限定 codex 是保守起见。
- 对 Claude 放行 `thread/list.searchTerm`（bridge 早已支持，此前被参数白名单剥掉），并按 `thread/search` 的同一上限校验。Codex 有独立的 `thread/search`，不放行，以免同一能力出现两条语义不同的入口。

**iOS 全局发现**
按 runtime 各跑一趟独立遍历：两条 opaque cursor 流互不交织，结果并进同一份 canonical sessions 由既有归并逻辑处理，因此**不需要跨 Runtime 排序状态机**（正是 facade 注释想避免的东西）。

两处容易引入回归的地方特意处理：

- **撤权**（删除不再被发现的会话）依赖「完整遍历」这一证据。沿用原写法的话，先跑的 Codex 那趟会把 Claude 刚发现的会话当成已不存在删掉。现在两趟都走完才允许撤权，并有用例锁定。
- `controlledGlobalDiscoveryUnavailable` 只由 Codex 触发。Claude bridge 未启用或不健康是常态，不能因此把 Codex 的外部 Worktree 发现也一起停掉。

**iOS 搜索**
Claude 没有 `thread/search`，改走 `thread/list` + `searchTerm`。首页同时查两条 runtime 并按 id 去重后拼接，**翻页只推进 Codex**。

代价明确写在代码注释里：Claude 的搜索结果限于首页 limit 条。搜索场景下用户通常继续收窄关键词而不是翻页；真出现「Claude 结果翻不动」再升级为按 runtime 分段。选这个方案是为了不把两条游标流编成复合 cursor。

Claude 搜索是增强项：bridge 不可用时静默跳过，不得连带让 Codex 搜索失败。bridge 的 `thread/list` 不返回命中片段，用会话 preview 兜底当 snippet；为空时上层本就会跳过片段行。

## MIM-248 下行授权对等

- 把 MIM-222 只给 Codex 做的「下行通知与反向请求必须属于已授权 thread」门禁扩到 Claude。helper 相应从 `codex*` 改名为 `inbound*`。
- 门禁范围限定 **codex + claude**。未知 runtime 保持既有透传语义 —— 那是被 `unknown-runtime-passthrough` 用例显式锁定的独立产品决定，不应由本 PR 顺手改变。
- **`serverRequest/replay` 按条目裁剪**，而不是整帧放行或整帧丢弃。它顶层没有 `threadId`（threadId 在 `outstanding` 各条目里），且是 Claude 重连恢复挂起审批与补充信息卡的唯一通道：整帧丢会让用户重连后永远等不到那张卡，整帧放行会泄露未授权 thread 的挂起请求。

顺带修正一处既有浪费：`account/chatgptAuthTokens/refresh` 这类客户端渲染不了的重放条目，旧代码不登记但仍原样转发，现在一并剥掉。

## 测试

**Go** — 新增 Claude 专属门禁用例（独立 fixture，不与 Codex 共用）：thread 通知授权、反向请求授权且被丢弃者不登记 pending、Claude 实际会发的全局通知放行而未登记的丢弃、replay 按条目裁剪且保留项仍可回答。3 处既有 Claude fixture 补上 thread 授权（还原生产条件：用户交互的 thread 必经 `thread/start` / `thread/resume` 授权）。replay 用例断言从「逐字节原样转发」改为「保留已授权、剥离未授权」，反映新的下发边界。

**iOS** — 5 个新用例：双 runtime 都被遍历且结果合并；某一趟未走完时不得撤销另一趟发现的会话；搜索首页合并且游标只来自 Codex（并断言请求带 `searchTerm`、不带 `cwd`）；翻页不向 Claude 发任何请求；Claude 失败不清空 Codex 结果。

`go test ./internal/httpapi/... ./internal/appserver/...` 全绿；iOS 全量 **1567 项 / 17 失败 / 0 unexpected**，失败集合与 `origin/main` 基线**逐条一致**（既有快照与两条历史用例），无新增回归；`scripts/check-source-size.sh` 通过。

## 尚未完成

真机验收未做：需要重启 agentd 让 gateway 改动生效，并把 App 装到真机，确认跨项目的 Claude 会话确实出现在「会话」tab、搜索能命中。单测覆盖了合并与撤权语义，但「用户真的看见了」这条只能在设备上确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
