### PR TITLE
MIM-135 收紧分层验证并缩短 iOS quick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,22 @@
 - 不得通过压缩代码、合并无关语句、删除必要测试或添加目录、通配符豁免来绕过门禁。
 - 只有确实无法立即拆分且有明确原因时，才允许在 `scripts/check-source-size.sh` 中添加精确文件路径例外。例外必须写明原因和后续拆分方向，不能作为长期默认方案。
 
+## 分层验证执行规范
+
+- 开发过程中只运行与当前行为直接相关的最小检查。Go 优先运行变更 package 的测试；iOS 优先运行精确 XCTest selector、相关快照或静态检查。不要在每次微调后运行 quick、完整 XCTest 或全仓测试。
+- 完成最后一次代码修改后，交付或 push 前只执行一次：
+  - `bash ./scripts/verify-change.sh --plan`
+  - `bash ./scripts/verify-change.sh`
+- quick 是普通 Issue 的默认收尾。iOS quick 只在固定 `iPad Pro 13-inch (M5)` Simulator 上编译 App，不编译或运行整个 XCTest 测试包；需要回归测试时，在开发阶段运行与问题直接相关的 selector。
+- 只有以下任一条件成立时，才允许执行一次 `bash ./scripts/verify-change.sh --full`：
+  - 修改 Go/iOS 共享协议、跨栈接口或同一用户链路的多个产品栈；
+  - 修改鉴权、权限、持久化格式或迁移、消息 exactly-once、并发、重连等高风险语义；
+  - 大范围重构导致直接影响范围无法可靠界定；
+  - 准备正式发布，或用户明确要求完整回归。
+- Issue 已完成、改动文件较多、准备提交和“为了保险”都不是 full 的触发条件。quick 或 CI 失败时先定位并重跑失败项，不自动升级为全量流程。
+- 真机验证仍只用于相机、通知、Keychain、Tailscale/弱网、性能、发布前专项或 Issue 明确要求。普通 UI、文案、局部状态和单 package 修复不得默认启动真机。
+- 交付时只报告实际执行的检查，并明确列出延后到 PR Gate、真机或发布阶段的范围。不得把 quick 结果表述为完整回归通过。
+
 ## iOS 日常构建与模拟器标准
 
 ### 默认链路

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,18 +38,20 @@ quick 验证。脚本会合并 `origin/main...HEAD`、暂存区、工作区和�
 - 纯文档不启动 Go、Cargo、Xcode 或真机；
 - CI、脚本和发布控制面只运行语法检查及对应的无设备自测；
 - Go 默认只测试直接变更的 package；
-- iOS 默认固定 `iPad Pro 13-inch (M5)`，只生成一次可复用测试产物；
+- iOS 默认固定 `iPad Pro 13-inch (M5)`，只编译 App，不编译或运行整个 XCTest 测试包；
 - Rust、Mac App、共享契约和打包改动只进入各自的必要门禁；
 - 未映射路径会明确失败，不会被静默当作通过。
 
-只有跨模块重构、共享协议/发布链路、准备正式发布，或 quick 无法覆盖风险时才升级：
+开发过程中需要 XCTest 时，只运行与当前问题直接相关的 selector。只有共享协议或跨栈接口、
+鉴权/权限/持久化/并发/重连等高风险语义、大范围重构、准备正式发布，或用户明确要求时才升级：
 
 ```bash
 bash ./scripts/verify-change.sh --full
 ```
 
-`--full` 仍只覆盖受影响语言栈，并补齐仓库级 Gate。CI 红灯时先重跑或定位失败的
-具体 job，不要为了“保险”把所有本地流程再跑一遍。
+`--full` 仍只覆盖受影响语言栈，并补齐仓库级 Gate。普通 UI、文案、单 package、测试文件、
+改动文件较多和准备提交都不是 full 的触发条件。CI 红灯时先重跑或定位失败的具体 job，
+不要为了“保险”把所有本地流程再跑一遍。
 
 日常 `build` / `run` 只通过 `bash ./scripts/ios-dev.sh` 执行，优先租用 available、paired、USB 连接的真机，再选择可达的本地网络真机。只有没有可达真机时才回退 `iPad Pro 13-inch (M5)` Simulator；检测到真机但全部忙时明确失败，不静默切换设备类型。`build-for-testing`、`test`、快照与 CI 精确固定这台 M5 iPad，忙或缺失时不切换 iPad mini。使用 `bash ./scripts/ios-dev.sh target` 查看目标和选择原因，使用 `bash ./scripts/ios-dev.sh leases` 查看跨 Worktree 租约和外部 `xcodebuild`；兼容性运行通过 `IOS_TARGET_MODE=simulator` 和 `IOS_SIMULATOR_NAME` 显式切换。
 

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -68,16 +68,52 @@ assert_not_contains "$nested_docs_output" "ios-dev.sh build-for-testing"
 assert_not_contains "$nested_docs_output" "cargo test"
 
 ios_output="$(assert_plan ios_only ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift)"
-assert_contains "$ios_output" "ios-dev.sh build-for-testing"
+assert_contains "$ios_output" "iOS quick 只编译 App，不编译或运行 XCTest"
+assert_contains "$ios_output" "IOS_TARGET_MODE=simulator IOS_SIMULATOR_ID= IOS_SIMULATOR_NAME='iPad Pro 13-inch (M5)' bash ./scripts/ios-dev.sh build"
+assert_contains "$ios_output" "当前：quick；只在最后一次代码修改后执行一次"
+assert_contains "$ios_output" "自动高风险信号：未检测到"
 assert_contains "$ios_output" "docs=false"
 assert_contains "$ios_output" "check-source-size.sh"
+assert_not_contains "$ios_output" "ios-dev.sh build-for-testing"
+assert_not_contains "$ios_output" "ios-dev.sh target"
+assert_not_contains "$ios_output" "ios-dev.sh leases"
 assert_not_contains "$ios_output" "go test"
 assert_not_contains "$ios_output" "cargo test"
+
+ios_execution_paths="$test_root/ios-execution.paths"
+ios_execution_xcodebuild_log="$test_root/ios-execution-xcodebuild.log"
+ios_execution_tailcat_log="$test_root/ios-execution-tailcat.log"
+ios_execution_lease_root="$test_root/ios-execution-leases"
+printf '%s\0' ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift \
+  > "$ios_execution_paths"
+: > "$ios_execution_xcodebuild_log"
+: > "$ios_execution_tailcat_log"
+ios_execution_output="$(
+  IOS_XCRUN_BIN="$ROOT_DIR/scripts/testdata/ios-device-management/fake-xcrun.sh" \
+  IOS_XCODEBUILD_BIN="$ROOT_DIR/scripts/testdata/ios-device-management/fake-xcodebuild.sh" \
+  IOS_TAILCAT_BUILD_SCRIPT="$ROOT_DIR/scripts/testdata/ios-device-management/fake-tailcat-mobile-build.sh" \
+  IOS_TEST_SIMULATORS_JSON="$ROOT_DIR/scripts/testdata/ios-device-management/simulators.json" \
+  IOS_TEST_PHYSICAL_JSON="$ROOT_DIR/scripts/testdata/ios-device-management/no-physical-devices.json" \
+  IOS_TEST_XCODEBUILD_LOG="$ios_execution_xcodebuild_log" \
+  IOS_TEST_TAILCAT_BUILD_LOG="$ios_execution_tailcat_log" \
+  IOS_DEVICE_LEASE_ROOT="$ios_execution_lease_root" \
+  bash ./scripts/verify-change.sh --paths-file "$ios_execution_paths"
+)"
+assert_contains "$ios_execution_output" "iOS quick 只编译 App，不编译或运行 XCTest"
+assert_contains "$(<"$ios_execution_xcodebuild_log")" \
+  "-destination platform=iOS Simulator,id=M5-27-UDID"
+assert_contains "$(<"$ios_execution_xcodebuild_log")" \
+  "CODE_SIGNING_ALLOWED=NO build"
+assert_not_contains "$(<"$ios_execution_xcodebuild_log")" "build-for-testing"
+assert_contains "$(<"$ios_execution_tailcat_log")" "build"
+[[ ! -d "$ios_execution_lease_root/M5-27-UDID.lease" ]] \
+  || fail "iOS quick 结束后必须释放固定 Simulator 租约。"
 
 tailcat_output="$(assert_plan tailcat experiments/tailcat/mobile/tailcatmobile/tailcatmobile.go)"
 assert_contains "$tailcat_output" "PR Gate scope：go=false, ios=true"
 assert_contains "$tailcat_output" "(cd experiments/tailcat && go test ./... -count=1)"
-assert_contains "$tailcat_output" "ios-dev.sh build-for-testing"
+assert_contains "$tailcat_output" "iOS quick 只编译 App，不编译或运行 XCTest"
+assert_not_contains "$tailcat_output" "ios-dev.sh build-for-testing"
 assert_not_contains "$tailcat_output" "Go 受影响范围使用完整回归"
 
 go_output="$(assert_plan go_only internal/httpapi/router.go)"
@@ -100,8 +136,11 @@ assert_contains "$rust_shared_output" "-p alleycat-claude-bridge"
 ios_full_output="$(assert_full_plan ios_full ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift)"
 assert_contains "$ios_full_output" "test-conversation-regressions.sh"
 assert_contains "$ios_full_output" "--ios-only"
+assert_contains "$ios_full_output" "当前：full；交付报告必须说明命中的高风险条件"
 assert_not_contains "$ios_full_output" "test-ios-localization-smoke.sh"
 assert_not_contains "$ios_full_output" "ios-dev.sh build-for-testing"
+assert_not_contains "$ios_full_output" "ios-dev.sh target"
+assert_not_contains "$ios_full_output" "ios-dev.sh leases"
 
 mixed_full_output="$(assert_full_plan mixed_full internal/httpapi/router.go ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift)"
 assert_contains "$mixed_full_output" "go test ./... -count=1"
@@ -163,7 +202,9 @@ assert_contains "$restart_control_output" "restart-agentd-dev-macos.sh --self-te
 
 contract_output="$(assert_plan contract contracts/mimi-protocol/contract.json)"
 assert_contains "$contract_output" "check-mimi-protocol-contract.sh"
-assert_contains "$contract_output" "ios-dev.sh build-for-testing"
+assert_contains "$contract_output" "iOS quick 只编译 App，不编译或运行 XCTest"
+assert_contains "$contract_output" "自动高风险信号：检测到 Go/iOS 共享协议路径"
+assert_not_contains "$contract_output" "ios-dev.sh build-for-testing"
 assert_not_contains "$contract_output" "go test ./... -count=1"
 
 contract_full_output="$(assert_full_plan contract_full contracts/mimi-protocol/contract.json)"
@@ -230,7 +271,9 @@ assert_contains "$collection_output" "internal/httpapi/committed.go"
 assert_contains "$collection_output" "ios/MimiRemote/Sources/Staged.swift"
 assert_contains "$collection_output" "bridges/claude/untracked.rs"
 assert_contains "$collection_output" "go test ./internal/httpapi -count=1"
-assert_contains "$collection_output" "ios-dev.sh build-for-testing"
+assert_contains "$collection_output" "iOS quick 只编译 App，不编译或运行 XCTest"
+assert_contains "$collection_output" "自动高风险信号：检测到多个产品栈"
+assert_not_contains "$collection_output" "ios-dev.sh build-for-testing"
 assert_contains "$collection_output" "cargo test --locked"
 
 # base 与 HEAD 都存在但没有共同祖先时，git diff 必须显式失败；不能把退出码

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -583,13 +583,14 @@ if [[ "$has_tailcat_source" == true ]]; then
 fi
 
 if [[ "$direct_ios" == true ]]; then
-  add_check "iOS 验证前只解析一次目标" "bash ./scripts/ios-dev.sh target"
-  add_check "iOS 验证前只查看一次设备占用" "bash ./scripts/ios-dev.sh leases"
   if [[ "$mode" == "full" ]]; then
     # Go 变更由上方独立 Go 计划覆盖；iOS 阶段不在 macOS/Simulator 链路重复执行。
     add_check "iOS full 单次执行核心链路与双语资源回归" "bash ./scripts/test-conversation-regressions.sh --ios-only"
   else
-    add_check "iOS quick 只编译一次可复用测试产物" "bash ./scripts/ios-dev.sh build-for-testing"
+    # quick 只证明生产 App 能在固定 M5 Simulator 上编译。整个 XCTest 测试包会随
+    # 项目增长而持续变慢；问题相关 selector 应在开发阶段单独执行，完整集合交给 full/CI。
+    add_check "iOS quick 只编译 App，不编译或运行 XCTest" \
+      "IOS_TARGET_MODE=simulator IOS_SIMULATOR_ID= IOS_SIMULATOR_NAME='iPad Pro 13-inch (M5)' bash ./scripts/ios-dev.sh build"
   fi
 fi
 
@@ -629,6 +630,29 @@ else
 fi
 echo "- 去重后路径：${#changed_paths[@]}"
 echo "- PR Gate scope：go=${go_scope}, ios=${ios_scope}, rust=${rust_scope}, macos=${macos_scope}, docs=${docs_scope}"
+echo
+
+echo "验证阶段："
+if [[ "$mode" == "full" ]]; then
+  echo "- 当前：full；交付报告必须说明命中的高风险条件。"
+else
+  echo "- 当前：quick；只在最后一次代码修改后执行一次，不要在每个微调后重复执行。"
+fi
+echo "- 开发中：只运行问题直接相关的 package、XCTest selector、快照或静态检查。"
+echo "- full 条件：共享协议/跨栈接口，高风险状态语义，影响范围无法界定的大重构，正式发布或用户明确要求。"
+echo "- 非 full 条件：普通 UI、文案、单 package、测试文件、改动文件较多、准备提交或“为了保险”。"
+if [[ "$has_contract" == true ]]; then
+  echo "- 自动高风险信号：检测到 Go/iOS 共享协议路径；建议显式评估 full。"
+elif [[ "$direct_go" == true && "$direct_ios" == true ]] || \
+     [[ "$direct_go" == true && "$direct_rust" == true ]] || \
+     [[ "$direct_go" == true && "$direct_macos" == true ]] || \
+     [[ "$direct_ios" == true && "$direct_rust" == true ]] || \
+     [[ "$direct_ios" == true && "$direct_macos" == true ]] || \
+     [[ "$direct_rust" == true && "$direct_macos" == true ]]; then
+  echo "- 自动高风险信号：检测到多个产品栈；建议确认是否修改同一跨栈接口。"
+else
+  echo "- 自动高风险信号：未检测到；除非存在脚本无法识别的高风险语义，否则保持 quick。"
+fi
 echo
 
 if [[ "${#changed_paths[@]}" -eq 0 ]]; then


### PR DESCRIPTION
## 目标

让普通 Issue 默认只做针对性验证和一次 quick，避免项目增长后每次改动都编译完整 XCTest 测试包或运行全量流程。

## 实现

- 在 AGENTS.md 固化开发中、交付前 quick、显式 full 三个验证阶段。
- 明确 full 的高风险触发条件，以及普通 UI、文案、单 package 等非触发条件。
- iOS quick 改为固定 M5 Simulator 的 App-only build，不再默认 build-for-testing。
- 移除 quick/full 前重复的 target 和 leases 查询；统一入口仍负责原子租约和目标校验。
- plan 输出当前验证阶段、full 条件和自动高风险信号。
- 增加 fake Simulator 执行自测，确认 quick 使用固定 M5、执行 build 且释放租约。

## 验证

- `bash ./scripts/test-verify-change.sh`：通过。
- `bash ./scripts/check-source-size.sh`：通过。
- `bash ./scripts/verify-change.sh --plan`：通过，判定仅需 docs/static 与分层验证自测。
- `bash ./scripts/verify-change.sh`：Shell 语法和 diff 检查通过；在现有 `scripts/test-install-linux.sh` 失败处停止。该脚本与本 PR 无差异，本机 Bash 3.2 报 `setup_transport_args[@]: unbound variable`。

## 延后范围

- 未运行 full、Xcode、Simulator 或真机；本 PR 不修改产品代码。
- required PR Gate 保持不变。