### PR TITLE
MIM-272: 固定会话菜单刷新入口并支持复制会话 ID

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -7108,6 +7108,24 @@
         }
       }
     },
+    "ui.copy_session_id": {
+      "comment": "Session menu action that copies the complete session identifier.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy session ID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制会话 ID"
+          }
+        }
+      }
+    },
     "ui.counts_joined": {
       "comment": "Join two localized count fragments.",
       "localizations": {
@@ -16204,6 +16222,24 @@
           "stringUnit": {
             "state": "translated",
             "value": "更多"
+          }
+        }
+      }
+    },
+    "ui.more_actions": {
+      "comment": "Submenu for session management actions that vary by session state and runtime.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More actions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更多操作"
           }
         }
       }

--- a/ios/MimiRemote/Sources/Features/Sessions/SessionActions.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionActions.swift
@@ -103,7 +103,7 @@ enum SessionActionPresentation: Identifiable {
 
 /// 列表、项目侧栏和详情工具栏共用同一组会话动作。
 ///
-/// 页面级的“刷新”和“显示详情”不属于会话自身能力，由各页面在此内容之后追加。
+/// 页面级的“刷新”和“显示详情”由各页面放在这组动作之前，避免刷新紧邻归档。
 struct SessionActionMenuContent: View {
     @EnvironmentObject private var sessionStore: SessionStore
 
@@ -116,24 +116,22 @@ struct SessionActionMenuContent: View {
         let fullDirectoryPath = session.dir.trimmingCharacters(in: .whitespacesAndNewlines)
 
         Group {
-            if !fullDirectoryPath.isEmpty {
-                Button {
-                    UIPasteboard.general.string = fullDirectoryPath
-                } label: {
-                    Label(L10n.text("ui.copy_path"), systemImage: "folder")
-                }
-                .accessibilityValue(fullDirectoryPath)
-
-                Divider()
+            Button {
+                UIPasteboard.general.string = fullDirectoryPath
+            } label: {
+                Label(L10n.text("ui.copy_path"), systemImage: "folder")
             }
+            .disabled(fullDirectoryPath.isEmpty)
+            .accessibilityValue(fullDirectoryPath)
 
-            if sessionStore.isSessionObserving(session) {
-                Button {
-                    sessionStore.takeOverSession(session)
-                } label: {
-                    Label(L10n.text("ui.take_over_to_ipad"), systemImage: "hand.raised.fill")
-                }
+            Button {
+                UIPasteboard.general.string = session.id
+            } label: {
+                Label(L10n.text("ui.copy_session_id"), systemImage: "number")
             }
+            .accessibilityValue(session.id)
+
+            Divider()
 
             Button {
                 actions.togglePinned()
@@ -144,6 +142,36 @@ struct SessionActionMenuContent: View {
                 )
             }
             .disabled(!actions.canChangePinState)
+
+            // 条件动作留在子菜单，保持顶层条数稳定，降低按记忆位置点击时误触归档的风险。
+            Menu {
+                managementActions(actions: actions, reminder: reminder)
+            } label: {
+                Label(L10n.text("ui.more_actions"), systemImage: "ellipsis")
+            }
+            .menuOrder(.fixed)
+
+            Divider()
+
+            Button(role: actions.isArchived ? nil : .destructive) {
+                actions.toggleArchived()
+            } label: {
+                Label(actions.archiveTitle, systemImage: actions.archiveSystemImage)
+            }
+            .disabled(!actions.canChangeArchiveState)
+        }
+    }
+
+    @ViewBuilder
+    private func managementActions(actions: SessionRowActionController, reminder: SessionReminder?) -> some View {
+        Group {
+            if sessionStore.isSessionObserving(session) {
+                Button {
+                    sessionStore.takeOverSession(session)
+                } label: {
+                    Label(L10n.text("ui.take_over_to_ipad"), systemImage: "hand.raised.fill")
+                }
+            }
 
             if actions.canChangeReadState {
                 Button {
@@ -230,14 +258,21 @@ struct SessionActionMenuContent: View {
                     systemImage: reminder == nil ? "bell" : "bell.fill"
                 )
             }
-
-            Button(role: actions.isArchived ? nil : .destructive) {
-                actions.toggleArchived()
-            } label: {
-                Label(actions.archiveTitle, systemImage: actions.archiveSystemImage)
-            }
-            .disabled(!actions.canChangeArchiveState)
         }
+    }
+}
+
+/// 两种详情布局共用刷新入口，禁用条件与刷新目标保持一致。
+struct CurrentSessionRefreshMenuButton: View {
+    @EnvironmentObject private var sessionStore: SessionStore
+
+    var body: some View {
+        Button {
+            Task { await sessionStore.refreshCurrentContext() }
+        } label: {
+            Label(L10n.text("ui.refresh_current_session"), systemImage: "arrow.clockwise")
+        }
+        .disabled(sessionStore.isRefreshingSelectedSession || sessionStore.isLoading)
     }
 }
 

--- a/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
+++ b/ios/MimiRemote/Sources/Features/Shell/UnifiedWorkbenchShell.swift
@@ -1296,20 +1296,7 @@ struct UnifiedWorkbenchShell: View {
             if layout.usesCompactNavigation {
                 workbenchChromeToolbarItem(placement: .topBarTrailing) {
                     Menu {
-                        if let session = sessionStore.selectedSession {
-                            SessionActionMenuContent(
-                                session: session,
-                                presentation: $sessionActionPresentation
-                            )
-                            Divider()
-                        }
-
-                        Button {
-                            Task { await sessionStore.refreshCurrentContext() }
-                        } label: {
-                            Label(L10n.text("ui.refresh_current_session"), systemImage: "arrow.clockwise")
-                        }
-                        .disabled(sessionStore.isRefreshingSelectedSession || sessionStore.isLoading)
+                        CurrentSessionRefreshMenuButton()
 
                         Button {
                             toggleInspector(layout: layout)
@@ -1319,11 +1306,20 @@ struct UnifiedWorkbenchShell: View {
                                 systemImage: "sidebar.right"
                             )
                         }
+
+                        if let session = sessionStore.selectedSession {
+                            Divider()
+                            SessionActionMenuContent(
+                                session: session,
+                                presentation: $sessionActionPresentation
+                            )
+                        }
                     } label: {
                         WorkbenchChromeIcon(systemName: "ellipsis")
                             .foregroundStyle(tokens.primaryText.opacity(0.72))
                             .workbenchToolbarChromeCircle(tokens: tokens)
                     }
+                    .menuOrder(.fixed)
                     .disabled(!canPresentSessionDetail)
                     .accessibilityLabel(L10n.text("ui.options"))
                 }
@@ -1331,6 +1327,8 @@ struct UnifiedWorkbenchShell: View {
                 if let session = sessionStore.selectedSession {
                     workbenchChromeToolbarItem(placement: .topBarTrailing) {
                         Menu {
+                            CurrentSessionRefreshMenuButton()
+                            Divider()
                             SessionActionMenuContent(
                                 session: session,
                                 presentation: $sessionActionPresentation
@@ -1340,6 +1338,7 @@ struct UnifiedWorkbenchShell: View {
                                 .foregroundStyle(tokens.secondaryText)
                                 .workbenchToolbarChromeCircle(tokens: tokens)
                         }
+                        .menuOrder(.fixed)
                         .accessibilityLabel(L10n.text("ui.options"))
                     }
                     if #available(iOS 26.0, *) {


### PR DESCRIPTION
会话详情菜单原先把刷新放在底部，前方条目随会话状态增减时，用户容易按旧位置误触归档。现在 iPhone 紧凑布局和 iPad 宽屏菜单均固定以“刷新当前会话”开头；动态管理操作移入“更多操作”，归档保留在末尾独立分组。

“复制路径”旁新增“复制会话 ID”，复制完整 `AgentSession.id`。路径缺失时保留禁用入口以稳定顶层条数。iPad 原有工具栏刷新捷径继续保留。

验证：
- `bash ./scripts/check-ios-localization.sh`：中英文静态检查及 String Catalog 编译通过。
- `bash ./scripts/verify-change.sh --plan`、`bash ./scripts/verify-change.sh`：quick 通过，包含差异检查、源码行数门禁及固定 iPad Pro 13-inch (M5) 的 Debug App 编译。
- 独立只读审查已核对原有操作条件、禁用规则、菜单顺序及 ID 复制语义。

- 实体 iPad mini（A17 Pro）通过统一 `scripts/ios-dev.sh run` 完成 Debug 真机构建、覆盖安装与启动；用户已查看并确认菜单效果无问题。

本地未运行 XCTest；完整 iOS 回归由 PR Gate 执行。尚未发布。MIM-230 的归档状态收敛修复不包含在此 PR。

关联：MIM-272

