### PR TITLE
MIM-265 不再把 Claude 的完整历史谎报为「内容未加载」

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		74C33F1F00402E08A331ABBF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 11B71BA07C5D393BC0EA9FD4 /* PrivacyInfo.xcprivacy */; };
 		756EEE669429D13559D42B29 /* SessionStoreWriterConflictFork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56D1548EFFC65F793C18F9F /* SessionStoreWriterConflictFork.swift */; };
 		759158BB4175D405D74CD30A /* ConversationDirectRuntimeHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */; };
+		D265A001D265A001D265A001 /* ConversationClaudeHistoryItemsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D265A002D265A002D265A002 /* ConversationClaudeHistoryItemsViewTests.swift */; };
 		76170D1C6A062582FBB87B0B /* MimiCarStatusWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 29E380F56E6FE63E8C13897A /* MimiCarStatusWidget.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		76CE769D2951CF9CEBE6B3FF /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-pro-1366-dark-contrast.png in Resources */ = {isa = PBXBuildFile; fileRef = 62EF5C12067114B2EBC4FE68 /* testSessionLibraryDensityAndAccessibilityLayouts.ipad-pro-1366-dark-contrast.png */; };
 		76DD6A7B8D4D93D4385A615D /* AssistantTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA631A94730FC521FE15F6 /* AssistantTextNormalizer.swift */; };
@@ -475,6 +476,7 @@
 		3AB921BC2A9B03335E3C8171 /* AppStoreCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCapabilities.swift; sourceTree = "<group>"; };
 		3CF761429383D479BD96FC52 /* AgentAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAPIClient.swift; sourceTree = "<group>"; };
 		3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeHistoryTests.swift; sourceTree = "<group>"; };
+		D265A002D265A002D265A002 /* ConversationClaudeHistoryItemsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationClaudeHistoryItemsViewTests.swift; sourceTree = "<group>"; };
 		3DA20088DF3CC377CBB6D7B4 /* HostConnectionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConnectionSupport.swift; sourceTree = "<group>"; };
 		3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreSupport.swift; sourceTree = "<group>"; };
 		3E5219F30FB1F37F4EE868FF /* SessionListPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListPresentationTests.swift; sourceTree = "<group>"; };
@@ -917,6 +919,7 @@
 				315746F97ABB8E16D93F98A4 /* ConversationDataFlowTests.swift */,
 				078AEE7E4BDAC1751244A05A /* ConversationDataFlowTestSupport.swift */,
 				3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */,
+				D265A002D265A002D265A002 /* ConversationClaudeHistoryItemsViewTests.swift */,
 				C0FE3675988DBD54585B3A79 /* ConversationDirectRuntimeSubscriptionTests.swift */,
 				025CFFED953120CE5B667800 /* ConversationDirectRuntimeTests.swift */,
 				3987365BB15E85F513EB187D /* ConversationGuidanceFallbackTests.swift */,
@@ -1762,6 +1765,7 @@
 				467ED9D49A463D5F5AF02A3C /* ConversationDataFlowTestSupport.swift in Sources */,
 				10BF43237408412ED651F5B4 /* ConversationDataFlowTests.swift in Sources */,
 				759158BB4175D405D74CD30A /* ConversationDirectRuntimeHistoryTests.swift in Sources */,
+				D265A001D265A001D265A001 /* ConversationClaudeHistoryItemsViewTests.swift in Sources */,
 				BA0F184AA3E72EE6A5A291B5 /* ConversationDirectRuntimeSubscriptionTests.swift in Sources */,
 				E790247242197F065BB1F1DE /* ConversationDirectRuntimeTests.swift in Sources */,
 				699762120516E7B19DB681E9 /* ConversationGuidanceFallbackTests.swift in Sources */,

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1108,12 +1108,11 @@ actor CodexAppServerSessionRuntime {
         recoveringInterruptedTurnID: TurnID? = nil
     ) async throws -> HistoryMessagesPage {
         let config = try await ensureConfig()
-        let hasTurnsList = config.policy.allowedMethods.contains("thread/turns/list")
-        let hasRequiredItemsList = loadMode == .economy
-            || config.policy.allowedMethods.contains("thread/items/list")
-        guard hasTurnsList, hasRequiredItemsList else {
-            let method = hasTurnsList ? "thread/items/list" : "thread/turns/list"
-            throw CodexAppServerSessionRuntimeError.paginatedHistoryUnavailable(method)
+        // 首屏只依赖 thread/turns/list。能不能逐 Turn 补 Item 由每个 Turn 自己的 itemsView
+        // 决定（见 messagesPageFromTurnPages）：已经带回完整 items 的 runtime 无需补齐，
+        // 不能因为缺少 thread/items/list 就把整个 full 首屏判死。
+        guard config.policy.allowedMethods.contains("thread/turns/list") else {
+            throw CodexAppServerSessionRuntimeError.paginatedHistoryUnavailable("thread/turns/list")
         }
         return try await messagesPageFromTurnPages(
             sessionID: sessionID,
@@ -1121,6 +1120,7 @@ actor CodexAppServerSessionRuntime {
             limit: limit,
             loadMode: loadMode,
             projects: config.projects,
+            canHydrateTurnItems: runtimeSupportsMethod("thread/items/list", in: config),
             recoveringInterruptedTurnID: recoveringInterruptedTurnID
         )
     }
@@ -1129,8 +1129,7 @@ actor CodexAppServerSessionRuntime {
     /// legacy 路径的 limit 是 message 数，不具备“完整一个 turn”的增量合并语义。
     func latestTurnHistoryPage(sessionID: SessionID) async throws -> HistoryMessagesPage? {
         let config = try await ensureConfig()
-        guard config.policy.allowedMethods.contains("thread/turns/list"),
-              config.policy.allowedMethods.contains("thread/items/list") else {
+        guard config.policy.allowedMethods.contains("thread/turns/list") else {
             throw CodexAppServerSessionRuntimeError.paginatedHistoryUnavailable("thread/turns/list")
         }
         return try await messagesPageFromTurnPages(
@@ -1139,6 +1138,7 @@ actor CodexAppServerSessionRuntime {
             limit: 1,
             loadMode: .full,
             projects: config.projects,
+            canHydrateTurnItems: runtimeSupportsMethod("thread/items/list", in: config),
             recoveringInterruptedTurnID: nil
         )
     }
@@ -1149,6 +1149,7 @@ actor CodexAppServerSessionRuntime {
         limit: Int?,
         loadMode: HistoryMessagesPage.LoadMode,
         projects: [AgentProject],
+        canHydrateTurnItems: Bool,
         recoveringInterruptedTurnID: TurnID?
     ) async throws -> HistoryMessagesPage {
         let builder = CodexAppServerRequestBuilder(allowlistedProjects: projects)
@@ -1226,9 +1227,16 @@ actor CodexAppServerSessionRuntime {
             )
         }
         let nextCursor = reachedInheritedBoundary ? nil : upstreamNextCursor
-        let itemContinuations = loadMode == .full
+        // 只给"确实还缺 Item"的 Turn 排补齐任务。summary 请求下有的 runtime（Claude bridge）
+        // 会忽略 itemsView 直接回完整 items 并标 itemsView=full，这类 Turn 再去发
+        // thread/items/list 只会被 gateway 按 runtime 白名单打回，把一次成功的首屏
+        // 误判成"内容未加载"。runtime 根本不支持 items/list 时同样不排任务。
+        let itemContinuations = loadMode == .full && canHydrateTurnItems
             ? chronologicalTurns.enumerated().compactMap { turnIndex, turn -> HistoryTurnItemsContinuation? in
                 guard let turnID = turn["id"]?.stringValue, !turnID.isEmpty else {
+                    return nil
+                }
+                guard Self.historyTurnNeedsItemHydration(turn) else {
                     return nil
                 }
                 var turnShell = turn
@@ -1247,13 +1255,23 @@ actor CodexAppServerSessionRuntime {
                 )
             }
             : []
+        // full 页需要补齐、但这个 runtime 没有 items/list 可用时内容确实不完整，必须如实提示，
+        // 不能沉默地把半截历史当成完整快照。
+        let hasUnhydratableTurnItems = loadMode == .full
+            && !canHydrateTurnItems
+            && chronologicalTurns.contains(where: Self.historyTurnNeedsItemHydration)
         return HistoryMessagesPage(
             messages: messages,
             previousCursor: nextCursor.map(Self.encodeThreadTurnsCursor),
             hasMoreBefore: nextCursor != nil,
             context: context,
             loadMode: loadMode,
-            notice: Self.historyNotice(loadMode: loadMode, hasMoreBefore: nextCursor != nil, turns: chronologicalTurns),
+            notice: Self.historyNotice(
+                loadMode: loadMode,
+                hasMoreBefore: nextCursor != nil,
+                turns: chronologicalTurns,
+                hasUnhydratableTurnItems: hasUnhydratableTurnItems
+            ),
             authoritativeCompletedTurnItems: [:],
             itemContinuations: itemContinuations,
             latestForkableTurnID: Self.latestForkableTurnID(fromTurns: chronologicalTurns)
@@ -1265,7 +1283,7 @@ actor CodexAppServerSessionRuntime {
         continuation: HistoryTurnItemsContinuation
     ) async throws -> HistoryTurnItemsPage {
         let config = try await ensureConfig()
-        guard config.policy.allowedMethods.contains("thread/items/list") else {
+        guard runtimeSupportsMethod("thread/items/list", in: config) else {
             throw CodexAppServerSessionRuntimeError.paginatedHistoryUnavailable("thread/items/list")
         }
         let builder = CodexAppServerRequestBuilder(allowlistedProjects: config.projects)
@@ -1761,22 +1779,34 @@ actor CodexAppServerSessionRuntime {
         }.first
     }
 
+    /// itemsView=full（或 hasFullItems=true）表示该 Turn 的 items 已随本页完整返回，
+    /// 不需要再逐页补齐。字段缺失时按"需要补齐"处理，保持既有 Codex 行为不变。
+    static func historyTurnNeedsItemHydration(_ turn: [String: CodexAppServerJSONValue]) -> Bool {
+        if turn["hasFullItems"]?.boolValue == true || turn["has_full_items"]?.boolValue == true {
+            return false
+        }
+        let itemsView = turn["itemsView"]?.stringValue ?? turn["items_view"]?.stringValue
+        return itemsView != "full"
+    }
+
     static func historyNotice(
         loadMode: HistoryMessagesPage.LoadMode,
         hasMoreBefore: Bool,
-        turns: [[String: CodexAppServerJSONValue]]
+        turns: [[String: CodexAppServerJSONValue]],
+        hasUnhydratableTurnItems: Bool = false
     ) -> String? {
+        // full 页本该补齐 Item，但当前 runtime 没有 thread/items/list 可用：内容确实不完整，
+        // 这是省流提示唯一成立的 full 场景。
+        if hasUnhydratableTurnItems {
+            return economyHistoryNotice
+        }
         guard loadMode == .economy else {
             return nil
         }
-        // 后端 summary 视图表示 item 详情可按需再拉；没有显式字段时，大历史分页也按省流提示处理。
-        let hasLazyContentSignal = turns.contains { turn in
-            turn["itemsView"]?.stringValue == "summary"
-                || turn["items_view"]?.stringValue == "summary"
-                || turn["hasFullItems"]?.boolValue == false
-                || turn["has_full_items"]?.boolValue == false
-        }
-        guard hasMoreBefore || hasLazyContentSignal || !turns.isEmpty else {
+        // 后端 summary 视图表示 item 详情可按需再拉。没有这个信号、也没有更早分页时，
+        // 这一页就是完整的——不能仅仅因为"页面非空"就声称有内容未加载。
+        let hasLazyContentSignal = turns.contains(where: historyTurnNeedsItemHydration)
+        guard hasMoreBefore || hasLazyContentSignal else {
             return nil
         }
         return economyHistoryNotice
@@ -3137,6 +3167,17 @@ actor CodexAppServerSessionRuntime {
             Self.normalizedRuntimeProvider(channel.runtimeID ?? channel.id) == runtimeProvider ||
                 Self.normalizedRuntimeProvider(channel.provider) == runtimeProvider
         }
+    }
+
+    /// 方法可用性必须按 runtime 判定。顶层 policy.allowed_methods 永远是 Codex 的方法表，
+    /// 各渠道的真实能力只在自己的 channel.methods 里；照着顶层表发请求会被 gateway 的
+    /// 按 runtime 白名单直接打回（例如 Claude 没有 thread/items/list）。老 agentd 不返回
+    /// channels 或 methods 时回落到顶层表，保持既有行为。
+    func runtimeSupportsMethod(_ method: String, in config: CodexAppServerConfigResponse) -> Bool {
+        if let methods = runtimeGatewayChannel(in: config)?.methods {
+            return methods.contains(method)
+        }
+        return config.policy.allowedMethods.contains(method)
     }
 
     /// 上游在连接重建或线程卸载时可能发送 thread/closed 或 notLoaded。这里只清理当前

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -714,16 +714,25 @@ extension SessionStore {
         }
         updateHistoryPageState(sessionID: sessionID, page: result.page, preserveExistingCursorOnEmptyPage: true)
         historyLoadedSignatureBySessionID[sessionID] = job.sessionSignature
+        // full 页自带 notice 只有一种成因：本页 Turn 需要补 Item，而当前 runtime 没有
+        // thread/items/list。这时快照不完整，既不能标 .full 也不能清掉提示。
+        let pageReportsIncompleteItems = !(result.page.notice ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
         if job.loadMode == .economy {
             historyLoadedQualityBySessionID[sessionID] = .summary
-        } else if result.page.itemContinuations.isEmpty {
-            historyLoadedQualityBySessionID[sessionID] = .full
-        } else {
+        } else if !result.page.itemContinuations.isEmpty {
             historyLoadedQualityBySessionID[sessionID] = .enriching
+        } else if pageReportsIncompleteItems {
+            historyLoadedQualityBySessionID[sessionID] = .summary
+        } else {
+            historyLoadedQualityBySessionID[sessionID] = .full
         }
         if job.loadMode == .full {
             deferredFullHistorySessionIDs.remove(sessionID)
-            historySavingsNoticesBySessionID.removeValue(forKey: sessionID)
+            if !pageReportsIncompleteItems {
+                historySavingsNoticesBySessionID.removeValue(forKey: sessionID)
+            }
         } else if !effectiveQuiet {
             setHistoryLoadNotice(
                 sessionID: sessionID,
@@ -1256,8 +1265,9 @@ extension SessionStore {
     }
 
     func updateHistorySavingsNotice(sessionID: SessionID, page: HistoryMessagesPage) {
-        guard page.loadMode == .economy,
-              let notice = page.notice?.trimmingCharacters(in: .whitespacesAndNewlines),
+        // full 页也可能带 notice：runtime 缺少 thread/items/list 时首屏内容确实补不齐。
+        // 是否提示只看 page.notice 本身，不再由 loadMode 反推。
+        guard let notice = page.notice?.trimmingCharacters(in: .whitespacesAndNewlines),
               !notice.isEmpty
         else {
             historySavingsNoticesBySessionID.removeValue(forKey: sessionID)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationClaudeHistoryItemsViewTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationClaudeHistoryItemsViewTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import MimiRemote
+
+/// MIM-265：Claude 渠道的 itemsView 与历史提示。
+/// 从 ConversationDirectRuntimeHistoryTests 拆出，该文件已达 check-source-size.sh
+/// 的测试文件上限；这几个用例自成一个职责，独立成文件而不是加例外。
+extension ConversationDataFlowTests {
+
+    // Claude bridge 无视 itemsView，thread/turns/list 直接回完整 items 并标 itemsView=full。
+    // 这类首屏已经是完整历史，不能再排 thread/items/list 补齐任务：Claude 渠道的 gateway
+    // 白名单没有该方法，请求必被打回，一次成功的加载会被误报成"内容未加载"。
+    func testDirectRuntimeClaudeFullHistorySkipsItemHydrationWhenTurnsCarryFullItems() async throws {
+        let project = AgentProject(id: "proj_claude_hist", name: "Claude History", path: "/tmp/claude-history")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            runtimeProvider: "claude",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(project: project, channels: [makeClaudeChannelMetadata()])
+            }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+
+        let pageTask = Task {
+            try await client.messagesPage(sessionID: "thr_claude_hist", before: nil, limit: 120)
+        }
+
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-claude","platformFamily":"macos"}"#
+        )
+
+        let metadataRead = try await waitForFakeAppServerRequest(transport, method: "thread/read")
+        transportResponse(
+            transport,
+            id: metadataRead.id,
+            result: #"{"thread":{"id":"thr_claude_hist","sessionId":"thr_claude_hist","preview":"claude","ephemeral":false,"modelProvider":"anthropic","createdAt":1780490300,"updatedAt":1780490301,"status":{"type":"idle"},"path":null,"cwd":"/tmp/claude-history","cliVersion":"0.0.0","source":"claude","threadSource":"user","name":"claude","turns":[]}}"#
+        )
+
+        let turnsRequest = try await waitForFakeAppServerRequest(transport, method: "thread/turns/list")
+        transportResponse(
+            transport,
+            id: turnsRequest.id,
+            result: #"{"data":[{"id":"turn_claude","status":"completed","itemsView":"full","started_at":1780490300,"completed_at":1780490301,"items":[{"type":"userMessage","id":"claude_1","content":[{"type":"text","text":"claude question"}]},{"type":"agentMessage","id":"claude_2","text":"claude answer","phase":"final_answer"}]}],"nextCursor":null}"#
+        )
+
+        let page = try await pageTask.value
+        XCTAssertEqual(page.messages.map(\.content), ["claude question", "claude answer"])
+        XCTAssertTrue(
+            page.itemContinuations.isEmpty,
+            "itemsView=full 的 Turn 内容已经齐了，不该再排补齐任务"
+        )
+        XCTAssertNil(page.notice, "内容完整时不能声称有图片或工具输出未加载")
+
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        XCTAssertFalse(
+            requests.contains { $0.method == "thread/items/list" },
+            "Claude 渠道没有 thread/items/list，一条都不该发出去"
+        )
+    }
+
+    // 反向边界：Turn 确实只回了 summary，而这个 runtime 又补不了 Item。这时快照真的不完整，
+    // 必须如实提示，不能因为不再排补齐任务就沉默地当成完整历史。
+    func testDirectRuntimeReportsNoticeWhenSummaryTurnsCannotBeHydrated() async throws {
+        let project = AgentProject(id: "proj_claude_summary", name: "Claude Summary", path: "/tmp/claude-summary")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            runtimeProvider: "claude",
+            transportFactory: { transport },
+            configProvider: {
+                makeDirectAppServerConfig(project: project, channels: [makeClaudeChannelMetadata()])
+            }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+
+        let pageTask = Task {
+            try await client.messagesPage(sessionID: "thr_claude_summary", before: nil, limit: 120)
+        }
+
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(
+            transport,
+            id: initialize.id,
+            result: #"{"userAgent":"fake-claude","platformFamily":"macos"}"#
+        )
+
+        let metadataRead = try await waitForFakeAppServerRequest(transport, method: "thread/read")
+        transportResponse(
+            transport,
+            id: metadataRead.id,
+            result: #"{"thread":{"id":"thr_claude_summary","sessionId":"thr_claude_summary","preview":"claude","ephemeral":false,"modelProvider":"anthropic","createdAt":1780490300,"updatedAt":1780490301,"status":{"type":"idle"},"path":null,"cwd":"/tmp/claude-summary","cliVersion":"0.0.0","source":"claude","threadSource":"user","name":"claude","turns":[]}}"#
+        )
+
+        let turnsRequest = try await waitForFakeAppServerRequest(transport, method: "thread/turns/list")
+        transportResponse(
+            transport,
+            id: turnsRequest.id,
+            result: #"{"data":[{"id":"turn_summary","status":"completed","itemsView":"summary","started_at":1780490300,"completed_at":1780490301,"items":[{"type":"userMessage","id":"summary_1","content":[{"type":"text","text":"summary question"}]}]}],"nextCursor":null}"#
+        )
+
+        let page = try await pageTask.value
+        XCTAssertTrue(page.itemContinuations.isEmpty, "补不了就不该排空转的补齐任务")
+        XCTAssertEqual(
+            page.notice,
+            CodexAppServerSessionRuntime.economyHistoryNotice,
+            "summary Turn 无法补齐时必须如实提示内容不完整"
+        )
+    }
+
+    // 省流页只要非空就挂提示，会让"是否真的省了内容"这个判断形同虚设。
+    func testEconomyHistoryNoticeRequiresRealLazyContentSignal() {
+        let completeTurn: [String: CodexAppServerJSONValue] = [
+            "id": .string("turn_full"),
+            "itemsView": .string("full")
+        ]
+        XCTAssertNil(
+            CodexAppServerSessionRuntime.historyNotice(
+                loadMode: .economy,
+                hasMoreBefore: false,
+                turns: [completeTurn]
+            ),
+            "整页内容都在、也没有更早分页时不该提示"
+        )
+
+        let summaryTurn: [String: CodexAppServerJSONValue] = [
+            "id": .string("turn_summary"),
+            "itemsView": .string("summary")
+        ]
+        XCTAssertEqual(
+            CodexAppServerSessionRuntime.historyNotice(
+                loadMode: .economy,
+                hasMoreBefore: false,
+                turns: [summaryTurn]
+            ),
+            CodexAppServerSessionRuntime.economyHistoryNotice
+        )
+        XCTAssertEqual(
+            CodexAppServerSessionRuntime.historyNotice(
+                loadMode: .economy,
+                hasMoreBefore: true,
+                turns: [completeTurn]
+            ),
+            CodexAppServerSessionRuntime.economyHistoryNotice
+        )
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeTestSupport.swift
@@ -628,7 +628,13 @@ func makeClaudeChannelMetadata() -> CodexAppServerChannelMetadata {
         experimental: true,
         lifecycle: "per_connection",
         bridge: nil,
-        methods: ["initialize", "initialized", "thread/list", "thread/start", "turn/start", "model/list"],
+        // 与 agentd 的 appServerClaudeAllowedMethods 保持一致：Claude 渠道没有
+        // thread/items/list，顶层 policy.allowed_methods 里的那一条对它不作数。
+        methods: [
+            "initialize", "initialized", "thread/list", "thread/start", "thread/resume",
+            "thread/read", "thread/turns/list", "turn/start", "turn/steer", "turn/interrupt",
+            "model/list", "account/rateLimits/read"
+        ],
         capabilities: ["history": true, "streaming": true]
     )
 }


### PR DESCRIPTION
每个 Claude 会话详情都常驻「已显示最近记录。较大的图片和工具输出暂未加载。」横幅，无论会话大小 —— 而内容其实早已完整渲染。**这个提示本身是假的。**

## 根因

iOS 从全局 `policy.allowed_methods` 判断 `thread/items/list` 是否可用，而 agentd 恒按 **Codex** 方法表构建这张表。gateway 实际按 per-runtime 白名单转发，`appServerClaudeAllowedMethods` 里没有 `thread/items/list`，于是每个 item 补齐请求都在到达 bridge 之前被 `-32080` 拒绝。

该错误不被识别为历史策略失败，补齐直接进入 failed → 质量降级为 `.summary` → 横幅常驻。

而且这个说法根本不成立：**Claude bridge 完全忽略 `itemsView`，`thread/turns/list` 已经返回带 `itemsView=full` 的完整 items**。数据一直是全的。

## 改动

- 只为**真正仍需补齐**的 turn（`itemsView != "full"`）排补齐任务，且仅在 runtime 确实暴露 `thread/items/list` 时才排。Codex 不受影响：它的 summary turn 照常分页。
- 方法可用性改从 runtime 自己的 `channel.methods` 解析（该字段一直被解码但无人使用），在 agentd 未下发 channels 的旧版本上回落到全局表。
- full 首屏的守卫去掉 items/list 前置条件：能返回完整 turn 的 runtime 不该因为缺少该方法就被整页判死。
- **保持诚实**：当 turn 确实需要补齐、而 runtime 又补不了时，如实给出提示，不把半截快照伪装成完整。这不是「把横幅删掉」，是「不再对本来完整的内容撒谎」。
- `historyNotice` 不再因 `!turns.isEmpty` 触发 —— 正是这一条让另外两个真实信号（`hasMoreBefore` / lazy content）变成死代码，也让横幅必现。
- `makeClaudeChannelMetadata` 对齐 `appServerClaudeAllowedMethods`，便于测试复现一个没有 `thread/items/list` 的 channel。

## 关于实现来源

实现取自 2026-09-02 的本地提交 `ed2c2977`，当时因沙箱无 CoreSimulator 且 SwiftPM 无法解析依赖，**从未构建也从未跑过测试**，一直躺在未推送的本地分支上。

本次摘到 main 后补齐了缺的那几步：

- cherry-pick 到 `52e42a56` 无冲突
- 逐条核对测试替身 `makeClaudeChannelMetadata` 的方法列表与当前 `appServerClaudeAllowedMethods` 一致（该 fixture 按 9/2 的白名单写成，需确认中间没有漂移）
- 构建通过 —— 这是它第一次被编译
- iOS 全量 **1571 项 / 17 失败 / 0 unexpected**，失败集合与 main 基线逐条一致；分支自带的 3 个用例全部通过

首轮全量另见一例 `LogStoreTests.testLogStoreTrimsLeastRecentlyUsedSessionCaches` 失败，单独复跑两次 + 全量复跑一次均通过，判定为抖动。

## 顺带的文件拆分

新增 144 行后 `ConversationDirectRuntimeHistoryTests.swift` 达 2606 行，超过 `check-source-size.sh` 的 2500 行上限。按 AGENTS.md 拆分而非加例外：这 3 个用例自成一个职责（Claude 的 itemsView 与历史提示），拆到新文件 `ConversationClaudeHistoryItemsViewTests.swift`。

## 验收要点（需真机）

- 打开 Claude 会话详情，顶部横幅**不应再必现**
- 消息 / 图片 / 工具输出完整可见
- **诚实性**：确实内容不全的会话，横幅**应该**仍在
- Codex 会话的 summary turn 仍能按需补齐，不回退

🤖 Generated with [Claude Code](https://claude.com/claude-code)
