### PR TITLE
[MIM-230] 修复跨端取消归档并加快会话刷新

### DIFF
--- a/internal/httpapi/appserver_gateway_websocket.go
+++ b/internal/httpapi/appserver_gateway_websocket.go
@@ -82,6 +82,7 @@ func (r *Router) copyClientFramesToAppServer(ctx context.Context, client *websoc
 		policyStart := time.Now()
 		forwardPayload, policyErr := policy.validateClientFrameContext(ctx, messageType, payload)
 		policyDuration := time.Since(policyStart)
+		monitor.logSessionListStage(payload, "request_policy", policyDuration)
 		if policyErr != nil {
 			monitor.recordPolicyError("client_to_upstream", len(payload), policyDuration)
 			if policyErr.historyBudgetRejected {
@@ -107,7 +108,9 @@ func (r *Router) copyClientFramesToAppServer(ctx context.Context, client *websoc
 			monitor.cancelRPCRequest(requestID)
 			return gatewayCloseReason("upstream_write", err)
 		}
-		monitor.recordForward("client_to_upstream", len(payload), len(forwardPayload), policyDuration, time.Since(writeStart), forwardPayload)
+		writeDuration := time.Since(writeStart)
+		monitor.recordForward("client_to_upstream", len(payload), len(forwardPayload), policyDuration, writeDuration, forwardPayload)
+		monitor.logSessionListStage(forwardPayload, "upstream_written", writeDuration)
 		r.scheduleAutoThreadTitleFromMessage(forwardPayload, policy, func(threadID string, title string) {
 			// thread/name/set 由独立 loopback 连接执行，它产生的 notification 只回到
 			// 那条连接；这里给发起会话的移动端补发同形通知，让 UI 无需轮询即可更新。
@@ -137,9 +140,11 @@ func copyWebSocketFrames(ctx context.Context, from *websocket.Conn, to *websocke
 		if err != nil {
 			return gatewayCloseReason("upstream_read", err)
 		}
+		monitor.logSessionListStage(payload, "upstream_received", 0)
 		policyStart := time.Now()
 		forwardPayload, forward, policyErr := policy.observeUpstreamFrame(messageType, payload)
 		policyDuration := time.Since(policyStart)
+		monitor.logSessionListStage(payload, "response_policy", policyDuration)
 		if policyErr != nil {
 			monitor.recordPolicyError("upstream_to_client", len(payload), policyDuration)
 			if policyErr.historyResponseBlocked {
@@ -162,7 +167,9 @@ func copyWebSocketFrames(ctx context.Context, from *websocket.Conn, to *websocke
 		if err := writeWebSocketFrame(to, toWriteMu, messageType, forwardPayload); err != nil {
 			return gatewayCloseReason("client_write", err)
 		}
-		monitor.recordForward("upstream_to_client", len(payload), len(forwardPayload), policyDuration, time.Since(writeStart), forwardPayload)
+		writeDuration := time.Since(writeStart)
+		monitor.logSessionListStage(payload, "client_written", writeDuration)
+		monitor.recordForward("upstream_to_client", len(payload), len(forwardPayload), policyDuration, writeDuration, forwardPayload)
 	}
 }
 

--- a/internal/httpapi/session_list_diagnostics.go
+++ b/internal/httpapi/session_list_diagnostics.go
@@ -1,0 +1,35 @@
+package httpapi
+
+import (
+	"crypto/sha256"
+	"log"
+	"time"
+)
+
+// 只追踪 thread/list 的时间边界；请求 ID 取摘要，不输出参数、目录或会话内容。
+// upstream_received 包含写入、SSH/Codex 往返及此前帧处理的等待，不能等同于 Codex 计算时间。
+func (c *relayGatewayConnMonitor) logSessionListStage(payload []byte, stage string, duration time.Duration) {
+	if c == nil || c.parent == nil {
+		return
+	}
+	meta := relayFrameMetaFromPayload(payload)
+	method := meta.Method
+	if meta.IsResponse && meta.ID != "" {
+		c.parent.mu.Lock()
+		var pending relayPendingRPC
+		if conn := c.parent.active[c.id]; conn != nil {
+			pending = conn.pendingRPC[meta.ID]
+		}
+		c.parent.mu.Unlock()
+		method = pending.Method
+		if stage == "upstream_received" && !pending.SentAt.IsZero() {
+			duration = time.Since(pending.SentAt)
+		}
+	}
+	if method != "thread/list" || meta.ID == "" {
+		return
+	}
+	digest := sha256.Sum256([]byte(meta.ID))
+	log.Printf("session_list_trace connection=%s rpc=%x stage=%s duration_ms=%.3f at_unix_ms=%d bytes=%d",
+		c.id, digest[:8], stage, float64(duration)/float64(time.Millisecond), time.Now().UnixMilli(), len(payload))
+}

--- a/internal/httpapi/session_list_diagnostics_test.go
+++ b/internal/httpapi/session_list_diagnostics_test.go
@@ -1,0 +1,50 @@
+package httpapi
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSessionListDiagnosticsRedactsPayloadAndCorrelatesResponse(t *testing.T) {
+	var output bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&output)
+	defer log.SetOutput(previous)
+	monitor := newRelayMonitor()
+	monitor.active["gateway-test"] = &relayGatewayConnectionStats{pendingRPC: map[string]relayPendingRPC{}}
+	connection := &relayGatewayConnMonitor{parent: monitor, id: "gateway-test"}
+	request := []byte(`{"id":"private-id","method":"thread/list","params":{"cwd":"/private/path"}}`)
+	response := []byte(`{"id":"private-id","result":{"data":[{"title":"private-title"}]}}`)
+	connection.logSessionListStage(request, "request_policy", time.Millisecond)
+	connection.beginRPCRequest(request, len(request))
+	connection.logSessionListStage(response, "upstream_received", 0)
+	connection.logSessionListStage(response, "response_policy", 2*time.Millisecond)
+	connection.logSessionListStage([]byte(`{"id":2,"method":"thread/read"}`), "request_policy", 0)
+	connection.logSessionListStage([]byte(`{"id":"unknown","result":{}}`), "upstream_received", 0)
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("只记录关联的列表请求和响应，got %d lines", len(lines))
+	}
+	for _, secret := range []string{"private-id", "/private/path", "private-title"} {
+		if strings.Contains(output.String(), secret) {
+			t.Fatal("诊断日志泄露请求 ID 或用户内容")
+		}
+	}
+	var correlation string
+	for _, line := range lines {
+		for _, field := range strings.Fields(line) {
+			if strings.HasPrefix(field, "rpc=") {
+				if correlation != "" && correlation != field {
+					t.Fatal("同一请求与响应的摘要必须相同")
+				}
+				correlation = field
+			}
+		}
+	}
+	if correlation == "" {
+		t.Fatal("缺少关联摘要")
+	}
+}

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		31B351EE974251896BA43252 /* SessionStoreHostSwitching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3369A709F1AC9D2CF790753C /* SessionStoreHostSwitching.swift */; };
 		32A0E61668E067F6489752B3 /* ConversationTurnCompletionReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935BC4C6AC831B2EAF7CA114 /* ConversationTurnCompletionReconciliationTests.swift */; };
 		32DBDC8F3CD7A4D20095C805 /* SessionStoreWorkspaceRuntimePagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = D430A72C9700460B5B2D8E3B /* SessionStoreWorkspaceRuntimePagination.swift */; };
+		9EDD23DB25E2430A815961A6 /* SessionStoreArchiveReconciliation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1249F41E96174B56B7186A9F /* SessionStoreArchiveReconciliation.swift */; };
 		332D0CF7E81E796945EFD9F0 /* ConversationActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6FA730D92E0B37BC0393F0 /* ConversationActivityRows.swift */; };
 		34F16E565666DBFB8CEBF4EF /* terms-of-use.md in Resources */ = {isa = PBXBuildFile; fileRef = 26A567B589D55867F71467D4 /* terms-of-use.md */; };
 		3555D54084E26E1CD6667F85 /* testUnifiedWorkbenchSidebarNavigationChrome.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 26D33D121E5B1B664D27BCCD /* testUnifiedWorkbenchSidebarNavigationChrome.1.png */; };
@@ -210,6 +211,7 @@
 		951475AE3120CB42A905E3B3 /* WorkspaceGitSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85879EDF3D64609C3C6BA873 /* WorkspaceGitSummaryTests.swift */; };
 		958AE82A3087284FEE63DBB8 /* TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30F059863E0778E0B00065D /* TokenStore.swift */; };
 		95B2C9AB9817A406C547063F /* ConversationSessionArchiveMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8EF812560A139C665A9D46 /* ConversationSessionArchiveMutationTests.swift */; };
+		905B937A256C4EDDBF0B5E76 /* SessionArchiveReconciliationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B573D212344DDD80D83F68 /* SessionArchiveReconciliationTests.swift */; };
 		96DD53AC053FBEC769A9FFAB /* EventReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52051A97BB3979091B39EB95 /* EventReducer.swift */; };
 		977FFBD5E0C5FFECBA16AF6F /* ShareJourneySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B28884F963A4A2A46FA564 /* ShareJourneySnapshotTests.swift */; };
 		980F0CA2DAD75C9AE4857810 /* GitQuickPublishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62624C0B89AA0B04BE5643F /* GitQuickPublishView.swift */; };
@@ -699,6 +701,7 @@
 		D31234CAC3FCACA63F93285D /* testSessionStateRingSemanticsAndAlignment.dark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testSessionStateRingSemanticsAndAlignment.dark.png; sourceTree = "<group>"; };
 		D36F897C3DF848C89B87C926 /* testInlineUserInputCardMatchesApprovalChromeOnIPad.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testInlineUserInputCardMatchesApprovalChromeOnIPad.1.png; sourceTree = "<group>"; };
 		D430A72C9700460B5B2D8E3B /* SessionStoreWorkspaceRuntimePagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreWorkspaceRuntimePagination.swift; sourceTree = "<group>"; };
+		1249F41E96174B56B7186A9F /* SessionStoreArchiveReconciliation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreArchiveReconciliation.swift; sourceTree = "<group>"; };
 		D4D9B1DC813DAB2FBDAA9084 /* testComposerStatusTrayIPadMiniSplitViewWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayIPadMiniSplitViewWidth.1.png; sourceTree = "<group>"; };
 		D51F224075928990E52845C8 /* testSingleImageMediaCardAlignmentAcrossLayouts.ipad-wide-1024.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleImageMediaCardAlignmentAcrossLayouts.ipad-wide-1024.png"; sourceTree = "<group>"; };
 		D56D1548EFFC65F793C18F9F /* SessionStoreWriterConflictFork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreWriterConflictFork.swift; sourceTree = "<group>"; };
@@ -760,6 +763,7 @@
 		FD791172EDEEA29731488D73 /* MimiTailcatBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MimiTailcatBridge.h; sourceTree = "<group>"; };
 		FD7E14A8B39BFA1C4D7C4D88 /* ManagedConnectionDeviceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConnectionDeviceAPIClient.swift; sourceTree = "<group>"; };
 		FD8EF812560A139C665A9D46 /* ConversationSessionArchiveMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSessionArchiveMutationTests.swift; sourceTree = "<group>"; };
+		73B573D212344DDD80D83F68 /* SessionArchiveReconciliationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArchiveReconciliationTests.swift; sourceTree = "<group>"; };
 		FDBE622C5ED274C1DA9803DB /* ComposerInputExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerInputExtensions.swift; sourceTree = "<group>"; };
 		FDD0D38CA5BBBF1F1D8A5F2B /* testLongEnglishFailureRemainsInline.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testLongEnglishFailureRemainsInline.1.png; sourceTree = "<group>"; };
 		FEBDB094EFEA5301CE33FD1C /* testUnconfiguredConnectionSettingsOnCompactWidthAtAccessibilitySize.unconfigured-compact-accessibility.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testUnconfiguredConnectionSettingsOnCompactWidthAtAccessibilitySize.unconfigured-compact-accessibility.png"; sourceTree = "<group>"; };
@@ -956,6 +960,7 @@
 				033E0CF93AA4A06CC89D7AD1 /* ConversationRuntimeFlowTests.swift */,
 				D9A1F29F52DC5CC790708ACC /* ConversationRuntimeTestSupport.swift */,
 				FD8EF812560A139C665A9D46 /* ConversationSessionArchiveMutationTests.swift */,
+				73B573D212344DDD80D83F68 /* SessionArchiveReconciliationTests.swift */,
 				121E340DD237BE03706546CA /* ConversationSessionStoreTests.swift */,
 				6C7C7C0DF7B33C596EBE5FC7 /* ConversationSnapshotTests.swift */,
 				C732DD4062EFC36827E1937A /* ConversationTimelineHistoryScrollTests.swift */,
@@ -1471,6 +1476,7 @@
 				3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */,
 				A38A8CE5A8F1D7EE3889F078 /* SessionStoreTurns.swift */,
 				D430A72C9700460B5B2D8E3B /* SessionStoreWorkspaceRuntimePagination.swift */,
+				1249F41E96174B56B7186A9F /* SessionStoreArchiveReconciliation.swift */,
 				D56D1548EFFC65F793C18F9F /* SessionStoreWriterConflictFork.swift */,
 				075FEFC74C482609AAAEEA39 /* TailcatExperimentController.swift */,
 				1F63FE197E70AD192F429877 /* ThemeStore.swift */,
@@ -1829,6 +1835,7 @@
 				7813EDBB1DC23A88A94CAF56 /* ConversationRuntimeFlowTests.swift in Sources */,
 				2B372F78E1EC09D8E4B7210F /* ConversationRuntimeTestSupport.swift in Sources */,
 				95B2C9AB9817A406C547063F /* ConversationSessionArchiveMutationTests.swift in Sources */,
+				905B937A256C4EDDBF0B5E76 /* SessionArchiveReconciliationTests.swift in Sources */,
 				6D9C8B57410AFA9A87956C6D /* ConversationSessionStoreTests.swift in Sources */,
 				5FD1DBDBCD89B51F6B22D679 /* ConversationSnapshotTests.swift in Sources */,
 				594989D4A8EF0493E3127965 /* ConversationTimelineHistoryScrollTests.swift in Sources */,
@@ -2030,6 +2037,7 @@
 				5CD51AE13B5D23F8FBE444C5 /* SessionStoreSupport.swift in Sources */,
 				D4B700AC9DF628887258F469 /* SessionStoreTurns.swift in Sources */,
 				32DBDC8F3CD7A4D20095C805 /* SessionStoreWorkspaceRuntimePagination.swift in Sources */,
+				9EDD23DB25E2430A815961A6 /* SessionStoreArchiveReconciliation.swift in Sources */,
 				756EEE669429D13559D42B29 /* SessionStoreWriterConflictFork.swift in Sources */,
 				FE5964208A6DD5D8EF26BAC8 /* SettingsChoiceRow.swift in Sources */,
 				F1F9DDC107FC643BC6F6EC95 /* SettingsDashboardViews.swift in Sources */,

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -78,6 +78,11 @@ enum CodexAppServerSessionRuntimeError: LocalizedError {
     }
 }
 
+struct CodexAppServerScanCursor: Hashable {
+    let cwd: String?
+    let cursor: String?
+}
+
 struct CodexAppServerSessionContext {
     var session: AgentSession
     var cwd: String
@@ -242,7 +247,10 @@ actor CodexAppServerSessionRuntime {
     var turnsStartedByThisRuntime: Set<TurnID> = []
     // 历史只读取 thread 元数据，并通过 turns/items 游标分页；这里不保留整段 thread 历史缓存。
     var stateDBOnlyListUnavailable = false
-    var stateDBOnlyScanRequiredCWDs: Set<String> = []
+    var stateDBOnlyVerifiedMissingSessionIDs: Set<SessionID> = []
+    var globalListVerifiedMissingSessionIDs: Set<SessionID> = []
+    // 游标属于生成它的查询模式；扫描回退后沿原链继续，不能把 opaque cursor 交给索引查询。
+    var threadListScanCursors: Set<CodexAppServerScanCursor> = []
     var recencySortUnavailable = false
     var turnStartTasksBySessionID: [
         SessionID: (token: UUID, task: Task<CodexAppServerTurnStartOutcome, Error>)
@@ -503,12 +511,48 @@ actor CodexAppServerSessionRuntime {
         limit: Int?
     ) async throws -> SessionsPage {
         let projects = try await projects()
-        let result = try await sendRecoveringFromStaleInitialization(
-            CodexAppServerRequestBuilder(allowlistedProjects: projects)
-                .controlledGlobalThreadList(limit: limit, cursor: cursor),
-            timeout: longRunningRequestTimeout
-        )
-        let page = threadListPage(from: result, projects: projects, fallbackProject: nil)
+        let builder = CodexAppServerRequestBuilder(allowlistedProjects: projects)
+        let useIndex = runtimeProvider == "codex" && !stateDBOnlyListUnavailable
+            && !threadListScanCursors.contains(.init(cwd: nil, cursor: cursor))
+        var page: SessionsPage
+        do {
+            let result = try await sendRecoveringFromStaleInitialization(
+                builder.controlledGlobalThreadList(limit: limit, cursor: cursor, useStateDBOnly: useIndex),
+                timeout: longRunningRequestTimeout
+            )
+            page = threadListPage(from: result, projects: projects, fallbackProject: nil)
+            if !useIndex { rememberThreadListScanCursor(page, cwd: nil) }
+            globalListVerifiedMissingSessionIDs.subtract(page.sessions.map(\.id))
+            // 全局遍历完成后 Store 会移除消失的受控会话；首屏必须先确认所有已知缺口，
+            // 包括授权裁剪后的空页，不能等后续索引页耗尽再把漏行当成撤权依据。
+            let repairCandidates = cursor == nil
+                ? Set(contextsBySessionID.keys).subtracting(page.sessions.map(\.id))
+                    .subtracting(globalListVerifiedMissingSessionIDs)
+                : []
+            // 没有已知缺口的带游标空页直接续读；完整空首屏或已知缺口才确认历史。
+            let needsEmptyPageVerification = cursor == nil && page.sessions.isEmpty && !page.hasMore
+            if useIndex, needsEmptyPageVerification || !repairCandidates.isEmpty {
+                let scanned = try await sendRecoveringFromStaleInitialization(
+                    builder.controlledGlobalThreadList(limit: limit, cursor: cursor),
+                    timeout: longRunningRequestTimeout
+                )
+                page = threadListPage(from: scanned, projects: projects, fallbackProject: nil)
+                rememberThreadListScanCursor(page, cwd: nil)
+                globalListVerifiedMissingSessionIDs.formUnion(repairCandidates.intersection(
+                    indexedThreadListMissingKnownSessionIDs(page, cwd: nil, sortKey: "updated_at")
+                ))
+            }
+        } catch {
+            guard useIndex, shouldFallbackFromStateDBOnlyList(error) else { throw error }
+            stateDBOnlyListUnavailable = true
+            let result = try await sendRecoveringFromStaleInitialization(
+                builder.controlledGlobalThreadList(limit: limit, cursor: cursor),
+                timeout: longRunningRequestTimeout
+            )
+            page = threadListPage(from: result, projects: projects, fallbackProject: nil)
+            rememberThreadListScanCursor(page, cwd: nil)
+        }
+        globalListVerifiedMissingSessionIDs.subtract(page.sessions.map(\.id))
         for session in page.sessions {
             contextsBySessionID[session.id] = CodexAppServerSessionContext(
                 session: session,
@@ -928,6 +972,8 @@ actor CodexAppServerSessionRuntime {
             ? builder.threadArchive(threadID: id)
             : builder.threadUnarchive(threadID: id)
         _ = try await sendRecoveringFromStaleInitialization(spec)
+        stateDBOnlyVerifiedMissingSessionIDs.remove(id)
+        globalListVerifiedMissingSessionIDs.remove(id)
         if archived {
             contextsBySessionID.removeValue(forKey: id)
             pendingTurnStartObservationsBySessionID.removeValue(forKey: id)
@@ -1570,11 +1616,11 @@ actor CodexAppServerSessionRuntime {
         fallbackProject: AgentProject,
         consistency: SessionListConsistency
     ) async throws -> SessionsPage {
-        // Codex 的跨端归档会同步写入服务端索引；主动刷新仍发送新请求，避免每次扫描历史文件。
+        // Codex 首屏和补页都读取最新索引；不能因为带游标就重扫整个历史目录。
         let canUseIndexedList = (consistency == .fastIndexed || runtimeProvider == "codex")
-            && cursor == nil
+            && (cursor == nil || runtimeProvider == "codex")
             && !stateDBOnlyListUnavailable
-            && !stateDBOnlyScanRequiredCWDs.contains(cwd)
+            && !threadListScanCursors.contains(.init(cwd: cwd, cursor: cursor))
         let sortKey = preferredThreadListSortKey
         do {
             let result = try await sendRecoveringFromStaleInitialization(
@@ -1593,17 +1639,19 @@ actor CodexAppServerSessionRuntime {
                 timeout: longRunningRequestTimeout
             )
             let page = threadListPage(from: result, projects: projects, fallbackProject: fallbackProject)
+            if !canUseIndexedList { rememberThreadListScanCursor(page, cwd: cwd) }
             // DB 不可用时上游可能返回空页；主动刷新需扫描确认，不能直接把现有列表清空。
-            let needsEmptyPageVerification = consistency == .authoritative && page.sessions.isEmpty
-            let needsKnownSessionRepair = indexedThreadListNeedsRepair(page, cwd: cwd)
-            guard canUseIndexedList, needsEmptyPageVerification || needsKnownSessionRepair else {
+            stateDBOnlyVerifiedMissingSessionIDs.subtract(page.sessions.map(\.id))
+            let needsEmptyPageVerification = cursor == nil && consistency == .authoritative && page.sessions.isEmpty
+            // 已知会话只与首屏比较；补页缺少较新的会话本来就是正常分页。
+            let repairCandidates = cursor == nil
+                ? indexedThreadListMissingKnownSessionIDs(page, cwd: cwd, sortKey: sortKey)
+                    .subtracting(stateDBOnlyVerifiedMissingSessionIDs)
+                : []
+            guard canUseIndexedList, needsEmptyPageVerification || !repairCandidates.isEmpty else {
                 return page
             }
-            // 状态库漏掉本连接已知 thread 时，本连接后续固定走普通扫描，避免每轮都先错一次再回退。
-            if needsKnownSessionRepair {
-                stateDBOnlyScanRequiredCWDs.insert(cwd)
-            }
-            return try await ordinaryThreadListPage(
+            let scannedPage = try await ordinaryThreadListPage(
                 cwd: cwd,
                 cursor: cursor,
                 limit: limit,
@@ -1611,6 +1659,12 @@ actor CodexAppServerSessionRuntime {
                 projects: projects,
                 fallbackProject: fallbackProject
             )
+            // 普通扫描也确认缺失时，可能只是外部归档。只记住这些 ID，不能永久降级整个目录。
+            // 会话重新出现在索引后会移除记录；真正被扫描找回的遗漏仍保留修复能力。
+            stateDBOnlyVerifiedMissingSessionIDs.formUnion(
+                repairCandidates.intersection(indexedThreadListMissingKnownSessionIDs(scannedPage, cwd: cwd, sortKey: sortKey))
+            )
+            return scannedPage
         } catch {
             if sortKey == "recency_at", shouldFallbackFromRecencySort(error) {
                 // 旧 agentd/Codex 不认识 recency_at 时，本连接只探测一次，之后稳定退回 updated_at。
@@ -1658,7 +1712,14 @@ actor CodexAppServerSessionRuntime {
             ),
             timeout: longRunningRequestTimeout
         )
-        return threadListPage(from: result, projects: projects, fallbackProject: fallbackProject)
+        let page = threadListPage(from: result, projects: projects, fallbackProject: fallbackProject)
+        rememberThreadListScanCursor(page, cwd: cwd)
+        return page
+    }
+
+    func rememberThreadListScanCursor(_ page: SessionsPage, cwd: String?) {
+        guard let cursor = page.nextCursor else { return }
+        threadListScanCursors.insert(.init(cwd: cwd, cursor: cursor))
     }
 
     /// Claude 的目录扫描只能由用户主动发起的权威首屏触发；其余请求保持索引/分页语义，
@@ -1673,27 +1734,30 @@ actor CodexAppServerSessionRuntime {
             && cursor == nil
     }
 
-    func indexedThreadListNeedsRepair(_ page: SessionsPage, cwd: String) -> Bool {
-        let knownSessions = contextsBySessionID.values.compactMap { context in
-            context.cwd == cwd ? context.session : nil
-        }
-        guard !knownSessions.isEmpty else {
-            return false
-        }
+    func indexedThreadListMissingKnownSessionIDs(
+        _ page: SessionsPage,
+        cwd: String?,
+        sortKey: String
+    ) -> Set<SessionID> {
         let pageIDs = Set(page.sessions.map(\.id))
-        let missing = knownSessions.filter { !pageIDs.contains($0.id) }
-        guard !missing.isEmpty else {
-            return false
+        let missing = contextsBySessionID.values.compactMap { context -> AgentSession? in
+            guard (cwd == nil || context.cwd == cwd), !pageIDs.contains(context.session.id) else { return nil }
+            return context.session
         }
-        guard page.hasMore, let tail = page.sessions.last else {
-            return true
+        guard page.hasMore else { return Set(missing.map(\.id)) }
+        // 全局授权裁剪可产生非末页空结果，此时没有排序边界，不能把旧会话全部判为漏行。
+        guard let tail = page.sessions.last else { return [] }
+        let orderingDate: (AgentSession) -> Date = { session in
+            sortKey == "updated_at"
+                ? (session.updatedAt ?? session.createdAt ?? .distantPast)
+                : SessionIndexStore.orderingDate(for: session)
         }
-        let tailDate = SessionIndexStore.orderingDate(for: tail)
-        // 满页时只修复“按最近活动本应位于本页”的缺口；更老的已知会话留在后续分页，避免无谓扫描。
-        return missing.contains { known in
-            let knownDate = SessionIndexStore.orderingDate(for: known)
+        let tailDate = orderingDate(tail)
+        // 满页时只修复“按当前查询排序本应位于本页”的缺口，更老的已知会话留在后续分页。
+        return Set(missing.filter { known in
+            let knownDate = orderingDate(known)
             return knownDate > tailDate || (knownDate == tailDate && known.id > tail.id)
-        }
+        }.map(\.id))
     }
 
     var preferredThreadListSortKey: String {

--- a/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
+++ b/ios/MimiRemote/Sources/Core/API/CodexAppServerSessionRuntime.swift
@@ -1570,7 +1570,8 @@ actor CodexAppServerSessionRuntime {
         fallbackProject: AgentProject,
         consistency: SessionListConsistency
     ) async throws -> SessionsPage {
-        let canUseIndexedList = consistency == .fastIndexed
+        // Codex 的跨端归档会同步写入服务端索引；主动刷新仍发送新请求，避免每次扫描历史文件。
+        let canUseIndexedList = (consistency == .fastIndexed || runtimeProvider == "codex")
             && cursor == nil
             && !stateDBOnlyListUnavailable
             && !stateDBOnlyScanRequiredCWDs.contains(cwd)
@@ -1592,11 +1593,16 @@ actor CodexAppServerSessionRuntime {
                 timeout: longRunningRequestTimeout
             )
             let page = threadListPage(from: result, projects: projects, fallbackProject: fallbackProject)
-            guard canUseIndexedList, indexedThreadListNeedsRepair(page, cwd: cwd) else {
+            // DB 不可用时上游可能返回空页；主动刷新需扫描确认，不能直接把现有列表清空。
+            let needsEmptyPageVerification = consistency == .authoritative && page.sessions.isEmpty
+            let needsKnownSessionRepair = indexedThreadListNeedsRepair(page, cwd: cwd)
+            guard canUseIndexedList, needsEmptyPageVerification || needsKnownSessionRepair else {
                 return page
             }
             // 状态库漏掉本连接已知 thread 时，本连接后续固定走普通扫描，避免每轮都先错一次再回退。
-            stateDBOnlyScanRequiredCWDs.insert(cwd)
+            if needsKnownSessionRepair {
+                stateDBOnlyScanRequiredCWDs.insert(cwd)
+            }
             return try await ordinaryThreadListPage(
                 cwd: cwd,
                 cursor: cursor,

--- a/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/AppServerProtocolModels.swift
@@ -527,7 +527,8 @@ struct CodexAppServerRequestBuilder {
 
     func controlledGlobalThreadList(
         limit: Int? = 50,
-        cursor: String? = nil
+        cursor: String? = nil,
+        useStateDBOnly: Bool = false
     ) -> CodexAppServerRequestSpec {
         CodexAppServerRequestSpec(method: "thread/list", params: CodexAppServerJSONValue.objectValue([
             "limit": limit.map { .int(Int64($0)) },
@@ -544,7 +545,7 @@ struct CodexAppServerRequestBuilder {
                 .string("subAgent"),
             ]),
             "archived": .bool(false),
-            "useStateDbOnly": .bool(false)
+            "useStateDbOnly": .bool(useStateDBOnly)
         ]))
     }
 

--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -45,7 +45,7 @@ struct SessionsPage: Equatable {
 enum SessionListConsistency: Hashable {
     /// 默认使用 State DB 索引；发现应位于当前页的已知会话缺失时由 runtime 自动回退扫描。
     case fastIndexed
-    /// 用户主动刷新时直接扫描历史，作为索引暂时落后的权威恢复路径。
+    /// 用户主动刷新时读取服务端最新列表并校正本地状态；具体索引与扫描策略由 runtime 决定。
     case authoritative
 }
 

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -996,7 +996,11 @@ struct WorkspaceRootView: View {
             currentDate: currentDate,
             onRefreshSessions: {
                 Task {
-                    await refreshWorkspaceSessions(project: project, presentationKey: presentationKey)
+                    await refreshWorkspaceSessions(
+                        project: project,
+                        presentationKey: presentationKey,
+                        restartFromFirst: true
+                    )
                 }
             },
             onLoadMoreSessions: {
@@ -1205,7 +1209,8 @@ struct WorkspaceRootView: View {
         // 下拉先提交用户正在看的会话列表，目录和全部工作区的 Git 摘要不能挡住它。
         await refreshWorkspaceSessions(
             project: project,
-            presentationKey: presentationKey
+            presentationKey: presentationKey,
+            restartFromFirst: true
         )
         // 目录同步要活过这次下拉手势本身，所以不能用 refreshable 任务的取消状态当门槛：
         // 指示器结束时这个任务就会被取消，拿它当条件会让后台同步永远起不来。
@@ -1217,7 +1222,8 @@ struct WorkspaceRootView: View {
 
     private func refreshWorkspaceSessions(
         project: AgentProject,
-        presentationKey: WorkspaceSessionPresentationKey
+        presentationKey: WorkspaceSessionPresentationKey,
+        restartFromFirst: Bool = false
     ) async {
         // 每个 Runtime 独立占有提交 token；切换筛选不会让旧请求覆盖当前 Runtime 的缓存。
         let invocationID = sessionLoadInvocationTokens.begin(for: presentationKey)
@@ -1233,7 +1239,8 @@ struct WorkspaceRootView: View {
                 projectID: project.id,
                 runtimeProvider: presentationKey.runtimeProvider,
                 cursor: nil,
-                limit: SessionStore.initialSessionPageLimit
+                limit: SessionStore.initialSessionPageLimit,
+                restartFromFirst: restartFromFirst
             )
             guard sessionLoadInvocationTokens.isCurrent(invocationID, for: presentationKey) else {
                 return

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceRootView.swift
@@ -1189,6 +1189,12 @@ struct WorkspaceRootView: View {
     }
 
     private func refreshWorkspaceContent(projectID: String) async {
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        SessionListDiagnostics.refreshStage("manual_begin", startedAt: startedAt, source: .workspaceForeground)
+        defer {
+            // 取消或失效响应也必须留下总耗时，不能只依赖 Store 成功提交的日志。
+            SessionListDiagnostics.refreshStage("manual_end", startedAt: startedAt, source: .workspaceForeground)
+        }
         guard !Task.isCancelled,
               selectedWorkspaceID == projectID,
               let project = sessionStore.sidebarProjects.first(where: { $0.id == projectID })

--- a/ios/MimiRemote/Sources/Features/Projects/WorkspaceSessionPresentation.swift
+++ b/ios/MimiRemote/Sources/Features/Projects/WorkspaceSessionPresentation.swift
@@ -36,7 +36,9 @@ struct WorkspaceRuntimeSessionPageState: Equatable {
     func reconciledSessions(with canonicalSessions: [AgentSession]) -> [AgentSession] {
         let canonicalByID = Dictionary(uniqueKeysWithValues: canonicalSessions.map { ($0.id, $0) })
         let cachedSessionIDs = Set(sessions.map(\.id))
-        let refreshedPageMembers = sessions.map { canonicalByID[$0.id] ?? $0 }
+        // canonical 投影已经应用本地归档可见性；缺失成员不能继续由页面缓存复活。
+        // 当前选中或仍在运行的归档会话会由 Store 保留，因此仍能通过这里的过滤。
+        let refreshedPageMembers = sessions.compactMap { canonicalByID[$0.id] }
         let newlyObserved = canonicalSessions.filter { session in
             !canonicalSessionIDsBeforeFirstPage.contains(session.id)
                 && !cachedSessionIDs.contains(session.id)

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -452,6 +452,7 @@ final class SessionStore: ObservableObject {
     var sessionFirstPageWaiterCountByProjectID: [String: Int] = [:]
     var sessionListFirstPageInFlightByKey: [SessionListFirstPageRequestKey: SessionListFirstPageInFlight] = [:]
     var sessionListFirstPageCacheByKey: [SessionListFirstPageRequestKey: SessionListFirstPageCacheEntry] = [:]
+    var sessionListRequestLineageByWorkspaceKey: [WorkspaceSessionFirstPageKey: UUID] = [:]
     @Published var workspaceSessionFirstPageCompletionByKey: [WorkspaceSessionFirstPageKey: WorkspaceSessionFirstPageCompletion] = [:]
     var sessionListCooldownUntilByBudgetKey: [SessionListBudgetKey: Date] = [:]
     var sessionListReconciliationTasksByProjectID: [String: Task<Void, Never>] = [:]

--- a/ios/MimiRemote/Sources/State/SessionStoreArchiveReconciliation.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreArchiveReconciliation.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct SessionArchiveReconciliationSnapshot {
+    let hostScope: HostScope
+    let profileID: String
+    let mutationToken: UInt64
+    let protectedSessionIDs: Set<SessionID>
+}
+
+extension SessionStore {
+    func archiveReconciliationSnapshot(
+        consistency: SessionListConsistency
+    ) -> SessionArchiveReconciliationSnapshot? {
+        guard consistency == .authoritative, !archivedSessionIDs.isEmpty else { return nil }
+        let profileID = appStore.notificationRoutingProfileID
+        return SessionArchiveReconciliationSnapshot(
+            hostScope: appStore.activeHostScope,
+            profileID: profileID,
+            mutationToken: sessionArchiveMutationToken,
+            protectedSessionIDs: Set(sessionArchiveMutationsByKey.keys.compactMap {
+                $0.profileID == profileID ? $0.sessionID : nil
+            })
+        )
+    }
+
+    func reconcileArchivedSessions(
+        _ returnedSessions: [AgentSession],
+        snapshot: SessionArchiveReconciliationSnapshot?
+    ) {
+        guard let snapshot, !Task.isCancelled,
+              appStore.activeHostScope == snapshot.hostScope,
+              appStore.notificationRoutingProfileID == snapshot.profileID,
+              sessionArchiveMutationToken == snapshot.mutationToken else { return }
+
+        // 只认本次未归档权威响应真正返回的 ID，未出现的会话不能据此恢复。
+        // 快照必须在实际网络请求前取得；共享请求的后加入者不能重置保护窗口。
+        // 请求期间新发起的归档，以及请求前尚未完成的归档，都不能被旧响应撤销。
+        let restoredIDs = archivedSessionIDs.intersection(returnedSessions.map(\.id))
+            .subtracting(snapshot.protectedSessionIDs)
+        guard !restoredIDs.isEmpty else { return }
+        archivedSessionIDs.subtract(restoredIDs)
+        saveSessionListPreferences()
+        rebuildSessionIndexes()
+    }
+}

--- a/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreConnection.swift
@@ -2615,6 +2615,7 @@ extension SessionStore {
         sessionListFirstPageInFlightByKey.values.forEach { $0.task.cancel() }
         sessionListFirstPageInFlightByKey = [:]
         sessionListFirstPageCacheByKey = [:]
+        sessionListRequestLineageByWorkspaceKey = [:]
         if !workspaceSessionFirstPageCompletionByKey.isEmpty {
             workspaceSessionFirstPageCompletionByKey = [:]
         }

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -2082,6 +2082,7 @@ extension SessionStore {
                 allowsAdaptiveOversampling: consistency == .authoritative
             )
             let archiveSnapshot = archiveReconciliationSnapshot(consistency: consistency)
+            let pageStartedAt = ProcessInfo.processInfo.systemUptime
             let page = try await client.sessionsPage(
                 workspace: workspace,
                 runtimeProvider: runtimeProvider,
@@ -2089,6 +2090,7 @@ extension SessionStore {
                 limit: rawPageLimit,
                 consistency: consistency
             )
+            SessionListDiagnostics.refreshStage("page_received", startedAt: pageStartedAt, source: source)
             try Task.checkCancellation()
             guard isCurrentWorkspaceIdentity(workspace, hostScope: expectedHostScope),
                   isRequestCurrent?() != false else {

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -2081,6 +2081,7 @@ extension SessionStore {
                 fillsPresentationWindow: fillsPresentationWindow,
                 allowsAdaptiveOversampling: consistency == .authoritative
             )
+            let archiveSnapshot = archiveReconciliationSnapshot(consistency: consistency)
             let page = try await client.sessionsPage(
                 workspace: workspace,
                 runtimeProvider: runtimeProvider,
@@ -2093,6 +2094,7 @@ extension SessionStore {
                   isRequestCurrent?() != false else {
                 throw CancellationError()
             }
+            reconcileArchivedSessions(page.sessions, snapshot: archiveSnapshot)
             pagesScanned += 1
             lastPage = page
 

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -1389,7 +1389,8 @@ extension SessionStore {
                 workspace: workspace,
                 page: page,
                 consistency: consistency,
-                requestedCursor: result.requestedCursor
+                requestedCursor: result.requestedCursor,
+                requestLineage: result.requestLineage
             )
             if updateStatusMessage, canReportForeground() {
                 setStatusMessage(L10n.plural("ui.sessions_loaded_count", count: filteredSessions.count))
@@ -1424,9 +1425,15 @@ extension SessionStore {
         workspace: AgentWorkspace,
         runtimeProvider: String = "codex",
         consistency: SessionListConsistency = .fastIndexed,
+        restartFromFirst: Bool = false,
         client: (any SessionStoreAPIClient)? = nil,
         hostScope: HostScope? = nil
-    ) async -> (workspace: AgentWorkspace, page: SessionsPage?, requestedCursor: String?) {
+    ) async -> (
+        workspace: AgentWorkspace,
+        page: SessionsPage?,
+        requestedCursor: String?,
+        requestLineage: UUID?
+    ) {
         let hostRequestStartedAt = sessionListNow()
         do {
             let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
@@ -1438,6 +1445,7 @@ extension SessionStore {
                     reuseRecent: consistency == .fastIndexed,
                     consistency: consistency,
                     source: .libraryIndex,
+                    restartFromFirst: restartFromFirst,
                     client: client,
                     hostScope: hostScope
                 )
@@ -1458,10 +1466,14 @@ extension SessionStore {
                     source: .libraryIndex,
                     expectedHostScope: hostScope ?? appStore.activeHostScope
                 )
-                result = SessionListFirstPageResult(page: page, requestedCursor: nil)
+                result = SessionListFirstPageResult(
+                    page: page,
+                    requestedCursor: nil,
+                    requestLineage: nil
+                )
             }
             recordCarStatusHostObservation(at: sessionListNow())
-            return (workspace, result.page, result.requestedCursor)
+            return (workspace, result.page, result.requestedCursor, result.requestLineage)
         } catch {
             if !isCancellationError(error) {
                 if Self.carStatusHostDidRespond(to: error) {
@@ -1471,23 +1483,37 @@ extension SessionStore {
                 }
             }
             // 某个最近工作区失效不能阻断整个会话库；该项目仍可在工作区页单独重试。
-            return (workspace, nil, nil)
+            return (workspace, nil, nil, nil)
         }
     }
 
     func mergeSessionLibraryPages(
-        _ results: [(workspace: AgentWorkspace, page: SessionsPage?, requestedCursor: String?)],
+        _ results: [(
+            workspace: AgentWorkspace,
+            page: SessionsPage?,
+            requestedCursor: String?,
+            requestLineage: UUID?
+        )],
         generation: Int,
         consistency: SessionListConsistency = .fastIndexed,
-        runtimeProvider: String = "codex"
+        runtimeProvider: String = "codex",
+        restartsFromFirst: Bool = false
     ) {
         guard generation == appStore.connectionGeneration else { return }
         let normalizedRuntime = Self.normalizedRuntimeProvider(runtimeProvider)
         for result in results {
             guard let page = result.page,
                   isCurrentWorkspaceIdentity(result.workspace) else { continue }
+            if let requestLineage = result.requestLineage,
+               !isCurrentSessionListRequestLineage(
+                   requestLineage,
+                   workspace: result.workspace
+               ) {
+                continue
+            }
             if normalizedRuntime == "codex",
                consistency == .authoritative,
+               !restartsFromFirst,
                authoritativeWorkspaceSessionFirstPageContinuationCursor(workspace: result.workspace)
                 != result.requestedCursor {
                 continue
@@ -1534,6 +1560,27 @@ extension SessionStore {
             workspaceID: workspace.id,
             workspacePath: standardizedSessionListPath(workspace.path)
         )
+    }
+
+    func currentSessionListRequestLineage(
+        workspace: AgentWorkspace,
+        hostScope: HostScope
+    ) -> UUID {
+        let key = workspaceSessionFirstPageKey(for: workspace, hostScope: hostScope)
+        if sessionListRequestLineageByWorkspaceKey[key] == nil {
+            sessionListRequestLineageByWorkspaceKey[key] = UUID()
+        }
+        return sessionListRequestLineageByWorkspaceKey[key]!
+    }
+
+    func isCurrentSessionListRequestLineage(
+        _ lineage: UUID,
+        workspace: AgentWorkspace,
+        hostScope: HostScope? = nil
+    ) -> Bool {
+        sessionListRequestLineageByWorkspaceKey[
+            workspaceSessionFirstPageKey(for: workspace, hostScope: hostScope)
+        ] == lineage
     }
 
     /// 任何跨 await 的工作区列表结果在提交前都要重新确认身份。
@@ -1750,10 +1797,18 @@ extension SessionStore {
         page: SessionsPage,
         consistency: SessionListConsistency,
         requestedCursor: String? = nil,
-        preserveAllLoaded: Bool = false
+        preserveAllLoaded: Bool = false,
+        restartsFromFirst: Bool = false,
+        requestLineage: UUID? = nil
     ) -> Bool {
         guard isCurrentWorkspaceIdentity(workspace) else { return false }
+        // 新首屏开始后，旧后台快速页也不能复活已从目录移除的成员。
+        if let requestLineage,
+           !isCurrentSessionListRequestLineage(requestLineage, workspace: workspace) {
+            return false
+        }
         if consistency == .authoritative,
+           !restartsFromFirst,
            authoritativeWorkspaceSessionFirstPageContinuationCursor(workspace: workspace)
             != requestedCursor {
             // 同 cursor waiter 的旧结果允许首个提交者推进；其余 waiter 若观察到进度已改变，
@@ -1817,6 +1872,7 @@ extension SessionStore {
         reuseRecent: Bool,
         consistency: SessionListConsistency = .fastIndexed,
         source: SessionListRequestSource,
+        restartFromFirst: Bool = false,
         client fixedClient: (any SessionStoreAPIClient)? = nil,
         hostScope expectedHostScope: HostScope? = nil
     ) async throws -> SessionListFirstPageResult {
@@ -1825,7 +1881,11 @@ extension SessionStore {
         guard isCurrentWorkspaceIdentity(workspace, hostScope: hostScope) else {
             throw CancellationError()
         }
-        let authoritativeProgress = consistency == .authoritative
+        var requestLineage = currentSessionListRequestLineage(
+            workspace: workspace,
+            hostScope: hostScope
+        )
+        let authoritativeProgress = consistency == .authoritative && !restartFromFirst
             ? authoritativeWorkspaceSessionFirstPageProgress(
                 workspace: workspace,
                 hostScope: hostScope
@@ -1852,7 +1912,11 @@ extension SessionStore {
                     count: page.sessions.count,
                     duration: sessionListNow().timeIntervalSince(requestStartedAt)
                 )
-                return SessionListFirstPageResult(page: page, requestedCursor: key.cursor)
+                return SessionListFirstPageResult(
+                    page: page,
+                    requestedCursor: key.cursor,
+                    requestLineage: inFlight.requestLineage
+                )
             }
 
             let matchesCurrentWorkspace: (SessionListFirstPageRequestKey) -> Bool = { candidate in
@@ -1875,6 +1939,28 @@ extension SessionStore {
                 retireSessionListFirstPageInFlight(
                     key: weakerInFlight.key,
                     id: weakerInFlight.value.id
+                )
+                guard isCurrentWorkspaceIdentity(workspace, hostScope: hostScope),
+                      !Task.isCancelled else {
+                    throw CancellationError()
+                }
+                continue
+            }
+
+            if consistency == .authoritative,
+               restartFromFirst,
+               let continuationInFlight = sessionListFirstPageInFlightByKey.first(where: { entry in
+                   matchesCurrentWorkspace(entry.key)
+                       && entry.key.consistency == .authoritative
+                       && entry.key.cursor != nil
+               }) {
+                // 用户主动刷新必须从 nil 首屏开始，但仍要先排空正在执行的 continuation，
+                // 避免同一工作区并发两条 thread/list cursor 链。
+                continuationInFlight.value.traversalControl.stopAfterCurrentPage()
+                _ = try? await continuationInFlight.value.task.value
+                retireSessionListFirstPageInFlight(
+                    key: continuationInFlight.key,
+                    id: continuationInFlight.value.id
                 )
                 guard isCurrentWorkspaceIdentity(workspace, hostScope: hostScope),
                       !Task.isCancelled else {
@@ -1922,7 +2008,11 @@ extension SessionStore {
                     count: page.sessions.count,
                     duration: sessionListNow().timeIntervalSince(requestStartedAt)
                 )
-                return SessionListFirstPageResult(page: page, requestedCursor: key.cursor)
+                return SessionListFirstPageResult(
+                    page: page,
+                    requestedCursor: key.cursor,
+                    requestLineage: largerInFlight.requestLineage
+                )
             }
             break
         }
@@ -1939,7 +2029,11 @@ extension SessionStore {
                 count: cached.page.sessions.count,
                 duration: sessionListNow().timeIntervalSince(requestStartedAt)
             )
-            return SessionListFirstPageResult(page: cached.page, requestedCursor: key.cursor)
+            return SessionListFirstPageResult(
+                page: cached.page,
+                requestedCursor: key.cursor,
+                requestLineage: requestLineage
+            )
         }
 
         if let cooldownDelay = sessionListCooldownDelayNanoseconds(for: workspace) {
@@ -1954,7 +2048,11 @@ extension SessionStore {
                     count: stale.sessions.count,
                     duration: sessionListNow().timeIntervalSince(requestStartedAt)
                 )
-                return SessionListFirstPageResult(page: stale, requestedCursor: key.cursor)
+                return SessionListFirstPageResult(
+                    page: stale,
+                    requestedCursor: key.cursor,
+                    requestLineage: requestLineage
+                )
             }
             // 冷启动或精确刷新等待窗口并继续请求，保证首屏最终自动恢复。
             await sessionListSleep(cooldownDelay)
@@ -1971,6 +2069,15 @@ extension SessionStore {
             sessionsByID[$0]
         } ?? []
         let requestID = UUID()
+        if restartFromFirst {
+            // 只有真正创建新的 nil 首屏任务时才换代；并发手动刷新若加入同一任务，
+            // 会在上面的 exact in-flight 分支复用同一 lineage，不会让 owner 失效。
+            requestLineage = UUID()
+            sessionListRequestLineageByWorkspaceKey[
+                workspaceSessionFirstPageKey(for: workspace, hostScope: hostScope)
+            ] = requestLineage
+        }
+        let traversalControl = SessionListFirstPageTraversalControl()
         let task = Task {
             try await sessionListPageFillingPresentationWindow(
                 client: client,
@@ -1982,12 +2089,15 @@ extension SessionStore {
                 source: source,
                 expectedHostScope: hostScope,
                 initialSessions: presentationSeedSessions,
-                fillsPresentationWindow: consistency == .authoritative
+                fillsPresentationWindow: consistency == .authoritative,
+                isRequestCurrent: { traversalControl.shouldContinue }
             )
         }
         sessionListFirstPageInFlightByKey[key] = SessionListFirstPageInFlight(
             id: requestID,
-            task: task
+            task: task,
+            traversalControl: traversalControl,
+            requestLineage: requestLineage
         )
         do {
             let page = try await task.value
@@ -2016,7 +2126,11 @@ extension SessionStore {
                 count: page.sessions.count,
                 duration: sessionListNow().timeIntervalSince(requestStartedAt)
             )
-            return SessionListFirstPageResult(page: page, requestedCursor: key.cursor)
+            return SessionListFirstPageResult(
+                page: page,
+                requestedCursor: key.cursor,
+                requestLineage: requestLineage
+            )
         } catch {
             retireSessionListFirstPageInFlight(key: key, id: requestID)
             if let policyFailure = sessionListPolicyFailure(from: error) {

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -671,7 +671,8 @@ extension SessionStore {
                 workspace: workspace,
                 page: page,
                 consistency: consistency,
-                requestedCursor: result.requestedCursor
+                requestedCursor: result.requestedCursor,
+                requestLineage: result.requestLineage
             )
 
             if isSelectionLeaseCurrent(foregroundLease),
@@ -808,7 +809,7 @@ extension SessionStore {
                 throw AgentAPIError.invalidResponse
             }
 
-            try await refreshWorkspaceSessions(projectID: projectID)
+            try await refreshWorkspaceSessions(projectID: projectID, restartFromFirst: false)
             guard needsAuthoritativeWorkspaceSessionFirstPage(projectID: projectID) else {
                 return
             }
@@ -831,7 +832,10 @@ extension SessionStore {
 
     /// 刷新工作区页正在浏览的会话，但不改变全局会话选择或 WebSocket。
     /// 工作区页有自己的本地浏览选择，不能复用 selectProject，否则刷新另一个目录会打断当前任务。
-    func refreshWorkspaceSessions(projectID: String) async throws {
+    func refreshWorkspaceSessions(
+        projectID: String,
+        restartFromFirst: Bool = true
+    ) async throws {
 #if DEBUG
         guard !isDebugWorkbenchUISeedActive else { return }
 #endif
@@ -857,9 +861,10 @@ extension SessionStore {
                 workspace: workspace,
                 limit: Self.initialSessionPageLimit,
                 reuseRecent: false,
-                // 用户明确点刷新时绕过可能滞后的 State DB 索引；后台轮询仍保留快速路径。
+                // 用户刷新读取最新首屏并校正归档状态；索引与扫描策略由 Runtime 决定。
                 consistency: .authoritative,
-                source: .workspaceForeground
+                source: .workspaceForeground,
+                restartFromFirst: restartFromFirst
             )
             let page = result.page
             guard isCurrentSessionPageRequest(projectID: workspace.id, token: requestToken) else {
@@ -872,7 +877,9 @@ extension SessionStore {
                 consistency: .authoritative,
                 requestedCursor: result.requestedCursor,
                 // 工作区页下拉刷新首屏时，保留用户已经翻到的旧页，避免列表突然收缩回 20 条。
-                preserveAllLoaded: sessionProjectsWithAdditionalPages.contains(workspace.id)
+                preserveAllLoaded: sessionProjectsWithAdditionalPages.contains(workspace.id),
+                restartsFromFirst: restartFromFirst,
+                requestLineage: result.requestLineage
             )
         } catch {
             _ = terminateConnectionIfCredentialsInvalid(error)

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -1674,12 +1674,14 @@ extension SessionStore {
                     guard appStore.activeHostScope == hostScope, !Task.isCancelled else { return }
                     let hostRequestStartedAt = sessionListNow()
                     do {
+                        let archiveSnapshot = archiveReconciliationSnapshot(consistency: consistency)
                         let page = try await client.controlledGlobalSessionsPage(
                             runtimeProvider: runtimeProvider,
                             cursor: cursor,
                             limit: 50
                         )
                         guard appStore.connectionGeneration == generation else { return }
+                        reconcileArchivedSessions(page.sessions, snapshot: archiveSnapshot)
                         recordCarStatusHostObservation(at: sessionListNow())
                         let pageSessionIDs = Set(page.sessions.map(\.id))
                         discoveredSessionIDs.formUnion(pageSessionIDs)

--- a/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreProjectsGit.swift
@@ -942,6 +942,9 @@ extension SessionStore {
         if retainedWorkspaceCompletions != workspaceSessionFirstPageCompletionByKey {
             workspaceSessionFirstPageCompletionByKey = retainedWorkspaceCompletions
         }
+        sessionListRequestLineageByWorkspaceKey = sessionListRequestLineageByWorkspaceKey.filter {
+            $0.key.workspaceID != project.id
+        }
         clearSessionReminders(forProjectID: project.id)
         sessions = sessions.filter { $0.projectID != project.id }
         clearWorkspaceUnavailable(project.id)
@@ -1789,6 +1792,7 @@ extension SessionStore {
             await refreshDirectoryScopedSessionLibrary(
                 workspace: workspace,
                 consistency: consistency,
+                restartFromFirst: authoritative,
                 client: client,
                 hostScope: hostScope,
                 generation: generation

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -146,6 +146,12 @@ enum SessionListDiagnostics {
         category: "SessionList"
     )
 
+    static func refreshStage(_ stage: String, startedAt: TimeInterval, source: SessionListRequestSource) {
+        // 用单调时钟测等待，不受系统校时影响；阶段名只由代码提供，不记录用户内容。
+        let milliseconds = Int(((ProcessInfo.processInfo.systemUptime - startedAt) * 1_000).rounded())
+        logger.info("source=\(source.rawValue, privacy: .public) stage=\(stage, privacy: .public) duration_ms=\(milliseconds) cancelled=\(Task.isCancelled)")
+    }
+
     static func completed(
         source: SessionListRequestSource,
         consistency: SessionListConsistency,

--- a/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreSupport.swift
@@ -121,6 +121,7 @@ struct WorkspaceSessionFirstPageCompletion: Equatable {
 struct SessionListFirstPageResult {
     let page: SessionsPage
     let requestedCursor: String?
+    let requestLineage: UUID?
 }
 
 enum SessionListRequestSource: String {
@@ -192,6 +193,17 @@ struct SessionListBudgetKey: Hashable {
 struct SessionListFirstPageInFlight {
     let id: UUID
     let task: Task<SessionsPage, Error>
+    let traversalControl: SessionListFirstPageTraversalControl
+    let requestLineage: UUID
+}
+
+@MainActor
+final class SessionListFirstPageTraversalControl {
+    private(set) var shouldContinue = true
+
+    func stopAfterCurrentPage() {
+        shouldContinue = false
+    }
 }
 
 struct SessionListFirstPageCacheEntry {

--- a/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreWorkspaceRuntimePagination.swift
@@ -96,6 +96,7 @@ extension SessionStore {
     func refreshDirectoryScopedSessionLibrary(
         workspace: AgentWorkspace,
         consistency: SessionListConsistency,
+        restartFromFirst: Bool = false,
         client: any SessionStoreAPIClient,
         hostScope: HostScope,
         generation: Int
@@ -107,6 +108,7 @@ extension SessionStore {
                 workspace: workspace,
                 runtimeProvider: runtimeProvider,
                 consistency: consistency,
+                restartFromFirst: restartFromFirst,
                 client: client,
                 hostScope: hostScope
             )
@@ -115,7 +117,8 @@ extension SessionStore {
                 [result],
                 generation: generation,
                 consistency: consistency,
-                runtimeProvider: runtimeProvider
+                runtimeProvider: runtimeProvider,
+                restartsFromFirst: restartFromFirst
             )
         }
     }
@@ -127,7 +130,8 @@ extension SessionStore {
         runtimeProvider: String,
         cursor: String?,
         limit: Int,
-        excludingListableSessionIDs: Set<SessionID> = []
+        excludingListableSessionIDs: Set<SessionID> = [],
+        restartFromFirst: Bool = false
     ) async throws -> SessionsPage {
         guard let workspace = ensureWorkspaceForKnownProjectID(projectID) else {
             throw CancellationError()
@@ -148,6 +152,7 @@ extension SessionStore {
                 reuseRecent: false,
                 consistency: .authoritative,
                 source: .workspaceForeground,
+                restartFromFirst: restartFromFirst,
                 client: lease.client,
                 hostScope: lease.scope
             )
@@ -167,6 +172,16 @@ extension SessionStore {
             )
         }
         try requireCurrentProjectsGitHost(lease)
+        if let canonicalFirstPageResult,
+           let requestLineage = canonicalFirstPageResult.requestLineage,
+           !isCurrentSessionListRequestLineage(
+               requestLineage,
+               workspace: workspace,
+               hostScope: lease.scope
+           ) {
+            // 旧首屏即使稍后在 apply 阶段会被拒绝，也不能先覆盖目录成员集合。
+            throw CancellationError()
+        }
 
         let prepared = sessions(page.sessions, in: workspace).map(sessionPreparedForStorage)
         recordWorkspaceDirectorySessionPage(
@@ -185,7 +200,9 @@ extension SessionStore {
                 requestedCursor: canonicalFirstPageResult.requestedCursor,
                 // Runtime 页面只拿到 Codex rows，不能整页替换并误删同工作区已缓存的
                 // Claude 会话或旧分页；沿用该入口原先的 merge-only 展示语义。
-                preserveAllLoaded: true
+                preserveAllLoaded: true,
+                restartsFromFirst: restartFromFirst,
+                requestLineage: canonicalFirstPageResult.requestLineage
             )
         } else {
             mergeSessionPage(prepared)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDataFlowTestSupport.swift
@@ -1292,6 +1292,7 @@ final class MutableSessionPageClient: SessionStoreAPIClient {
     var requestedSessionLimits: [Int?] = []
     var requestedSessionListConsistencies: [SessionListConsistency] = []
     var onSessionPageRequest: ((String?) -> Void)?
+    var sessionPageHandler: ((String?) async throws -> SessionsPage)?
 
     init(
         projects: [AgentProject],
@@ -1324,6 +1325,9 @@ final class MutableSessionPageClient: SessionStoreAPIClient {
         requestedSessionCursors.append(cursor)
         requestedSessionLimits.append(limit)
         onSessionPageRequest?(cursor)
+        if let sessionPageHandler {
+            return try await sessionPageHandler(cursor)
+        }
         if let cursor, let page = cursorPages[cursor] {
             return page
         }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeHistoryTests.swift
@@ -1499,25 +1499,32 @@ extension ConversationDataFlowTests {
         let listMessages = try await waitForFakeAppServerMessages(transport, count: 3)
         let listRequest = try decodeAppServerRequest(listMessages[2])
         XCTAssertEqual(listRequest.method, "thread/list")
+        // 主动刷新先查索引；空页还需普通扫描确认，之后才能进入新会话的 model/list 链路。
+        XCTAssertEqual(listRequest.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
         transport.enqueue(#"{"id":\#(try jsonFragment(for: listRequest.id)),"result":{"data":[],"nextCursor":null,"backwardsCursor":null}}"#)
+        let verifiedListMessages = try await waitForFakeAppServerMessages(transport, count: 4)
+        let verifiedListRequest = try decodeAppServerRequest(verifiedListMessages[3])
+        XCTAssertEqual(verifiedListRequest.method, "thread/list")
+        XCTAssertEqual(verifiedListRequest.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+        transportResponse(transport, id: verifiedListRequest.id, result: #"{"data":[],"nextCursor":null}"#)
         await refreshTask.value
         XCTAssertEqual(store.selectedProjectID, project.id)
 
         let sendTask = Task { await store.sendPrompt("帮我验收 direct Store") }
-        let threadMessages = try await waitForFakeAppServerMessages(transport, count: 4)
-        let modelList = try decodeAppServerRequest(threadMessages[3])
+        let threadMessages = try await waitForFakeAppServerMessages(transport, count: 5)
+        let modelList = try decodeAppServerRequest(threadMessages[4])
         XCTAssertEqual(modelList.method, "model/list")
         transport.enqueue(#"{"id":\#(try jsonFragment(for: modelList.id)),"result":{"models":[{"id":"gpt-store-default","name":"Store Default","provider":"openai","isDefault":true}]}}"#)
 
-        let threadStartMessages = try await waitForFakeAppServerMessages(transport, count: 5)
-        let threadStart = try decodeAppServerRequest(threadStartMessages[4])
+        let threadStartMessages = try await waitForFakeAppServerMessages(transport, count: 6)
+        let threadStart = try decodeAppServerRequest(threadStartMessages[5])
         XCTAssertEqual(threadStart.method, "thread/start")
         XCTAssertNil(threadStart.params?.objectValue?["model"]?.stringValue)
         XCTAssertNil(threadStart.params?.objectValue?["modelProvider"])
         transport.enqueue(#"{"id":\#(try jsonFragment(for: threadStart.id)),"result":{"thread":{"id":"thr_store_direct","sessionId":"thr_store_direct","preview":"帮我验收 direct Store","ephemeral":false,"modelProvider":"openai","createdAt":1780490100,"updatedAt":1780490101,"status":{"type":"idle"},"path":null,"cwd":"/tmp/store-direct","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"Store 直连","turns":[]}}}"#)
 
-        let turnMessages = try await waitForFakeAppServerMessages(transport, count: 6)
-        let turnStart = try decodeAppServerRequest(turnMessages[5])
+        let turnMessages = try await waitForFakeAppServerMessages(transport, count: 7)
+        let turnStart = try decodeAppServerRequest(turnMessages[6])
         XCTAssertEqual(turnStart.method, "turn/start")
         XCTAssertEqual(turnStart.params?.objectValue?["model"]?.stringValue, "gpt-store-default")
         let collaborationMode = try XCTUnwrap(turnStart.params?.objectValue?["collaborationMode"]?.objectValue)
@@ -1527,7 +1534,7 @@ extension ConversationDataFlowTests {
         // 新线程首轮由本地回显和 buffered event replay 承接，不能在 rollout 尚未就绪时
         // 追加 thread/read；若未来回归到旧行为，先响应请求让 sendTask 能退出，再给出明确断言。
         for _ in 0..<20 {
-            if (await transport.sentMessages()).count > 6 {
+            if (await transport.sentMessages()).count > 7 {
                 break
             }
             try await Task.sleep(nanoseconds: 10_000_000)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
@@ -173,6 +173,69 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(text?.contains("任务已经完成") == true)
     }
 
+    func testCodexAuthoritativeFirstPageReadsFreshIndexIncludingExternalUnarchive() async throws {
+        let project = AgentProject(id: "fresh-index", name: "Fresh Index", path: "/tmp/fresh-index")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let firstTask = Task {
+            try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20, consistency: .authoritative)
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex"}"#)
+        let firstList = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        XCTAssertEqual(firstList.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        let existing = appServerThreadJSON(id: "existing", cwd: project.path, source: "appServer", updatedAt: 200)
+        transportResponse(transport, id: firstList.id, result: appServerThreadListResult([existing], nextCursor: nil))
+        let firstPage = try await firstTask.value
+        XCTAssertEqual(firstPage.sessions.map(\.id), ["existing"])
+
+        let sentBeforeRefresh = await transport.sentMessages().count
+        let refreshTask = Task {
+            try await runtime.sessionsPage(
+                workspace: AgentWorkspace(project: project), cursor: nil, limit: 20, consistency: .authoritative
+            )
+        }
+        let freshList = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: sentBeforeRefresh)
+        XCTAssertEqual(freshList.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        XCTAssertEqual(freshList.params?.objectValue?["sortKey"]?.stringValue, "recency_at")
+        XCTAssertNil(freshList.params?.objectValue?["refreshHistory"])
+        let restored = appServerThreadJSON(id: "externally-unarchived", cwd: project.path, source: "appServer", updatedAt: 300)
+        transportResponse(transport, id: freshList.id, result: appServerThreadListResult([restored, existing], nextCursor: nil))
+        let refreshed = try await refreshTask.value
+        XCTAssertEqual(refreshed.sessions.map(\.id), ["externally-unarchived", "existing"])
+    }
+
+    func testCodexAuthoritativeEmptyIndexFallsBackToHistoryScan() async throws {
+        let project = AgentProject(id: "empty-index", name: "Empty Index", path: "/tmp/empty-index")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let pageTask = Task {
+            try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20, consistency: .authoritative)
+        }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake-codex"}"#)
+        let indexedList = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        XCTAssertEqual(indexedList.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        let sentBeforeScan = await transport.sentMessages().count
+        transportResponse(transport, id: indexedList.id, result: appServerThreadListResult([], nextCursor: nil))
+        let scan = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: sentBeforeScan)
+        XCTAssertEqual(scan.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+        let recovered = appServerThreadJSON(id: "history-only", cwd: project.path, source: "appServer", updatedAt: 200)
+        transportResponse(transport, id: scan.id, result: appServerThreadListResult([recovered], nextCursor: nil))
+        let page = try await pageTask.value
+        XCTAssertEqual(page.sessions.map(\.id), ["history-only"])
+    }
+
     func testClaudeAuthoritativeFirstPageRequestsHistoryRefresh() async throws {
         let project = AgentProject(
             id: "proj_claude_history_refresh",

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ConversationDirectRuntimeSubscriptionTests.swift
@@ -873,3 +873,216 @@ extension ConversationDataFlowTests {
         XCTAssertTrue(resumedAfterUnarchive)
     }
 }
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testExternalArchiveDoesNotPermanentlyDisableDirectoryIndex() async throws {
+        let project = AgentProject(id: "archive-index", name: "Archive Index", path: "/tmp/archive-index")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787", token: "test",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let archived = appServerThreadJSON(id: "external-archive", cwd: project.path, source: "appServer", updatedAt: 300)
+        let remaining = appServerThreadJSON(id: "remaining", cwd: project.path, source: "appServer", updatedAt: 200)
+        let initial = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake"}"#)
+        let first = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: first.id, result: appServerThreadListResult([archived, remaining], nextCursor: nil))
+        _ = try await initial.value
+
+        // 首次缺失由扫描确认；之后仍访问新索引，不能把一次正常归档变成目录永久扫描。
+        for round in 0..<3 {
+            let sentBefore = await transport.sentMessages().count
+            let refresh = Task {
+                try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 20, consistency: .authoritative)
+            }
+            let indexed = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: sentBefore)
+            XCTAssertEqual(indexed.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+            let rows = round == 2 ? [archived, remaining] : [remaining]
+            let beforeResponse = await transport.sentMessages().count
+            transportResponse(transport, id: indexed.id, result: appServerThreadListResult(rows, nextCursor: nil))
+            if round == 0 {
+                let scan = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeResponse)
+                XCTAssertEqual(scan.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+                transportResponse(transport, id: scan.id, result: appServerThreadListResult([remaining], nextCursor: nil))
+            }
+            let page = try await refresh.value
+            XCTAssertEqual(page.sessions.map(\.id), round == 2 ? ["external-archive", "remaining"] : ["remaining"])
+        }
+        let verifiedMissing = await runtime.stateDBOnlyVerifiedMissingSessionIDs
+        XCTAssertTrue(verifiedMissing.isEmpty, "取消归档重新返回后，不保留过期缺失记录")
+    }
+
+    func testCodexContinuationUsesIndexWithoutRepairingFirstPageRows() async throws {
+        let project = AgentProject(id: "page-index", name: "Page Index", path: "/tmp/page-index")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787", token: "test",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let firstTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: nil, limit: 1, consistency: .authoritative) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake"}"#)
+        let first = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        let recent = appServerThreadJSON(id: "recent", cwd: project.path, source: "appServer", updatedAt: 300)
+        transportResponse(transport, id: first.id, result: appServerThreadListResult([recent], nextCursor: "older"))
+        _ = try await firstTask.value
+        let beforePage = await transport.sentMessages().count
+        let nextTask = Task { try await runtime.sessionsPage(projectID: project.id, cursor: "older", limit: 1, consistency: .authoritative) }
+        let next = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforePage)
+        XCTAssertEqual(next.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        XCTAssertEqual(next.params?.objectValue?["cursor"]?.stringValue, "older")
+        let old = appServerThreadJSON(id: "old", cwd: project.path, source: "appServer", updatedAt: 100)
+        transportResponse(transport, id: next.id, result: appServerThreadListResult([old], nextCursor: nil))
+        let page = try await nextTask.value
+        XCTAssertEqual(page.sessions.map(\.id), ["old"])
+    }
+
+    func testCodexGlobalDiscoveryUsesIndexAcrossPages() async throws {
+        let project = AgentProject(id: "global-index", name: "Global Index", path: "/tmp/global-index")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787", token: "test",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let firstTask = Task { try await runtime.controlledGlobalSessionsPage(cursor: nil, limit: 50) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake"}"#)
+        let first = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        XCTAssertEqual(first.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        XCTAssertNil(first.params?.objectValue?["cwd"])
+        // 授权裁剪后的空页还有下一页时不能额外扫描历史。
+        transportResponse(transport, id: first.id, result: appServerThreadListResult([], nextCursor: "opaque-next"))
+        _ = try await firstTask.value
+        let beforePage = await transport.sentMessages().count
+        let nextTask = Task { try await runtime.controlledGlobalSessionsPage(cursor: "opaque-next", limit: 50) }
+        let next = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforePage)
+        XCTAssertEqual(next.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        XCTAssertEqual(next.params?.objectValue?["cursor"]?.stringValue, "opaque-next")
+        let row = appServerThreadJSON(id: "visible", cwd: project.path, source: "appServer", updatedAt: 100)
+        transportResponse(transport, id: next.id, result: appServerThreadListResult([row], nextCursor: nil))
+        let page = try await nextTask.value
+        XCTAssertEqual(page.sessions.map(\.id), ["visible"])
+    }
+
+    func testCodexGlobalDiscoveryFallsBackWhenIndexUnsupported() async throws {
+        let project = AgentProject(id: "legacy-index", name: "Legacy Index", path: "/tmp/legacy-index")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787", token: "test",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let task = Task { try await runtime.controlledGlobalSessionsPage(cursor: nil, limit: 50) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake"}"#)
+        let indexed = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        let beforeError = await transport.sentMessages().count
+        transportErrorResponse(transport, id: indexed.id, code: -32602, message: "useStateDbOnly unsupported")
+        let scan = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeError)
+        XCTAssertEqual(scan.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+        let row = appServerThreadJSON(id: "visible", cwd: project.path, source: "appServer", updatedAt: 100)
+        transportResponse(transport, id: scan.id, result: appServerThreadListResult([row], nextCursor: nil))
+        let page = try await task.value
+        XCTAssertEqual(page.sessions.map(\.id), ["visible"])
+        let beforeNext = await transport.sentMessages().count
+        let nextTask = Task { try await runtime.controlledGlobalSessionsPage(cursor: nil, limit: 50) }
+        let next = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeNext)
+        XCTAssertEqual(next.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+        transportResponse(transport, id: next.id, result: appServerThreadListResult([row], nextCursor: nil))
+        _ = try await nextTask.value
+    }
+}
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testScanFallbackContinuationKeepsItsQueryModeForDirectoryAndGlobalLists() async throws {
+        let project = AgentProject(id: "scan-cursor", name: "Scan Cursor", path: "/tmp/scan-cursor")
+        for global in [false, true] {
+            let transport = FakeCodexAppServerTransport()
+            let runtime = CodexAppServerSessionRuntime(
+                endpoint: "http://127.0.0.1:8787", token: "test",
+                transportFactory: { transport },
+                configProvider: { makeDirectAppServerConfig(project: project) }
+            )
+            func page(_ cursor: String?) async throws -> SessionsPage {
+                if global { return try await runtime.controlledGlobalSessionsPage(cursor: cursor, limit: 20) }
+                return try await runtime.sessionsPage(projectID: project.id, cursor: cursor, limit: 20, consistency: .authoritative)
+            }
+            let initial = Task { try await page(nil) }
+            let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+            transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake"}"#)
+            let indexed = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+            XCTAssertEqual(indexed.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+            let beforeFallback = await transport.sentMessages().count
+            transportResponse(transport, id: indexed.id, result: appServerThreadListResult([], nextCursor: nil))
+            let scanned = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeFallback)
+            XCTAssertEqual(scanned.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+            let first = appServerThreadJSON(id: "history", cwd: project.path, source: "appServer", updatedAt: 200)
+            transportResponse(transport, id: scanned.id, result: appServerThreadListResult([first], nextCursor: "scan-only-cursor"))
+            let firstPage = try await initial.value
+            XCTAssertEqual(firstPage.nextCursor, "scan-only-cursor")
+
+            let beforeNext = await transport.sentMessages().count
+            let nextTask = Task { try await page(firstPage.nextCursor) }
+            let next = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeNext)
+            XCTAssertEqual(next.params?.objectValue?["cursor"]?.stringValue, "scan-only-cursor")
+            XCTAssertEqual(next.params?.objectValue?["useStateDbOnly"]?.boolValue, false, "扫描生成的游标不能交给索引查询")
+            let second = appServerThreadJSON(id: "older-history", cwd: project.path, source: "appServer", updatedAt: 100)
+            transportResponse(transport, id: next.id, result: appServerThreadListResult([second], nextCursor: nil))
+            _ = try await nextTask.value
+
+            let beforeRefresh = await transport.sentMessages().count
+            let refresh = Task { try await page(nil) }
+            let fresh = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeRefresh)
+            XCTAssertEqual(fresh.params?.objectValue?["useStateDbOnly"]?.boolValue, true, "扫描游标不能降级下一次新首屏")
+            transportResponse(transport, id: fresh.id, result: appServerThreadListResult([first, second], nextCursor: nil))
+            _ = try await refresh.value
+        }
+    }
+}
+
+@MainActor
+extension ConversationDataFlowTests {
+    func testGlobalIndexRepairsKnownMissingSessionsAcrossFilteredAndCompletePages() async throws {
+        let project = AgentProject(id: "global-repair", name: "Global Repair", path: "/tmp/global-repair")
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787", token: "test",
+            transportFactory: { transport },
+            configProvider: { makeDirectAppServerConfig(project: project) }
+        )
+        let known = appServerThreadJSON(id: "known", cwd: project.path, source: "appServer", updatedAt: 300)
+        let remaining = appServerThreadJSON(id: "remaining", cwd: project.path, source: "appServer", updatedAt: 200)
+        let firstTask = Task { try await runtime.controlledGlobalSessionsPage(cursor: nil, limit: 50) }
+        let initialize = try await waitForFakeAppServerRequest(transport, method: "initialize")
+        transportResponse(transport, id: initialize.id, result: #"{"userAgent":"fake"}"#)
+        let first = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: 1)
+        transportResponse(transport, id: first.id, result: appServerThreadListResult([known, remaining], nextCursor: nil))
+        _ = try await firstTask.value
+
+        for round in 0..<4 {
+            let beforeRefresh = await transport.sentMessages().count
+            let refresh = Task { try await runtime.controlledGlobalSessionsPage(cursor: nil, limit: 50) }
+            let indexed = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeRefresh)
+            XCTAssertEqual(indexed.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+            let beforeScan = await transport.sentMessages().count
+            transportResponse(transport, id: indexed.id, result: appServerThreadListResult(
+                round == 0 ? [] : [remaining], nextCursor: round == 0 ? "filtered-next" : nil
+            ))
+            if round < 3 {
+                let scan = try await waitForFakeAppServerRequest(transport, method: "thread/list", after: beforeScan)
+                XCTAssertEqual(scan.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+                // 前两次覆盖授权裁剪空页和非空索引漏行，第三次正常归档才允许免除重复扫描。
+                transportResponse(transport, id: scan.id, result: appServerThreadListResult(round < 2 ? [known, remaining] : [remaining], nextCursor: nil))
+            }
+            let result = try await refresh.value
+            XCTAssertEqual(result.sessions.map(\.id), round < 2 ? ["known", "remaining"] : ["remaining"])
+        }
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SessionArchiveReconciliationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SessionArchiveReconciliationTests.swift
@@ -1,0 +1,271 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class SessionArchiveReconciliationTests: XCTestCase {
+    func testWorkspaceRefreshRestoresPersistedArchiveWithoutChangingOtherPreferences() async throws {
+        let f = try await fixture()
+        let otherWorkspace = AgentWorkspace(project: makeProject(id: "other-workspace"))
+        f.store.recentWorkspaces.append(otherWorkspace)
+        let hidden = makeSession(id: "still-archived", projectID: f.project.id, title: "仍归档", status: "history", source: "codex")
+        let pinned = makeSession(id: "pinned", projectID: f.project.id, title: "置顶", status: "history", source: "codex")
+        f.store.toggleSessionArchived(hidden)
+        f.store.toggleSessionPinned(pinned)
+        f.store.sessionWorkspaceIDs = [f.project.id]
+        f.store.saveSessionListPreferences()
+
+        // 重建 Store，验证修复同样适用于已落盘的旧标记，而非只修改当前内存。
+        let reloaded = makeStore(appStore: f.appStore, client: f.client, preferences: f.preferences, project: f.project, additionalWorkspace: otherWorkspace)
+        XCTAssertEqual(reloaded.sessionWorkspaceIDs, [f.project.id], "刷新前先确认工作区筛选夹具有效")
+        let page = try await refresh(reloaded, project: f.project)
+        XCTAssertEqual(page.sessions.map(\.id), [f.session.id])
+        XCTAssertEqual(reloaded.sessionLibrarySessions.map(\.id), [f.session.id])
+        XCTAssertFalse(reloaded.isSessionArchived(f.session.id))
+        let saved = f.preferences.load(profileID: f.appStore.notificationRoutingProfileID)
+        XCTAssertEqual(saved.archivedSessionIDs, [hidden.id])
+        XCTAssertEqual(saved.pinnedSessionIDs, [pinned.id])
+        XCTAssertEqual(saved.sessionWorkspaceIDs, [f.project.id])
+        let restarted = makeStore(appStore: f.appStore, client: f.client, preferences: f.preferences, project: f.project, additionalWorkspace: otherWorkspace)
+        XCTAssertFalse(restarted.isSessionArchived(f.session.id))
+        XCTAssertEqual(f.client.workspaceConsistencies, [.authoritative])
+    }
+
+    func testRestoredRowCountsTowardPresentationWindowWithoutExtraPage() async throws {
+        let f = try await fixture()
+        f.client.page = SessionsPage(sessions: [f.session], nextCursor: "next", hasMore: true)
+        let page = try await refresh(f.store, project: f.project, limit: 1)
+        XCTAssertEqual(page.sessions.map(\.id), [f.session.id])
+        XCTAssertEqual(f.client.workspaceConsistencies.count, 1, "恢复后的行应直接计入展示窗口，不能多发补页请求")
+        XCTAssertEqual(page.nextCursor, "next")
+    }
+
+    func testAuthoritativeLibraryRefreshRestoresGlobalAndDirectoryResults() async throws {
+        for globalOnly in [true, false] {
+            let f = try await fixture()
+            f.client.globalPage = globalOnly ? SessionsPage(sessions: [f.session]) : SessionsPage(sessions: [])
+            if globalOnly { f.store.recentWorkspaces = [] }
+            await f.store.refreshSessionLibraryIndex(authoritative: true)
+            XCTAssertFalse(f.store.isSessionArchived(f.session.id))
+            XCTAssertTrue(f.store.sessionLibrarySessions.contains { $0.id == f.session.id })
+            XCTAssertFalse(f.preferences.load(profileID: f.appStore.notificationRoutingProfileID).archivedSessionIDs.contains(f.session.id))
+        }
+    }
+
+    func testWeakListsDoNotClearArchivePreferences() async throws {
+        let f = try await fixture()
+        let workspace = try XCTUnwrap(f.store.workspacesByID[f.project.id])
+        _ = try await f.store.sessionListFirstPage(
+            workspace: workspace, limit: 20, reuseRecent: false,
+            consistency: .fastIndexed, source: .libraryIndex
+        )
+        f.client.globalPage = SessionsPage(sessions: [f.session])
+        await f.store.refreshSessionLibraryIndex(authoritative: false)
+        assertArchived(f)
+    }
+
+    func testMissingRowsAndFailedRequestsDoNotRestoreArchives() async throws {
+        let f = try await fixture()
+        f.client.page = SessionsPage(sessions: [])
+        _ = try await refresh(f.store, project: f.project)
+        assertArchived(f)
+        f.client.pageHandler = { throw MockError.unimplemented }
+        do {
+            _ = try await refresh(f.store, project: f.project)
+            XCTFail("请求失败必须继续上抛")
+        } catch {}
+        assertArchived(f)
+    }
+
+    func testSharedOldResponseCannotUndoArchiveStartedAfterRequest() async throws {
+        let f = try await fixture()
+        let gate = ArchiveReconciliationGate<SessionsPage>()
+        f.client.pageHandler = { try await gate.response() }
+        let first = Task { try await self.refresh(f.store, project: f.project) }
+        await gate.waitUntilRequested()
+        // 第一条请求仍在途中：本机先恢复再归档，之后第二个刷新加入同一条旧请求。
+        let unarchived = await f.store.setSessionArchivedRemote(f.session, archived: false)
+        let archived = await f.store.setSessionArchivedRemote(f.session, archived: true)
+        XCTAssertTrue(unarchived && archived)
+        var secondStarted = false
+        let second = Task {
+            secondStarted = true
+            return try await self.refresh(f.store, project: f.project)
+        }
+        while !secondStarted { await Task.yield() }
+        await gate.resolve(SessionsPage(sessions: [f.session]))
+        let firstPage = try await first.value
+        let secondPage = try await second.value
+        XCTAssertTrue(firstPage.sessions.isEmpty)
+        XCTAssertTrue(secondPage.sessions.isEmpty)
+        XCTAssertEqual(f.client.workspaceConsistencies.count, 1)
+        assertArchived(f)
+    }
+
+    func testArchiveAlreadyPendingAtRequestStartRemainsProtectedAfterSuccess() async throws {
+        let f = try await fixture(archived: false)
+        let archiveGate = ArchiveReconciliationGate<Bool>()
+        let pageGate = ArchiveReconciliationGate<SessionsPage>()
+        f.client.archiveHandler = { _ = try await archiveGate.response() }
+        let archive = Task { await f.store.setSessionArchivedRemote(f.session, archived: true) }
+        await archiveGate.waitUntilRequested()
+        f.client.pageHandler = { try await pageGate.response() }
+        let refreshTask = Task { try await self.refresh(f.store, project: f.project) }
+        await pageGate.waitUntilRequested()
+        await archiveGate.resolve(true)
+        let didArchive = await archive.value
+        XCTAssertTrue(didArchive)
+        await pageGate.resolve(SessionsPage(sessions: [f.session]))
+        let page = try await refreshTask.value
+        XCTAssertTrue(page.sessions.isEmpty)
+        assertArchived(f)
+    }
+
+    func testGlobalResponseCannotUndoNewArchive() async throws {
+        let f = try await fixture()
+        f.store.recentWorkspaces = []
+        let gate = ArchiveReconciliationGate<SessionsPage>()
+        f.client.globalHandler = { try await gate.response() }
+        let refreshTask = Task { await f.store.refreshSessionLibraryIndex(authoritative: true) }
+        await gate.waitUntilRequested()
+        _ = await f.store.setSessionArchivedRemote(f.session, archived: false)
+        _ = await f.store.setSessionArchivedRemote(f.session, archived: true)
+        await gate.resolve(SessionsPage(sessions: [f.session]))
+        await refreshTask.value
+        assertArchived(f)
+    }
+
+    func testLateResponseAfterHostSwitchDoesNotChangeEitherProfile() async throws {
+        let f = try await fixture()
+        let oldProfileID = f.appStore.notificationRoutingProfileID
+        let gate = ArchiveReconciliationGate<SessionsPage>()
+        f.client.pageHandler = { try await gate.response() }
+        let request = Task { try await self.refresh(f.store, project: f.project) }
+        await gate.waitUntilRequested()
+        _ = try await f.appStore.commitConnectionSettings(PreparedConnectionSettings(
+            endpoint: "http://100.64.0.20:8787", token: "test-token",
+            profileTarget: .newProfile(id: "other-mac", displayName: "Other Mac"), installationID: "other-installation"
+        ))
+        f.preferences.save(SessionListPreferences(archivedSessionIDs: [f.session.id]), profileID: "other-mac")
+        f.store.reloadSessionListPreferences()
+        await gate.resolve(SessionsPage(sessions: [f.session]))
+        do {
+            _ = try await request.value
+            XCTFail("旧 Host 的刷新必须失效")
+        } catch is CancellationError {} catch { XCTFail("非预期错误：\(error)") }
+        XCTAssertTrue(f.preferences.load(profileID: oldProfileID).archivedSessionIDs.contains(f.session.id))
+        assertArchived(f)
+    }
+
+    private struct Fixture {
+        let project: AgentProject
+        let session: AgentSession
+        let client: ArchiveReconciliationClient
+        let appStore: AppStore
+        let preferences: SessionListPreferenceStore
+        let store: SessionStore
+    }
+
+    private func fixture(archived: Bool = true) async throws -> Fixture {
+        let project = makeProject(id: "archive-reconciliation")
+        let session = makeSession(
+            id: "restored-history", projectID: project.id, title: "外部恢复的会话",
+            status: "history", source: "codex", runtimeProvider: "codex"
+        )
+        let client = ArchiveReconciliationClient(project: project, page: SessionsPage(sessions: [session]))
+        let appStore = makeIsolatedAppStore()
+        let suiteName = "ArchiveReconciliation.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        let preferences = SessionListPreferenceStore(defaults: defaults)
+        let store = makeStore(appStore: appStore, client: client, preferences: preferences, project: project)
+        store.sessions = [session]
+        if archived {
+            let didArchive = await store.setSessionArchivedRemote(session, archived: true)
+            XCTAssertTrue(didArchive)
+        }
+        return Fixture(project: project, session: session, client: client, appStore: appStore, preferences: preferences, store: store)
+    }
+
+    private func makeStore(
+        appStore: AppStore, client: ArchiveReconciliationClient,
+        preferences: SessionListPreferenceStore, project: AgentProject,
+        additionalWorkspace: AgentWorkspace? = nil
+    ) -> SessionStore {
+        let store = SessionStore(
+            appStore: appStore, conversationStore: ConversationStore(), logStore: LogStore(),
+            sessionListPreferenceStore: preferences, clientFactory: { client }
+        )
+        store.projects = [project]
+        // 必须一次提交完整目录集；先设一个再追加，会把已选的单目录暂时归一成全选。
+        store.recentWorkspaces = [AgentWorkspace(project: project)] + (additionalWorkspace.map { [$0] } ?? [])
+        store.selectedSessionID = nil
+        store.reloadSessionListPreferences()
+        return store
+    }
+
+    private func refresh(_ store: SessionStore, project: AgentProject, limit: Int = 20) async throws -> SessionsPage {
+        try await store.workspaceRuntimeSessionsPage(projectID: project.id, runtimeProvider: "codex", cursor: nil, limit: limit)
+    }
+
+    private func assertArchived(_ f: Fixture, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(f.store.isSessionArchived(f.session.id), file: file, line: line)
+        XCTAssertTrue(f.preferences.load(profileID: f.appStore.notificationRoutingProfileID).archivedSessionIDs.contains(f.session.id), file: file, line: line)
+        XCTAssertFalse(f.store.sessionLibrarySessions.contains { $0.id == f.session.id }, file: file, line: line)
+    }
+}
+
+private final class ArchiveReconciliationClient: SessionStoreAPIClient {
+    let project: AgentProject
+    var page: SessionsPage
+    var globalPage = SessionsPage(sessions: [])
+    var pageHandler: (() async throws -> SessionsPage)?
+    var globalHandler: (() async throws -> SessionsPage)?
+    var archiveHandler: (() async throws -> Void)?
+    var workspaceConsistencies: [SessionListConsistency] = []
+
+    init(project: AgentProject, page: SessionsPage) {
+        self.project = project
+        self.page = page
+    }
+
+    func projects() async throws -> [AgentProject] { [project] }
+    func sessions(projectID: String?, cursor: String?, limit: Int?) async throws -> [AgentSession] { page.sessions }
+    func sessionsPage(workspace: AgentWorkspace, cursor: String?, limit: Int?, consistency: SessionListConsistency) async throws -> SessionsPage {
+        workspaceConsistencies.append(consistency)
+        if let pageHandler { return try await pageHandler() }
+        return page
+    }
+    func controlledGlobalSessionsPage(runtimeProvider: String, cursor: String?, limit: Int?) async throws -> SessionsPage {
+        guard runtimeProvider == "codex" else { return SessionsPage(sessions: []) }
+        if let globalHandler { return try await globalHandler() }
+        return globalPage
+    }
+    func setSessionArchived(id: String, archived: Bool) async throws { try await archiveHandler?() }
+    func session(id: String, afterSeq: EventSequence?) async throws -> SessionResponse { throw MockError.unimplemented }
+    func createSession(_ payload: CreateSessionRequest) async throws -> CreateSessionResponse { throw MockError.unimplemented }
+    func stopSession(id: String) async throws { throw MockError.unimplemented }
+    func messages(sessionID: String, before: String?, limit: Int?) async throws -> [CodexHistoryMessage] { [] }
+}
+
+private actor ArchiveReconciliationGate<Value> {
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func response() async throws -> Value {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            waiters.forEach { $0.resume() }
+            waiters.removeAll()
+        }
+    }
+
+    func waitUntilRequested() async {
+        guard continuation == nil else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func resolve(_ value: Value) {
+        continuation?.resume(returning: value)
+        continuation = nil
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionLoadingTests.swift
@@ -418,7 +418,10 @@ extension ConversationDataFlowTests {
         )
         XCTAssertFalse(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
 
-        try await store.refreshWorkspaceSessions(projectID: project.id)
+        try await store.refreshWorkspaceSessions(
+            projectID: project.id,
+            restartFromFirst: false
+        )
 
         XCTAssertEqual(client.requestedSessionCursors.count, SessionStore.maximumSessionPresentationFillPageCount)
         XCTAssertTrue(store.needsAuthoritativeWorkspaceSessionFirstPage(projectID: project.id))
@@ -463,7 +466,10 @@ extension ConversationDataFlowTests {
             nextCursor: "fresh-authoritative-cursor",
             hasMore: true
         )
-        try await store.refreshWorkspaceSessions(projectID: project.id)
+        try await store.refreshWorkspaceSessions(
+            projectID: project.id,
+            restartFromFirst: false
+        )
 
         XCTAssertEqual(client.requestedSessionCursors.last, "budget-12", "权威重试必须续跑已保存游标")
         XCTAssertEqual(store.sessionPageCursorByProjectID[project.id], "fresh-authoritative-cursor")
@@ -1044,7 +1050,12 @@ extension ConversationDataFlowTests {
 
         store.forgetWorkspace(project)
         store.mergeSessionLibraryPages(
-            [(workspace: workspace, page: SessionsPage(sessions: [lateSession]), requestedCursor: nil)],
+            [(
+                workspace: workspace,
+                page: SessionsPage(sessions: [lateSession]),
+                requestedCursor: nil,
+                requestLineage: nil
+            )],
             generation: store.appStore.connectionGeneration,
             consistency: .authoritative
         )
@@ -1116,7 +1127,8 @@ extension ConversationDataFlowTests {
                     nextCursor: "stale-library-cursor",
                     hasMore: true
                 ),
-                requestedCursor: nil
+                requestedCursor: nil,
+                requestLineage: nil
             )],
             generation: store.appStore.connectionGeneration,
             consistency: .fastIndexed
@@ -1180,7 +1192,8 @@ extension ConversationDataFlowTests {
                     nextCursor: "partial-stale-library-cursor",
                     hasMore: true
                 ),
-                requestedCursor: nil
+                requestedCursor: nil,
+                requestLineage: nil
             )],
             generation: store.appStore.connectionGeneration,
             consistency: .fastIndexed
@@ -1246,7 +1259,8 @@ extension ConversationDataFlowTests {
             [(
                 workspace: workspace,
                 page: SessionsPage(sessions: [newAuthoritative]),
-                requestedCursor: nil
+                requestedCursor: nil,
+                requestLineage: nil
             )],
             generation: store.appStore.connectionGeneration,
             consistency: .authoritative
@@ -1597,7 +1611,10 @@ extension ConversationDataFlowTests {
         )
 
         let authoritative = Task { @MainActor in
-            try await store.refreshWorkspaceSessions(projectID: project.id)
+            try await store.refreshWorkspaceSessions(
+                projectID: project.id,
+                restartFromFirst: false
+            )
         }
         await client.waitForBlockedSessionListRefresh()
         let fastIndexed = Task { @MainActor in

--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspaceSessionPresentationTests.swift
@@ -212,4 +212,362 @@ extension ConversationDataFlowTests {
         XCTAssertEqual(client.requestedSessionLimits, [20])
         XCTAssertEqual(client.requestedSessionCursors, [nil])
     }
+
+    func testManualWorkspaceRefreshRestartsFromFirstCursor() async throws {
+        let project = makeProject(id: "workspace_manual_restart")
+        let staleChild = makeSubagentSession(
+            id: "stale_child",
+            projectID: project.id,
+            parentThreadID: "stale_parent"
+        )
+        let refreshed = makeSession(
+            id: "refreshed_root",
+            projectID: project.id,
+            title: "刷新后的首屏",
+            status: "history",
+            source: "codex"
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [refreshed])
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        let workspace = try XCTUnwrap(store.ensureWorkspaceForKnownProjectID(project.id))
+        store.recordWorkspaceSessionFirstPageCompletion(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: [staleChild],
+                nextCursor: "stale-continuation",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+
+        try await store.refreshWorkspaceSessions(projectID: project.id)
+
+        XCTAssertEqual(client.requestedSessionCursors, [nil])
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), [refreshed.id])
+    }
+
+    func testManualSessionLibraryRefreshRestartsDirectoryPageFromFirstCursor() async throws {
+        let project = makeProject(id: "library_manual_restart")
+        let workspace = AgentWorkspace(project: project)
+        let refreshed = makeSession(
+            id: "library_refreshed_root",
+            projectID: project.id,
+            title: "会话库刷新后的首屏",
+            status: "history",
+            source: "codex"
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [refreshed])
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        store.recentWorkspaces = [workspace]
+        store.recordWorkspaceSessionFirstPageCompletion(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: [makeSubagentSession(
+                    id: "library_stale_child",
+                    projectID: project.id,
+                    parentThreadID: "library_stale_parent"
+                )],
+                nextCursor: "library-stale-continuation",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+
+        await store.refreshSessionLibraryIndex(authoritative: true)
+
+        XCTAssertEqual(client.requestedSessionCursors, [nil])
+        XCTAssertTrue(store.sessionLibrarySessions.contains { $0.id == refreshed.id })
+    }
+
+    func testWorkspacePageDropsLocallyArchivedCacheWhileKeepingProtectedRows() {
+        let project = makeProject(id: "workspace_archive_cache")
+        let archived = makeSession(
+            id: "archived_cached",
+            projectID: project.id,
+            title: "普通归档会话",
+            status: "history",
+            source: "codex"
+        )
+        let selected = makeSession(
+            id: "selected_archived_cached",
+            projectID: project.id,
+            title: "当前选中会话",
+            status: "history",
+            source: "codex"
+        )
+        let running = makeSession(
+            id: "running_archived_cached",
+            projectID: project.id,
+            title: "仍在运行的会话",
+            status: "running",
+            source: "codex"
+        )
+        let allSessions = [archived, selected, running]
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { MockSessionStoreClient(projects: [project], sessions: allSessions) }
+        )
+        store.projects = [project]
+        store.recentWorkspaces = [AgentWorkspace(project: project)]
+        store.sessions = allSessions
+        store.selectedSessionID = selected.id
+        allSessions.forEach(store.toggleSessionArchived)
+        var pageState = WorkspaceRuntimeSessionPageState()
+        pageState.replace(
+            with: SessionsPage(sessions: allSessions),
+            canonicalSessionIDsBeforeLoad: Set(allSessions.map(\.id))
+        )
+
+        let canonical = store.directoryScopedSessions(
+            workspaceID: project.id,
+            runtimeProvider: "codex"
+        )
+        let visible = pageState.reconciledSessions(with: canonical)
+
+        XCTAssertEqual(Set(visible.map(\.id)), Set([selected.id, running.id]))
+
+        // 回滚或取消归档恢复 canonical 可见性后，原页应立即恢复该行，无需再请求列表。
+        store.toggleSessionArchived(archived)
+        let restored = pageState.reconciledSessions(with: store.directoryScopedSessions(
+            workspaceID: project.id,
+            runtimeProvider: "codex"
+        ))
+        XCTAssertEqual(Set(restored.map(\.id)), Set(allSessions.map(\.id)))
+    }
+
+    func testManualRestartStopsContinuationAfterCurrentNetworkPage() async throws {
+        let project = makeProject(id: "workspace_stop_old_continuation")
+        let roots = (0..<SessionStore.initialSessionPageLimit).map { index in
+            makeSession(
+                id: "fresh_root_\(index)",
+                projectID: project.id,
+                title: "新首屏 \(index)",
+                status: "history",
+                source: "codex"
+            )
+        }
+        let gate = WorkspaceSessionPageGate()
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: roots)
+        )
+        client.sessionPageHandler = { cursor in
+            if cursor == "old-continuation" {
+                return try await gate.response()
+            }
+            return SessionsPage(sessions: roots)
+        }
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        let workspace = try XCTUnwrap(store.ensureWorkspaceForKnownProjectID(project.id))
+        store.recordWorkspaceSessionFirstPageCompletion(
+            workspace: workspace,
+            page: SessionsPage(
+                sessions: [makeSubagentSession(
+                    id: "old_child",
+                    projectID: project.id,
+                    parentThreadID: "old_parent"
+                )],
+                nextCursor: "old-continuation",
+                hasMore: true
+            ),
+            consistency: .authoritative
+        )
+
+        let continuation = Task { @MainActor in
+            try await store.refreshWorkspaceSessions(
+                projectID: project.id,
+                restartFromFirst: false
+            )
+        }
+        await gate.waitUntilRequested()
+        let traversal = try XCTUnwrap(store.sessionListFirstPageInFlightByKey.values.first?.traversalControl)
+        let manual = Task { @MainActor in
+            try await store.refreshWorkspaceSessions(projectID: project.id)
+        }
+        // 等手动刷新接管旧链后再放回当前页，避免测试结果依赖两个 actor 的调度先后。
+        for _ in 0..<200 where traversal.shouldContinue {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertFalse(traversal.shouldContinue)
+        await gate.resolve(SessionsPage(
+            sessions: [makeSubagentSession(
+                id: "old_child_returned",
+                projectID: project.id,
+                parentThreadID: "old_parent"
+            )],
+            nextCursor: "must-not-be-requested",
+            hasMore: true
+        ))
+
+        _ = try? await continuation.value
+        try await manual.value
+
+        XCTAssertEqual(client.requestedSessionCursors, ["old-continuation", nil])
+        XCTAssertEqual(Set(store.sessions(forProjectID: project.id).map(\.id)), Set(roots.map(\.id)))
+    }
+
+    func testConcurrentManualRestartsShareFirstPageAndLineage() async throws {
+        let project = makeProject(id: "workspace_concurrent_manual_restart")
+        let refreshed = makeSession(
+            id: "shared_manual_result",
+            projectID: project.id,
+            title: "共享刷新结果",
+            status: "history",
+            source: "codex"
+        )
+        let gate = WorkspaceSessionPageGate()
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [refreshed])
+        )
+        client.sessionPageHandler = { _ in try await gate.response() }
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+
+        let first = Task { @MainActor in
+            try await store.refreshWorkspaceSessions(projectID: project.id)
+        }
+        await gate.waitUntilRequested()
+        let second = Task { @MainActor in
+            try await store.refreshWorkspaceSessions(projectID: project.id)
+        }
+        for _ in 0..<200 where (store.sessionFirstPageWaiterCountByProjectID[project.id] ?? 0) < 2 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(store.sessionFirstPageWaiterCountByProjectID[project.id], 2)
+        XCTAssertEqual(client.requestedSessionCursors, [nil])
+        await gate.resolve(SessionsPage(sessions: [refreshed]))
+        try await first.value
+        try await second.value
+
+        XCTAssertEqual(client.requestedSessionCursors, [nil])
+        XCTAssertEqual(store.sessions(forProjectID: project.id).map(\.id), [refreshed.id])
+    }
+
+    func testRestartedFirstPageRejectsOldLineageEvenWhenCursorMatches() async throws {
+        let project = makeProject(id: "workspace_restart_lineage")
+        let fresh = makeSession(
+            id: "lineage_root",
+            projectID: project.id,
+            title: "新结果",
+            status: "history",
+            source: "codex"
+        )
+        let stale = makeSession(
+            id: fresh.id,
+            projectID: project.id,
+            title: "旧结果",
+            status: "history",
+            source: "codex"
+        )
+        let client = MutableSessionPageClient(
+            projects: [project],
+            page: SessionsPage(sessions: [fresh])
+        )
+        let store = SessionStore(
+            appStore: makeIsolatedAppStore(),
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            clientFactory: { client }
+        )
+        store.projects = [project]
+        let workspace = try XCTUnwrap(store.ensureWorkspaceForKnownProjectID(project.id))
+        let oldLineage = store.currentSessionListRequestLineage(
+            workspace: workspace,
+            hostScope: store.appStore.activeHostScope
+        )
+        let freshResult = try await store.sessionListFirstPage(
+            workspace: workspace,
+            limit: SessionStore.initialSessionPageLimit,
+            reuseRecent: false,
+            consistency: .authoritative,
+            source: .workspaceForeground,
+            restartFromFirst: true
+        )
+        XCTAssertTrue(store.applyWorkspaceSessionFirstPage(
+            workspace: workspace,
+            page: freshResult.page,
+            consistency: .authoritative,
+            requestedCursor: freshResult.requestedCursor,
+            restartsFromFirst: true,
+            requestLineage: freshResult.requestLineage
+        ))
+
+        for consistency in [SessionListConsistency.authoritative, .fastIndexed] {
+            XCTAssertFalse(store.applyWorkspaceSessionFirstPage(
+                workspace: workspace,
+                page: SessionsPage(sessions: [stale]),
+                consistency: consistency,
+                requestedCursor: nil,
+                requestLineage: oldLineage
+            ))
+            store.mergeSessionLibraryPages(
+                [(workspace, SessionsPage(sessions: [stale]), nil, oldLineage)],
+                generation: store.appStore.connectionGeneration,
+                consistency: consistency
+            )
+            XCTAssertEqual(store.sessionsByID[fresh.id]?.title, fresh.title)
+        }
+    }
+}
+
+private actor WorkspaceSessionPageGate {
+    private var resolvedPage: SessionsPage?
+    private var continuation: CheckedContinuation<SessionsPage, Error>?
+    private var requestWaiters: [CheckedContinuation<Void, Never>] = []
+    private var didRequest = false
+
+    func response() async throws -> SessionsPage {
+        // 多发请求时让测试通过请求计数失败，不能因为没有第二次 resolve 而挂住整个测试包。
+        if let resolvedPage { return resolvedPage }
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            didRequest = true
+            let waiters = requestWaiters
+            requestWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    func waitUntilRequested() async {
+        if didRequest { return }
+        await withCheckedContinuation { requestWaiters.append($0) }
+    }
+
+    func resolve(_ page: SessionsPage) {
+        resolvedPage = page
+        continuation?.resume(returning: page)
+        continuation = nil
+    }
 }

--- a/scripts/test-conversation-regressions.sh
+++ b/scripts/test-conversation-regressions.sh
@@ -83,6 +83,12 @@ bash "$ROOT_DIR/scripts/ios-dev.sh" test \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testSessionStoreConsumesDirectAppServerEventsWithoutMobileProtocolConversion \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAuthoritativeFirstPageReadsFreshIndexIncludingExternalUnarchive \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAuthoritativeEmptyIndexFallsBackToHistoryScan \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testExternalArchiveDoesNotPermanentlyDisableDirectoryIndex \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexContinuationUsesIndexWithoutRepairingFirstPageRows \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexGlobalDiscoveryUsesIndexAcrossPages \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexGlobalDiscoveryFallsBackWhenIndexUnsupported \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testScanFallbackContinuationKeepsItsQueryModeForDirectoryAndGlobalLists \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testGlobalIndexRepairsKnownMissingSessionsAcrossFilteredAndCompletePages \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAppServerSessionRuntimeReconnectsAfterTransportReceiveFailure \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testDirectRuntimeKeepsStaleReplayedServerRequestSilentOnIdleThread \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testTurnInterruptAcknowledgementPollsUntilAuthoritativeTerminalTurn \
@@ -108,6 +114,12 @@ bash "$ROOT_DIR/scripts/ios-dev.sh" test \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testColdStartResolvedCandidateCannotCommitAfterUserSelectsAnotherSession \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testLateGitStatusFromPreviousHostCannotOverwriteCurrentHostState \
   -only-testing:MimiRemoteTests/SessionArchiveReconciliationTests \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testManualWorkspaceRefreshRestartsFromFirstCursor \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testManualSessionLibraryRefreshRestartsDirectoryPageFromFirstCursor \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testWorkspacePageDropsLocallyArchivedCacheWhileKeepingProtectedRows \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testManualRestartStopsContinuationAfterCurrentNetworkPage \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testConcurrentManualRestartsShareFirstPageAndLineage \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testRestartedFirstPageRejectsOldLineageEvenWhenCursorMatches \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testArchiveFailureRollsBackPinnedStateOrderingAndPreservesProjections \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testUnarchiveFailureRollsBackToArchivedVisibility \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testArchivePendingSuppressesDuplicateButAllowsDifferentSessionsConcurrently \

--- a/scripts/test-conversation-regressions.sh
+++ b/scripts/test-conversation-regressions.sh
@@ -105,6 +105,7 @@ bash "$ROOT_DIR/scripts/ios-dev.sh" test \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testWorkbenchRestorationRouteRejectsSnapshotFromDifferentEndpoint \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testColdStartResolvedCandidateCannotCommitAfterUserSelectsAnotherSession \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testLateGitStatusFromPreviousHostCannotOverwriteCurrentHostState \
+  -only-testing:MimiRemoteTests/SessionArchiveReconciliationTests \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testArchiveFailureRollsBackPinnedStateOrderingAndPreservesProjections \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testUnarchiveFailureRollsBackToArchivedVisibility \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testArchivePendingSuppressesDuplicateButAllowsDifferentSessionsConcurrently \

--- a/scripts/test-conversation-regressions.sh
+++ b/scripts/test-conversation-regressions.sh
@@ -81,6 +81,8 @@ bash "$ROOT_DIR/scripts/ios-dev.sh" test \
   -only-testing:MimiRemoteTests/CodexAppServerProtocolTests \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAppServerFakeSmokeCoversThreadTurnAndApproval \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testSessionStoreConsumesDirectAppServerEventsWithoutMobileProtocolConversion \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAuthoritativeFirstPageReadsFreshIndexIncludingExternalUnarchive \
+  -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAuthoritativeEmptyIndexFallsBackToHistoryScan \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAppServerSessionRuntimeReconnectsAfterTransportReceiveFailure \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testDirectRuntimeKeepsStaleReplayedServerRequestSilentOnIdleThread \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testTurnInterruptAcknowledgementPollsUntilAuthoritativeTerminalTurn \


### PR DESCRIPTION
手动刷新现在重新读取最新首屏，修复未完成分页导致外部取消归档会话继续缺失的问题。旧分页链只排空当前网络页；刷新后的列表和目录成员不会再被旧响应覆盖。工作区页面也会立即过滤本地已归档的普通历史会话，并在回滚或取消归档后恢复显示。当前选中或仍在运行的会话保留原有可见性保护。

Codex 目录首屏与索引补页读取服务端最新索引。普通扫描确认缺失后，只记录对应会话，不再永久降级整个目录；真正的索引漏行仍可扫描修复。受控全局发现同样尝试索引，但缺少已知会话时保守扫描确认，避免把索引漏行当作会话已移除。扫描产生的游标沿原模式继续，新的首屏可以重新尝试索引。Claude 主动历史刷新行为保持原样。

验证：
- 固定 iPad Pro 13-inch (M5) Simulator：36 个不同的定向 XCTest 用例最终通过，覆盖查询模式、扫描回退、归档校正、失败回滚、手动刷新、并发请求与旧响应隔离。
- 最后一次修改后执行 verify-change 的 plan 与 quick；8 项检查通过，包含源码行数门禁、关键回归映射、Go httpapi package 测试和 iOS App 编译。
- 新增行为用例已加入 PR 回归脚本。
- 本轮未运行完整回归，未覆盖安装真机或发布 TestFlight；不沿用此前真机耗时样本作为本轮性能验收。索引为空、不支持索引，或全局首屏无法确认全部已知会话时，扫描仍可能较慢。

Refs #363
