### PR TITLE
Mimi 新会话默认使用 GPT-6 / medium

### DIFF
--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -649,7 +649,7 @@ enum CodexAppServerPersonality: String, Codable, CaseIterable, Hashable, Identif
 
 private enum CodexAppServerDefaults {
     static let model: String? = nil
-    static let reasoningEffort: CodexAppServerReasoningEffort = .xhigh
+    static let reasoningEffort: CodexAppServerReasoningEffort = .medium
 }
 
 enum CodexAppServerApprovalPolicy: String, Codable, CaseIterable, Hashable, Identifiable {
@@ -1256,10 +1256,17 @@ struct CodexAppServerModelOption: Codable, Hashable, Identifiable {
 
     static let builtInFallback: [CodexAppServerModelOption] = [
         CodexAppServerModelOption(
+            id: "gpt-6-astra",
+            title: "GPT-6 Astra",
+            description: "Our most capable model for complex, demanding work.",
+            isDefault: true,
+            supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+            defaultReasoningEffort: "medium"
+        ),
+        CodexAppServerModelOption(
             id: "gpt-5.6-sol",
             title: "GPT-5.6 Sol",
             description: "Detail and polish",
-            isDefault: true,
             supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
             defaultReasoningEffort: "xhigh"
         ),

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
@@ -139,7 +139,7 @@ extension ComposerView {
             layout: layout
         )
         return ModelReasoningGridSelection(
-            modelID: option?.model ?? "gpt-5.6-sol",
+            modelID: option?.model ?? "gpt-6-astra",
             effort: effort
         )
     }
@@ -308,7 +308,7 @@ extension ComposerView {
         composerState.updateTurnOptions { options in
             if runtimeChanged || unsupportedModel {
                 // 切换 runtime 或目录刷新淘汰旧模型时，使用设置里的对应默认值；
-                // 没有自定义设置时仍回到 Codex Sol/xhigh、Claude Opus/high。
+                // 没有自定义设置时回到 Codex GPT-6/medium、Claude Opus/high。
                 applyPreferredDefaultModel(runtimeProvider: runtimeProvider, to: &options)
             } else if unsupportedEffort {
                 options.reasoningEffort = normalizedEffort
@@ -323,7 +323,7 @@ extension ComposerView {
         runtimeProvider: String,
         to options: inout CodexAppServerTurnOptions
     ) {
-        // 默认模型统一从本机设置读取；没有保存配置时仍沿用原来的 Sol/xhigh、Opus/high。
+        // 默认模型统一从本机设置读取；没有保存配置时使用 GPT-6/medium、Opus/high。
         DefaultModelPreferences.applyDefault(
             for: runtimeProvider,
             allOptions: modelOptionsForMenu,

--- a/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
@@ -157,10 +157,10 @@ enum ModelReasoningGridCatalog {
             }) {
                 return opus
             }
-        } else if let sol = candidates.first(where: {
-            $0.model.caseInsensitiveCompare("gpt-5.6-sol") == .orderedSame
+        } else if let astra = candidates.first(where: {
+            $0.model.caseInsensitiveCompare("gpt-6-astra") == .orderedSame
         }) {
-            return sol
+            return astra
         }
 
         // 账号尚未获得目标模型时不能发送目录外 ID；退回该 runtime 的可用默认项。
@@ -173,7 +173,7 @@ enum ModelReasoningGridCatalog {
         layout: ModelReasoningGridLayout
     ) -> CodexAppServerReasoningEffort? {
         let normalizedRuntime = CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider)
-        let preferred: CodexAppServerReasoningEffort = normalizedRuntime == "claude" ? .high : .xhigh
+        let preferred: CodexAppServerReasoningEffort = normalizedRuntime == "claude" ? .high : .medium
         return normalizedVisibleEffort(
             option: option,
             current: preferred,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -445,7 +445,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(request.method, "turn/start")
         XCTAssertEqual(params["cwd"]?.stringValue, "/Users/me/repo")
         XCTAssertNil(params["model"]?.stringValue)
-        XCTAssertEqual(params["effort"]?.stringValue, "xhigh")
+        XCTAssertEqual(params["effort"]?.stringValue, "medium")
         XCTAssertEqual(params["approvalPolicy"]?.stringValue, "on-request")
         XCTAssertEqual(params["clientUserMessageId"]?.stringValue, "client-1")
         XCTAssertEqual(params["collaborationMode"]?.objectValue?["mode"]?.stringValue, "default")

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -818,7 +818,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(standardMode["mode"]?.stringValue, "default")
         let standardSettings = try XCTUnwrap(standardMode["settings"]?.objectValue)
         XCTAssertNil(standardSettings["model"]?.stringValue)
-        XCTAssertEqual(standardSettings["reasoning_effort"]?.stringValue, "xhigh")
+        XCTAssertEqual(standardSettings["reasoning_effort"]?.stringValue, "medium")
         XCTAssertEqual(standardSettings["developer_instructions"], .null)
     }
 
@@ -827,7 +827,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         let decoded = try JSONDecoder().decode(CodexAppServerTurnOptions.self, from: legacy)
 
         XCTAssertNil(decoded.model)
-        XCTAssertEqual(decoded.reasoningEffort, .xhigh)
+        XCTAssertEqual(decoded.reasoningEffort, .medium)
         XCTAssertEqual(decoded.approvalPolicy, .onRequest)
         XCTAssertEqual(decoded.sandboxMode, .dangerFullAccess)
         XCTAssertEqual(decoded.collaborationMode, .default)
@@ -1490,7 +1490,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
     }
 
     func testCodexStandardMenuUsesModelSpecificFourthEffort() {
-        let options = CodexAppServerModelOption.builtInFallback
+        let options = CodexAppServerModelOption.builtInFallback.filter { $0.model.hasPrefix("gpt-5.6-") }
         let sol = options[0]
         let terra = options[1]
         let luna = options[2]
@@ -1528,7 +1528,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
             [.medium, .high, .xhigh, .max]
         )
         XCTAssertEqual(sol.defaultReasoningEffort, "xhigh")
-        XCTAssertTrue(sol.isDefault)
+        XCTAssertFalse(sol.isDefault)
         XCTAssertEqual(terra.defaultReasoningEffort, "medium")
         XCTAssertEqual(luna.defaultReasoningEffort, "medium")
         XCTAssertTrue(ModelReasoningGridCatalog.supports(.ultra, option: sol))
@@ -1546,7 +1546,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertEqual(ModelReasoningGridCatalog.effortTitle(.ultra), "Ultra")
     }
 
-    func testPreferredCodexDefaultOverridesServerDefaultWithSolXHigh() throws {
+    func testPreferredCodexDefaultOverridesServerDefaultWithGPT6Medium() throws {
         let options = [
             CodexAppServerModelOption(
                 id: "gpt-5.6-terra",
@@ -1556,12 +1556,12 @@ final class CodexAppServerProtocolTests: XCTestCase {
                 supportedReasoningEfforts: ["medium", "high", "xhigh"]
             ),
             CodexAppServerModelOption(
-                id: "gpt-5.6-sol",
-                title: "GPT-5.6 Sol",
+                id: "gpt-6-astra",
+                title: "GPT-6 Astra",
                 provider: "openai",
                 runtimeProvider: "codex",
                 supportedReasoningEfforts: ["medium", "high", "xhigh", "ultra"],
-                defaultReasoningEffort: "medium"
+                defaultReasoningEffort: "xhigh"
             )
         ]
         let option = try XCTUnwrap(
@@ -1572,14 +1572,14 @@ final class CodexAppServerProtocolTests: XCTestCase {
         )
         let layout = ModelReasoningGridCatalog.layout(runtimeProvider: "codex", options: options)
 
-        XCTAssertEqual(option.model, "gpt-5.6-sol")
+        XCTAssertEqual(option.model, "gpt-6-astra")
         XCTAssertEqual(
             ModelReasoningGridCatalog.preferredDefaultEffort(
                 runtimeProvider: "codex",
                 option: option,
                 layout: layout
             ),
-            .xhigh
+            .medium
         )
     }
 
@@ -1672,7 +1672,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
                 layout: layout
             ),
             .medium,
-            "账号没有 Sol 时必须使用目录内可发送组合，不能硬编码未授权模型"
+            "账号没有 GPT-6 时必须使用目录内可发送组合，不能硬编码未授权模型"
         )
     }
 
@@ -1761,8 +1761,8 @@ final class CodexAppServerProtocolTests: XCTestCase {
         XCTAssertNil(options.serviceTier)
     }
 
-    func testLeavingDeveloperMaxFallsBackToStandardCodexEffort() {
-        let sol = CodexAppServerModelOption.builtInFallback[0]
+    func testLeavingDeveloperMaxFallsBackToStandardCodexEffort() throws {
+        let sol = try XCTUnwrap(CodexAppServerModelOption.builtInFallback.first { $0.model == "gpt-5.6-sol" })
         let layout = ModelReasoningGridCatalog.layout(runtimeProvider: "codex", options: [sol])
 
         XCTAssertTrue(ModelReasoningGridCatalog.supports(.max, option: sol))

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTests.swift
@@ -3306,7 +3306,7 @@ final class ConversationDataFlowTests: XCTestCase {
         let composerState = ComposerState()
 
         XCTAssertNil(composerState.turnOptions.model)
-        XCTAssertEqual(composerState.turnOptions.reasoningEffort, .xhigh)
+        XCTAssertEqual(composerState.turnOptions.reasoningEffort, .medium)
         XCTAssertEqual(composerState.permissionMode, .fullAccess)
         XCTAssertEqual(composerState.turnOptions.approvalPolicy, .never)
         XCTAssertEqual(composerState.turnOptions.approvalsReviewer, "user")
@@ -3452,6 +3452,27 @@ final class ConversationDataFlowTests: XCTestCase {
         XCTAssertEqual(restored.serviceTier, "priority")
     }
 
+    func testDefaultModelPreferencesUseGPT6MediumWithoutSavedSelection() throws {
+        let suiteName = "DefaultModelPreferencesInitialTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var options = CodexAppServerTurnOptions.default
+        DefaultModelPreferences.applyDefault(
+            for: "codex",
+            allOptions: [],
+            defaults: defaults,
+            to: &options
+        )
+
+        XCTAssertEqual(options.model, "gpt-6-astra")
+        XCTAssertEqual(options.reasoningEffort, .medium)
+        XCTAssertEqual(CodexAppServerModelOption.builtInFallback.filter(\.isDefault).map(\.model), ["gpt-6-astra"])
+        XCTAssertEqual(CodexAppServerModelOption.builtInFallback.first?.defaultReasoningEffort, "medium")
+        XCTAssertNil(DefaultModelPreferences.storedModelOptionID(for: "codex", in: defaults))
+        XCTAssertNil(DefaultModelPreferences.storedReasoningEffort(for: "codex", in: defaults))
+    }
+
     func testDefaultModelPreferencesKeepCodexAndClaudeIndependent() throws {
         let suiteName = "DefaultModelPreferencesTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -3522,26 +3543,29 @@ final class ConversationDataFlowTests: XCTestCase {
         defaults.set("removed-model", forKey: DefaultModelPreferences.codexModelOptionIDKey)
         defaults.set(CodexAppServerReasoningEffort.ultra.rawValue, forKey: DefaultModelPreferences.codexReasoningEffortKey)
 
+        let luna = try XCTUnwrap(
+            CodexAppServerModelOption.builtInFallback.first { $0.model == "gpt-5.6-luna" }
+        )
         let selection = try XCTUnwrap(
             DefaultModelPreferences.resolvedSelection(
                 for: DefaultModelRuntime.codex.rawValue,
-                allOptions: [CodexAppServerModelOption.builtInFallback[2]],
+                allOptions: [luna],
                 defaults: defaults
             )
         )
 
         XCTAssertEqual(selection.option.model, "gpt-5.6-luna")
-        XCTAssertEqual(selection.effort, .xhigh)
+        XCTAssertEqual(selection.effort, .medium)
 
         var turnOptions = CodexAppServerTurnOptions.default
         DefaultModelPreferences.applyDefault(
             for: DefaultModelRuntime.codex.rawValue,
-            allOptions: [CodexAppServerModelOption.builtInFallback[2]],
+            allOptions: [luna],
             defaults: defaults,
             to: &turnOptions
         )
         XCTAssertEqual(turnOptions.model, "gpt-5.6-luna")
-        XCTAssertEqual(turnOptions.reasoningEffort, .xhigh)
+        XCTAssertEqual(turnOptions.reasoningEffort, .medium)
     }
 
     func testComposerDraftCacheKeepsDraftsScopedToSessionOrNewProject() {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationRuntimeFlowTests.swift
@@ -2321,7 +2321,7 @@ extension ConversationDataFlowTests {
 
         XCTAssertTrue(accepted)
         let createPayload = try XCTUnwrap(client.createPayloads.first)
-        XCTAssertEqual(createPayload.turnOptions.model, "gpt-5.6-sol")
+        XCTAssertEqual(createPayload.turnOptions.model, "gpt-6-astra")
         XCTAssertNil(createPayload.turnOptions.modelProvider)
         XCTAssertEqual(client.modelOptionsCallCount, 1)
     }
@@ -2731,12 +2731,12 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(failedMessage.sendStatus, .failed)
         XCTAssertTrue(payloadContainsInlineImage(failedMessage.turnPayload))
         XCTAssertEqual(failedMessage.turnPayload?.input, payload.input)
-        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-5.6-sol")
+        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-6-astra")
 
         let retryTask = Task { await store.retryFailedUserMessage(failedMessage) }
         await client.waitForCreateRequestCount(2)
         XCTAssertEqual(client.createPayloads[1].input, payload.input)
-        XCTAssertEqual(client.createPayloads[1].turnOptions.model, "gpt-5.6-sol")
+        XCTAssertEqual(client.createPayloads[1].turnOptions.model, "gpt-6-astra")
         XCTAssertTrue(client.createPayloads[1].input.contains { item in
             if case .image(let url, _) = item {
                 return url == "data:image/png;base64,AA=="
@@ -3001,7 +3001,7 @@ extension ConversationDataFlowTests {
         let sent = try XCTUnwrap(sockets[0].sentTurns.first)
         XCTAssertEqual(sent.clientMessageID, "client-rich-retry")
         XCTAssertEqual(sent.payload.input, payload.input)
-        XCTAssertEqual(sent.payload.options.model, "gpt-5.6-sol")
+        XCTAssertEqual(sent.payload.options.model, "gpt-6-astra")
     }
 
     func testRunningSendKeepsInlineImagePayloadAfterAcceptedForPreview() async throws {
@@ -3044,7 +3044,7 @@ extension ConversationDataFlowTests {
         let clientMessageID = try XCTUnwrap(localEcho.clientMessageID)
         XCTAssertTrue(payloadContainsInlineImage(localEcho.turnPayload))
         XCTAssertEqual(localEcho.turnPayload?.input, payload.input)
-        XCTAssertEqual(localEcho.turnPayload?.options.model, "gpt-5.6-sol")
+        XCTAssertEqual(localEcho.turnPayload?.options.model, "gpt-6-astra")
 
         sockets[0].onSendAccepted?(clientMessageID)
         let acceptedMessages = try await waitForConversationMessages(in: conversationStore, sessionID: running.id) { messages in

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationTurnQueueTests.swift
@@ -1640,7 +1640,7 @@ extension ConversationDataFlowTests {
 
         let failedMessage = try XCTUnwrap(conversationStore.messages(for: running.id).first { $0.clientMessageID == clientMessageID })
         XCTAssertEqual(failedMessage.turnPayload?.input, payload.input)
-        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-5.6-sol")
+        XCTAssertEqual(failedMessage.turnPayload?.options.model, "gpt-6-astra")
         XCTAssertTrue(payloadContainsInlineImage(failedMessage.turnPayload))
         XCTAssertTrue(payloadContainsMention(failedMessage.turnPayload, name: "README"))
         let expectedError = "待发送消息结果不确定，请确认后重试：app-server 错误 -32000：no rollout found"

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
@@ -4,6 +4,11 @@ import SwiftUI
 import XCTest
 @testable import MimiRemote
 
+// 固定视觉验收使用的模型组合，避免产品默认模型更新改变布局基线。
+private let codex56SnapshotModels = CodexAppServerModelOption.builtInFallback.filter {
+    $0.model.hasPrefix("gpt-5.6-")
+}
+
 @MainActor
 final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
     func testEffectiveModelUsesExplicitSelectionBeforeServerDefault() {
@@ -115,7 +120,7 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
     }
 
     func testCodexStandardMenuUsesModelSpecificFourthEffortAndInlineLabel() {
-        let options = CodexAppServerModelOption.builtInFallback
+        let options = codex56SnapshotModels
         let sol = options[0]
         let terra = options[1]
         let luna = options[2]
@@ -278,10 +283,10 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
             }
 
             ModelReasoningGridPicker(
-                options: CodexAppServerModelOption.builtInFallback,
+                options: codex56SnapshotModels,
                 layout: ModelReasoningGridCatalog.layout(
                     runtimeProvider: "codex",
-                    options: CodexAppServerModelOption.builtInFallback
+                    options: codex56SnapshotModels
                 ),
                 selection: ModelReasoningGridSelection(modelID: "gpt-5.6-terra", effort: .high),
                 selectedModelID: "gpt-5.6-terra",
@@ -316,10 +321,10 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
         themeStore.mode = .light
 
         let view = ModelReasoningGridPicker(
-            options: CodexAppServerModelOption.builtInFallback,
+            options: codex56SnapshotModels,
             layout: ModelReasoningGridCatalog.layout(
                 runtimeProvider: "codex",
-                options: CodexAppServerModelOption.builtInFallback
+                options: codex56SnapshotModels
             ),
             selection: ModelReasoningGridSelection(modelID: "gpt-5.6-sol", effort: .xhigh),
             selectedModelID: "gpt-5.6-sol",
@@ -349,10 +354,10 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
         themeStore.mode = .dark
 
         let view = ModelReasoningGridPicker(
-            options: CodexAppServerModelOption.builtInFallback,
+            options: codex56SnapshotModels,
             layout: ModelReasoningGridCatalog.layout(
                 runtimeProvider: "codex",
-                options: CodexAppServerModelOption.builtInFallback
+                options: codex56SnapshotModels
             ),
             selection: ModelReasoningGridSelection(modelID: "gpt-5.6-sol", effort: .xhigh),
             selectedModelID: "gpt-5.6-sol",
@@ -568,7 +573,7 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
         dynamicTypeSize: DynamicTypeSize = .large,
         horizontalSizeClass: UserInterfaceSizeClass,
         runtimeProvider: String = "codex",
-        options: [CodexAppServerModelOption] = CodexAppServerModelOption.builtInFallback,
+        options: [CodexAppServerModelOption] = codex56SnapshotModels,
         selection: ModelReasoningGridSelection = ModelReasoningGridSelection(
             modelID: "gpt-5.6-sol",
             effort: .xhigh


### PR DESCRIPTION
Mimi 在未保存自定义默认模型时，原来优先使用 GPT-5.6 Sol / xhigh；现在改为 GPT-6（`gpt-6-astra`）/ medium，模型列表不可用时的内置回退也使用相同默认值。

保留已保存的自定义默认配置和会话模型选择。账号目录没有 GPT-6 时，继续回退到目录内可用模型。Claude 默认行为和模型列表刷新机制保持不变。

验证：
- 20 个相关 XCTest 通过，覆盖默认选择、自定义偏好保留、目录回退、发送参数及模型选择器。
- `bash ./scripts/verify-change.sh --plan` 和 `bash ./scripts/verify-change.sh` 已执行；quick 的 5 项检查通过，包括源码行数检查和固定 M5 Simulator App 编译。
- 通过 `scripts/ios-dev.sh run` 在实体 iPad Pro 上构建、安装并启动；用户已确认试用无问题。
- 未执行完整回归；PR Gate 由 CI 执行。

Linear 归档未成功：工作区已达到免费 Issue 数量上限，因此本 PR 暂无 Issue 编号。
