### PR TITLE
MIM-259 授权临时 Mac 节点以完成严格 DERP 配对

### DIFF
--- a/cmd/agentd/tailcat.go
+++ b/cmd/agentd/tailcat.go
@@ -27,6 +27,7 @@ type tailcatCommandStatus struct {
 	PublicKey         string `json:"public_key,omitempty"`
 	MacInstallationID string `json:"mac_installation_id,omitempty"`
 	PairAddress       string `json:"pair_address,omitempty"`
+	PairPublicKey     string `json:"pair_public_key,omitempty"`
 	PairExpiresAt     string `json:"pair_expires_at,omitempty"`
 	PairedDeviceCount int    `json:"paired_device_count"`
 	Error             string `json:"error,omitempty"`
@@ -88,6 +89,7 @@ func runTailcatWithWriters(args []string, stdout io.Writer, stderr io.Writer) er
 			status.PairAddress,
 			status.MacInstallationID,
 			status.PublicKey,
+			status.PairPublicKey,
 		)
 		if err != nil {
 			return err

--- a/experiments/tailcat/internal/managed/manager.go
+++ b/experiments/tailcat/internal/managed/manager.go
@@ -47,6 +47,7 @@ type Status struct {
 	Address           string `json:"address,omitempty"`
 	PublicKey         string `json:"public_key,omitempty"`
 	PairAddress       string `json:"pair_address,omitempty"`
+	PairPublicKey     string `json:"pair_public_key,omitempty"`
 	PairExpiresAt     string `json:"pair_expires_at,omitempty"`
 	PairedDeviceCount int    `json:"paired_device_count"`
 }
@@ -316,6 +317,7 @@ func (m *Manager) statusLocked() Status {
 	}
 	if m.pairHost != nil && time.Now().Before(m.pairExpiresAt) {
 		status.PairAddress = m.pairHost.Address()
+		status.PairPublicKey = m.pairHost.PublicKey()
 		status.PairExpiresAt = m.pairExpiresAt.Format(time.RFC3339Nano)
 	}
 	return status

--- a/experiments/tailcat/internal/managed/manager_test.go
+++ b/experiments/tailcat/internal/managed/manager_test.go
@@ -87,6 +87,25 @@ func TestStartPairingRetainsOldPairHostWhenCloseFails(t *testing.T) {
 	}
 }
 
+func TestStatusIncludesOnlyCurrentPairHostPublicKey(t *testing.T) {
+	pairHost := &fakeManagedHost{address: "pair-address", publicKey: "nodekey:pair-public"}
+	manager := &Manager{
+		pairHost:      pairHost,
+		pairExpiresAt: time.Now().Add(time.Minute),
+	}
+
+	status := manager.Status()
+	if status.PairAddress != pairHost.address || status.PairPublicKey != pairHost.publicKey {
+		t.Fatalf("有效配对状态缺少临时主机身份：%+v", status)
+	}
+
+	manager.pairExpiresAt = time.Now().Add(-time.Second)
+	status = manager.Status()
+	if status.PairAddress != "" || status.PairPublicKey != "" || status.PairExpiresAt != "" {
+		t.Fatalf("过期配对状态不能暴露临时主机身份：%+v", status)
+	}
+}
+
 func TestExpiredPairHostRetriesCloseFailure(t *testing.T) {
 	oldPairHost := &fakeManagedHost{closeErr: errors.New("close failed")}
 	manager := &Manager{

--- a/experiments/tailcat/internal/managed/pairing_derp_integration_test.go
+++ b/experiments/tailcat/internal/managed/pairing_derp_integration_test.go
@@ -1,0 +1,309 @@
+//go:build !ios && !js
+
+package managed
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gaixianggeng/mimi-remote/experiments/tailcat/internal/tunnel"
+	"tailscale.com/derp/derpserver"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+	"tailscale.com/types/logger"
+)
+
+func TestPairingHostReconnectsThroughStrictDERPAfterAdmission(t *testing.T) {
+	// 关闭 UDP，避免同机 Tailcat 两端直连后让健康检查产生假阳性。
+	t.Setenv("TS_DEBUG_ALWAYS_USE_DERP", "1")
+
+	admission := newAdmissionFixture(t)
+	derp, region := startStrictDERP(t, admission.server.URL)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "managed-pairing-ready")
+	}))
+	t.Cleanup(backend.Close)
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := t.TempDir()
+	startHost := func(config tunnel.HostConfig) (managedHost, error) {
+		config.Region = region
+		return tunnel.StartHost(config)
+	}
+	stableHost, err := startHost(tunnel.HostConfig{
+		TargetAddr:   backendURL.Host,
+		RemotePort:   8787,
+		IdentityPath: filepath.Join(stateDir, "host.private.json"),
+		AddressPath:  filepath.Join(stateDir, "host.address"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := &Manager{
+		config: Config{
+			TargetAddr: backendURL.Host,
+			RemotePort: 8787,
+			StateDir:   stateDir,
+		},
+		host:       stableHost,
+		startHost:  startHost,
+		instanceID: "strict-derp-test",
+	}
+	t.Cleanup(func() { _ = manager.Close() })
+
+	status, err := manager.StartPairing(time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.PairAddress == "" || status.PairPublicKey == "" {
+		t.Fatalf("配对状态缺少地址或临时公钥：%+v", status)
+	}
+	pairHost := manager.pairHost
+	pairAddress := status.PairAddress
+
+	mobilePrivate, err := tunnel.NewClientPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mobilePublic, err := tunnel.ClientPublicKey(mobilePrivate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 先只允许发起探测的移动端，才能让 DERP 单独观察并拒绝尚未授权的配对主机。
+	admission.authorize(mobilePublic)
+	deniedContext, cancelDenied := context.WithTimeout(context.Background(), 8*time.Second)
+	deniedForwarder, deniedErr := tunnel.StartForwarder(deniedContext, tunnel.ForwarderConfig{
+		Address:    pairAddress,
+		RemotePort: 8787,
+		ListenAddr: "127.0.0.1:0",
+		PrivateKey: mobilePrivate,
+	})
+	cancelDenied()
+	if deniedErr == nil {
+		_ = deniedForwarder.Close()
+		t.Fatal("严格 DERP 在授权前必须拒绝临时配对链路")
+	}
+	if !admission.observedDenied(status.PairPublicKey) {
+		t.Fatalf("没有观察到临时配对主机被 DERP 拒绝：key=%s denied=%v", status.PairPublicKey, admission.deniedSnapshot())
+	}
+
+	// 模拟 cloud authorize 提交三种身份，并精确失效此前缓存的 deny。
+	admission.authorize(
+		mobilePublic,
+		status.PublicKey,
+		status.PairPublicKey,
+	)
+
+	forwarderConfig := tunnel.ForwarderConfig{
+		Address:    pairAddress,
+		RemotePort: 8787,
+		ListenAddr: "127.0.0.1:0",
+		PrivateKey: mobilePrivate,
+	}
+	forwarder, err := startForwarderUntil(t, 45*time.Second, forwarderConfig)
+	if err != nil {
+		t.Fatalf("授权后同一配对身份没有恢复：%v admissions=%v", err, admission.cacheSnapshot())
+	}
+	t.Cleanup(func() { _ = forwarder.Close() })
+	if manager.pairHost != pairHost || manager.Status().PairAddress != pairAddress {
+		t.Fatal("恢复连接时不应重启或替换临时配对主机")
+	}
+
+	pingContext, cancelPing := context.WithTimeout(context.Background(), 10*time.Second)
+	diagnostic, err := forwarder.DiscoPing(pingContext)
+	cancelPing()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diagnostic.Path != "derp" {
+		t.Fatalf("链路没有经过指定 DERP：%+v", diagnostic)
+	}
+
+	before := derpCounters(t, derp)
+	client := &http.Client{Timeout: 10 * time.Second}
+	response, err := client.Get(forwarder.Endpoint() + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, readErr := io.ReadAll(response.Body)
+	response.Body.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if response.StatusCode != http.StatusOK || string(body) != "managed-pairing-ready" {
+		t.Fatalf("健康检查异常：status=%d body=%q", response.StatusCode, body)
+	}
+	after := derpCounters(t, derp)
+	if after.BytesReceived <= before.BytesReceived || after.BytesSent <= before.BytesSent {
+		t.Fatalf("健康检查没有产生 DERP 转发流量：before=%+v after=%+v", before, after)
+	}
+}
+
+type admissionFixture struct {
+	mu     sync.Mutex
+	origin map[string]bool
+	cache  map[string]bool
+	denied map[string]int
+	server *httptest.Server
+}
+
+func newAdmissionFixture(t *testing.T) *admissionFixture {
+	t.Helper()
+	fixture := &admissionFixture{
+		origin: make(map[string]bool),
+		cache:  make(map[string]bool),
+		denied: make(map[string]int),
+	}
+	fixture.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request tailcfg.DERPAdmitClientRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		publicKey := request.NodePublic.String()
+		fixture.mu.Lock()
+		allow, exists := fixture.cache[publicKey]
+		if !exists {
+			allow = fixture.origin[publicKey]
+			fixture.cache[publicKey] = allow
+		}
+		if !allow {
+			fixture.denied[publicKey]++
+		}
+		fixture.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tailcfg.DERPAdmitClientResponse{Allow: allow})
+	}))
+	t.Cleanup(fixture.server.Close)
+	return fixture
+}
+
+func (f *admissionFixture) authorize(publicKeys ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, publicKey := range publicKeys {
+		f.origin[publicKey] = true
+		delete(f.cache, publicKey)
+	}
+}
+
+func (f *admissionFixture) observedDenied(publicKey string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.denied[publicKey] > 0
+}
+
+func (f *admissionFixture) deniedSnapshot() map[string]int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make(map[string]int, len(f.denied))
+	for publicKey, count := range f.denied {
+		result[publicKey] = count
+	}
+	return result
+}
+
+func (f *admissionFixture) cacheSnapshot() map[string]bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make(map[string]bool, len(f.cache))
+	for publicKey, allow := range f.cache {
+		result[publicKey] = allow
+	}
+	return result
+}
+
+func startForwarderUntil(t *testing.T, timeout time.Duration, config tunnel.ForwarderConfig) (*tunnel.Forwarder, error) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		attemptContext, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		forwarder, err := tunnel.StartForwarder(attemptContext, config)
+		cancel()
+		if err == nil {
+			return forwarder, nil
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, lastErr
+}
+
+func startStrictDERP(t *testing.T, verifyURL string) (*derpserver.Server, *tailcfg.DERPRegion) {
+	t.Helper()
+	server := derpserver.New(key.NewNode(), logger.Discard)
+	server.SetVerifyClientURL(verifyURL)
+	server.SetVerifyClientURLFailOpen(false)
+	handler := derpserver.AddWebSocketSupport(server, derpserver.Handler(server))
+	httpServer := httptest.NewUnstartedServer(handler)
+	httpServer.Config.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
+	httpServer.StartTLS()
+	t.Cleanup(func() {
+		httpServer.CloseClientConnections()
+		httpServer.Close()
+		server.Close()
+	})
+	port := httpServer.Listener.Addr().(*net.TCPAddr).Port
+	region := &tailcfg.DERPRegion{
+		RegionID:   1,
+		RegionCode: "strict-test",
+		Nodes: []*tailcfg.DERPNode{{
+			Name:             "strict-test-1",
+			RegionID:         1,
+			HostName:         "127.0.0.1",
+			IPv4:             "127.0.0.1",
+			IPv6:             "none",
+			STUNPort:         -1,
+			DERPPort:         port,
+			InsecureForTests: true,
+		}},
+	}
+	return server, region
+}
+
+type trafficCounters struct {
+	BytesReceived float64
+	BytesSent     float64
+	ForwardedIn   float64
+	ForwardedOut  float64
+}
+
+func derpCounters(t *testing.T, server *derpserver.Server) trafficCounters {
+	t.Helper()
+	var values map[string]any
+	if err := json.Unmarshal([]byte(server.ExpVar(false).String()), &values); err != nil {
+		t.Fatal(err)
+	}
+	value := func(name string) float64 {
+		number, ok := values[name].(float64)
+		if !ok {
+			t.Fatalf("DERP 指标 %s 缺失或类型异常：%v", name, values[name])
+		}
+		return number
+	}
+	return trafficCounters{
+		BytesReceived: value("bytes_received"),
+		BytesSent:     value("bytes_sent"),
+		ForwardedIn:   value("packets_forwarded_in"),
+		ForwardedOut:  value("packets_forwarded_out"),
+	}
+}
+
+func (c trafficCounters) String() string {
+	return fmt.Sprintf("recv=%.0f sent=%.0f forwarded-in=%.0f forwarded-out=%.0f", c.BytesReceived, c.BytesSent, c.ForwardedIn, c.ForwardedOut)
+}

--- a/internal/httpapi/tailcat_sidecar.go
+++ b/internal/httpapi/tailcat_sidecar.go
@@ -41,6 +41,7 @@ type tailcatStatus struct {
 	PublicKey         string `json:"public_key,omitempty"`
 	MacInstallationID string `json:"mac_installation_id,omitempty"`
 	PairAddress       string `json:"pair_address,omitempty"`
+	PairPublicKey     string `json:"pair_public_key,omitempty"`
 	PairExpiresAt     string `json:"pair_expires_at,omitempty"`
 	PairedDeviceCount int    `json:"paired_device_count"`
 	Error             string `json:"error,omitempty"`

--- a/internal/setup/tailcat.go
+++ b/internal/setup/tailcat.go
@@ -139,16 +139,17 @@ func commitTailcatConfiguration(
 }
 
 func TailcatPair(configPath, pairAddress string) (Result, error) {
-	return TailcatPairWithManagedHost(configPath, pairAddress, "", "")
+	return TailcatPairWithManagedHost(configPath, pairAddress, "", "", "")
 }
 
-// TailcatPairWithManagedHost 只把 Mac 的随机安装 ID 和稳定 Tailcat 公钥加入
-// 二维码。两者都不是凭证；移动端仍需先取得订阅权益和短期配对授权。
+// TailcatPairWithManagedHost 只把 Mac 的随机安装 ID、稳定公钥和当前临时
+// 配对公钥加入二维码。它们都不是凭证；移动端仍需取得订阅权益和短期授权。
 func TailcatPairWithManagedHost(
 	configPath string,
 	pairAddress string,
 	macInstallationID string,
 	macTailcatPublicKey string,
+	pairTailcatPublicKey string,
 ) (Result, error) {
 	pairAddress = strings.TrimSpace(pairAddress)
 	if pairAddress == "" {
@@ -175,12 +176,15 @@ func TailcatPairWithManagedHost(
 	query.Set("tailcat_pair_address", pairAddress)
 	macInstallationID = strings.TrimSpace(macInstallationID)
 	macTailcatPublicKey = strings.TrimSpace(macTailcatPublicKey)
-	if (macInstallationID == "") != (macTailcatPublicKey == "") {
-		return Result{}, fmt.Errorf("托管配对的 Mac 安装身份和 Tailcat 公钥必须同时提供")
+	pairTailcatPublicKey = strings.TrimSpace(pairTailcatPublicKey)
+	if (macInstallationID == "") != (macTailcatPublicKey == "") ||
+		(macInstallationID == "") != (pairTailcatPublicKey == "") {
+		return Result{}, fmt.Errorf("托管配对的 Mac 安装身份、稳定 Tailcat 公钥和临时 Tailcat 公钥必须同时提供")
 	}
 	if macInstallationID != "" {
 		query.Set("managed_mac_installation_id", macInstallationID)
 		query.Set("managed_mac_tailcat_public_key", macTailcatPublicKey)
+		query.Set("managed_pair_tailcat_public_key", pairTailcatPublicKey)
 	}
 	parsed.RawQuery = query.Encode()
 	return Result{

--- a/internal/setup/tailcat_test.go
+++ b/internal/setup/tailcat_test.go
@@ -168,6 +168,7 @@ func TestTailcatPairIncludesOnlyPublicManagedHostMetadata(t *testing.T) {
 		"tailcat-temporary-address",
 		"20000000-0000-4000-8000-000000000001",
 		"nodekey:mac-public-key",
+		"nodekey:pair-public-key",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +179,8 @@ func TestTailcatPairIncludesOnlyPublicManagedHostMetadata(t *testing.T) {
 	}
 	query := parsed.Query()
 	if query.Get("managed_mac_installation_id") != "20000000-0000-4000-8000-000000000001" ||
-		query.Get("managed_mac_tailcat_public_key") != "nodekey:mac-public-key" {
+		query.Get("managed_mac_tailcat_public_key") != "nodekey:mac-public-key" ||
+		query.Get("managed_pair_tailcat_public_key") != "nodekey:pair-public-key" {
 		t.Fatalf("二维码缺少托管授权所需的公开主机元数据：%s", result.PairURL)
 	}
 	if strings.Contains(result.PairURL, token) || query.Get("managed_pairing_grant") != "" {

--- a/ios/MimiRemote/Sources/Core/API/ManagedConnectionDeviceAPIClient.swift
+++ b/ios/MimiRemote/Sources/Core/API/ManagedConnectionDeviceAPIClient.swift
@@ -46,6 +46,7 @@ protocol ManagedConnectionDeviceAPIClient: Sendable {
         macInstallationID: String,
         mobileTailcatPublicKey: String,
         macTailcatPublicKey: String,
+        pairingMacTailcatPublicKey: String,
         managedPairingGrant: String
     ) async throws -> ManagedConnectionPairingSession
 
@@ -96,6 +97,7 @@ struct LiveManagedConnectionDeviceAPIClient: ManagedConnectionDeviceAPIClient {
         macInstallationID: String,
         mobileTailcatPublicKey: String,
         macTailcatPublicKey: String,
+        pairingMacTailcatPublicKey: String,
         managedPairingGrant: String
     ) async throws -> ManagedConnectionPairingSession {
         var request = jsonRequest(
@@ -109,6 +111,7 @@ struct LiveManagedConnectionDeviceAPIClient: ManagedConnectionDeviceAPIClient {
                 macInstallationId: macInstallationID,
                 mobileTailcatPublicKey: mobileTailcatPublicKey,
                 macTailcatPublicKey: macTailcatPublicKey,
+                pairingMacTailcatPublicKey: pairingMacTailcatPublicKey,
                 managedPairingGrant: managedPairingGrant
             )
         )
@@ -280,6 +283,7 @@ private struct AuthorizePairingRequest: Encodable {
     let macInstallationId: String
     let mobileTailcatPublicKey: String
     let macTailcatPublicKey: String
+    let pairingMacTailcatPublicKey: String
     let managedPairingGrant: String
 }
 

--- a/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
+++ b/ios/MimiRemote/Sources/State/HostConnectionSupport.swift
@@ -97,6 +97,7 @@ struct TailcatPairingLink: Equatable {
     let pairAddress: String
     let managedMacInstallationID: String?
     let managedMacTailcatPublicKey: String?
+    let managedPairTailcatPublicKey: String?
 
     @MainActor
     static func parse(_ url: URL) throws -> TailcatPairingLink? {
@@ -119,16 +120,22 @@ struct TailcatPairingLink: Equatable {
         let managedMacTailcatPublicKey = components?.queryItems?
             .first(where: { $0.name == "managed_mac_tailcat_public_key" })?.value?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let managedPairTailcatPublicKey = components?.queryItems?
+            .first(where: { $0.name == "managed_pair_tailcat_public_key" })?.value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let hasManagedInstallationID = !(managedMacInstallationID ?? "").isEmpty
         let hasManagedPublicKey = !(managedMacTailcatPublicKey ?? "").isEmpty
-        guard hasManagedInstallationID == hasManagedPublicKey else {
+        let hasManagedPairPublicKey = !(managedPairTailcatPublicKey ?? "").isEmpty
+        guard hasManagedInstallationID == hasManagedPublicKey,
+              !hasManagedPairPublicKey || hasManagedInstallationID else {
             throw PairingLinkError.unsupportedURL
         }
         return TailcatPairingLink(
             ticket: ticket,
             pairAddress: pairAddress,
             managedMacInstallationID: hasManagedInstallationID ? managedMacInstallationID : nil,
-            managedMacTailcatPublicKey: hasManagedPublicKey ? managedMacTailcatPublicKey : nil
+            managedMacTailcatPublicKey: hasManagedPublicKey ? managedMacTailcatPublicKey : nil,
+            managedPairTailcatPublicKey: hasManagedPairPublicKey ? managedPairTailcatPublicKey : nil
         )
     }
 }

--- a/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionDeviceStore.swift
@@ -10,6 +10,7 @@ protocol ManagedConnectionPairingAuthorizing: AnyObject {
     func authorizeManagedPairing(
         macInstallationID: String,
         macTailcatPublicKey: String,
+        pairingMacTailcatPublicKey: String,
         mobileTailcatPublicKey: String
     ) async throws -> ManagedConnectionPairingAuthorization
 
@@ -29,6 +30,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
     private struct PendingPairingAuthorization {
         let macInstallationID: String
         let macTailcatPublicKey: String
+        let pairingMacTailcatPublicKey: String
         let mobileTailcatPublicKey: String
         let requestID: String
         let grant: String
@@ -120,12 +122,14 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
     func authorizeManagedPairing(
         macInstallationID: String,
         macTailcatPublicKey: String,
+        pairingMacTailcatPublicKey: String,
         mobileTailcatPublicKey: String
     ) async throws -> ManagedConnectionPairingAuthorization {
         let identity = try await ensureMobileDeviceRegistered()
         let pending = try reusableOrNewPendingPairing(
             macInstallationID: macInstallationID,
             macTailcatPublicKey: macTailcatPublicKey,
+            pairingMacTailcatPublicKey: pairingMacTailcatPublicKey,
             mobileTailcatPublicKey: mobileTailcatPublicKey
         )
         if let session = pending.session, session.expiresAt > now() {
@@ -138,6 +142,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
             macInstallationID: macInstallationID,
             mobileTailcatPublicKey: mobileTailcatPublicKey,
             macTailcatPublicKey: macTailcatPublicKey,
+            pairingMacTailcatPublicKey: pairingMacTailcatPublicKey,
             managedPairingGrant: pending.grant
         )
         pendingPairing?.session = session
@@ -227,11 +232,13 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
     private func reusableOrNewPendingPairing(
         macInstallationID: String,
         macTailcatPublicKey: String,
+        pairingMacTailcatPublicKey: String,
         mobileTailcatPublicKey: String
     ) throws -> PendingPairingAuthorization {
         if let pendingPairing,
            pendingPairing.macInstallationID == macInstallationID,
            pendingPairing.macTailcatPublicKey == macTailcatPublicKey,
+           pendingPairing.pairingMacTailcatPublicKey == pairingMacTailcatPublicKey,
            pendingPairing.mobileTailcatPublicKey == mobileTailcatPublicKey,
            pendingPairing.localExpiresAt > now()
         {
@@ -240,6 +247,7 @@ final class ManagedConnectionDeviceStore: ObservableObject, ManagedConnectionPai
         let pending = PendingPairingAuthorization(
             macInstallationID: macInstallationID,
             macTailcatPublicKey: macTailcatPublicKey,
+            pairingMacTailcatPublicKey: pairingMacTailcatPublicKey,
             mobileTailcatPublicKey: mobileTailcatPublicKey,
             requestID: makeUUID().uuidString.lowercased(),
             grant: try makeToken(),

--- a/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
+++ b/ios/MimiRemote/Sources/State/TailcatExperimentController.swift
@@ -570,6 +570,7 @@ final class TailcatExperimentController: ObservableObject {
             if requiresManagedAuthorization {
                 guard let macInstallationID = link.managedMacInstallationID,
                       let macTailcatPublicKey = link.managedMacTailcatPublicKey,
+                      let pairingMacTailcatPublicKey = link.managedPairTailcatPublicKey,
                       let managedPairingAuthorizer
                 else {
                     throw ManagedConnectionDeviceStoreError.managedQRCodeRequired
@@ -577,6 +578,7 @@ final class TailcatExperimentController: ObservableObject {
                 managedAuthorization = try await managedPairingAuthorizer.authorizeManagedPairing(
                     macInstallationID: macInstallationID,
                     macTailcatPublicKey: macTailcatPublicKey,
+                    pairingMacTailcatPublicKey: pairingMacTailcatPublicKey,
                     mobileTailcatPublicKey: clientKey
                 )
             } else {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceAPIClientTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceAPIClientTests.swift
@@ -57,6 +57,7 @@ final class ManagedConnectionDeviceAPIClientTests: XCTestCase {
             macInstallationID: "20000000-0000-4000-8000-000000000001",
             mobileTailcatPublicKey: "nodekey:mobile",
             macTailcatPublicKey: "nodekey:mac",
+            pairingMacTailcatPublicKey: "nodekey:pair",
             managedPairingGrant: grant
         )
 
@@ -66,7 +67,15 @@ final class ManagedConnectionDeviceAPIClientTests: XCTestCase {
         XCTAssertEqual(json["macInstallationId"], "20000000-0000-4000-8000-000000000001")
         XCTAssertEqual(json["mobileTailcatPublicKey"], "nodekey:mobile")
         XCTAssertEqual(json["macTailcatPublicKey"], "nodekey:mac")
+        XCTAssertEqual(json["pairingMacTailcatPublicKey"], "nodekey:pair")
         XCTAssertEqual(json["managedPairingGrant"], grant)
+        XCTAssertEqual(
+            Set(json.keys),
+            Set([
+                "requestId", "macInstallationId", "mobileTailcatPublicKey",
+                "macTailcatPublicKey", "pairingMacTailcatPublicKey", "managedPairingGrant"
+            ])
+        )
         XCTAssertEqual(result.macSlot, .reserved)
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
@@ -76,6 +76,7 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         _ = try await deviceStore.authorizeManagedPairing(
             macInstallationID: "20000000-0000-4000-8000-000000000001",
             macTailcatPublicKey: "nodekey:mac",
+            pairingMacTailcatPublicKey: "nodekey:pair-mac",
             mobileTailcatPublicKey: "nodekey:mobile"
         )
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionDeviceStoreTests.swift
@@ -49,11 +49,13 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         let first = try await fixture.store.authorizeManagedPairing(
             macInstallationID: "20000000-0000-4000-8000-000000000001",
             macTailcatPublicKey: "nodekey:mac",
+            pairingMacTailcatPublicKey: "nodekey:pair",
             mobileTailcatPublicKey: "nodekey:mobile"
         )
         let retry = try await fixture.store.authorizeManagedPairing(
             macInstallationID: "20000000-0000-4000-8000-000000000001",
             macTailcatPublicKey: "nodekey:mac",
+            pairingMacTailcatPublicKey: "nodekey:pair",
             mobileTailcatPublicKey: "nodekey:mobile"
         )
 
@@ -66,6 +68,7 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         XCTAssertEqual(authorizationCount, 1, "响应丢失后的同一逻辑配对应复用授权")
         XCTAssertEqual(authorizedRequest?.mobileKey, "nodekey:mobile")
         XCTAssertEqual(authorizedRequest?.macKey, "nodekey:mac")
+        XCTAssertEqual(authorizedRequest?.pairingMacKey, "nodekey:pair")
         XCTAssertEqual(fixture.identity.registeredDeviceID, "mobile-device-id")
     }
 
@@ -75,11 +78,13 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         _ = try await fixture.store.authorizeManagedPairing(
             macInstallationID: "20000000-0000-4000-8000-000000000001",
             macTailcatPublicKey: "nodekey:mac-old",
+            pairingMacTailcatPublicKey: "nodekey:pair",
             mobileTailcatPublicKey: "nodekey:mobile"
         )
         _ = try await fixture.store.authorizeManagedPairing(
             macInstallationID: "20000000-0000-4000-8000-000000000001",
             macTailcatPublicKey: "nodekey:mac-new",
+            pairingMacTailcatPublicKey: "nodekey:pair",
             mobileTailcatPublicKey: "nodekey:mobile"
         )
 
@@ -87,6 +92,28 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
         let authorizedRequest = await fixture.api.lastAuthorizedRequest
         XCTAssertEqual(authorizationCount, 2)
         XCTAssertEqual(authorizedRequest?.macKey, "nodekey:mac-new")
+    }
+
+    func testTemporaryPairKeyRotationDoesNotReusePairingAuthorization() async throws {
+        let fixture = await makeFixture()
+
+        _ = try await fixture.store.authorizeManagedPairing(
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            macTailcatPublicKey: "nodekey:mac",
+            pairingMacTailcatPublicKey: "nodekey:pair-old",
+            mobileTailcatPublicKey: "nodekey:mobile"
+        )
+        _ = try await fixture.store.authorizeManagedPairing(
+            macInstallationID: "20000000-0000-4000-8000-000000000001",
+            macTailcatPublicKey: "nodekey:mac",
+            pairingMacTailcatPublicKey: "nodekey:pair-new",
+            mobileTailcatPublicKey: "nodekey:mobile"
+        )
+
+        let authorizationCount = await fixture.api.authorizationCount
+        let authorizedRequest = await fixture.api.lastAuthorizedRequest
+        XCTAssertEqual(authorizationCount, 2)
+        XCTAssertEqual(authorizedRequest?.pairingMacKey, "nodekey:pair-new")
     }
 
     func testMobileQuotaFailureStopsBeforePairingAuthorization() async {
@@ -99,6 +126,7 @@ final class ManagedConnectionDeviceStoreTests: XCTestCase {
             _ = try await fixture.store.authorizeManagedPairing(
                 macInstallationID: "20000000-0000-4000-8000-000000000001",
                 macTailcatPublicKey: "nodekey:mac",
+                pairingMacTailcatPublicKey: "nodekey:pair",
                 mobileTailcatPublicKey: "nodekey:mobile"
             )
             XCTFail("第六台移动设备必须被名额门禁拒绝")
@@ -368,6 +396,7 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
         let requestID: String
         let mobileKey: String
         let macKey: String
+        let pairingMacKey: String
         let grant: String
     }
 
@@ -421,6 +450,7 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
         macInstallationID: String,
         mobileTailcatPublicKey: String,
         macTailcatPublicKey: String,
+        pairingMacTailcatPublicKey: String,
         managedPairingGrant: String
     ) async throws -> ManagedConnectionPairingSession {
         authorizationCount += 1
@@ -428,6 +458,7 @@ private actor MIM260DeviceAPIFake: ManagedConnectionDeviceAPIClient {
             requestID: requestID,
             mobileKey: mobileTailcatPublicKey,
             macKey: macTailcatPublicKey,
+            pairingMacKey: pairingMacTailcatPublicKey,
             grant: managedPairingGrant
         )
         return ManagedConnectionPairingSession(

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedPairingContractTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedPairingContractTests.swift
@@ -5,11 +5,12 @@ import XCTest
 @MainActor
 final class ManagedPairingContractTests: XCTestCase {
     func testTailcatPairingLinkCarriesManagedHostMetadataAndGrant() throws {
-        let url = try XCTUnwrap(URL(string: "mimiremote://pair?endpoint=http%3A%2F%2F127.0.0.1%3A8787&issued_at=2026-09-01T00%3A00%3A00Z&expires_at=4102444800&pair_sig=abcdef&transport=tailcat&tailcat_pair_address=tc%3Atest-address&managed_mac_installation_id=20000000-0000-4000-8000-000000000001&managed_mac_tailcat_public_key=nodekey%3Amac-public"))
+        let url = try XCTUnwrap(URL(string: "mimiremote://pair?endpoint=http%3A%2F%2F127.0.0.1%3A8787&issued_at=2026-09-01T00%3A00%3A00Z&expires_at=4102444800&pair_sig=abcdef&transport=tailcat&tailcat_pair_address=tc%3Atest-address&managed_mac_installation_id=20000000-0000-4000-8000-000000000001&managed_mac_tailcat_public_key=nodekey%3Amac-public&managed_pair_tailcat_public_key=nodekey%3Apair-public"))
         let link = try XCTUnwrap(TailcatPairingLink.parse(url))
 
         XCTAssertEqual(link.managedMacInstallationID, "20000000-0000-4000-8000-000000000001")
         XCTAssertEqual(link.managedMacTailcatPublicKey, "nodekey:mac-public")
+        XCTAssertEqual(link.managedPairTailcatPublicKey, "nodekey:pair-public")
         let request = link.ticket.managedClaimRequest(
             tailcatClientKey: "nodekey:mobile-public",
             pairingSessionID: "30000000-0000-4000-8000-000000000001",

--- a/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/TailcatExperimentRoutingTests.swift
@@ -118,15 +118,16 @@ private actor TailcatExperimentRuntimeStub: TailcatExperimentRuntimeProtocol {
 
 @MainActor
 private final class ManagedPairingAuthorizerStub: ManagedConnectionPairingAuthorizing {
-    private(set) var requests: [(macInstallationID: String, macKey: String, mobileKey: String)] = []
+    private(set) var requests: [(macInstallationID: String, macKey: String, pairingMacKey: String, mobileKey: String)] = []
     private(set) var completions: [ManagedConnectionPairingAuthorization] = []
 
     func authorizeManagedPairing(
         macInstallationID: String,
         macTailcatPublicKey: String,
+        pairingMacTailcatPublicKey: String,
         mobileTailcatPublicKey: String
     ) async throws -> ManagedConnectionPairingAuthorization {
-        requests.append((macInstallationID, macTailcatPublicKey, mobileTailcatPublicKey))
+        requests.append((macInstallationID, macTailcatPublicKey, pairingMacTailcatPublicKey, mobileTailcatPublicKey))
         return ManagedConnectionPairingAuthorization(sessionID: "managed-session", grant: "managed-grant")
     }
 
@@ -238,23 +239,26 @@ final class TailcatExperimentRoutingTests: XCTestCase {
         XCTAssertEqual(startCallCount, 1)
     }
 
-    func testManagedPairingRequiresManagedQRCodeBeforeStartingRuntime() async throws {
+    func testManagedPairingRequiresCurrentManagedQRCodeBeforeStartingRuntime() async throws {
         let authorizer = ManagedPairingAuthorizerStub()
         let fixture = try makeControllerFixture(
             startResults: [.failure(.startFailed)],
             managedPairingAuthorizer: authorizer
         )
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
-        let url = try XCTUnwrap(URL(string: Self.freeTailcatPairingURL))
+        let url = try XCTUnwrap(URL(string: Self.legacyManagedTailcatPairingURL))
 
-        await XCTAssertThrowsErrorAsync(
+        do {
             try await fixture.controller.preparePairingURL(
                 url,
                 appStore: fixture.store,
                 profileTarget: .currentOrNew(displayName: nil),
                 requiresManagedAuthorization: true
             )
-        )
+            XCTFail("旧版托管二维码缺少临时配对公钥时必须停止")
+        } catch {
+            XCTAssertEqual(error as? ManagedConnectionDeviceStoreError, .managedQRCodeRequired)
+        }
 
         let startCallCount = await fixture.runtime.startCallCount()
         XCTAssertTrue(authorizer.requests.isEmpty)
@@ -282,6 +286,7 @@ final class TailcatExperimentRoutingTests: XCTestCase {
         XCTAssertEqual(authorizer.requests.count, 1)
         XCTAssertEqual(authorizer.requests.first?.macInstallationID, "20000000-0000-4000-8000-000000000001")
         XCTAssertEqual(authorizer.requests.first?.macKey, "nodekey:mac-public")
+        XCTAssertEqual(authorizer.requests.first?.pairingMacKey, "nodekey:pair-public")
         XCTAssertEqual(authorizer.requests.first?.mobileKey, "nodekey:public-key")
         let startCallCount = await fixture.runtime.startCallCount()
         XCTAssertEqual(startCallCount, 1)
@@ -888,7 +893,10 @@ final class TailcatExperimentRoutingTests: XCTestCase {
     private static let freeTailcatPairingURL =
         "mimiremote://pair?endpoint=http%3A%2F%2F127.0.0.1%3A8787&issued_at=2026-09-01T00%3A00%3A00Z&expires_at=4102444800&pair_sig=abcdef&transport=tailcat&tailcat_pair_address=tc%3Atest-address"
 
-    private static let managedTailcatPairingURL = freeTailcatPairingURL
+    private static let legacyManagedTailcatPairingURL = freeTailcatPairingURL
         + "&managed_mac_installation_id=20000000-0000-4000-8000-000000000001"
         + "&managed_mac_tailcat_public_key=nodekey%3Amac-public"
+
+    private static let managedTailcatPairingURL = legacyManagedTailcatPairingURL
+        + "&managed_pair_tailcat_public_key=nodekey%3Apair-public"
 }


### PR DESCRIPTION
## 目标

让首次托管配对在严格 DERP 节点准入下可以完成，不依赖中转公开放行。

## 改动

- Mac 只在临时配对有效时公开临时节点公钥，并写入二维码。
- iOS 在启动连接前向云端授权该临时节点；刷新二维码后不复用旧授权。
- 托管入口拒绝缺少临时公钥的旧二维码，免费 Tailcat 配对保持兼容。
- 增加真实严格 DERP 测试：先拒绝、后授权，同一配对地址和主机无需重启即可连接；确认实际 DERP 路径及数据流量。

## 验证

- Go Tailcat 定向测试和独立 module 测试通过。
- 合入 MIM-260、MIM-261 后，固定 M5 的 44 项托管专项全部通过；核心链路回归 366 passed、3 skipped、0 failures。
- Go vet 与源码行数检查通过。
- 已执行 quick / full。两者 Go 阶段都被已有 Claude 50ms 登录探测测试阻断；不含本次修改的 MIM-271 基线独立运行也同样失败。本 PR 不扩大范围修改 Claude 探测。
- 完整历史安全扫描、第三方许可和 PR Gate 自检通过。Codex 协议本机因 0.153.0 与仓库固定 0.149.1 不一致而停止，CI 固定版本检查通过，未改变快照或全局 CLI。
- GitHub PR Gate 全部通过，包括 Go、Windows 和 iOS。

## 发布边界

- 云端临时准入接口已随 mimi-cloud PR #9 部署。
- 当前共享 DERP 尚未开启严格准入。本地真实 DERP 测试不代表线上付费线路的安全门槛已经完成。
- 实际 Sandbox 购买、Mac/iPad 安装和扫码仍需联合验收。
