### PR TITLE
MIM-270 复用 Worktree 开发缓存并清理重复构建产物

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,16 @@
 - 完成前在 Issue 中回写 Branch / Worktree、Commit / PR、测试结果、运行态验证和发布结果。
 - `Done` 的最低条件是：相关改动已进入并推送 `main`、必要验证或发布已完成、临时 Worktree 已清理。
 
+## Worktree 与开发缓存
+
+- Worktree 只隔离源码、未提交改动和必须与分支绑定的状态。不得默认在每个 Worktree 内保存独立的 Xcode DerivedData、Rust `target`、Go 工具下载或其他 GB 级可再生缓存。
+- 本地开发脚本统一通过 `bash ./scripts/development-cache-path.sh <组件>` 取得仓库外缓存路径。同一 Git common-dir 的所有 Worktree 必须复用同一命名空间；另一份 clone 必须使用不同命名空间。
+- iOS DerivedData 按配置、设备类型和 UDID 隔离。同一 UDID 继续通过设备租约串行写入。Mac DerivedData 按架构和配置隔离，并通过开发缓存锁串行写入。
+- Rust 验证默认设置共享 `CARGO_TARGET_DIR`。Go 默认复用 Go 自身的全局 build/module cache；不得改成 Worktree 内缓存。
+- 新增本地构建或工具下载脚本时，默认复用上述共享缓存。只有产物确实依赖分支路径且工具不能可靠检测输入变化时，才允许放进 Worktree，并必须在脚本旁说明原因。
+- 清理磁盘前先确认没有相关构建进程或设备租约。只删除 Git 忽略且可再生成的目录，例如旧的 `.build`、`target` 和 `ios/MimiRemote/build`；不得删除 Worktree、分支、未提交源码、发布归档或模拟器数据。
+- 共享缓存异常时，只清理对应组件目录并重新构建。不得通过为同一设备、配置或 Issue 新建另一份缓存来绕过问题。
+
 ## 源码文件行数约束
 
 - 开发时必须遵守 `scripts/check-source-size.sh` 定义的源码文件行数上限。该脚本是行数限制的唯一事实来源；规则变更时，以脚本中的当前配置为准。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@
 - Worktree 只隔离源码、未提交改动和必须与分支绑定的状态。不得默认在每个 Worktree 内保存独立的 Xcode DerivedData、Rust `target`、Go 工具下载或其他 GB 级可再生缓存。
 - 本地开发脚本统一通过 `bash ./scripts/development-cache-path.sh <组件>` 取得仓库外缓存路径。同一 Git common-dir 的所有 Worktree 必须复用同一命名空间；另一份 clone 必须使用不同命名空间。
 - iOS DerivedData 按配置、设备类型和 UDID 隔离。同一 UDID 继续通过设备租约串行写入。Mac DerivedData 按架构和配置隔离，并通过开发缓存锁串行写入。
+- Mac 安装每次先从当前 Worktree 增量构建，并在同一缓存锁内复制到独立暂存目录。不得仅凭共享目录中已有 App 就跳过构建；系统锁文件保留不代表缓存正在占用，不得删除锁文件来抢占缓存。
 - Rust 验证默认设置共享 `CARGO_TARGET_DIR`。Go 默认复用 Go 自身的全局 build/module cache；不得改成 Worktree 内缓存。
 - 新增本地构建或工具下载脚本时，默认复用上述共享缓存。只有产物确实依赖分支路径且工具不能可靠检测输入变化时，才允许放进 Worktree，并必须在脚本旁说明原因。
 - 清理磁盘前先确认没有相关构建进程或设备租约。只删除 Git 忽略且可再生成的目录，例如旧的 `.build`、`target` 和 `ios/MimiRemote/build`；不得删除 Worktree、分支、未提交源码、发布归档或模拟器数据。

--- a/macos/MimiRemoteMac/README.md
+++ b/macos/MimiRemoteMac/README.md
@@ -23,19 +23,11 @@ App 不读取或展示长期 Token。设置和配对只调用 `agentd ... --qr-o
 ### 构建与测试
 
 ```bash
-cd macos/MimiRemoteMac
-xcodegen generate --spec project.yml
-
-cd ../..
-xcodebuild \
-  -project macos/MimiRemoteMac/MimiRemoteMac.xcodeproj \
-  -scheme MimiRemoteMac \
-  -configuration Debug \
-  -destination 'platform=macOS,arch=arm64' \
-  -derivedDataPath .build/MimiRemoteMac \
-  CODE_SIGN_STYLE=Automatic \
-  test
+bash scripts/test-macos-app.sh
 ```
+
+本地构建和测试默认把 DerivedData、Go 与 Rust 中间产物放到仓库外的共享开发缓存。
+同一仓库的不同 Worktree 会复用该目录，并通过缓存锁避免并发写入。
 
 构建本地 Release：
 

--- a/macos/MimiRemoteMac/README.md
+++ b/macos/MimiRemoteMac/README.md
@@ -28,6 +28,7 @@ bash scripts/test-macos-app.sh
 
 本地构建和测试默认把 DerivedData、Go 与 Rust 中间产物放到仓库外的共享开发缓存。
 同一仓库的不同 Worktree 会复用该目录，并通过缓存锁避免并发写入。
+安装脚本每次从当前 Worktree 增量构建，并在同一把锁内复制到独立暂存目录，避免安装另一分支的旧产物。
 
 构建本地 Release：
 

--- a/macos/MimiRemoteMac/Scripts/build-local.sh
+++ b/macos/MimiRemoteMac/Scripts/build-local.sh
@@ -17,17 +17,27 @@ development_cache="$(
 derived_data="${MACOS_DERIVED_DATA_PATH:-$development_cache/DerivedData}"
 embed_cache="${MACOS_EMBED_CACHE_DIR:-$development_cache/EmbedCache}"
 cache_lock="${MACOS_DEVELOPMENT_CACHE_LOCK:-$derived_data.lock}"
+[[ $# -le 1 ]] || { echo "用法：build-local.sh [暂存 App 路径]" >&2; exit 2; }
 
-for command_name in xcodegen xcodebuild; do
+for command_name in xcodegen xcodebuild codesign ditto; do
   if ! command -v "$command_name" >/dev/null 2>&1; then
     echo "缺少构建工具：$command_name" >&2
     exit 1
   fi
 done
 
-xcodegen generate --spec "$project_dir/project.yml" --project "$project_dir"
+# 从当前 Worktree 增量构建、验证和复制必须持有同一把锁，避免安装时
+# 被另一分支替换共享 DerivedData 中的 App。可选参数仅用于安装暂存。
 bash "$repo_root/scripts/development-cache-lock.sh" "$cache_lock" -- \
-  xcodebuild \
+  bash -euo pipefail -c '
+project_dir="$1"
+configuration="$2"
+architecture="$3"
+derived_data="$4"
+embed_cache="$5"
+staged_app="$6"
+xcodegen generate --spec "$project_dir/project.yml" --project "$project_dir"
+xcodebuild \
   -quiet \
   -project "$project_dir/MimiRemoteMac.xcodeproj" \
   -scheme MimiRemoteMac \
@@ -39,7 +49,11 @@ bash "$repo_root/scripts/development-cache-lock.sh" "$cache_lock" -- \
   build
 
 app_path="$derived_data/Build/Products/$configuration/Mimi Remote Mac.app"
-/usr/bin/codesign --verify --deep --strict "$app_path"
+codesign --verify --deep --strict "$app_path"
 "$app_path/Contents/Resources/agentd" version >/dev/null
+if [[ -n "$staged_app" ]]; then
+  ditto "$app_path" "$staged_app"
+fi
 
 echo "本地构建完成：$app_path"
+' _ "$project_dir" "$configuration" "$architecture" "$derived_data" "$embed_cache" "${1:-}"

--- a/macos/MimiRemoteMac/Scripts/build-local.sh
+++ b/macos/MimiRemoteMac/Scripts/build-local.sh
@@ -4,13 +4,19 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 project_dir="$(cd "$script_dir/.." && pwd)"
 repo_root="$(cd "$project_dir/../.." && pwd)"
-derived_data="$repo_root/.build/MimiRemoteMac"
 configuration="${CONFIGURATION:-Release}"
 architecture="$(uname -m)"
 case "$architecture" in
   arm64|x86_64) ;;
   *) echo "不支持的 Mac 架构：$architecture" >&2; exit 1 ;;
 esac
+development_cache="$(
+  bash "$repo_root/scripts/development-cache-path.sh" \
+    "xcode/macos/$architecture/$configuration"
+)"
+derived_data="${MACOS_DERIVED_DATA_PATH:-$development_cache/DerivedData}"
+embed_cache="${MACOS_EMBED_CACHE_DIR:-$development_cache/EmbedCache}"
+cache_lock="${MACOS_DEVELOPMENT_CACHE_LOCK:-$derived_data.lock}"
 
 for command_name in xcodegen xcodebuild; do
   if ! command -v "$command_name" >/dev/null 2>&1; then
@@ -20,13 +26,15 @@ for command_name in xcodegen xcodebuild; do
 done
 
 xcodegen generate --spec "$project_dir/project.yml" --project "$project_dir"
-xcodebuild \
+bash "$repo_root/scripts/development-cache-lock.sh" "$cache_lock" -- \
+  xcodebuild \
   -quiet \
   -project "$project_dir/MimiRemoteMac.xcodeproj" \
   -scheme MimiRemoteMac \
   -configuration "$configuration" \
   -destination "platform=macOS,arch=$architecture" \
   -derivedDataPath "$derived_data" \
+  MACOS_EMBED_CACHE_DIR="$embed_cache" \
   CODE_SIGN_STYLE=Automatic \
   build
 

--- a/macos/MimiRemoteMac/Scripts/install-local.sh
+++ b/macos/MimiRemoteMac/Scripts/install-local.sh
@@ -2,14 +2,6 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-repo_root="$(cd "$script_dir/../../.." && pwd)"
-architecture="$(uname -m)"
-development_cache="$(
-  bash "$repo_root/scripts/development-cache-path.sh" \
-    "xcode/macos/$architecture/Release"
-)"
-derived_data="${MACOS_DERIVED_DATA_PATH:-$development_cache/DerivedData}"
-source_app="$derived_data/Build/Products/Release/Mimi Remote Mac.app"
 
 # Default to wherever the app is already installed. Picking a fixed default
 # instead is how a rebuild silently lands beside the running copy: the new
@@ -41,9 +33,6 @@ else
 fi
 destination_parent="$(dirname "$destination")"
 
-if [[ ! -d "$source_app" ]]; then
-  CONFIGURATION=Release bash "$script_dir/build-local.sh"
-fi
 if [[ "$(basename "$destination")" != "Mimi Remote Mac.app" ]]; then
   echo "安装目标必须以 Mimi Remote Mac.app 结尾：$destination" >&2
   exit 2
@@ -62,8 +51,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-/usr/bin/ditto "$source_app" "$staged_app"
-/usr/bin/codesign --verify --deep --strict "$staged_app"
+# 共享目录中的现有 App 可能来自另一个 Worktree；必须先从当前源码
+# 增量构建，并在构建锁内复制到本次安装独占的暂存目录。
+CONFIGURATION=Release bash "$script_dir/build-local.sh" "$staged_app"
+codesign --verify --deep --strict "$staged_app"
 
 if [[ -e "$destination" ]]; then
   backup_app="$destination_parent/Mimi Remote Mac.backup-$(date +%Y%m%d-%H%M%S).app"

--- a/macos/MimiRemoteMac/Scripts/install-local.sh
+++ b/macos/MimiRemoteMac/Scripts/install-local.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
-source_app="$repo_root/.build/MimiRemoteMac/Build/Products/Release/Mimi Remote Mac.app"
+architecture="$(uname -m)"
+development_cache="$(
+  bash "$repo_root/scripts/development-cache-path.sh" \
+    "xcode/macos/$architecture/Release"
+)"
+derived_data="${MACOS_DERIVED_DATA_PATH:-$development_cache/DerivedData}"
+source_app="$derived_data/Build/Products/Release/Mimi Remote Mac.app"
 
 # Default to wherever the app is already installed. Picking a fixed default
 # instead is how a rebuild silently lands beside the running copy: the new

--- a/scripts/build-tailcat-mobile.sh
+++ b/scripts/build-tailcat-mobile.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MODULE_DIR="${TAILCAT_MOBILE_MODULE_DIR:-$REPO_ROOT/experiments/tailcat}"
-TOOL_DIR="${TAILCAT_MOBILE_TOOL_DIR:-$REPO_ROOT/.build/tailcat-mobile-tools}"
+DEVELOPMENT_CACHE_ROOT="$(
+  bash "$REPO_ROOT/scripts/development-cache-path.sh" "go/tailcat-mobile"
+)"
+TOOL_DIR="${TAILCAT_MOBILE_TOOL_DIR:-$DEVELOPMENT_CACHE_ROOT/tools}"
 OUTPUT_DIR="${TAILCAT_MOBILE_OUTPUT_DIR:-$REPO_ROOT/ios/MimiRemote/Generated}"
 OUTPUT="$OUTPUT_DIR/TailcatMobile.xcframework"
 FINGERPRINT_FILE="$OUTPUT_DIR/.tailcat-mobile-fingerprint"

--- a/scripts/development-cache-lock.sh
+++ b/scripts/development-cache-lock.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOCK_DIR="${1:-}"
-[[ -n "$LOCK_DIR" ]] || { echo "开发缓存锁失败：缺少锁目录。" >&2; exit 2; }
+LOCK_FILE="${1:-}"
+[[ -n "$LOCK_FILE" ]] || { echo "开发缓存锁失败：缺少锁文件。" >&2; exit 2; }
 shift
 [[ "${1:-}" == "--" ]] || { echo "开发缓存锁失败：缺少 --。" >&2; exit 2; }
 shift
@@ -12,28 +12,11 @@ WAIT_SECONDS="${MIMI_DEVELOPMENT_CACHE_LOCK_WAIT_SECONDS:-300}"
 [[ "$WAIT_SECONDS" =~ ^[0-9]+$ ]] \
   || { echo "开发缓存锁失败：等待秒数必须是非负整数。" >&2; exit 2; }
 
-mkdir -p "$(dirname "$LOCK_DIR")"
-waited=0
-while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-  owner_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
-  if [[ ! "$owner_pid" =~ ^[0-9]+$ ]] || ! kill -0 "$owner_pid" 2>/dev/null; then
-    rm -f -- "$LOCK_DIR/pid"
-    rmdir "$LOCK_DIR" 2>/dev/null || true
-    continue
-  fi
-  if (( waited >= WAIT_SECONDS )); then
-    echo "开发缓存正被进程 ${owner_pid} 使用：${LOCK_DIR}" >&2
-    exit 75
-  fi
-  sleep 1
-  waited=$((waited + 1))
-done
-
-printf '%s\n' "$$" > "$LOCK_DIR/pid"
-cleanup() {
-  rm -f -- "$LOCK_DIR/pid"
-  rmdir "$LOCK_DIR" 2>/dev/null || true
-}
-trap cleanup EXIT
-
-"$@"
+mkdir -p "$(dirname "$LOCK_FILE")"
+# 由系统原子获取和释放锁，不再把尚未写入 PID 的锁误认成死锁。
+# 锁文件必须保留：删除后重建会让等待者锁住不同的 inode，失去互斥。
+if [[ "$(uname -s)" == Darwin ]]; then
+  exec lockf -k -t "$WAIT_SECONDS" "$LOCK_FILE" "$@"
+else
+  exec flock -E 75 -w "$WAIT_SECONDS" "$LOCK_FILE" "$@"
+fi

--- a/scripts/development-cache-lock.sh
+++ b/scripts/development-cache-lock.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCK_DIR="${1:-}"
+[[ -n "$LOCK_DIR" ]] || { echo "开发缓存锁失败：缺少锁目录。" >&2; exit 2; }
+shift
+[[ "${1:-}" == "--" ]] || { echo "开发缓存锁失败：缺少 --。" >&2; exit 2; }
+shift
+[[ "$#" -gt 0 ]] || { echo "开发缓存锁失败：缺少要执行的命令。" >&2; exit 2; }
+
+WAIT_SECONDS="${MIMI_DEVELOPMENT_CACHE_LOCK_WAIT_SECONDS:-300}"
+[[ "$WAIT_SECONDS" =~ ^[0-9]+$ ]] \
+  || { echo "开发缓存锁失败：等待秒数必须是非负整数。" >&2; exit 2; }
+
+mkdir -p "$(dirname "$LOCK_DIR")"
+waited=0
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+  owner_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [[ ! "$owner_pid" =~ ^[0-9]+$ ]] || ! kill -0 "$owner_pid" 2>/dev/null; then
+    rm -f -- "$LOCK_DIR/pid"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+    continue
+  fi
+  if (( waited >= WAIT_SECONDS )); then
+    echo "开发缓存正被进程 ${owner_pid} 使用：${LOCK_DIR}" >&2
+    exit 75
+  fi
+  sleep 1
+  waited=$((waited + 1))
+done
+
+printf '%s\n' "$$" > "$LOCK_DIR/pid"
+cleanup() {
+  rm -f -- "$LOCK_DIR/pid"
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+"$@"

--- a/scripts/development-cache-path.sh
+++ b/scripts/development-cache-path.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${MIMI_DEVELOPMENT_CACHE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+COMPONENT="${1:-}"
+
+case "$COMPONENT" in
+  ""|/*|..|../*|*/../*|*/..)
+    echo "开发缓存路径失败：必须提供仓库内使用的相对组件名称。" >&2
+    exit 2
+    ;;
+esac
+
+for command_name in env git shasum awk basename dirname; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || { echo "开发缓存路径失败：缺少 ${command_name}。" >&2; exit 1; }
+done
+
+# DEVELOPER_DIR 只属于 Xcode 工具链选择。测试或兼容性构建可能把它指向
+# 临时 Xcode 目录，不能让 macOS 的 git shim 因此失效。
+git_common_dir="$(env -u DEVELOPER_DIR git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir)"
+repository_name="$(basename "$(dirname "$git_common_dir")")"
+repository_hash="$(printf '%s' "$git_common_dir" | shasum -a 256 | awk '{ print substr($1, 1, 12) }')"
+
+if [[ -n "${MIMI_DEVELOPMENT_CACHE_ROOT:-}" ]]; then
+  cache_parent="${MIMI_DEVELOPMENT_CACHE_ROOT%/}"
+elif [[ "$(uname -s)" == "Darwin" ]]; then
+  cache_parent="${XDG_CACHE_HOME:-$HOME/Library/Caches}/MimiRemote/Development"
+else
+  cache_parent="${XDG_CACHE_HOME:-$HOME/.cache}/mimi-remote/development"
+fi
+
+# Git common-dir 在同一仓库的所有 Worktree 中相同。路径哈希让这些 Worktree
+# 复用缓存，同时避免另一份 clone 意外写入同一个构建数据库。
+printf '%s/%s-%s/%s\n' \
+  "$cache_parent" "$repository_name" "$repository_hash" "$COMPONENT"

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -12,8 +12,11 @@ SIMULATOR_ID="${IOS_SIMULATOR_ID:-}"
 DEFAULT_DEVICE_NAME="iPad Pro"
 DEVICE_NAME="${IOS_DEVICE_NAME:-${DEVICE_NAME:-$DEFAULT_DEVICE_NAME}}"
 DEVICE_ID="${IOS_DEVICE_ID:-${DEVICE_ID:-}}"
-SIMULATOR_DERIVED_DATA_ROOT="$ROOT_DIR/ios/MimiRemote/build/dev-simulator-derived"
-DEVICE_DERIVED_DATA_ROOT="$ROOT_DIR/ios/MimiRemote/build/dev-device-derived"
+DEVELOPMENT_CACHE_ROOT="$(
+  bash "$ROOT_DIR/scripts/development-cache-path.sh" "xcode/ios/$CONFIGURATION"
+)"
+SIMULATOR_DERIVED_DATA_ROOT="$DEVELOPMENT_CACHE_ROOT/dev-simulator-derived"
+DEVICE_DERIVED_DATA_ROOT="$DEVELOPMENT_CACHE_ROOT/dev-device-derived"
 BUNDLE_ID="${BUNDLE_ID:-com.gaixianggeng.mimi}"
 XCRUN_BIN="${IOS_XCRUN_BIN:-xcrun}"
 XCODEBUILD_BIN="${IOS_XCODEBUILD_BIN:-xcodebuild}"
@@ -64,6 +67,7 @@ usage() {
   IOS_TEST_DESTINATION    CI 解析一次的测试 destination；设备必须仍是固定 M5 iPad
   IOS_DERIVED_DATA_PATH   覆盖本次 Simulator DerivedData
   IOS_DEVICE_DERIVED_DATA_PATH 覆盖本次真机 DerivedData
+  MIMI_DEVELOPMENT_CACHE_ROOT  覆盖同仓库 Worktree 共用的开发缓存根目录
   IOS_DEVICE_LEASE_WAIT_SECONDS 固定测试设备忙时的等待秒数，默认 0（明确失败）
 
 兼容别名：destination / prepare、derived-data-path 仍分别等同于

--- a/scripts/test-development-cache.sh
+++ b/scripts/test-development-cache.sh
@@ -35,27 +35,50 @@ if bash "$ROOT_DIR/scripts/development-cache-path.sh" ../outside >/dev/null 2>&1
 fi
 
 result_file="$TEMP_DIR/result"
-lock_dir="$TEMP_DIR/cache.lock"
-bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_dir" -- \
+lock_file="$TEMP_DIR/cache.lock"
+bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_file" -- \
   bash -c 'printf completed > "$1"' _ "$result_file"
 [[ "$(cat "$result_file")" == "completed" ]] || fail "缓存锁没有执行命令"
-[[ ! -e "$lock_dir" ]] || fail "命令结束后没有释放缓存锁"
+[[ -f "$lock_file" ]] || fail "锁文件必须保留，避免等待者锁住不同 inode"
+bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_file" -- true
 
-mkdir "$lock_dir"
-printf '99999999\n' > "$lock_dir/pid"
-bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_dir" -- true
-[[ ! -e "$lock_dir" ]] || fail "过期缓存锁没有被清理"
-
-mkdir "$lock_dir"
-printf '%s\n' "$$" > "$lock_dir/pid"
+bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_file" -- \
+  bash -c 'touch "$1"; while [[ ! -f "$2" ]]; do sleep 0.1; done' \
+  _ "$TEMP_DIR/ready" "$TEMP_DIR/release" &
+owner_pid=$!
+for attempt in {1..100}; do
+  [[ -f "$TEMP_DIR/ready" ]] && break
+  sleep 0.1
+done
+[[ -f "$TEMP_DIR/ready" ]] || fail "测试进程未及时取得锁"
 set +e
 MIMI_DEVELOPMENT_CACHE_LOCK_WAIT_SECONDS=0 \
-  bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_dir" -- true \
+  bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_file" -- true \
   >"$TEMP_DIR/busy.log" 2>&1
 busy_status=$?
 set -e
 [[ "$busy_status" -eq 75 ]] || fail "活跃缓存锁必须明确失败"
-rm -f "$lock_dir/pid"
-rmdir "$lock_dir"
+touch "$TEMP_DIR/release"
+wait "$owner_pid"
+
+# 同时启动多个真实进程，检查临界区不能重叠，而非只模拟 PID 文件。
+pids=()
+for attempt in {1..12}; do
+  bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_file" -- \
+    bash -euc 'mkdir "$1"; sleep 0.02; rmdir "$1"' _ "$TEMP_DIR/critical" &
+  pids+=("$!")
+done
+for child_pid in "${pids[@]}"; do
+  wait "$child_pid" || fail "并发进程同时进入了共享缓存临界区"
+done
+set +e
+bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_file" -- bash -c 'exit 42'
+failure_status=$?
+set -e
+[[ "$failure_status" -eq 42 ]] || fail "没有保留构建失败的退出码"
+MIMI_DEVELOPMENT_CACHE_LOCK_WAIT_SECONDS=0 \
+  bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_file" -- true
+
+bash "$ROOT_DIR/scripts/test-macos-local-cache.sh"
 
 echo "开发缓存路径、跨 Worktree 复用和写入锁自测通过。"

--- a/scripts/test-development-cache.sh
+++ b/scripts/test-development-cache.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mimi-development-cache.XXXXXX")"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+fail() {
+  echo "开发缓存自测失败：$1" >&2
+  exit 1
+}
+
+cache_path="$({
+  MIMI_DEVELOPMENT_CACHE_ROOT="$TEMP_DIR/cache" \
+    bash "$ROOT_DIR/scripts/development-cache-path.sh" xcode/ios/Debug
+})"
+[[ "$cache_path" == "$TEMP_DIR/cache/"*"/xcode/ios/Debug" ]] \
+  || fail "共享缓存没有使用显式根目录和组件名称：$cache_path"
+[[ "$cache_path" != "$ROOT_DIR/"* ]] \
+  || fail "默认开发缓存不得写入 Worktree"
+
+expected_path="$cache_path"
+while IFS= read -r worktree_root; do
+  actual_path="$({
+    MIMI_DEVELOPMENT_CACHE_ROOT="$TEMP_DIR/cache" \
+    MIMI_DEVELOPMENT_CACHE_REPO_ROOT="$worktree_root" \
+      bash "$ROOT_DIR/scripts/development-cache-path.sh" xcode/ios/Debug
+  })"
+  [[ "$actual_path" == "$expected_path" ]] \
+    || fail "同一 Git 仓库的 Worktree 必须解析到同一缓存：$worktree_root"
+done < <(git -C "$ROOT_DIR" worktree list --porcelain | awk '/^worktree / { sub(/^worktree /, ""); print }')
+
+if bash "$ROOT_DIR/scripts/development-cache-path.sh" ../outside >/dev/null 2>&1; then
+  fail "缓存组件不得逃逸共享缓存根目录"
+fi
+
+result_file="$TEMP_DIR/result"
+lock_dir="$TEMP_DIR/cache.lock"
+bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_dir" -- \
+  bash -c 'printf completed > "$1"' _ "$result_file"
+[[ "$(cat "$result_file")" == "completed" ]] || fail "缓存锁没有执行命令"
+[[ ! -e "$lock_dir" ]] || fail "命令结束后没有释放缓存锁"
+
+mkdir "$lock_dir"
+printf '99999999\n' > "$lock_dir/pid"
+bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_dir" -- true
+[[ ! -e "$lock_dir" ]] || fail "过期缓存锁没有被清理"
+
+mkdir "$lock_dir"
+printf '%s\n' "$$" > "$lock_dir/pid"
+set +e
+MIMI_DEVELOPMENT_CACHE_LOCK_WAIT_SECONDS=0 \
+  bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$lock_dir" -- true \
+  >"$TEMP_DIR/busy.log" 2>&1
+busy_status=$?
+set -e
+[[ "$busy_status" -eq 75 ]] || fail "活跃缓存锁必须明确失败"
+rm -f "$lock_dir/pid"
+rmdir "$lock_dir"
+
+echo "开发缓存路径、跨 Worktree 复用和写入锁自测通过。"

--- a/scripts/test-ios-device-management.sh
+++ b/scripts/test-ios-device-management.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$TEMP_DIR"' EXIT
 export IOS_XCRUN_BIN="$FIXTURE_DIR/fake-xcrun.sh"
 export IOS_XCODEBUILD_BIN="$FIXTURE_DIR/fake-xcodebuild.sh"
 export IOS_DEVICE_LEASE_ROOT="$TEMP_DIR/leases"
+export MIMI_DEVELOPMENT_CACHE_ROOT="$TEMP_DIR/development-cache"
 export IOS_TEST_SIMULATORS_JSON="$FIXTURE_DIR/simulators.json"
 export IOS_TEST_PHYSICAL_JSON="$FIXTURE_DIR/physical-devices.json"
 export IOS_TEST_XCODEBUILD_LOG="$TEMP_DIR/xcodebuild.log"
@@ -153,6 +154,8 @@ assert_contains "$m5_26_derived" "dev-simulator-derived/M5-26-UDID" \
   "旧 Runtime 的同名 M5 必须使用自己的 DerivedData"
 assert_contains "$m5_27_derived" "dev-simulator-derived/M5-27-UDID" \
   "新 Runtime 的同名 M5 必须使用自己的 DerivedData"
+assert_contains "$m5_27_derived" "$MIMI_DEVELOPMENT_CACHE_ROOT/" \
+  "不同 Worktree 必须使用仓库外的共享 DerivedData 根目录"
 [[ "$m5_26_derived" != "$m5_27_derived" ]] \
   || fail "不同 Runtime 的同名 M5 不得共用 DerivedData"
 

--- a/scripts/test-macos-app.sh
+++ b/scripts/test-macos-app.sh
@@ -8,10 +8,13 @@ project_path="macos/MimiRemoteMac/MimiRemoteMac.xcodeproj"
 scheme="MimiRemoteMac"
 configuration="${MACOS_TEST_CONFIGURATION:-Debug}"
 architecture="${MACOS_TEST_ARCH:-$(uname -m)}"
-derived_data="${MACOS_DERIVED_DATA_PATH:-$ROOT_DIR/.build/MimiRemoteMacTests}"
-# 传给 Xcode build phase 的可复用缓存必须位于 DerivedData 或调用方明确指定的
-# 临时目录；默认值不会把 Rust/Go 的中间产物写进仓库。
-embed_cache="${MACOS_EMBED_CACHE_DIR:-$derived_data/MimiRemoteMacEmbedCache}"
+development_cache="$(
+  bash "$ROOT_DIR/scripts/development-cache-path.sh" \
+    "xcode/macos/$architecture/$configuration"
+)"
+derived_data="${MACOS_DERIVED_DATA_PATH:-$development_cache/DerivedData}"
+embed_cache="${MACOS_EMBED_CACHE_DIR:-$development_cache/EmbedCache}"
+cache_lock="${MACOS_DEVELOPMENT_CACHE_LOCK:-$derived_data.lock}"
 
 log() {
   printf '[macos-test %s] %s\n' "$(date '+%H:%M:%S')" "$*"
@@ -34,7 +37,8 @@ done
 # 编译 Mac App、内嵌 agentd / Claude bridge 和现有单测，但不读取发布签名凭据。
 log "开始真实 Scheme 测试：scheme=${scheme} configuration=${configuration} arch=${architecture}"
 log "DerivedData=${derived_data} embed-cache=${embed_cache}"
-xcodebuild \
+bash "$ROOT_DIR/scripts/development-cache-lock.sh" "$cache_lock" -- \
+  xcodebuild \
   -project "$project_path" \
   -scheme "$scheme" \
   -configuration "$configuration" \

--- a/scripts/test-macos-local-cache.sh
+++ b/scripts/test-macos-local-cache.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mimi-macos-local-cache.XXXXXX")"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+fixture="$TEMP_DIR/repo"
+mkdir -p "$fixture/scripts" "$fixture/macos/MimiRemoteMac/Scripts" "$TEMP_DIR/bin"
+cp "$ROOT_DIR/scripts/development-cache-"*.sh "$fixture/scripts/"
+cp "$ROOT_DIR/macos/MimiRemoteMac/Scripts/"{build-local,install-local}.sh \
+  "$fixture/macos/MimiRemoteMac/Scripts/"
+
+export PATH="$TEMP_DIR/bin:$PATH"
+export MIMI_DEVELOPMENT_CACHE_REPO_ROOT="$ROOT_DIR"
+export MIMI_DEVELOPMENT_CACHE_ROOT="$TEMP_DIR/cache"
+export MACOS_DERIVED_DATA_PATH="$TEMP_DIR/shared-derived"
+export MACOS_EMBED_CACHE_DIR="$TEMP_DIR/embed"
+export MACOS_DEVELOPMENT_CACHE_LOCK="$TEMP_DIR/build.lock"
+export FIXTURE_LOCK_SCRIPT="$ROOT_DIR/scripts/development-cache-lock.sh"
+export FIXTURE_BUILD_LOG="$TEMP_DIR/build.log"
+export FIXTURE_REVISION="current-worktree"
+
+# 仅替换外部构建工具，不启动真实 App，也不改动用户已安装的 App。
+cat > "$TEMP_DIR/bin/xcodegen" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+cat > "$TEMP_DIR/bin/xcodebuild" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+app="$MACOS_DERIVED_DATA_PATH/Build/Products/Release/Mimi Remote Mac.app"
+mkdir -p "$app/Contents/Resources"
+cp /usr/bin/true "$app/Contents/Resources/agentd"
+printf '%s\n' "$FIXTURE_REVISION" > "$app/revision"
+printf '%s\n' "$FIXTURE_REVISION" >> "$FIXTURE_BUILD_LOG"
+STUB
+cat > "$TEMP_DIR/bin/codesign" <<'STUB'
+#!/usr/bin/env bash
+[[ -f "${!#}/revision" ]]
+STUB
+cat > "$TEMP_DIR/bin/ditto" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+set +e
+MIMI_DEVELOPMENT_CACHE_LOCK_WAIT_SECONDS=0 \
+  bash "$FIXTURE_LOCK_SCRIPT" "$MACOS_DEVELOPMENT_CACHE_LOCK" -- true >/dev/null 2>&1
+lock_status=$?
+set -e
+[[ "$lock_status" -eq 75 ]] || { echo "复制 App 时没有持有构建锁" >&2; exit 1; }
+cp -R "$1" "$2"
+STUB
+cat > "$TEMP_DIR/bin/pgrep" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$TEMP_DIR/bin/"*
+
+old_app="$MACOS_DERIVED_DATA_PATH/Build/Products/Release/Mimi Remote Mac.app"
+mkdir -p "$old_app"
+printf 'other-worktree\n' > "$old_app/revision"
+destination="$TEMP_DIR/installed/Mimi Remote Mac.app"
+bash "$fixture/macos/MimiRemoteMac/Scripts/install-local.sh" "$destination"
+[[ "$(cat "$destination/revision")" == current-worktree ]]
+[[ "$(wc -l < "$FIXTURE_BUILD_LOG" | tr -d ' ')" == 1 ]]
+
+export FIXTURE_REVISION="updated-worktree"
+bash "$fixture/macos/MimiRemoteMac/Scripts/install-local.sh" "$destination"
+[[ "$(cat "$destination/revision")" == updated-worktree ]]
+[[ "$(wc -l < "$FIXTURE_BUILD_LOG" | tr -d ' ')" == 2 ]]
+[[ "$(cat "$TEMP_DIR/installed/"Mimi\ Remote\ Mac.backup-*.app/revision)" == current-worktree ]]
+echo "Mac 安装使用当前 Worktree 增量构建，并在共享缓存锁内暂存的自测通过。"

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -418,7 +418,7 @@ for path in "${changed_paths[@]:-}"; do
       ;;
   esac
   case "$path" in
-    scripts/development-cache-path.sh|scripts/development-cache-lock.sh|scripts/test-development-cache.sh|scripts/ios-dev.sh|scripts/build-tailcat-mobile.sh|scripts/test-macos-app.sh|macos/MimiRemoteMac/Scripts/build-local.sh|macos/MimiRemoteMac/Scripts/install-local.sh)
+    scripts/development-cache-path.sh|scripts/development-cache-lock.sh|scripts/test-development-cache.sh|scripts/test-macos-local-cache.sh|scripts/ios-dev.sh|scripts/build-tailcat-mobile.sh|scripts/test-macos-app.sh|macos/MimiRemoteMac/Scripts/build-local.sh|macos/MimiRemoteMac/Scripts/install-local.sh)
       has_development_cache_control=true
       ;;
   esac

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -221,6 +221,7 @@ has_ios_asc_control=false
 has_critical_mapping_control=false
 has_linear_polling_control=false
 has_agentd_restart_control=false
+has_development_cache_control=false
 unknown_paths=()
 shell_paths=()
 yaml_paths=()
@@ -416,6 +417,11 @@ for path in "${changed_paths[@]:-}"; do
       has_agentd_restart_control=true
       ;;
   esac
+  case "$path" in
+    scripts/development-cache-path.sh|scripts/development-cache-lock.sh|scripts/test-development-cache.sh|scripts/ios-dev.sh|scripts/build-tailcat-mobile.sh|scripts/test-macos-app.sh|macos/MimiRemoteMac/Scripts/build-local.sh|macos/MimiRemoteMac/Scripts/install-local.sh)
+      has_development_cache_control=true
+      ;;
+  esac
 
   case "$path" in
     *.sh|scripts/git-testflight-push)
@@ -552,6 +558,9 @@ fi
 if [[ "$has_agentd_restart_control" == true ]]; then
   add_check "agentd 本地重启链路只执行无安装副作用的 self-test" "bash ./scripts/restart-agentd-dev-macos.sh --self-test"
 fi
+if [[ "$has_development_cache_control" == true ]]; then
+  add_check "本地重型构建必须复用仓库外缓存并串行写入" "bash ./scripts/test-development-cache.sh"
+fi
 if [[ "$has_contract" == true ]]; then
   add_check "Go/iOS 共享契约变化" "bash ./scripts/check-mimi-protocol-contract.sh"
 fi
@@ -596,7 +605,7 @@ fi
 
 if [[ "$direct_rust" == true ]]; then
   add_check "Rust 格式检查" "cargo fmt --all -- --check"
-  rust_test_command="cargo test --locked"
+  rust_test_command='CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(bash ./scripts/development-cache-path.sh cargo/target)}" cargo test --locked'
   if [[ "$rust_all" == true || "$mode" == "full" ]]; then
     rust_codex=true
     rust_core=true


### PR DESCRIPTION
## 目标

让同一仓库的 Issue Worktree 复用仓库外的开发缓存，避免每个目录重复保存 GB 级 Xcode、Rust 和工具产物。

## 改动

- iOS DerivedData 按配置、设备类型和 UDID 复用同一外部缓存。
- Mac DerivedData 与内嵌 Go/Rust 产物按架构和配置复用，并用缓存锁串行写入。
- Rust 分层验证复用共享 CARGO_TARGET_DIR；Tailcat 工具下载复用共享目录。
- 项目规则明确 Worktree 只隔离源码，并规定安全清理边界。
- 新增共享路径与锁自测。

## 验证

- bash ./scripts/check-source-size.sh
- bash ./scripts/verify-change.sh --plan
- bash ./scripts/verify-change.sh
- quick 共 8 项通过；Mac App 69 个测试通过。

## 本机清理

已删除登记 Worktree 中被 Git 忽略的旧 .build、target 和 ios/MimiRemote/build。清理前合计约 37.3 GiB；清理后为 0。