### PR TITLE
MIM-260 恢复失效凭证并在重装后保留托管设备身份

### DIFF
--- a/ios/MimiRemote/Sources/Core/Security/ManagedConnectionMobileIdentityStore.swift
+++ b/ios/MimiRemote/Sources/Core/Security/ManagedConnectionMobileIdentityStore.swift
@@ -10,7 +10,7 @@ struct ManagedConnectionMobileIdentity: Equatable, Sendable {
 @MainActor
 protocol ManagedConnectionMobileIdentityStoring: AnyObject {
     func loadOrCreate() throws -> ManagedConnectionMobileIdentity
-    func rememberRegisteredDeviceID(_ id: String)
+    func rememberRegisteredDeviceID(_ id: String) throws
     func rotateCredentialAfterRevocation(deviceID: String) throws
 }
 
@@ -51,8 +51,7 @@ final class ManagedConnectionMobileIdentityStore: ManagedConnectionMobileIdentit
     }
 
     func loadOrCreate() throws -> ManagedConnectionMobileIdentity {
-        let installationID = validInstallationID(defaults.string(forKey: Self.installationIDKey))
-            ?? createInstallationID()
+        let installationID = try loadOrCreateInstallationID()
         var deviceToken = try tokenStore.loadManagedMobileDeviceToken(installationID: installationID)
         if !Self.isCanonicalDeviceToken(deviceToken) {
             deviceToken = try makeToken()
@@ -61,14 +60,16 @@ final class ManagedConnectionMobileIdentityStore: ManagedConnectionMobileIdentit
             }
             try tokenStore.saveManagedMobileDeviceToken(deviceToken, installationID: installationID)
         }
+        let registeredDeviceID = try loadRegisteredDeviceID()
         return ManagedConnectionMobileIdentity(
             installationID: installationID,
             deviceToken: deviceToken,
-            registeredDeviceID: defaults.string(forKey: Self.registeredDeviceIDKey)
+            registeredDeviceID: registeredDeviceID
         )
     }
 
-    func rememberRegisteredDeviceID(_ id: String) {
+    func rememberRegisteredDeviceID(_ id: String) throws {
+        try tokenStore.saveManagedMobileRegisteredDeviceID(id)
         defaults.set(id, forKey: Self.registeredDeviceIDKey)
     }
 
@@ -81,7 +82,47 @@ final class ManagedConnectionMobileIdentityStore: ManagedConnectionMobileIdentit
         }
         // 服务端明确禁止复用已撤销 Token。安装 ID 保持稳定，下一次登记生成新 Token。
         try tokenStore.deleteManagedMobileDeviceToken(installationID: installationID)
+        try tokenStore.deleteManagedMobileRegisteredDeviceID()
         defaults.removeObject(forKey: Self.registeredDeviceIDKey)
+    }
+
+    private func loadRegisteredDeviceID() throws -> String? {
+        let keychainValue = try tokenStore.loadManagedMobileRegisteredDeviceID()
+        if !keychainValue.isEmpty {
+            defaults.set(keychainValue, forKey: Self.registeredDeviceIDKey)
+            return keychainValue
+        }
+        guard let legacyValue = defaults.string(forKey: Self.registeredDeviceIDKey),
+              !legacyValue.isEmpty else {
+            return nil
+        }
+        try tokenStore.saveManagedMobileRegisteredDeviceID(legacyValue)
+        return legacyValue
+    }
+
+    private func loadOrCreateInstallationID() throws -> String {
+        let defaultsInstallationID = validInstallationID(defaults.string(forKey: Self.installationIDKey))
+        let keychainValue = try tokenStore.loadManagedMobileInstallationID()
+        if !keychainValue.isEmpty {
+            guard let installationID = validInstallationID(keychainValue) else {
+                throw ManagedConnectionDeviceAPIError.invalidResponse
+            }
+            if defaultsInstallationID != installationID {
+                defaults.removeObject(forKey: Self.registeredDeviceIDKey)
+            }
+            defaults.set(installationID, forKey: Self.installationIDKey)
+            return installationID
+        }
+
+        // 首次升级优先迁移 UserDefaults 中的旧安装身份，保持原 device token 的 Keychain account 可寻址。
+        let installationID = defaultsInstallationID ?? createInstallationID()
+        // 先持久化不可重建的安装身份；Keychain 写入失败时不能发布一个临时身份。
+        try tokenStore.saveManagedMobileInstallationID(installationID)
+        defaults.set(installationID, forKey: Self.installationIDKey)
+        if defaultsInstallationID == nil {
+            defaults.removeObject(forKey: Self.registeredDeviceIDKey)
+        }
+        return installationID
     }
 
     private func createInstallationID() -> String {
@@ -89,8 +130,6 @@ final class ManagedConnectionMobileIdentityStore: ManagedConnectionMobileIdentit
         while !Self.isUUIDv4(value) {
             value = UUID().uuidString.lowercased()
         }
-        defaults.set(value, forKey: Self.installationIDKey)
-        defaults.removeObject(forKey: Self.registeredDeviceIDKey)
         return value
     }
 

--- a/ios/MimiRemote/Sources/Core/Security/TokenStore.swift
+++ b/ios/MimiRemote/Sources/Core/Security/TokenStore.swift
@@ -57,6 +57,8 @@ struct TokenStore {
     private let tailcatExperimentAccount = "tailcat-experiment-client-key.v1"
     private let tailcatExperimentAddressAccount = "tailcat-experiment-address.v1"
     private let tailcatProfileAddressAccountPrefix = "tailcat-profile-address.v1."
+    private let managedMobileInstallationIDAccount = "managed-mobile-installation-id.v1"
+    private let managedMobileRegisteredDeviceIDAccount = "managed-mobile-registered-device-id.v1"
     private let managedMobileDeviceTokenAccountPrefix = "managed-mobile-device-token.v1."
     private let keychain: any KeychainOperating
 
@@ -86,6 +88,14 @@ struct TokenStore {
 
     func loadManagedMobileDeviceToken(installationID: String) throws -> String {
         try load(account: managedMobileDeviceTokenAccountPrefix + installationID.lowercased())
+    }
+
+    func loadManagedMobileInstallationID() throws -> String {
+        try load(account: managedMobileInstallationIDAccount)
+    }
+
+    func loadManagedMobileRegisteredDeviceID() throws -> String {
+        try load(account: managedMobileRegisteredDeviceIDAccount)
     }
 
     private func load(account: String) throws -> String {
@@ -131,6 +141,14 @@ struct TokenStore {
         try save(token, account: managedMobileDeviceTokenAccountPrefix + installationID.lowercased())
     }
 
+    func saveManagedMobileInstallationID(_ installationID: String) throws {
+        try save(installationID.lowercased(), account: managedMobileInstallationIDAccount)
+    }
+
+    func saveManagedMobileRegisteredDeviceID(_ deviceID: String) throws {
+        try save(deviceID, account: managedMobileRegisteredDeviceIDAccount)
+    }
+
     func deleteTailcatExperimentAddress(allowMissing: Bool = true) throws {
         try delete(account: tailcatExperimentAddressAccount, allowMissing: allowMissing)
     }
@@ -144,6 +162,10 @@ struct TokenStore {
             account: managedMobileDeviceTokenAccountPrefix + installationID.lowercased(),
             allowMissing: allowMissing
         )
+    }
+
+    func deleteManagedMobileRegisteredDeviceID(allowMissing: Bool = true) throws {
+        try delete(account: managedMobileRegisteredDeviceIDAccount, allowMissing: allowMissing)
     }
 
     private func save(_ token: String, account: String) throws {

--- a/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
@@ -83,8 +83,9 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         isRefreshing = true
         defer { isRefreshing = false }
         do {
-            let token = try await validManagementToken()
-            let refreshedDevices = try await api.listDevices(managementToken: token)
+            let refreshedDevices = try await withRefreshedManagementToken { token in
+                try await api.listDevices(managementToken: token)
+            }
                 .sorted { $0.createdAt > $1.createdAt }
             devices = refreshedDevices
             try reconcileCurrentDeviceAfterRemoteRevocation(refreshedDevices)
@@ -99,9 +100,10 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         removingDeviceID = device.id
         defer { removingDeviceID = nil }
         do {
-            let token = try await validManagementToken()
             do {
-                try await api.removeDevice(id: device.id, managementToken: token)
+                try await withRefreshedManagementToken { token in
+                    try await api.removeDevice(id: device.id, managementToken: token)
+                }
             } catch let error as ManagedConnectionDeviceAPIError
                 where error.rejectionCode == "device_not_found" {
                 // 服务端删除已完成但客户端未收到响应时，重试仍要完成本地凭证轮换。
@@ -159,7 +161,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
                 installationID: identity.installationID,
                 deviceToken: identity.deviceToken
             )
-            identityStore.rememberRegisteredDeviceID(result.device.id)
+            try identityStore.rememberRegisteredDeviceID(result.device.id)
             return ManagedConnectionMobileIdentity(
                 installationID: identity.installationID,
                 deviceToken: identity.deviceToken,
@@ -173,7 +175,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
                 installationID: identity.installationID,
                 deviceToken: identity.deviceToken
             )
-            identityStore.rememberRegisteredDeviceID(result.device.id)
+            try identityStore.rememberRegisteredDeviceID(result.device.id)
             return ManagedConnectionMobileIdentity(
                 installationID: identity.installationID,
                 deviceToken: identity.deviceToken,
@@ -222,6 +224,35 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
             productID: evidence.productID
         )
         return session.token
+    }
+
+    private func withRefreshedManagementToken<Result>(
+        _ request: (String) async throws -> Result
+    ) async throws -> Result {
+        let token = try await validManagementToken()
+        do {
+            return try await request(token)
+        } catch let error as ManagedConnectionDeviceAPIError where error.rejectionCode == "unauthorized" {
+            invalidateManagementSession(matching: token)
+        }
+
+        let refreshedToken = try await validManagementToken()
+        do {
+            return try await request(refreshedToken)
+        } catch {
+            // 第二次 401 仍清除缓存，但不继续重试，避免失效凭证形成请求循环。
+            if let apiError = error as? ManagedConnectionDeviceAPIError,
+               apiError.rejectionCode == "unauthorized" {
+                invalidateManagementSession(matching: refreshedToken)
+            }
+            throw error
+        }
+    }
+
+    private func invalidateManagementSession(matching token: String) {
+        // await 期间可能已有另一请求签发新会话；旧 401 不能清除较新的凭证。
+        guard managementSession?.session.token == token else { return }
+        managementSession = nil
     }
 
     private func reusableOrNewPendingPairing(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
@@ -6,6 +6,106 @@ import XCTest
 final class ManagedConnectionDeviceStoreTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
 
+    func testLegacyInstallationIdentityAndDeviceTokenMigrateToKeychain() throws {
+        let suiteName = "ManagedConnectionDeviceStoreTests.Migration.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let keychain = TestKeychainOperations()
+        let tokenStore = TokenStore(keychain: keychain)
+        let installationID = "10000000-0000-4000-8000-000000000001"
+        let deviceToken = Self.token(byte: 1)
+        defaults.set(installationID, forKey: "managedConnection.mobileInstallationID.v1")
+        defaults.set("mobile-device-id", forKey: "managedConnection.mobileDeviceID.v1")
+        try tokenStore.saveManagedMobileDeviceToken(deviceToken, installationID: installationID)
+        let store = ManagedConnectionMobileIdentityStore(defaults: defaults, tokenStore: tokenStore)
+
+        let identity = try store.loadOrCreate()
+
+        XCTAssertEqual(identity.installationID, installationID)
+        XCTAssertEqual(identity.deviceToken, deviceToken)
+        XCTAssertEqual(identity.registeredDeviceID, "mobile-device-id")
+        XCTAssertEqual(try tokenStore.loadManagedMobileInstallationID(), installationID)
+    }
+
+    func testReinstalledIdentityDetectsRemoteRevocationAndReregistersWithStableInstallationID() async throws {
+        let suiteName = "ManagedConnectionDeviceStoreTests.Reinstall.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let keychain = TestKeychainOperations()
+        let tokenStore = TokenStore(keychain: keychain)
+        let firstStore = ManagedConnectionMobileIdentityStore(
+            defaults: defaults,
+            tokenStore: tokenStore,
+            makeUUID: { UUID(uuidString: "10000000-0000-4000-8000-000000000001")! },
+            makeToken: { Self.token(byte: 1) }
+        )
+        let first = try firstStore.loadOrCreate()
+        try firstStore.rememberRegisteredDeviceID("old-local-cache")
+
+        defaults.removePersistentDomain(forName: suiteName)
+        let reinstalledStore = ManagedConnectionMobileIdentityStore(
+            defaults: defaults,
+            tokenStore: tokenStore,
+            makeUUID: { UUID(uuidString: "20000000-0000-4000-8000-000000000002")! },
+            makeToken: { Self.token(byte: 2) }
+        )
+        let reinstalled = try reinstalledStore.loadOrCreate()
+
+        XCTAssertEqual(reinstalled.installationID, first.installationID)
+        XCTAssertEqual(reinstalled.deviceToken, first.deviceToken)
+        XCTAssertEqual(reinstalled.registeredDeviceID, "old-local-cache")
+
+        let storeKit = MIM260StoreKitFake(evidence: Self.evidence)
+        let entitlementStore = ManagedConnectionEntitlementStore(
+            storeKit: storeKit,
+            entitlementAPI: MIM260EntitlementAPIFake(grant: grant),
+            now: { self.now }
+        )
+        await entitlementStore.refreshEntitlement()
+        let api = MIM260DeviceAPIFake(now: now)
+        let deviceStore = ManagedConnectionDeviceStore(
+            entitlementStore: entitlementStore,
+            api: api,
+            identityStore: reinstalledStore,
+            now: { self.now },
+            makeUUID: { UUID(uuidString: "30000000-0000-4000-8000-000000000002")! },
+            makeToken: { Self.token(byte: 2) }
+        )
+
+        await deviceStore.refreshDevices()
+        _ = try await deviceStore.authorizeManagedPairing(
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            macTailcatPublicKey: "nodekey:mac",
+            mobileTailcatPublicKey: "nodekey:mobile"
+        )
+
+        let registeredInstallationID = await api.lastRegisteredInstallationID
+        let registeredDeviceToken = await api.lastRegisteredDeviceToken
+        XCTAssertEqual(registeredInstallationID, first.installationID)
+        XCTAssertNotEqual(registeredDeviceToken, first.deviceToken)
+        XCTAssertEqual(registeredDeviceToken, Self.token(byte: 2))
+    }
+
+    func testKeychainFailureDoesNotPublishTemporaryInstallationIdentity() throws {
+        for (name, keychain) in [
+            ("read", TestKeychainOperations(forcedCopyStatus: errSecInteractionNotAllowed)),
+            ("write", TestKeychainOperations(forcedAddStatus: errSecInteractionNotAllowed)),
+        ] {
+            let suiteName = "ManagedConnectionDeviceStoreTests.KeychainFailure.\(name).\(UUID().uuidString)"
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+            let store = ManagedConnectionMobileIdentityStore(
+                defaults: defaults,
+                tokenStore: TokenStore(keychain: keychain),
+                makeUUID: { UUID(uuidString: "10000000-0000-4000-8000-000000000001")! },
+                makeToken: { Self.token(byte: 1) }
+            )
+
+            XCTAssertThrowsError(try store.loadOrCreate(), name)
+            XCTAssertNil(defaults.string(forKey: "managedConnection.mobileInstallationID.v1"), name)
+        }
+    }
+
     func testMobileIdentityPersistsAcrossLaunchAndRotatesOnlyAfterThisDeviceIsRevoked() throws {
         let suiteName = "ManagedConnectionDeviceStoreTests.Identity.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -21,7 +121,7 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         )
 
         let first = try store.loadOrCreate()
-        store.rememberRegisteredDeviceID("mobile-device-id")
+        try store.rememberRegisteredDeviceID("mobile-device-id")
         let relaunched = ManagedConnectionMobileIdentityStore(
             defaults: defaults,
             tokenStore: tokenStore,
@@ -163,6 +263,104 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         let evidence = await fixture.api.lastManagementEvidence
         XCTAssertEqual(sessionCount, 2, "同一交易复用会话，交易身份变化后必须重新创建")
         XCTAssertEqual(evidence?.transaction, "signed-transaction-new-account")
+    }
+
+    func testDeviceRefreshReissuesCachedManagementTokenAfterUnauthorized() async {
+        let fixture = await makeFixture()
+        await fixture.store.refreshDevices()
+        await fixture.api.setListFailures([
+            .rejected(code: "unauthorized", deviceType: nil, limit: nil),
+            nil,
+        ])
+
+        await fixture.store.refreshDevices()
+
+        let sessionCount = await fixture.api.managementSessionCount
+        let tokens = await fixture.api.listManagementTokens
+        XCTAssertEqual(sessionCount, 2)
+        XCTAssertEqual(Array(tokens.suffix(2)), [
+            "management-token-1-that-is-long-enough",
+            "management-token-2-that-is-long-enough",
+        ])
+        XCTAssertNil(fixture.store.errorMessage)
+    }
+
+    func testDeviceRemovalReissuesCachedManagementTokenAfterUnauthorized() async {
+        let fixture = await makeFixture()
+        let device = ManagedConnectionDevice(id: "mac-device-id", deviceType: .mac, createdAt: now)
+        await fixture.api.setDevices([device])
+        await fixture.store.refreshDevices()
+        await fixture.api.setRemovalFailures([
+            .rejected(code: "unauthorized", deviceType: nil, limit: nil),
+            nil,
+        ])
+
+        await fixture.store.removeDevice(device)
+
+        let sessionCount = await fixture.api.managementSessionCount
+        let tokens = await fixture.api.removeManagementTokens
+        let removedDeviceIDs = await fixture.api.removedDeviceIDs
+        XCTAssertEqual(sessionCount, 2)
+        XCTAssertEqual(tokens, [
+            "management-token-1-that-is-long-enough",
+            "management-token-2-that-is-long-enough",
+        ])
+        XCTAssertEqual(removedDeviceIDs, [device.id])
+        XCTAssertNil(fixture.store.errorMessage)
+    }
+
+    func testSecondUnauthorizedStopsRetryAndLeavesNoCachedManagementToken() async {
+        let fixture = await makeFixture()
+        await fixture.store.refreshDevices()
+        await fixture.api.setListFailures([
+            .rejected(code: "unauthorized", deviceType: nil, limit: nil),
+            .rejected(code: "unauthorized", deviceType: nil, limit: nil),
+        ])
+
+        await fixture.store.refreshDevices()
+
+        let failedSessionCount = await fixture.api.managementSessionCount
+        let failedRequestCount = await fixture.api.listManagementTokens.count
+        XCTAssertEqual(failedSessionCount, 2)
+        XCTAssertEqual(failedRequestCount, 3)
+        XCTAssertNotNil(fixture.store.errorMessage)
+
+        await fixture.store.refreshDevices()
+
+        let recoveredSessionCount = await fixture.api.managementSessionCount
+        XCTAssertEqual(recoveredSessionCount, 3)
+        XCTAssertNil(fixture.store.errorMessage)
+    }
+
+    func testStaleUnauthorizedCannotInvalidateNewerManagementToken() async {
+        let fixture = await makeFixture()
+        let device = ManagedConnectionDevice(id: "mac-device-id", deviceType: .mac, createdAt: now)
+        await fixture.api.setDevices([device])
+        await fixture.store.refreshDevices()
+        await fixture.api.setListFailures([
+            .rejected(code: "unauthorized", deviceType: nil, limit: nil),
+            nil,
+        ])
+        await fixture.api.setRemovalFailures([
+            .rejected(code: "unauthorized", deviceType: nil, limit: nil),
+            nil,
+        ])
+        await fixture.api.blockNextDeviceList()
+
+        let staleRefresh = Task { await fixture.store.refreshDevices() }
+        await fixture.api.waitForBlockedDeviceList()
+        await fixture.store.removeDevice(device)
+        await fixture.api.releaseBlockedDeviceList()
+        await staleRefresh.value
+
+        let sessionCount = await fixture.api.managementSessionCount
+        let listTokens = await fixture.api.listManagementTokens
+        XCTAssertEqual(sessionCount, 2, "旧请求的 401 不能清除并发撤销已签发的新凭证")
+        XCTAssertEqual(Array(listTokens.suffix(2)), [
+            "management-token-1-that-is-long-enough",
+            "management-token-2-that-is-long-enough",
+        ])
+        XCTAssertNil(fixture.store.errorMessage)
     }
 
     func testRevocationReconcilesAfterLocalCredentialRotationInitiallyFails() async {
@@ -373,14 +571,23 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
 
     let now: Date
     private(set) var registrationCount = 0
+    private(set) var lastRegisteredInstallationID: String?
+    private(set) var lastRegisteredDeviceToken: String?
     private(set) var authorizationCount = 0
     private(set) var lastAuthorizedRequest: AuthorizedRequest?
     private(set) var lastManagementEvidence: (app: String, transaction: String)?
     private(set) var removedDeviceIDs: [String] = []
     private(set) var managementSessionCount = 0
+    private(set) var listManagementTokens: [String] = []
+    private(set) var removeManagementTokens: [String] = []
     private var registrationFailure: ManagedConnectionDeviceAPIError?
     private var removalFailure: ManagedConnectionDeviceAPIError?
+    private var listFailures: [ManagedConnectionDeviceAPIError?] = []
+    private var removalFailures: [ManagedConnectionDeviceAPIError?] = []
     private var devices: [ManagedConnectionDevice] = []
+    private var shouldBlockNextList = false
+    private var blockedListContinuation: CheckedContinuation<Void, Never>?
+    private var blockedListWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(now: Date) {
         self.now = now
@@ -398,12 +605,42 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
         removalFailure = error
     }
 
+    func setListFailures(_ failures: [ManagedConnectionDeviceAPIError?]) {
+        listFailures = failures
+    }
+
+    func setRemovalFailures(_ failures: [ManagedConnectionDeviceAPIError?]) {
+        removalFailures = failures
+    }
+
+    func blockNextDeviceList() {
+        shouldBlockNextList = true
+    }
+
+    func waitForBlockedDeviceList() async {
+        guard blockedListContinuation == nil else { return }
+        await withCheckedContinuation { continuation in
+            guard blockedListContinuation == nil else {
+                continuation.resume()
+                return
+            }
+            blockedListWaiters.append(continuation)
+        }
+    }
+
+    func releaseBlockedDeviceList() {
+        blockedListContinuation?.resume()
+        blockedListContinuation = nil
+    }
+
     func registerMobileDevice(
         entitlementToken: String,
         installationID: String,
         deviceToken: String
     ) async throws -> ManagedConnectionDeviceRegistration {
         registrationCount += 1
+        lastRegisteredInstallationID = installationID
+        lastRegisteredDeviceToken = deviceToken
         if let registrationFailure { throw registrationFailure }
         return ManagedConnectionDeviceRegistration(
             device: ManagedConnectionDevice(
@@ -451,10 +688,26 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
     }
 
     func listDevices(managementToken: String) async throws -> [ManagedConnectionDevice] {
-        devices
+        listManagementTokens.append(managementToken)
+        if shouldBlockNextList {
+            shouldBlockNextList = false
+            blockedListWaiters.forEach { $0.resume() }
+            blockedListWaiters.removeAll()
+            await withCheckedContinuation { continuation in
+                blockedListContinuation = continuation
+            }
+        }
+        if !listFailures.isEmpty, let failure = listFailures.removeFirst() {
+            throw failure
+        }
+        return devices
     }
 
     func removeDevice(id: String, managementToken: String) async throws {
+        removeManagementTokens.append(managementToken)
+        if !removalFailures.isEmpty, let failure = removalFailures.removeFirst() {
+            throw failure
+        }
         if let removalFailure { throw removalFailure }
         removedDeviceIDs.append(id)
         devices.removeAll { $0.id == id }


### PR DESCRIPTION
## 结果
- 设备列表/删除遇401时失效对应缓存并只重试一次；并发旧请求不删除新凭证。
- 随机安装ID与已登记设备ID迁移到ThisDeviceOnly Keychain，重装与远端撤销后可恢复登记。
- 只轮换撤销的device token，不重置Tailcat私钥/连接档案。

## 验证
- 固定M5 ManagedConnectionDeviceStoreTests：15 tests/0 failures。
- verify-change --plan与quick5/5通过，App BUILD SUCCEEDED、source-size/diff checks通过。
- 基于最新main共享构建缓存，清理本WT生成framework，未清其它任务共享缓存。

## 边界
- 不猜测旧版本在未迁移前重装丢失的installation ID；当前联调云端设备数为0。
- 真机Keychain、真实Sandbox购买/恢复与重新扫码仍需联合验收。
- 不含MIM259临时配对二维码契约，不修改默认线路。