### PR TITLE
MIM-267 Scope session list to opened workspaces

### DIFF
--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -952,11 +952,10 @@ struct WorkspaceRootView: View {
         let cachedPageState = runtimeSessionPagesByKey[presentationKey]
         // Store 已有首屏时先按当前 Runtime 投影，避免进入工作区或切换筛选后先退回骨架屏；
         // authoritative 请求仍会在后台刷新，并在返回后接管独立 cursor 与 hasMore。
-        let storedRuntimeSessions = sessionStore.sessions(forProjectID: project.id).filter { session in
-            sessionStore.isListableSession(session)
-                && CodexAppServerSessionRuntime.normalizedRuntimeProvider(session.runtimeProvider ?? session.source)
-                    == presentationKey.runtimeProvider
-        }
+        let storedRuntimeSessions = sessionStore.directoryScopedSessions(
+            workspaceID: project.id,
+            runtimeProvider: presentationKey.runtimeProvider
+        )
         let loadedSessions = cachedPageState?.reconciledSessions(with: storedRuntimeSessions) ?? storedRuntimeSessions
         let loadState = sessionLoadState(for: presentationKey)
         let visibleLimit = workspaceSessionVisibleLimit(for: presentationKey)
@@ -1190,16 +1189,10 @@ struct WorkspaceRootView: View {
         // 每个 Runtime 独立占有提交 token；切换筛选不会让旧请求覆盖当前 Runtime 的缓存。
         let invocationID = sessionLoadInvocationTokens.begin(for: presentationKey)
         let canonicalSessionIDsBeforeLoad = Set<SessionID>(
-            sessionStore.sessions(forProjectID: project.id).compactMap { session in
-                guard sessionStore.isListableSession(session),
-                      CodexAppServerSessionRuntime.normalizedRuntimeProvider(
-                          session.runtimeProvider ?? session.source
-                      ) == presentationKey.runtimeProvider
-                else {
-                    return nil
-                }
-                return session.id
-            }
+            sessionStore.directoryScopedSessions(
+                workspaceID: project.id,
+                runtimeProvider: presentationKey.runtimeProvider
+            ).map(\.id)
         )
         sessionLoadStates[presentationKey] = .loading
         do {

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -500,7 +500,7 @@ struct SessionListView: View {
     }
 
     private var visibleSessions: [AgentSession] {
-        sessionStore.sessionLibrarySessions.filter { session in
+        sessionStore.openedWorkspaceSessionLibrarySessions.filter { session in
             (selectedWorkspaceID == "all" || session.projectID == selectedWorkspaceID) &&
                 selectedStatus.includes(session)
         }

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -1001,12 +1001,9 @@ struct UnifiedWorkbenchShell: View {
     }
 
     private func sidebarMonitorSections(now: Date) -> [SessionSidebarSection] {
-        let openedWorkspaceSessions = sessionStore.sortedAllSessions.compactMap {
-            sessionStore.sessionAlignedToOpenedWorkspace($0)
-        }
-        let chronologicallySortedSessions = openedWorkspaceSessions.isEmpty
-            ? SessionStore.sortedSessions(sessionStore.openedWorkspaceSessionLibrarySessions)
-            : openedWorkspaceSessions
+        let chronologicallySortedSessions = SessionStore.sortedSessions(
+            sessionStore.openedWorkspaceSessionLibrarySessions
+        )
         return SessionListPresentation.sidebarSections(
             sessions: chronologicallySortedSessions,
             pinnedIDs: sessionStore.pinnedSessionIDs,

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -1001,9 +1001,12 @@ struct UnifiedWorkbenchShell: View {
     }
 
     private func sidebarMonitorSections(now: Date) -> [SessionSidebarSection] {
-        let chronologicallySortedSessions = sessionStore.sortedAllSessions.isEmpty
-            ? SessionStore.sortedSessions(sessionStore.sessionLibrarySessions)
-            : sessionStore.sortedAllSessions
+        let openedWorkspaceSessions = sessionStore.sortedAllSessions.compactMap {
+            sessionStore.sessionAlignedToOpenedWorkspace($0)
+        }
+        let chronologicallySortedSessions = openedWorkspaceSessions.isEmpty
+            ? SessionStore.sortedSessions(sessionStore.openedWorkspaceSessionLibrarySessions)
+            : openedWorkspaceSessions
         return SessionListPresentation.sidebarSections(
             sessions: chronologicallySortedSessions,
             pinnedIDs: sessionStore.pinnedSessionIDs,
@@ -1736,7 +1739,7 @@ struct UnifiedWorkbenchShell: View {
         case .selectSession(let sessionID):
             let session = preferredSession?.id == sessionID
                 ? preferredSession
-                : sessionStore.sessionLibrarySessions.first(where: { $0.id == sessionID })
+                : sessionStore.openedWorkspaceSessionLibrarySessions.first(where: { $0.id == sessionID })
             guard let session else {
                 applyNavigation(.sessionSelectionFinished(sessionID), layout: layout)
                 return

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -372,6 +372,8 @@ final class SessionStore: ObservableObject {
             rebuildProjectSessionListSnapshots()
         }
     }
+    /// 记录按工作区真实目录查询到的会话 ID。默认列表只用这份证据接纳全局发现结果。
+    @Published var workspaceDirectorySessionIDsByKey: [WorkspaceDirectorySessionScopeKey: Set<SessionID>] = [:]
     var connectionChangeGeneration = 0
     var inFlightConnectionChangeGeneration: Int?
     var connectionSwitchTargetGeneration: Int?
@@ -1606,14 +1608,13 @@ final class SessionStore: ObservableObject {
         return sessionsMatchingSearch(sortedSessionsForList(merged))
     }
 
-    /// 受控全局发现继续保留 canonical 会话；会话 Tab 只消费真实目录命中已打开工作区的投影。
-    /// 投影同时按目录修正 workspace identity，避免外部 Worktree 沿用根项目标注。
+    /// 受控全局发现继续保留 canonical 会话；会话 Tab 只消费目录查询确认属于已打开工作区的投影。
     var openedWorkspaceSessionLibrarySessions: [AgentSession] {
         sessionLibrarySessions.compactMap(sessionAlignedToOpenedWorkspace)
     }
 
     func sessionAlignedToOpenedWorkspace(_ item: AgentSession) -> AgentSession? {
-        workspaceForPath(item.dir).map { session(item, in: $0) }
+        workspaceForDirectoryScopedSession(item).map { session(item, in: $0) }
     }
 
     /// 最近列表严格按活动时间排序，置顶只影响完整会话库，不改变“最近”的时间语义。

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -1606,6 +1606,16 @@ final class SessionStore: ObservableObject {
         return sessionsMatchingSearch(sortedSessionsForList(merged))
     }
 
+    /// 受控全局发现继续保留 canonical 会话；会话 Tab 只消费真实目录命中已打开工作区的投影。
+    /// 投影同时按目录修正 workspace identity，避免外部 Worktree 沿用根项目标注。
+    var openedWorkspaceSessionLibrarySessions: [AgentSession] {
+        sessionLibrarySessions.compactMap(sessionAlignedToOpenedWorkspace)
+    }
+
+    func sessionAlignedToOpenedWorkspace(_ item: AgentSession) -> AgentSession? {
+        workspaceForPath(item.dir).map { session(item, in: $0) }
+    }
+
     /// 最近列表严格按活动时间排序，置顶只影响完整会话库，不改变“最近”的时间语义。
     var recentSessions: [AgentSession] {
         Array(Self.sortedSessions(sessions.filter(isListableSession)).prefix(8))

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -2611,6 +2611,7 @@ extension SessionStore {
         if !workspaceSessionFirstPageCompletionByKey.isEmpty {
             workspaceSessionFirstPageCompletionByKey = [:]
         }
+        workspaceDirectorySessionIDsByKey = [:]
         sessionListCooldownUntilByBudgetKey = [:]
         sessionLibraryIndexRefreshJob?.task.cancel()
         sessionLibraryIndexRefreshJob = nil

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -1412,21 +1412,44 @@ extension SessionStore {
 
     func sessionLibraryPage(
         workspace: AgentWorkspace,
+        runtimeProvider: String = "codex",
         consistency: SessionListConsistency = .fastIndexed,
         client: (any SessionStoreAPIClient)? = nil,
         hostScope: HostScope? = nil
     ) async -> (workspace: AgentWorkspace, page: SessionsPage?, requestedCursor: String?) {
         let hostRequestStartedAt = sessionListNow()
         do {
-            let result = try await sessionListFirstPage(
-                workspace: workspace,
-                limit: Self.initialSessionPageLimit,
-                reuseRecent: consistency == .fastIndexed,
-                consistency: consistency,
-                source: .libraryIndex,
-                client: client,
-                hostScope: hostScope
-            )
+            let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
+            let result: SessionListFirstPageResult
+            if normalizedRuntime == "codex" {
+                result = try await sessionListFirstPage(
+                    workspace: workspace,
+                    limit: Self.initialSessionPageLimit,
+                    reuseRecent: consistency == .fastIndexed,
+                    consistency: consistency,
+                    source: .libraryIndex,
+                    client: client,
+                    hostScope: hostScope
+                )
+            } else {
+                let resolvedClient: any SessionStoreAPIClient
+                if let client {
+                    resolvedClient = client
+                } else {
+                    resolvedClient = try clientFactory()
+                }
+                let page = try await sessionListPageFillingPresentationWindow(
+                    client: resolvedClient,
+                    workspace: workspace,
+                    runtimeProvider: normalizedRuntime,
+                    cursor: nil,
+                    limit: Self.initialSessionPageLimit,
+                    consistency: consistency,
+                    source: .libraryIndex,
+                    expectedHostScope: hostScope ?? appStore.activeHostScope
+                )
+                result = SessionListFirstPageResult(page: page, requestedCursor: nil)
+            }
             recordCarStatusHostObservation(at: sessionListNow())
             return (workspace, result.page, result.requestedCursor)
         } catch {
@@ -1445,17 +1468,26 @@ extension SessionStore {
     func mergeSessionLibraryPages(
         _ results: [(workspace: AgentWorkspace, page: SessionsPage?, requestedCursor: String?)],
         generation: Int,
-        consistency: SessionListConsistency = .fastIndexed
+        consistency: SessionListConsistency = .fastIndexed,
+        runtimeProvider: String = "codex"
     ) {
         guard generation == appStore.connectionGeneration else { return }
+        let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
         for result in results {
             guard let page = result.page,
                   isCurrentWorkspaceIdentity(result.workspace) else { continue }
-            if consistency == .authoritative,
+            if normalizedRuntime == "codex",
+               consistency == .authoritative,
                authoritativeWorkspaceSessionFirstPageContinuationCursor(workspace: result.workspace)
                 != result.requestedCursor {
                 continue
             }
+            recordWorkspaceDirectorySessionPage(
+                page.sessions,
+                in: result.workspace,
+                runtimeProvider: runtimeProvider,
+                replacing: consistency == .authoritative && result.requestedCursor == nil
+            )
             let pageSessions = sessions(page.sessions, in: result.workspace)
             if consistency == .fastIndexed {
                 mergeFastIndexedSessionPagePreservingAuthoritativeFields(
@@ -1466,17 +1498,19 @@ extension SessionStore {
                 // 新一轮权威刷新必须能修正旧权威数据；只有弱一致性页需要降级保护。
                 mergeSessionPage(pageSessions)
             }
-            updateWorkspaceSessionFirstPageState(
-                workspace: result.workspace,
-                page: page,
-                consistency: consistency,
-                requestedCursor: result.requestedCursor
-            )
-            recordWorkspaceSessionFirstPageCompletion(
-                workspace: result.workspace,
-                page: page,
-                consistency: consistency
-            )
+            if normalizedRuntime == "codex" {
+                updateWorkspaceSessionFirstPageState(
+                    workspace: result.workspace,
+                    page: page,
+                    consistency: consistency,
+                    requestedCursor: result.requestedCursor
+                )
+                recordWorkspaceSessionFirstPageCompletion(
+                    workspace: result.workspace,
+                    page: page,
+                    consistency: consistency
+                )
+            }
             clearWorkspaceUnavailable(result.workspace.id)
         }
     }
@@ -1716,6 +1750,12 @@ extension SessionStore {
             // 必须丢弃，不能把 completion 或 opaque cursor 倒回上一批。
             return false
         }
+        recordWorkspaceDirectorySessionPage(
+            page.sessions,
+            in: workspace,
+            runtimeProvider: "codex",
+            replacing: consistency == .authoritative && requestedCursor == nil
+        )
         let pageSessions = sessions(page.sessions, in: workspace)
         let presentationWindowComplete = isWorkspaceSessionPresentationWindowComplete(
             workspace: workspace,

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -935,6 +935,7 @@ extension SessionStore {
         sessionPageLoadingTokenByProjectID.removeValue(forKey: project.id)
         sessionFirstPageLoadingConsistencyByProjectID.removeValue(forKey: project.id)
         sessionFirstPageWaiterCountByProjectID.removeValue(forKey: project.id)
+        removeWorkspaceDirectorySessionScopes(workspaceID: project.id)
         let retainedWorkspaceCompletions = workspaceSessionFirstPageCompletionByKey.filter {
             $0.key.workspaceID != project.id
         }
@@ -1683,18 +1684,14 @@ extension SessionStore {
                         let pageSessionIDs = Set(page.sessions.map(\.id))
                         discoveredSessionIDs.formUnion(pageSessionIDs)
                         discoveredByRuntime[runtimeProvider, default: []].formUnion(pageSessionIDs)
-                        // 先发布授权 ID 再合并 Session；这样首次发现的外部 Worktree 在同一轮
-                        // sessions 更新里即可进入根侧栏补充集，不依赖后续精确 cwd 刷新。
+                        // 先发布授权 ID 再合并 Session，确保后续目录归属判断能识别全局结果。
                         let expandedControlledIDs = controlledGlobalSessionIDs.union(pageSessionIDs)
                         if expandedControlledIDs != controlledGlobalSessionIDs {
                             controlledGlobalSessionIDs = expandedControlledIDs
                         }
-                        // 全局发现只携带根项目归属；进入 canonical sessions 前先沿用 Store
-                        // 已知的 workspace identity（已有同 ID 会话或 dir 命中 recent workspace）。
-                        // 否则同一 session.id 的全局响应会把稳定的 workspace projectID 覆盖回
-                        // root projectID，导致侧栏分组和会话头像命名空间在两种身份之间来回跳变。
-                        // 未命中的外部 worktree 仍返回原始 session，保留既有受控发现行为。
-                        mergeSessionPage(page.sessions.map(alignSessionToKnownWorkspace))
+                        // 全局发现只携带根项目归属。只有同 ID 已被对应 cwd 查询确认时，
+                        // 才沿用工作区 identity；不能根据父子路径关系猜测归属。
+                        mergeSessionPage(page.sessions.map(alignGlobalSessionToKnownDirectoryScope))
                         guard page.hasMore,
                               let nextCursor = page.nextCursor,
                               nextCursor != cursor else {
@@ -1749,6 +1746,7 @@ extension SessionStore {
                     return !(discoveredByRuntime[runtime]?.contains(sessionID) ?? false)
                 }
                 if !revokedSessionIDs.isEmpty {
+                    removeWorkspaceDirectorySessionIDs(Set(revokedSessionIDs))
                     let retainedSessions = sessions.filter { !revokedSessionIDs.contains($0.id) }
                     if retainedSessions != sessions {
                         // 授权撤销与列表删除必须在同一轮完成。不能等待精确 cwd 刷新：
@@ -1786,17 +1784,12 @@ extension SessionStore {
         // 也不让多个 thread/list 与前台 resume/turn 请求同时挤压 app-server。
         for workspace in workspaces {
             guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
-            let result = await sessionLibraryPage(
+            await refreshDirectoryScopedSessionLibrary(
                 workspace: workspace,
                 consistency: consistency,
                 client: client,
-                hostScope: hostScope
-            )
-            guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
-            mergeSessionLibraryPages(
-                [result],
-                generation: generation,
-                consistency: consistency
+                hostScope: hostScope,
+                generation: generation
             )
         }
     }

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -100,6 +100,14 @@ struct WorkspaceSessionFirstPageKey: Hashable {
     let workspacePath: String
 }
 
+/// 只有携带工作区 cwd 的 thread/list 才能建立这个归属；全局发现不能靠路径包含关系冒充。
+struct WorkspaceDirectorySessionScopeKey: Hashable {
+    let hostScope: HostScope
+    let workspaceID: String
+    let workspacePath: String
+    let runtimeProvider: String
+}
+
 struct WorkspaceSessionFirstPageCompletion: Equatable {
     let consistency: SessionListConsistency
     let isPresentationWindowComplete: Bool

--- a/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
@@ -1,6 +1,123 @@
 import Foundation
 
 extension SessionStore {
+    func workspaceDirectoryScopeKey(
+        for workspace: AgentWorkspace,
+        runtimeProvider: String
+    ) -> WorkspaceDirectorySessionScopeKey {
+        WorkspaceDirectorySessionScopeKey(
+            hostScope: appStore.activeHostScope,
+            workspaceID: workspace.id,
+            workspacePath: standardizedSessionListPath(workspace.path),
+            runtimeProvider: Self.normalizedRuntimeProvider(runtimeProvider)
+        )
+    }
+
+    func recordWorkspaceDirectorySessionPage(
+        _ items: [AgentSession],
+        in workspace: AgentWorkspace,
+        runtimeProvider: String,
+        replacing: Bool
+    ) {
+        guard isCurrentWorkspaceIdentity(workspace) else { return }
+        let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
+        let key = workspaceDirectoryScopeKey(for: workspace, runtimeProvider: normalizedRuntime)
+        let pageIDs = Set(items.compactMap { item in
+            Self.normalizedRuntimeProvider(item.runtimeProvider ?? item.source) == normalizedRuntime
+                ? item.id
+                : nil
+        })
+        var next = workspaceDirectorySessionIDsByKey
+        next[key] = replacing ? pageIDs : next[key, default: []].union(pageIDs)
+        if next != workspaceDirectorySessionIDsByKey {
+            workspaceDirectorySessionIDsByKey = next
+        }
+    }
+
+    func workspaceForDirectoryScopedSession(_ item: AgentSession) -> AgentWorkspace? {
+        let runtime = Self.normalizedRuntimeProvider(item.runtimeProvider ?? item.source)
+        return recentWorkspaces.first { workspace in
+            if controlledGlobalSessionIDs.contains(item.id) {
+                let key = workspaceDirectoryScopeKey(for: workspace, runtimeProvider: runtime)
+                return workspaceDirectorySessionIDsByKey[key]?.contains(item.id) == true
+            }
+            return item.projectID == workspace.id
+        }
+    }
+
+    func directoryScopedSessions(
+        workspaceID: String,
+        runtimeProvider: String
+    ) -> [AgentSession] {
+        guard let workspace = workspacesByID[workspaceID] else { return [] }
+        let runtime = Self.normalizedRuntimeProvider(runtimeProvider)
+        let key = workspaceDirectoryScopeKey(for: workspace, runtimeProvider: runtime)
+        let confirmedGlobalIDs = workspaceDirectorySessionIDsByKey[key] ?? []
+        let scoped = sessions.compactMap { item -> AgentSession? in
+            let belongsToWorkspace = controlledGlobalSessionIDs.contains(item.id)
+                ? confirmedGlobalIDs.contains(item.id)
+                : item.projectID == workspace.id
+            guard isListableSession(item),
+                  Self.normalizedRuntimeProvider(item.runtimeProvider ?? item.source) == runtime,
+                  belongsToWorkspace
+            else {
+                return nil
+            }
+            return session(item, in: workspace)
+        }
+        return Self.sortedSessions(scoped)
+    }
+
+    func alignGlobalSessionToKnownDirectoryScope(_ item: AgentSession) -> AgentSession {
+        guard controlledGlobalSessionIDs.contains(item.id),
+              let workspace = workspaceForDirectoryScopedSession(item) else {
+            return item
+        }
+        return session(item, in: workspace)
+    }
+
+    func removeWorkspaceDirectorySessionScopes(workspaceID: String) {
+        let next = workspaceDirectorySessionIDsByKey.filter { $0.key.workspaceID != workspaceID }
+        if next != workspaceDirectorySessionIDsByKey {
+            workspaceDirectorySessionIDsByKey = next
+        }
+    }
+
+    func removeWorkspaceDirectorySessionIDs(_ sessionIDs: Set<SessionID>) {
+        guard !sessionIDs.isEmpty else { return }
+        let next = workspaceDirectorySessionIDsByKey.mapValues { $0.subtracting(sessionIDs) }
+        if next != workspaceDirectorySessionIDsByKey {
+            workspaceDirectorySessionIDsByKey = next
+        }
+    }
+
+    func refreshDirectoryScopedSessionLibrary(
+        workspace: AgentWorkspace,
+        consistency: SessionListConsistency,
+        client: any SessionStoreAPIClient,
+        hostScope: HostScope,
+        generation: Int
+    ) async {
+        let includesClaude = (try? await client.runtimeChannelAvailable(runtimeProvider: "claude")) == true
+        for runtimeProvider in includesClaude ? ["codex", "claude"] : ["codex"] {
+            guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
+            let result = await sessionLibraryPage(
+                workspace: workspace,
+                runtimeProvider: runtimeProvider,
+                consistency: consistency,
+                client: client,
+                hostScope: hostScope
+            )
+            guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
+            mergeSessionLibraryPages(
+                [result],
+                generation: generation,
+                consistency: consistency,
+                runtimeProvider: runtimeProvider
+            )
+        }
+    }
+
     /// 工作区详情按 Runtime 独立分页。Codex 首屏复用 canonical single-flight，
     /// opaque cursor 和 Claude 请求仍独立归属于当前 Runtime。
     func workspaceRuntimeSessionsPage(
@@ -50,6 +167,12 @@ extension SessionStore {
         try requireCurrentProjectsGitHost(lease)
 
         let prepared = sessions(page.sessions, in: workspace).map(sessionPreparedForStorage)
+        recordWorkspaceDirectorySessionPage(
+            page.sessions,
+            in: workspace,
+            runtimeProvider: normalizedRuntime,
+            replacing: cursor == nil
+        )
         if let canonicalFirstPageResult {
             // 复用 canonical 请求也必须提交同一条 authoritative cursor 的推进结果；
             // 否则 child-dense 首屏会反复从旧 continuation 重拉，View 与 Store 看到两套进度。

--- a/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
@@ -22,6 +22,8 @@ extension SessionStore {
         guard isCurrentWorkspaceIdentity(workspace) else { return }
         let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
         let key = workspaceDirectoryScopeKey(for: workspace, runtimeProvider: normalizedRuntime)
+        // agentd 已按 canonical scope 校验本次 cwd 查询；返回项仍可能保留 symlink 形式的上游 cwd。
+        // 因此归属只认“由该查询返回的 ID”，不能再次用 item.dir 的原始拼写做路径比较。
         let pageIDs = Set(items.compactMap { item in
             Self.normalizedRuntimeProvider(item.runtimeProvider ?? item.source) == normalizedRuntime
                 ? item.id

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -1364,6 +1364,57 @@ extension ConversationDataFlowTests {
         )
     }
 
+    func testDirectoryScopedProjectionPreservesSymlinkCWDReturnedForCanonicalWorkspace() async {
+        let rootProject = AgentProject(
+            id: "proj_symlink_scope_root",
+            name: "Root",
+            path: "/Users/test/code/root"
+        )
+        let workspace = AgentWorkspace(
+            id: "ws_symlink_scope",
+            name: "canonical-workspace",
+            path: "/Users/test/real/canonical-workspace",
+            rootProjectID: rootProject.id,
+            rootProjectName: rootProject.name,
+            rootProjectPath: rootProject.path
+        )
+        let symlinkSession = AgentSession(
+            id: "thread-symlink-scope",
+            projectID: rootProject.id,
+            project: rootProject.name,
+            dir: "/Users/test/links/workspace-alias",
+            title: "Symlink cwd",
+            status: "history",
+            source: "codex",
+            runtimeProvider: "codex",
+            resumeID: "thread-symlink-scope",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+        let client = MockSessionStoreClient(
+            projects: [rootProject],
+            sessions: [],
+            workspaceSessions: [workspace.id: [symlinkSession]],
+            controlledGlobalSessionsHandler: { _, _ in
+                SessionsPage(sessions: [symlinkSession])
+            }
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.recentWorkspaces = [workspace]
+
+        await store.refreshSessionLibraryIndex(authoritative: true)
+
+        let visible = store.openedWorkspaceSessionLibrarySessions
+        XCTAssertEqual(visible.map(\.id), [symlinkSession.id])
+        XCTAssertEqual(visible.first?.projectID, workspace.id)
+        XCTAssertEqual(visible.first?.dir, symlinkSession.dir, "展示归属应使用 canonical workspace，同时保留上游 cwd")
+    }
+
     func testSessionLibrarySerializesBackgroundWorkspaceRequests() async throws {
         let firstProject = makeProject(id: "proj_library_serial_first")
         let secondProject = makeProject(id: "proj_library_serial_second")

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -1121,7 +1121,7 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.filteredSessions.map(\.id), [session.id])
     }
 
-    func testSessionLibraryGlobalDiscoveryPreservesKnownWorkspaceIdentityWhenSelectedRefreshIsSkipped() async {
+    func testSessionLibraryGlobalDiscoveryRequiresDirectoryQueryBeforeAssigningWorkspace() async {
         let rootProject = AgentProject(
             id: "proj_library_identity_root",
             name: "proj_library_identity_root",
@@ -1203,19 +1203,17 @@ extension ConversationDataFlowTests {
 
         await store.refreshAll(autoAttach: false)
         XCTAssertEqual(store.sessions(forProjectID: workspace.id).map(\.id), [canonical.id])
-        XCTAssertEqual(store.alignSessionToKnownWorkspace(globalPathMatched).projectID, workspace.id)
 
         await store.refreshSessionLibraryIndex()
 
-        // 当前工作区首屏已有结果，因此精确 workspace 请求被跳过；不能依靠后写的精确页
-        // 把全局响应“修正”回来，两个全局结果本身都必须在 merge 前稳定到 workspace.id。
+        // 当前工作区首屏已有结果，因此目录请求被跳过。只有此前真正由目录查询命中的
+        // canonical 会话能保留 workspace identity；新全局结果不能按路径包含关系猜归属。
         XCTAssertEqual(client.requestedWorkspaceIDs, [workspace.id])
         XCTAssertEqual(store.recentWorkspaces.map(\.id), [workspace.id])
         XCTAssertEqual(store.sessionsByID[canonical.id]?.projectID, workspace.id)
-        XCTAssertEqual(store.sessionsByID[globalPathMatched.id]?.projectID, workspace.id)
-        // 没有 recent workspace 或 dir 命中的受控外部 worktree 仍保留 root projectID，
-        // 不能因为统一 identity 而误删或伪造工作区归属。
+        XCTAssertEqual(store.sessionsByID[globalPathMatched.id]?.projectID, rootProject.id)
         XCTAssertEqual(store.sessionsByID[globalUnknownExternal.id]?.projectID, rootProject.id)
+        XCTAssertEqual(store.openedWorkspaceSessionLibrarySessions.map(\.id), [canonical.id])
     }
 
     func testSessionTabProjectionUsesOnlyOpenedWorkspaceDirectoriesAndRealPathIdentity() {
@@ -1268,7 +1266,7 @@ extension ConversationDataFlowTests {
         )
         let unopenedCodex = makeProjectedSession(
             id: "unopened-codex",
-            dir: "/Users/test/worktrees/unopened-codex",
+            dir: rootProject.path + "/mimi-remote",
             source: "codex",
             updatedAt: 4
         )
@@ -1286,6 +1284,19 @@ extension ConversationDataFlowTests {
         )
         store.recentWorkspaces = [AgentWorkspace(project: rootProject), openedWorktree]
         store.sessions = [rootCodex, openedClaude, unopenedCodex, unopenedClaude]
+        store.controlledGlobalSessionIDs = Set(store.sessions.map(\.id))
+        store.recordWorkspaceDirectorySessionPage(
+            [rootCodex],
+            in: AgentWorkspace(project: rootProject),
+            runtimeProvider: "codex",
+            replacing: true
+        )
+        store.recordWorkspaceDirectorySessionPage(
+            [openedClaude],
+            in: openedWorktree,
+            runtimeProvider: "claude",
+            replacing: true
+        )
 
         let visible = store.openedWorkspaceSessionLibrarySessions
 
@@ -1296,9 +1307,61 @@ extension ConversationDataFlowTests {
             Set(store.sessions.map(\.id)),
             Set([rootCodex.id, openedClaude.id, unopenedCodex.id, unopenedClaude.id])
         )
+        XCTAssertEqual(
+            store.directoryScopedSessions(workspaceID: rootProject.id, runtimeProvider: "codex").map(\.id),
+            [rootCodex.id],
+            "父工作区不能靠路径包含关系接纳全局发现的子仓库会话"
+        )
 
         store.recentWorkspaces = []
         XCTAssertTrue(store.openedWorkspaceSessionLibrarySessions.isEmpty)
+    }
+
+    func testSessionLibraryQueriesOpenedWorkspaceDirectoryForBothRuntimes() async {
+        let project = makeProject(id: "proj_directory_scoped_library")
+        let workspace = AgentWorkspace(project: project)
+        let codexSession = makeSession(
+            id: "directory-codex",
+            projectID: project.id,
+            title: "Codex",
+            status: "history",
+            source: "codex",
+            runtimeProvider: "codex",
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+        let claudeSession = makeSession(
+            id: "directory-claude",
+            projectID: project.id,
+            title: "Claude",
+            status: "history",
+            source: "claude",
+            runtimeProvider: "claude",
+            updatedAt: Date(timeIntervalSince1970: 3)
+        )
+        let client = MockSessionStoreClient(
+            projects: [project],
+            sessions: [],
+            workspaceSessions: [project.id: [codexSession, claudeSession]],
+            runtimeChannelAvailability: ["claude": true],
+            controlledGlobalSessionsByRuntimeHandler: { runtimeProvider, _, _ in
+                SessionsPage(sessions: runtimeProvider == "claude" ? [claudeSession] : [codexSession])
+            }
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.recentWorkspaces = [workspace]
+
+        await store.refreshSessionLibraryIndex(authoritative: true)
+
+        XCTAssertEqual(client.requestedWorkspaceIDs, [workspace.id, workspace.id])
+        XCTAssertEqual(
+            store.openedWorkspaceSessionLibrarySessions.map(\.id),
+            [claudeSession.id, codexSession.id]
+        )
     }
 
     func testSessionLibrarySerializesBackgroundWorkspaceRequests() async throws {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationConnectionRecoveryTests.swift
@@ -1218,6 +1218,89 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(store.sessionsByID[globalUnknownExternal.id]?.projectID, rootProject.id)
     }
 
+    func testSessionTabProjectionUsesOnlyOpenedWorkspaceDirectoriesAndRealPathIdentity() {
+        let rootProject = AgentProject(
+            id: "proj_session_tab_root",
+            name: "Root",
+            path: "/Users/test/code/root"
+        )
+        let openedWorktree = AgentWorkspace(
+            id: "ws_session_tab_opened",
+            name: "Opened worktree",
+            path: "/Users/test/worktrees/opened",
+            rootProjectID: rootProject.id,
+            rootProjectName: rootProject.name,
+            rootProjectPath: rootProject.path
+        )
+
+        func makeProjectedSession(
+            id: String,
+            dir: String,
+            source: String,
+            updatedAt: TimeInterval
+        ) -> AgentSession {
+            AgentSession(
+                id: id,
+                projectID: rootProject.id,
+                project: rootProject.name,
+                dir: dir,
+                title: id,
+                status: "history",
+                source: source,
+                runtimeProvider: source,
+                resumeID: id,
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: updatedAt)
+            )
+        }
+
+        let rootCodex = makeProjectedSession(
+            id: "root-codex",
+            dir: rootProject.path + "/Sources",
+            source: "codex",
+            updatedAt: 2
+        )
+        let openedClaude = makeProjectedSession(
+            id: "opened-claude",
+            dir: openedWorktree.path,
+            source: "claude",
+            updatedAt: 3
+        )
+        let unopenedCodex = makeProjectedSession(
+            id: "unopened-codex",
+            dir: "/Users/test/worktrees/unopened-codex",
+            source: "codex",
+            updatedAt: 4
+        )
+        let unopenedClaude = makeProjectedSession(
+            id: "unopened-claude",
+            dir: "/Users/test/worktrees/unopened-claude",
+            source: "claude",
+            updatedAt: 5
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [], sessions: []) }
+        )
+        store.recentWorkspaces = [AgentWorkspace(project: rootProject), openedWorktree]
+        store.sessions = [rootCodex, openedClaude, unopenedCodex, unopenedClaude]
+
+        let visible = store.openedWorkspaceSessionLibrarySessions
+
+        XCTAssertEqual(visible.map(\.id), [openedClaude.id, rootCodex.id])
+        XCTAssertEqual(visible.first(where: { $0.id == openedClaude.id })?.projectID, openedWorktree.id)
+        XCTAssertEqual(visible.first(where: { $0.id == openedClaude.id })?.dir, openedWorktree.path)
+        XCTAssertEqual(
+            Set(store.sessions.map(\.id)),
+            Set([rootCodex.id, openedClaude.id, unopenedCodex.id, unopenedClaude.id])
+        )
+
+        store.recentWorkspaces = []
+        XCTAssertTrue(store.openedWorkspaceSessionLibrarySessions.isEmpty)
+    }
+
     func testSessionLibrarySerializesBackgroundWorkspaceRequests() async throws {
         let firstProject = makeProject(id: "proj_library_serial_first")
         let secondProject = makeProject(id: "proj_library_serial_second")


### PR DESCRIPTION
## 变更

- 会话 Tab 与工作区页面分别使用每个已打开工作区的真实 cwd 查询会话。
- 全局发现只保留为 canonical 数据源；只有被对应 cwd 查询确认的会话才能进入该工作区列表。
- 移除父子路径包含关系推断，避免 code 工作区误收 mimi-remote 等子目录会话。
- 目录归属按 canonical scope 查询返回的 session ID 保存；上游 cwd 使用 symlink 拼写时仍保留会话。
- Codex 与 Claude 分别按同一工作区目录查询，并独立记录归属。

## 验证

- bash ./scripts/check-source-size.sh：通过。
- 目录归属与 symlink 回归：4/4 通过。
- 现有全局分页、双 Runtime 和撤权回归：3/3 通过。
- 上一提交的 GitHub iOS conversation-regressions：通过；最新提交正在重新运行。
- 首轮完整测试的既有结果：执行 1569 项，新增用例通过；22 项既有失败与本改动无关，包括 2 项历史加载断言和 20 项视觉快照差异。

Linear: MIM-267