### PR TITLE
MIM-252 用 Claude transcript 里的标题填充会话列表

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/thread.rs
@@ -120,6 +120,8 @@ pub async fn handle_thread_start(
         metadata: crate::index::ClaudeSessionRef {
             claude_session_path: claude_session_path_for(&cwd, &thread_id),
             claude_session_id: thread_id.clone(),
+            // transcript 还没写标题；首次历史扫描会补上。
+            claude_title: None,
         },
     };
     state
@@ -328,6 +330,9 @@ pub async fn handle_thread_fork(
         metadata: crate::index::ClaudeSessionRef {
             claude_session_path: new_session_path,
             claude_session_id: new_thread_id.clone(),
+            // 名字是从源线程整行拷来的，来源标记也一起拷，
+            // 否则新线程自己的 transcript 标题会被当成用户命名挡住。
+            claude_title: source.metadata.claude_title.clone(),
         },
     };
     state

--- a/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/turn.rs
@@ -1630,6 +1630,7 @@ mod tests {
             metadata: crate::index::ClaudeSessionRef {
                 claude_session_path: "/tmp/a.jsonl".into(),
                 claude_session_id: id.into(),
+                claude_title: None,
             },
         };
         state

--- a/bridges/claude/crates/claude-bridge/src/index/claude_session_scan.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/claude_session_scan.rs
@@ -172,8 +172,8 @@ async fn build_session_info(path: &Path) -> Option<ClaudeSessionInfo> {
         };
         if title_candidate {
             match title_record(&value) {
-                Some(TitleRecord::Custom(title)) => custom_title = Some(title),
-                Some(TitleRecord::Ai(title)) => ai_title = Some(title),
+                Some(TitleRecord::Custom(title)) => custom_title = title,
+                Some(TitleRecord::Ai(title)) => ai_title = title,
                 None => {}
             }
         }
@@ -221,9 +221,11 @@ async fn build_session_info(path: &Path) -> Option<ClaudeSessionInfo> {
     })
 }
 
+/// 外层 `Option` 区分“不是标题记录”；变体里的 `Option` 区分有效标题和空标题。
+/// 空标题必须保留下来清除同类型的旧值，不能在解析阶段直接丢弃。
 enum TitleRecord {
-    Custom(String),
-    Ai(String),
+    Custom(Option<String>),
+    Ai(Option<String>),
 }
 
 /// 便宜的预筛：只有出现过标题记录类型字面量的行才值得整行 JSON 解析。
@@ -239,10 +241,12 @@ fn looks_like_title_record(line: &str) -> bool {
 
 fn title_record(value: &Value) -> Option<TitleRecord> {
     match value.get("type").and_then(Value::as_str)? {
-        CUSTOM_TITLE_TYPE => {
-            title_text(value, "customTitle", "custom_title").map(TitleRecord::Custom)
-        }
-        AI_TITLE_TYPE => title_text(value, "aiTitle", "ai_title").map(TitleRecord::Ai),
+        CUSTOM_TITLE_TYPE => Some(TitleRecord::Custom(title_text(
+            value,
+            "customTitle",
+            "custom_title",
+        ))),
+        AI_TITLE_TYPE => Some(TitleRecord::Ai(title_text(value, "aiTitle", "ai_title"))),
         _ => None,
     }
 }
@@ -376,13 +380,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn falls_back_to_ai_title_and_ignores_blank_titles() {
+    async fn latest_blank_custom_title_clears_previous_value_and_falls_back_to_ai_title() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("ai-only.jsonl");
         let records = [
-            r#"{"type":"custom-title","customTitle":"   ","sessionId":"ai-only"}"#,
             r#"{"type":"user","cwd":"/private/tmp","message":{"role":"user","content":"hello"},"timestamp":"2026-09-04T10:00:00Z"}"#,
             r#"{"type":"ai-title","aiTitle":"自动标题","sessionId":"ai-only"}"#,
+            r#"{"type":"custom-title","customTitle":"旧的自定义标题","sessionId":"ai-only"}"#,
+            r#"{"type":"custom-title","customTitle":"   ","sessionId":"ai-only"}"#,
         ];
         std::fs::write(&path, records.join("\n")).unwrap();
 

--- a/bridges/claude/crates/claude-bridge/src/index/claude_session_scan.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/claude_session_scan.rs
@@ -11,6 +11,10 @@
 //! user message for `first_message`, skipping Claude CLI metadata, local
 //! commands, and tool-result-only records. Files without a real user message,
 //! or that fail to open or parse, are skipped quietly.
+//!
+//! Claude 自己会把会话标题写进同一份 transcript（`custom-title` / `ai-title`
+//! 记录），桌面端列表显示的就是它。扫描时一并读出来当作 `title`，Mimi 不需要
+//! 再生成一次标题。
 
 use std::path::{Path, PathBuf};
 
@@ -33,7 +37,23 @@ pub struct ClaudeSessionInfo {
     pub created: DateTime<Utc>,
     pub modified: DateTime<Utc>,
     pub first_message: String,
+    /// Claude 写在 transcript 里的会话标题；`custom-title` 优先于 `ai-title`。
+    /// 旧会话没有这两种记录时为 `None`，列表继续回退到首条用户消息。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
+
+/// 标题记录的两种 `type`。同一文件每次 checkpoint 都会追加当前值，取最后一条。
+const CUSTOM_TITLE_TYPE: &str = "custom-title";
+const AI_TITLE_TYPE: &str = "ai-title";
+
+/// 标题被截断的上限。Claude 写的都是短标题，异常长的值更可能是坏记录，
+/// 不能让它撑坏列表行。
+const MAX_TITLE_CHARS: usize = 120;
+
+/// 一条标题记录的字节上限，用于跳过大行的预筛。真实记录不到 200 字节，
+/// 这里留足余量。
+const MAX_TITLE_RECORD_BYTES: usize = 4096;
 
 /// `~/.claude/projects/`. Honors `CLAUDE_PROJECTS_DIR` for tests.
 pub fn claude_projects_dir() -> Option<PathBuf> {
@@ -131,15 +151,35 @@ async fn build_session_info(path: &Path) -> Option<ClaudeSessionInfo> {
     let mut first_message: Option<String> = None;
     let mut found_real_user_message = false;
     let mut first_message_ts: Option<DateTime<Utc>> = None;
+    let mut custom_title: Option<String> = None;
+    let mut ai_title: Option<String> = None;
     for line in text.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
+            continue;
+        }
+        // 头部信息（cwd + 首条消息）通常在前几行就齐了，但标题记录一直追加到
+        // 文件末尾。补齐头部后只对可能是标题的行做 JSON 解析：transcript 动辄
+        // 上万行，逐行解析比子串预筛贵一个量级。
+        let header_done = !cwd.is_empty() && first_message.is_some();
+        let title_candidate = looks_like_title_record(trimmed);
+        if header_done && !title_candidate {
             continue;
         }
         let value: serde_json::Value = match serde_json::from_str(trimmed) {
             Ok(v) => v,
             Err(_) => continue,
         };
+        if title_candidate {
+            match title_record(&value) {
+                Some(TitleRecord::Custom(title)) => custom_title = Some(title),
+                Some(TitleRecord::Ai(title)) => ai_title = Some(title),
+                None => {}
+            }
+        }
+        if header_done {
+            continue;
+        }
         if cwd.is_empty() {
             if let Some(c) = value.get("cwd").and_then(|v| v.as_str()) {
                 cwd = c.to_string();
@@ -162,9 +202,6 @@ async fn build_session_info(path: &Path) -> Option<ClaudeSessionInfo> {
                 }
             }
         }
-        if !cwd.is_empty() && first_message.is_some() {
-            break;
-        }
     }
 
     let created = first_message_ts.unwrap_or(created);
@@ -178,7 +215,49 @@ async fn build_session_info(path: &Path) -> Option<ClaudeSessionInfo> {
         created,
         modified,
         first_message: first_message.unwrap_or_default(),
+        // 用户或桌面端设定的 `custom-title` 压过自动生成的 `ai-title`，
+        // 与 Claude 自己的列表一致。
+        title: custom_title.or(ai_title),
     })
+}
+
+enum TitleRecord {
+    Custom(String),
+    Ai(String),
+}
+
+/// 便宜的预筛：只有出现过标题记录类型字面量的行才值得整行 JSON 解析。
+/// 普通消息里恰好出现同样文本时最多多解析一行，`title_record` 会再判一次类型。
+///
+/// 长度先行是因为 transcript 的字节数几乎都集中在少数几行超大的助手输出和附件
+/// 上；标题记录只有几十字节，先按长度筛掉大行，扫描整份历史的成本才不会
+/// 随对话体积增长。
+fn looks_like_title_record(line: &str) -> bool {
+    line.len() <= MAX_TITLE_RECORD_BYTES
+        && (line.contains(CUSTOM_TITLE_TYPE) || line.contains(AI_TITLE_TYPE))
+}
+
+fn title_record(value: &Value) -> Option<TitleRecord> {
+    match value.get("type").and_then(Value::as_str)? {
+        CUSTOM_TITLE_TYPE => {
+            title_text(value, "customTitle", "custom_title").map(TitleRecord::Custom)
+        }
+        AI_TITLE_TYPE => title_text(value, "aiTitle", "ai_title").map(TitleRecord::Ai),
+        _ => None,
+    }
+}
+
+/// 标题只取首个非空行并裁到 [`MAX_TITLE_CHARS`]；空标题按“没有标题”处理，
+/// 否则列表会显示一行空白而不是回退到首条用户消息。
+fn title_text(value: &Value, camel_key: &str, snake_key: &str) -> Option<String> {
+    let raw = value
+        .get(camel_key)
+        .or_else(|| value.get(snake_key))
+        .and_then(Value::as_str)?;
+    let line = raw.lines().map(str::trim).find(|line| !line.is_empty())?;
+    let title: String = line.chars().take(MAX_TITLE_CHARS).collect();
+    let title = title.trim();
+    (!title.is_empty()).then(|| title.to_string())
 }
 
 /// 提取会话标题时只认真实用户文本。Claude 会把 `/model` 等本地命令、
@@ -272,6 +351,95 @@ mod tests {
         assert_eq!(sessions[0].session_id, "abc-123");
         assert_eq!(sessions[0].cwd, "/private/tmp");
         assert_eq!(sessions[0].first_message, "hello world");
+    }
+
+    #[tokio::test]
+    async fn reads_claude_title_written_after_the_first_message() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("titled.jsonl");
+        let records = [
+            r#"{"type":"user","cwd":"/private/tmp","message":{"role":"user","content":"帮我看下会话列表"},"timestamp":"2026-09-04T10:00:00Z"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"好的"}]}}"#,
+            r#"{"type":"ai-title","aiTitle":"旧的自动标题","sessionId":"titled"}"#,
+            r#"{"type":"custom-title","customTitle":"旧的自定义标题","sessionId":"titled"}"#,
+            r#"{"type":"ai-title","aiTitle":"最新自动标题","sessionId":"titled"}"#,
+            r#"{"type":"custom-title","customTitle":"最新自定义标题","sessionId":"titled"}"#,
+        ];
+        std::fs::write(&path, records.join("\n")).unwrap();
+
+        let sessions = list_sessions_from_dir(dir.path()).await;
+
+        assert_eq!(sessions.len(), 1);
+        // 标题记录整份 transcript 一路追加，取最后一条；custom 压过 ai。
+        assert_eq!(sessions[0].title.as_deref(), Some("最新自定义标题"));
+        assert_eq!(sessions[0].first_message, "帮我看下会话列表");
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_ai_title_and_ignores_blank_titles() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("ai-only.jsonl");
+        let records = [
+            r#"{"type":"custom-title","customTitle":"   ","sessionId":"ai-only"}"#,
+            r#"{"type":"user","cwd":"/private/tmp","message":{"role":"user","content":"hello"},"timestamp":"2026-09-04T10:00:00Z"}"#,
+            r#"{"type":"ai-title","aiTitle":"自动标题","sessionId":"ai-only"}"#,
+        ];
+        std::fs::write(&path, records.join("\n")).unwrap();
+
+        let sessions = list_sessions_from_dir(dir.path()).await;
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].title.as_deref(), Some("自动标题"));
+    }
+
+    #[tokio::test]
+    async fn leaves_title_empty_when_transcript_has_none() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("untitled.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"user","cwd":"/private/tmp","message":{"role":"user","content":"hello"},"timestamp":"2026-09-04T10:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let sessions = list_sessions_from_dir(dir.path()).await;
+
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].title.is_none());
+    }
+
+    #[tokio::test]
+    async fn ignores_title_text_inside_ordinary_messages() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mentions-title.jsonl");
+        let records = [
+            r#"{"type":"user","cwd":"/private/tmp","message":{"role":"user","content":"custom-title 这个记录该怎么读"},"timestamp":"2026-09-04T10:00:00Z"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ai-title 是自动生成的"}]}}"#,
+        ];
+        std::fs::write(&path, records.join("\n")).unwrap();
+
+        let sessions = list_sessions_from_dir(dir.path()).await;
+
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].title.is_none());
+    }
+
+    #[tokio::test]
+    async fn truncates_overlong_title_to_one_line() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("long-title.jsonl");
+        let long = "标".repeat(MAX_TITLE_CHARS + 40);
+        let records = [
+            r#"{"type":"user","cwd":"/private/tmp","message":{"role":"user","content":"hello"},"timestamp":"2026-09-04T10:00:00Z"}"#.to_string(),
+            format!(r#"{{"type":"custom-title","customTitle":"{long}\n第二行","sessionId":"long-title"}}"#),
+        ];
+        std::fs::write(&path, records.join("\n")).unwrap();
+
+        let sessions = list_sessions_from_dir(dir.path()).await;
+
+        let title = sessions[0].title.as_deref().unwrap();
+        assert_eq!(title.chars().count(), MAX_TITLE_CHARS);
+        assert!(!title.contains('\n'));
     }
 
     #[tokio::test]

--- a/bridges/claude/crates/claude-bridge/src/index/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/index/mod.rs
@@ -49,6 +49,10 @@ pub struct ClaudeSessionRef {
     pub claude_session_path: PathBuf,
     /// Claude session id (== `thread_id` in v1).
     pub claude_session_id: String,
+    /// 上一次从 transcript 导入的标题。用来区分「行名来自 transcript」和
+    /// 「用户在 Mimi 里 `thread/name/set` 改过名」：只有前者才允许被后续扫描推进。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_title: Option<String>,
 }
 
 /// Bridge-local alias so handler code reads `IndexEntry` instead of the
@@ -63,7 +67,7 @@ pub fn entry_from_claude(info: &ClaudeSessionInfo) -> IndexEntry {
         created_at: info.created.timestamp_millis(),
         updated_at: info.modified.timestamp_millis(),
         archived: false,
-        name: None,
+        name: info.title.clone(),
         preview: info.first_message.clone(),
         forked_from_id: None,
         model_provider: "anthropic".to_string(),
@@ -71,6 +75,7 @@ pub fn entry_from_claude(info: &ClaudeSessionInfo) -> IndexEntry {
         metadata: ClaudeSessionRef {
             claude_session_path: info.path.clone(),
             claude_session_id: info.session_id.clone(),
+            claude_title: info.title.clone(),
         },
     }
 }
@@ -275,10 +280,18 @@ async fn reconcile_scanned_entries(
             continue;
         };
         let mut repaired = entry.clone();
+        let title_owns_name = transcript_title_owns_name(&entry);
         repaired.cwd.clone_from(&fresh.cwd);
         repaired.created_at = fresh.created_at;
         repaired.updated_at = fresh.updated_at;
         repaired.metadata.clone_from(&fresh.metadata);
+        // Claude 会在会话进行中改写 transcript 里的标题，已建索引的旧行也要跟上；
+        // 但用户在 Mimi 里手动改的名字优先，扫描结果不能覆盖。
+        if let Some(fresh_title) = fresh.metadata.claude_title.clone()
+            && title_owns_name
+        {
+            repaired.name = Some(fresh_title);
+        }
         if is_legacy_invalid_preview(entry.preview.trim()) {
             repaired.preview.clone_from(&fresh.preview);
         }
@@ -289,6 +302,16 @@ async fn reconcile_scanned_entries(
 
     index.upsert_many(repaired_entries).await?;
     Ok(scanned)
+}
+
+/// 索引行的名字是否仍由 transcript 决定：没有名字，或名字与上次导入的
+/// transcript 标题一致时为真。升级前写入的行没有导入记录，只要它有名字就
+/// 一律当作用户命名保留。
+fn transcript_title_owns_name(entry: &IndexEntry) -> bool {
+    match entry.name.as_deref().map(str::trim) {
+        None | Some("") => true,
+        Some(name) => entry.metadata.claude_title.as_deref().map(str::trim) == Some(name),
+    }
 }
 
 /// 同一 session ID 偶尔会在多个 Claude project 目录短暂共存。当前索引路径仍可见时
@@ -385,6 +408,7 @@ mod tests {
             metadata: ClaudeSessionRef {
                 claude_session_path: PathBuf::from(format!("/sessions/{id}.jsonl")),
                 claude_session_id: id.to_string(),
+                claude_title: None,
             },
         }
     }
@@ -539,6 +563,91 @@ mod tests {
         assert_eq!(row.name.as_deref(), Some("用户命名"));
         assert_eq!(row.forked_from_id.as_deref(), Some("parent"));
         assert!(row.archived);
+    }
+
+    #[tokio::test]
+    async fn refresh_fills_transcript_title_but_keeps_user_rename() {
+        let dir = TempDir::new().unwrap();
+        let projects_dir = dir.path().join("projects");
+        std::fs::create_dir_all(&projects_dir).unwrap();
+        let write_session = |id: &str, title: &str| {
+            std::fs::write(
+                projects_dir.join(format!("{id}.jsonl")),
+                [
+                    format!(
+                        r#"{{"type":"user","cwd":"/work","message":{{"role":"user","content":"第一句话"}},"timestamp":"2026-09-04T07:00:00Z"}}"#
+                    ),
+                    format!(r#"{{"type":"ai-title","aiTitle":"{title}","sessionId":"{id}"}}"#),
+                ]
+                .join("\n"),
+            )
+            .unwrap();
+        };
+        write_session("fresh", "Claude 的标题");
+        write_session("renamed", "Claude 的标题");
+        write_session("advanced", "新的自动标题");
+
+        let index = CoreThreadIndex::<ClaudeSessionRef>::open_at(dir.path().join("threads.json"))
+            .await
+            .unwrap();
+        index
+            .insert(entry("fresh", "/work", 100, 200, false))
+            .await
+            .unwrap();
+        let mut renamed = entry("renamed", "/work", 100, 200, false);
+        renamed.name = Some("用户命名".into());
+        index.insert(renamed).await.unwrap();
+        // 上一轮扫描导入过标题的行：Claude 改了标题，索引要跟着走。
+        let mut advanced = entry("advanced", "/work", 100, 200, false);
+        advanced.name = Some("旧的自动标题".into());
+        advanced.metadata.claude_title = Some("旧的自动标题".into());
+        index.insert(advanced).await.unwrap();
+
+        let refresher = ClaudeHistoryRefresher::with_interval(
+            Arc::clone(&index),
+            ClaudeHydrator::with_override_dir(projects_dir),
+            Duration::ZERO,
+        );
+        refresher.refresh_if_due().await.unwrap();
+
+        let fresh = index.lookup("fresh").await.unwrap();
+        assert_eq!(fresh.name.as_deref(), Some("Claude 的标题"));
+        assert_eq!(
+            index.lookup("renamed").await.unwrap().name.as_deref(),
+            Some("用户命名")
+        );
+        assert_eq!(
+            index.lookup("advanced").await.unwrap().name.as_deref(),
+            Some("新的自动标题")
+        );
+    }
+
+    #[tokio::test]
+    async fn new_session_enters_index_with_its_transcript_title() {
+        let dir = TempDir::new().unwrap();
+        let projects_dir = dir.path().join("projects");
+        std::fs::create_dir_all(&projects_dir).unwrap();
+        std::fs::write(
+            projects_dir.join("titled.jsonl"),
+            [
+                r#"{"type":"user","cwd":"/work","message":{"role":"user","content":"第一句话"},"timestamp":"2026-09-04T07:00:00Z"}"#,
+                r#"{"type":"custom-title","customTitle":"会话列表标题","sessionId":"titled"}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let hydrator = ClaudeHydrator::with_override_dir(projects_dir);
+        let index = open_index_and_hydrate(dir.path().join("threads.json"), &hydrator)
+            .await
+            .unwrap();
+
+        let row = index.lookup("titled").await.unwrap();
+        assert_eq!(row.name.as_deref(), Some("会话列表标题"));
+        assert_eq!(row.metadata.claude_title.as_deref(), Some("会话列表标题"));
+        // 标题进 name，首条消息留在 preview 当第二行副标题。
+        assert_eq!(entry_to_thread(&row).name.as_deref(), Some("会话列表标题"));
+        assert_eq!(entry_to_thread(&row).preview, "第一句话");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 问题

iPad 上 Claude 会话行只有一行原始 prompt，Codex 会话行是「短标题 + 摘要」两行。根因在 bridge：建索引时 `name` 恒为 `None`，iOS 只能退回 preview 首行当标题；标题与 preview 重复后，第二行副标题又被 `distinctPreviewDisplayText` 的去重逻辑吞掉。会话区和工作区两个列表都受影响。

## 改法

Claude 自己就把标题写在 `~/.claude/projects/**/<session>.jsonl` 里，桌面端列表显示的正是它：

- `{"type":"custom-title","customTitle":"…"}`（用户 / 桌面端设定）
- `{"type":"ai-title","aiTitle":"…"}`（自动生成）

所以不需要像 issue 原方案那样再拨 Codex upstream 生成一次标题、再新开一条写回 bridge 的链路。扫描 transcript 时直接把标题读出来填进索引 `name`，标题与 Claude 桌面端完全一致，preview 保持首条用户消息，列表自然回到「标题 + 副标题」两行。

- 标题取最后一条记录（每次 checkpoint 都会追加当前值），`custom-title` 优先于 `ai-title`；空标题按没有标题处理，继续回退首条消息。
- 已建索引的旧行由 `refreshHistory` 扫描补齐，并跟随 Claude 后续改名；metadata 里记下导入值，用户在 Mimi 里 `thread/name/set` 改过的名字不会被扫描覆盖。
- fork 出的新线程把来源标记一起拷走，否则它自己的 transcript 标题会被当成用户命名挡住。

## 扫描成本

标题记录会一路追加到文件末尾，所以头部齐了以后不能再 break。补偿手段是预筛：只有小于 4KB 且含标题类型字面量的行才做 JSON 解析。本机 305MB / 145 份 transcript 实测全量扫描 85ms → 114ms（release，热缓存），`refreshHistory` 本身仍有 2s 冷却。

## 验证

- `cargo test`（bridges/claude 全量）、`cargo clippy --all-targets`、`cargo fmt --check`、`scripts/check-source-size.sh` 全通过。
- 新增单测覆盖：标题写在首条消息之后仍能读到、custom 压过 ai、空标题回退、普通消息里出现同名文本不误判、超长标题截断；索引侧覆盖首次入库带标题、旧行补齐、用户改名不被覆盖、transcript 改名跟随。
- 端到端：用 release bridge 二进制对着真实索引副本（`CODEX_HOME` 指向拷贝，不动线上文件）跑 `initialize` + `thread/list`，本仓库 127 行里 58 行拿到 Claude 自己的标题，`thread/list` 响应同时带回 `name` 与 `preview`。

Closes MIM-252

🤖 Generated with [Claude Code](https://claude.com/claude-code)