### PR TITLE
MIM-261 托管线路不可用时等待用户手动恢复

### DIFF
--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -291,9 +291,7 @@ struct InitialConnectionSettingsSections: View {
                     } label: {
                         SettingsValueLabel(
                             title: tailcatConnectionTitle,
-                            value: tailcatController.isEnabled
-                                ? L10n.text("ui.connected")
-                                : L10n.text("ui.deactivated"),
+                            value: tailcatController.state.connectionMethodSummary,
                             systemImage: "point.3.connected.trianglepath.dotted"
                         )
                     }

--- a/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
@@ -253,10 +253,28 @@ struct ManagedConnectionSubscriptionView: View {
     }
 
     private var showsManagedRecoveryActions: Bool {
-        if case .usingTemporaryRoute = tailcatController.state { return true }
-        if case .failed = tailcatController.state { return true }
-        if case .failed = appStore.connectionStatus { return true }
-        return false
+        let connectionFailed: Bool
+        if case .failed = appStore.connectionStatus {
+            connectionFailed = true
+        } else {
+            connectionFailed = false
+        }
+        return Self.showsManagedRecoveryActions(
+            tailcatState: tailcatController.state,
+            connectionFailed: connectionFailed
+        )
+    }
+
+    static func showsManagedRecoveryActions(
+        tailcatState: TailcatExperimentState,
+        connectionFailed: Bool
+    ) -> Bool {
+        switch tailcatState {
+        case .usingTemporaryRoute, .failed, .unavailable, .needsAddress:
+            return true
+        case .disabled, .starting, .connected:
+            return connectionFailed
+        }
     }
 
     private var managedRouteStatusText: String {

--- a/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
+++ b/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
@@ -8,6 +8,26 @@ enum TailcatExperimentState: Equatable {
     case usingTemporaryRoute(ConnectionProfileRoute)
     case failed(message: String)
     case unavailable
+
+    var connectionMethodSummary: String {
+        // 启用线路不代表连接成功；故障关闭时仍保留启用状态，不能据此显示“已连接”。
+        switch self {
+        case .disabled:
+            return L10n.text("ui.deactivated")
+        case .needsAddress:
+            return L10n.text("ui.tailcat_needs_address")
+        case .starting:
+            return L10n.text("ui.connecting")
+        case .connected:
+            return L10n.text("ui.connected")
+        case .usingTemporaryRoute(let route):
+            return L10n.format("ui.managed_connection_using_temporary_route", route.title)
+        case .failed:
+            return L10n.text("ui.connection_failed")
+        case .unavailable:
+            return L10n.text("ui.tailcat_framework_unavailable")
+        }
+    }
 }
 
 struct TailcatPathDiagnostic: Codable, Equatable, Identifiable {

--- a/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
+++ b/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
@@ -250,9 +250,12 @@ final class TailcatExperimentController: ObservableObject {
                 defaults.removeObject(forKey: Self.enabledKey)
             }
         }
-        let initialEnabled = (appStore.activeConnectionProfileID == nil
+        let requestsTailcat = appStore.activeConnectionProfileID == nil
             ? savedEnabled
-            : profileRoute.usesTailcat) && available
+            : profileRoute.usesTailcat
+        // 托管档案即使无法启动 Tailcat，也要保持 loopback fail-closed。
+        // 只有用户明确选择临时线路后，才允许请求回到已保存的地址。
+        let initialEnabled = requestsTailcat && (available || profileRoute.isManaged)
         self.defaults = defaults
         self.tokenStore = tokenStore
         self.runtime = runtime

--- a/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
@@ -160,6 +160,23 @@ private final class ManagedConnectionEventReporterStub: ManagedConnectionEventRe
 
 @MainActor
 final class TailcatExperimentRoutingTests: XCTestCase {
+    func testConnectionMethodSummaryReflectsRouteStateInsteadOfEnabledFlag() {
+        XCTAssertEqual(TailcatExperimentState.unavailable.connectionMethodSummary,
+                       L10n.text("ui.tailcat_framework_unavailable"))
+        XCTAssertEqual(TailcatExperimentState.needsAddress.connectionMethodSummary,
+                       L10n.text("ui.tailcat_needs_address"))
+        XCTAssertEqual(TailcatExperimentState.starting.connectionMethodSummary,
+                       L10n.text("ui.connecting"))
+        XCTAssertEqual(TailcatExperimentState.failed(message: "offline").connectionMethodSummary,
+                       L10n.text("ui.connection_failed"))
+        XCTAssertEqual(TailcatExperimentState.usingTemporaryRoute(.lan).connectionMethodSummary,
+                       L10n.format("ui.managed_connection_using_temporary_route", ConnectionProfileRoute.lan.title))
+        XCTAssertEqual(TailcatExperimentState.connected(endpoint: "http://127.0.0.1:8787").connectionMethodSummary,
+                       L10n.text("ui.connected"))
+        XCTAssertEqual(TailcatExperimentState.disabled.connectionMethodSummary,
+                       L10n.text("ui.deactivated"))
+    }
+
     func testUnavailableManagedRouteStaysFailClosedUntilManualFallback() async throws {
         let fixture = try makeControllerFixture(
             startResults: [],

--- a/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
@@ -160,6 +160,63 @@ private final class ManagedConnectionEventReporterStub: ManagedConnectionEventRe
 
 @MainActor
 final class TailcatExperimentRoutingTests: XCTestCase {
+    func testUnavailableManagedRouteStaysFailClosedUntilManualFallback() async throws {
+        let fixture = try makeControllerFixture(
+            startResults: [],
+            managedProfile: true,
+            bridgeAvailable: false
+        )
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let prepared = await fixture.controller.prepareRoute(appStore: fixture.store)
+        let startCallCount = await fixture.runtime.startCallCount()
+
+        XCTAssertFalse(prepared)
+        XCTAssertTrue(fixture.controller.isEnabled)
+        XCTAssertEqual(fixture.controller.state, .unavailable)
+        XCTAssertTrue(fixture.store.isTailcatExperimentModeEnabled)
+        XCTAssertEqual(fixture.store.connectionEndpoint, "http://127.0.0.1:1")
+        XCTAssertEqual(startCallCount, 0)
+        XCTAssertTrue(ManagedConnectionSubscriptionView.showsManagedRecoveryActions(
+            tailcatState: fixture.controller.state,
+            connectionFailed: false
+        ))
+
+        let usedFallback = await fixture.controller.useSavedRouteOnce(.tailscale, appStore: fixture.store)
+
+        XCTAssertTrue(usedFallback)
+        XCTAssertEqual(fixture.controller.state, .usingTemporaryRoute(.tailscale))
+        XCTAssertFalse(fixture.store.isTailcatExperimentModeEnabled)
+        XCTAssertEqual(fixture.store.connectionEndpoint, "http://100.64.0.10:8787")
+    }
+
+    func testManagedRouteWithoutAddressStaysFailClosedAndOffersManualFallback() async throws {
+        let fixture = try makeControllerFixture(
+            startResults: [],
+            managedProfile: true,
+            managedAddress: nil
+        )
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let prepared = await fixture.controller.prepareRoute(appStore: fixture.store)
+
+        XCTAssertFalse(prepared)
+        XCTAssertTrue(fixture.controller.isEnabled)
+        XCTAssertEqual(fixture.controller.state, .needsAddress)
+        XCTAssertTrue(fixture.store.isTailcatExperimentModeEnabled)
+        XCTAssertEqual(fixture.store.connectionEndpoint, "http://127.0.0.1:1")
+        XCTAssertTrue(ManagedConnectionSubscriptionView.showsManagedRecoveryActions(
+            tailcatState: fixture.controller.state,
+            connectionFailed: false
+        ))
+
+        let usedFallback = await fixture.controller.useSavedRouteOnce(.tailscale, appStore: fixture.store)
+
+        XCTAssertTrue(usedFallback)
+        XCTAssertEqual(fixture.controller.state, .usingTemporaryRoute(.tailscale))
+        XCTAssertFalse(fixture.store.isTailcatExperimentModeEnabled)
+    }
+
     func testForegroundRecoveryPreservesTemporaryManagedFallback() async throws {
         let fixture = try makeControllerFixture(
             startResults: [.success("http://127.0.0.1:49152")],
@@ -832,6 +889,8 @@ final class TailcatExperimentRoutingTests: XCTestCase {
         blockedStartCall: Int? = nil,
         managedPairingAuthorizer: (any ManagedConnectionPairingAuthorizing)? = nil,
         managedProfile: Bool = false,
+        managedAddress: String? = "tailcat:managed-mac",
+        bridgeAvailable: Bool = true,
         managedConnectionEventReporter: (any ManagedConnectionEventReporting)? = nil
     ) throws -> (
         controller: TailcatExperimentController,
@@ -848,7 +907,7 @@ final class TailcatExperimentRoutingTests: XCTestCase {
             blockedStartCall: blockedStartCall
         )
         let bridge = TailcatExperimentBridgeAdapter(
-            isAvailable: true,
+            isAvailable: bridgeAvailable,
             generatePrivateKey: { "private-key" },
             publicKey: { _ in "nodekey:public-key" }
         )
@@ -865,7 +924,9 @@ final class TailcatExperimentRoutingTests: XCTestCase {
             defaults.set(try JSONEncoder().encode([profile]), forKey: "agentd.connectionProfiles.v2")
             defaults.set(profile.id, forKey: "agentd.activeConnectionProfileID.v1")
             try tokenStore.save("managed-token", profileID: profile.id)
-            try tokenStore.saveTailcatAddress("tailcat:managed-mac", profileID: profile.id)
+            if let managedAddress {
+                try tokenStore.saveTailcatAddress(managedAddress, profileID: profile.id)
+            }
         }
         let store = AppStore(
             defaults: defaults,


### PR DESCRIPTION
## 结果
- 托管档案在 Tailcat bridge 不可用时保持停止连接，不自动探测已保存的 LAN/Tailscale。
- unavailable 和 needsAddress 状态显示既有恢复操作。
- 只有用户明确选择保存的线路后才临时切换，不改变默认线路。

## 验证
- 基于最新 main f1c23b67。
- 固定 iPad Pro 13-inch (M5) 两个定向 XCTest 通过。
- verify-change --plan / quick 通过，5 项门禁（含 App build、源码行数和差异检查）。
- 已清理本 Worktree 的 DerivedData 和生成 Tailcat framework。
- 真机网络失败与手动切换仍待联合验收。