### PR TITLE
MIM-269 修复进入 Mimi 托管连接时闪退

### DIFF
--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -681,7 +681,9 @@ struct InitialConnectionSettingsSections: View {
     @ViewBuilder
     private var tailcatSettingsDestination: some View {
         if appStore.activeConnectionProfile?.connectionRoute.isManaged == true {
-            ManagedConnectionSubscriptionView()
+            ManagedConnectionSubscriptionView(
+                qrScannerPresentation: qrScannerPresentation
+            )
         } else {
             TailcatExperimentSettingsView()
         }

--- a/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
@@ -7,7 +7,7 @@ struct ManagedConnectionSubscriptionView: View {
     @EnvironmentObject private var entitlementStore: ManagedConnectionEntitlementStore
     @EnvironmentObject private var deviceStore: ManagedConnectionDeviceStore
     @EnvironmentObject private var tailcatController: TailcatExperimentController
-    @EnvironmentObject private var qrScannerPresentation: ConnectionQRCodeScannerPresentation
+    @ObservedObject var qrScannerPresentation: ConnectionQRCodeScannerPresentation
     @EnvironmentObject private var themeStore: ThemeStore
     @State private var pendingRemoval: ManagedConnectionDevice?
     @State private var localError: String?

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
@@ -12,7 +12,9 @@ struct InitialPairingView: View {
         Form {
             Section {
                 NavigationLink {
-                    ManagedConnectionSubscriptionView()
+                    ManagedConnectionSubscriptionView(
+                        qrScannerPresentation: qrScannerPresentation
+                    )
                 } label: {
                     SettingsValueLabel(
                         title: L10n.text("ui.managed_subscription_title"),

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsView.swift
@@ -301,7 +301,9 @@ struct SettingsView: View {
 
             Section {
                 NavigationLink {
-                    ManagedConnectionSubscriptionView()
+                    ManagedConnectionSubscriptionView(
+                        qrScannerPresentation: qrScannerPresentation
+                    )
                 } label: {
                     SettingsValueLabel(
                         title: L10n.text("ui.managed_subscription_title"),


### PR DESCRIPTION
## 变更

- 将托管连接页面的扫码控制器改为显式参数
- 三个导航入口传入 SettingsView 持有的同一实例
- 避免页面 onAppear 读取缺失的 EnvironmentObject

## 验证

- iPad Pro 真机构建、安装和启动通过
- 用户确认再次点击 Mimi 托管连接可正常进入
- bash ./scripts/verify-change.sh：5 项 quick 验证通过
- bash ./scripts/check-source-size.sh：通过
- 两次构建缓存共 693 MB、698 MB，均已立即清理

关联：MIM-269