### PR TITLE
MIM-258 Preserve StoreKit grace period entitlement

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		391A66E7F197E57DBA1239DF /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 6C892E2BB83F2EE5FDD6EDA4 /* Localizable.xcstrings */; };
 		3942D0F45FDBA6578D875940 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 2EBD11FEEFA3EA7C03993BE1 /* testCompletedGoalStatusTrayRemainsVisibleAfterTurnFinishes.1.png */; };
 		39BC098D3DD6A3AB3EA13BCA /* SessionStoreHistoryItemEnrichment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B21C203D451C1F559CD1327 /* SessionStoreHistoryItemEnrichment.swift */; };
+		3AA6DA50C95E3E7A2D9899EC /* ManagedConnectionStoreKitClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7557CAF6E405B0327D0B7E9 /* ManagedConnectionStoreKitClientTests.swift */; };
 		3B0E963BB2856F7CDD36EB67 /* MessageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CAFB1927C976C000C9E026 /* MessageStore.swift */; };
 		3B7C6F8101AC352585369923 /* SettingsChoiceRowSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADF7C1BCDC8114BB0CC589D /* SettingsChoiceRowSnapshotTests.swift */; platformFilters = (ios, ); };
 		3C66496C0EC02D59EC54C711 /* testLoadedActivityInDarkAppearance.loaded-compact-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = 405D5433F81D4DFCDCD6008B /* testLoadedActivityInDarkAppearance.loaded-compact-dark.png */; };
@@ -257,6 +258,7 @@
 		BA0F184AA3E72EE6A5A291B5 /* ConversationDirectRuntimeSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FE3675988DBD54585B3A79 /* ConversationDirectRuntimeSubscriptionTests.swift */; };
 		BA142EA7D865810EAD1A968F /* testEmptyActivityDrawsInactiveGrid.empty-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = 52836A26EDEF7D6BD84CA133 /* testEmptyActivityDrawsInactiveGrid.empty-compact.png */; };
 		BAA573B7BCCDD95153331C04 /* ManagedConnectionStoreKitClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8F22C82C007839E2D06A90 /* ManagedConnectionStoreKitClient.swift */; };
+		BBCEA2D532E84288D5EDC227 /* MimiRemote.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 91BA7011F99F49B437A5ACEF /* MimiRemote.storekit */; };
 		BC8113C02839555625D96A97 /* FloatingSidebarPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECDC4F6FDDB66F610BF6FC2D /* FloatingSidebarPresentation.swift */; };
 		BC8B20DA0FE42207D5D2CA8C /* ComposerTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E9EA7D6A93EB6697C0B874 /* ComposerTextEditor.swift */; };
 		BC9DC86B9FC058DBBDDDAE0F /* testPermissionOptionPageShowsEveryDetail.permission-page-compact.png in Resources */ = {isa = PBXBuildFile; fileRef = 73B98B7856DBCB29BD8FA4BB /* testPermissionOptionPageShowsEveryDetail.permission-page-compact.png */; };
@@ -628,6 +630,7 @@
 		B4C046A065EC50889673C918 /* SessionAPIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAPIModels.swift; sourceTree = "<group>"; };
 		B546C68F6A4EDDA47CD25FD7 /* LegalDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalDocumentView.swift; sourceTree = "<group>"; };
 		B75153DC244B9C9543B87E2E /* WorkspaceSessionAuthoritativeContinuationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSessionAuthoritativeContinuationTests.swift; sourceTree = "<group>"; };
+		B7557CAF6E405B0327D0B7E9 /* ManagedConnectionStoreKitClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionStoreKitClientTests.swift; sourceTree = "<group>"; };
 		B7E83526E3C22DF48B2DD911 /* NewSessionPresentationSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionPresentationSource.swift; sourceTree = "<group>"; };
 		B7FD02CA5030B3E70BC7E09D /* ConnectionProfileRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionProfileRenameTests.swift; sourceTree = "<group>"; };
 		B87B13F0356B9B4613FFBA94 /* MimiRemoteTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MimiRemoteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -951,6 +954,7 @@
 				04DF31C6F06A2786DE678E4A /* ManagedConnectionDeviceStoreTests.swift */,
 				417026D5C6353D2982527627 /* ManagedConnectionEntitlementStoreTests.swift */,
 				828DECD2F01CFABB9CB3E1F1 /* ManagedConnectionEventAPIClientTests.swift */,
+				B7557CAF6E405B0327D0B7E9 /* ManagedConnectionStoreKitClientTests.swift */,
 				4CAF352234E74EEAF7B023AE /* ManagedPairingContractTests.swift */,
 				24B74985F9E77EEE70BC1856 /* MarkdownRenderingTests.swift */,
 				81FDFD00533B31F16F861BFB /* MimiInteractionFeedbackTests.swift */,
@@ -1599,6 +1603,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BBCEA2D532E84288D5EDC227 /* MimiRemote.storekit in Resources */,
 				8EEEC2243F3EE20F96B3B62D /* direct_app_server_approval_stream.jsonl in Resources */,
 				8E170E7635D6973BC280CD96 /* testAccessibilityWorkspaceRowsGrowAndKeepDistinctPreview.1.png in Resources */,
 				439355570F5ED69354673D07 /* testAppearancePreview.1.png in Resources */,
@@ -1797,6 +1802,7 @@
 				70625989072AA4231FE732EA /* ManagedConnectionDeviceStoreTests.swift in Sources */,
 				491F23C64F7108C5B28BBD1B /* ManagedConnectionEntitlementStoreTests.swift in Sources */,
 				6242237BF55EAA0D2945AC77 /* ManagedConnectionEventAPIClientTests.swift in Sources */,
+				3AA6DA50C95E3E7A2D9899EC /* ManagedConnectionStoreKitClientTests.swift in Sources */,
 				7FCF7AE789CFBC4E2148BCD3 /* ManagedPairingContractTests.swift in Sources */,
 				4DDCF6949E6DDCC9ABEBE709 /* MarkdownRenderingTests.swift in Sources */,
 				20D78099D1CE0CC7A660BFA1 /* MimiInteractionFeedbackTests.swift in Sources */,

--- a/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
+++ b/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
@@ -172,10 +172,12 @@ actor LiveManagedConnectionStoreKitClient: ManagedConnectionStoreKitClient {
     ) -> ManagedConnectionCurrentEntitlementOutcome {
         guard case .verified(let transaction) = verification,
               transaction.revocationDate == nil,
-              transaction.expirationDate.map({ $0 > Date() }) ?? true
+              !transaction.isUpgraded
         else {
             return .unverified
         }
+        // currentEntitlements 已按 StoreKit 的订阅状态筛选，并会返回宽限期交易。
+        // 宽限期内原服务期可能已过，不能再次按 expirationDate 把它降为无权益。
         // 冷启动可能恢复到尚未 finish 的已验证交易；服务端授权后再幂等 finish。
         unfinishedTransactions[transaction.id] = transaction
         return .verified(Self.evidence(from: verification, transaction: transaction))

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionStoreKitClientTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionStoreKitClientTests.swift
@@ -1,0 +1,70 @@
+import StoreKit
+import StoreKitTest
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class ManagedConnectionStoreKitClientTests: XCTestCase {
+    func testCurrentEntitlementRejectsRefundedTransaction() async throws {
+        let (session, client) = try makeSessionAndClient()
+        let revoked = try await session.buyProduct(identifier: ManagedConnectionProductID.monthly)
+        try session.disableAutoRenewForTransaction(identifier: UInt(revoked.id))
+        try await waitUntilVerified(client, transactionID: revoked.id)
+        try session.refundTransaction(identifier: UInt(revoked.id))
+        try await waitUntilNotVerified(client, productID: ManagedConnectionProductID.monthly)
+    }
+
+    private func makeSessionAndClient() throws -> (
+        SKTestSession,
+        LiveManagedConnectionStoreKitClient
+    ) {
+        let configurationURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "MimiRemote", withExtension: "storekit")
+        )
+        let session = try SKTestSession(contentsOf: configurationURL)
+        session.resetToDefaultState()
+        session.clearTransactions()
+        session.disableDialogs = true
+        addTeardownBlock {
+            session.resetToDefaultState()
+            session.clearTransactions()
+        }
+        return (session, LiveManagedConnectionStoreKitClient())
+    }
+
+    private func waitUntilNotVerified(
+        _ client: LiveManagedConnectionStoreKitClient,
+        productID: String
+    ) async throws {
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            let outcome = await client.currentEntitlement(productID: productID)
+            if case .verified = outcome {
+                try await Task.sleep(for: .milliseconds(100))
+                continue
+            }
+            return
+        }
+        throw StoreKitTestError.timedOut("过期或撤销交易仍被识别为有效权益")
+    }
+
+    private func waitUntilVerified(
+        _ client: LiveManagedConnectionStoreKitClient,
+        transactionID: UInt64
+    ) async throws {
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if case .verified(let evidence) = await client.currentEntitlement(
+                productID: ManagedConnectionProductID.monthly
+            ), evidence.transactionID == transactionID {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw StoreKitTestError.timedOut("新交易没有先成为当前有效权益")
+    }
+}
+
+private enum StoreKitTestError: Error {
+    case timedOut(String)
+}

--- a/ios/MimiRemote/project.yml
+++ b/ios/MimiRemote/project.yml
@@ -176,6 +176,8 @@ targets:
       - path: Tests/MimiRemoteTests/WorkspaceVisualSnapshotTests.swift
         destinationFilters:
           - iOS
+      - path: Resources/MimiRemote.storekit
+        buildPhase: resources
     dependencies:
       - target: MimiRemote
       - package: SnapshotTesting


### PR DESCRIPTION
## 目标

避免 `Transaction.currentEntitlements` 明确返回宽限期交易时，客户端因原服务期 `expirationDate` 已过而提前降级。

## 实现

- 保留 StoreKit verified、revocationDate 和 isUpgraded 校验。
- 不再对 currentEntitlements 的结果重复执行 expirationDate 过滤。Apple 文档说明该序列提供当前权益：https://developer.apple.com/documentation/storekit/transaction/currententitlements
- 测试 target 引入现有本地 `MimiRemote.storekit`，覆盖 active→refund 后不再返回已验证交易。测试不访问线上。

`currentEntitlement` 的 `.verified` 只表示 Apple 交易证据验证通过，不直接授予服务。过期与撤销的最终服务状态仍由云端裁决；既有 EntitlementStore 测试覆盖云端 `expired` / `revoked` 决策。

## 验证

- 固定 M5 精准测试：3 passed（真实 StoreKit active→refund；既有 expired/revoked 云端状态各一项）
- `bash ./scripts/check-source-size.sh`：通过
- `bash ./scripts/verify-change.sh --plan`：iOS quick，6项
- `bash ./scripts/verify-change.sh`：6/6通过，iOS Simulator build succeeded

## 未验证范围

Xcode 27.0 beta 6 的本地 SKTestSession 两次都未产生 `inGracePeriod` 且 expirationDate 已过的 fixture；`expireSubscription` 后 currentEntitlements 也未在有界等待内移除交易。因此没有保留失败或 skip 的测试，也没有为测试增加生产入口。真实宽限期恢复与过期链路延期到 Sandbox 端到端人工验证。