### PR TITLE
MIM-271 将托管连接切换到独立控制面域名

### DIFF
--- a/internal/httpapi/tailcat_managed_pairing.go
+++ b/internal/httpapi/tailcat_managed_pairing.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	defaultManagedConnectionAPIBaseURL = "https://api.code89757.com"
+	defaultManagedConnectionAPIBaseURL = "https://mimi.code89757.com"
 	defaultManagedPolicySyncInterval   = 5 * time.Minute
 	defaultManagedPolicyOfflineTTL     = 24 * time.Hour
 	managedPairingStateFileName        = "managed-policy.json"

--- a/internal/httpapi/tailcat_managed_pairing_test.go
+++ b/internal/httpapi/tailcat_managed_pairing_test.go
@@ -30,6 +30,12 @@ func managedToken(fill byte) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(strings.Repeat(string([]byte{fill}), 32)))
 }
 
+func TestManagedConnectionUsesDedicatedControlPlane(t *testing.T) {
+	if defaultManagedConnectionAPIBaseURL != "https://mimi.code89757.com" {
+		t.Fatalf("托管连接控制面地址异常：%s", defaultManagedConnectionAPIBaseURL)
+	}
+}
+
 func newManagedControllerForTest(
 	t *testing.T,
 	serverURL string,

--- a/ios/MimiRemote/Sources/Core/API/ManagedConnectionDeviceAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/ManagedConnectionDeviceAPIClient.swift
@@ -63,7 +63,7 @@ struct LiveManagedConnectionDeviceAPIClient: ManagedConnectionDeviceAPIClient {
     private let session: URLSession
 
     init(
-        baseURL: URL = URL(string: "https://api.code89757.com")!,
+        baseURL: URL = URL(string: "https://mimi.code89757.com")!,
         session: URLSession = .shared
     ) {
         self.baseURL = baseURL

--- a/ios/MimiRemote/Sources/Core/API/ManagedConnectionEntitlementAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/ManagedConnectionEntitlementAPIClient.swift
@@ -33,7 +33,7 @@ struct LiveManagedConnectionEntitlementAPIClient: ManagedConnectionEntitlementAP
     private let session: URLSession
 
     init(
-        baseURL: URL = URL(string: "https://api.code89757.com")!,
+        baseURL: URL = URL(string: "https://mimi.code89757.com")!,
         session: URLSession = .shared
     ) {
         self.baseURL = baseURL

--- a/ios/MimiRemote/Sources/Core/API/ManagedConnectionEventAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/ManagedConnectionEventAPIClient.swift
@@ -117,7 +117,7 @@ struct LiveManagedConnectionEventAPIClient: ManagedConnectionEventAPIClient {
     private let session: URLSession
 
     init(
-        baseURL: URL = URL(string: "https://api.code89757.com")!,
+        baseURL: URL = URL(string: "https://mimi.code89757.com")!,
         session: URLSession = .shared
     ) {
         self.baseURL = baseURL

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceAPIClientTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceAPIClientTests.swift
@@ -26,6 +26,7 @@ final class ManagedConnectionDeviceAPIClientTests: XCTestCase {
         let request = try XCTUnwrap(MIM260DeviceURLProtocol.capturedRequest())
         let body = try XCTUnwrap(MIM260DeviceURLProtocol.capturedBody())
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(request.url?.absoluteString, "https://mimi.code89757.com/v1/devices")
         XCTAssertEqual(request.url?.path, "/v1/devices")
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
@@ -511,10 +511,7 @@ final class ManagedConnectionEntitlementAPIClientTests: XCTestCase {
         )
         let session = makeSession()
         defer { session.invalidateAndCancel() }
-        let client = LiveManagedConnectionEntitlementAPIClient(
-            baseURL: URL(string: "https://api.code89757.com")!,
-            session: session
-        )
+        let client = LiveManagedConnectionEntitlementAPIClient(session: session)
 
         let grant = try await client.resolve(
             signedAppTransaction: "signed-app-transaction",
@@ -522,7 +519,7 @@ final class ManagedConnectionEntitlementAPIClientTests: XCTestCase {
         )
 
         let request = try XCTUnwrap(ManagedConnectionEntitlementURLProtocol.capturedRequest())
-        XCTAssertEqual(request.url?.absoluteString, "https://api.code89757.com/v1/entitlements/resolve")
+        XCTAssertEqual(request.url?.absoluteString, "https://mimi.code89757.com/v1/entitlements/resolve")
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
         let body = try XCTUnwrap(ManagedConnectionEntitlementURLProtocol.capturedBody())

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEventAPIClientTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEventAPIClientTests.swift
@@ -28,6 +28,7 @@ final class ManagedConnectionEventAPIClientTests: XCTestCase {
         let request = try XCTUnwrap(MIM261EventURLProtocol.capturedRequest)
         let body = try XCTUnwrap(MIM261EventURLProtocol.capturedBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(request.url?.absoluteString, "https://mimi.code89757.com/v1/connection-events")
         XCTAssertEqual(request.url?.path, "/v1/connection-events")
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(Self.deviceToken)")


### PR DESCRIPTION
## 变更

- iOS 权益、设备、连接事件请求改用 `https://mimi.code89757.com`
- Mac agentd 托管配对和策略同步改用同一独立域名
- 保持 DERP Map `https://api.code89757.com/v1/relay/tailcat-derp-map.json` 不变
- 增加默认请求地址回归断言

## 验证

- `go test ./internal/httpapi -run 'TestManaged(ConnectionUsesDedicatedControlPlane|PairingCompletesCloudAuthorizationBeforeApplyingPolicy)$'`\n- 3 个相关 iOS XCTest selector 通过\n- `bash ./scripts/verify-change.sh --plan`\n- `bash ./scripts/verify-change.sh`：6 项 quick 门禁通过\n- 线上独立域名路由可达；DERP Map 返回 200\n\n## 缓存\n\n- 定向测试后清理 985 MB Simulator DerivedData\n- quick 后清理 699 MB Simulator DerivedData\n- 保留可复用 TailcatMobile.xcframework