### PR TITLE
修复订阅刷新、过期交易处理与恢复购买反馈

### DIFF
--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -39971,8 +39971,22 @@
     "ui.managed_subscription_expired": {
       "comment": "Error shown when the server says the subscription expired.",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "This subscription has expired." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此订阅已过期。" } }
+        "en": { "stringUnit": { "state": "translated", "value": "This subscription has expired. Select a plan to subscribe again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此订阅已过期，请重新选择方案订阅。" } }
+      }
+    },
+    "ui.managed_subscription_restored": {
+      "comment": "Confirmation after a manual restore receives an active server entitlement.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Your subscription has been restored." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "订阅已恢复。" } }
+      }
+    },
+    "ui.managed_subscription_restore_empty": {
+      "comment": "A manual restore completed without finding an active subscription.",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No active subscription was found. If your subscription has expired, select a plan to subscribe again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未找到有效订阅。若订阅已过期，请重新选择方案订阅。" } }
       }
     },
     "ui.managed_subscription_inactive": {

--- a/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
+++ b/ios/MimiRemote/Sources/Core/StoreKit/ManagedConnectionStoreKitClient.swift
@@ -112,14 +112,7 @@ actor LiveManagedConnectionStoreKitClient: ManagedConnectionStoreKitClient {
 
         switch try await product.purchase() {
         case .success(let verification):
-            guard case .verified(let transaction) = verification,
-                  transaction.revocationDate == nil,
-                  transaction.expirationDate.map({ $0 > Date() }) ?? true
-            else {
-                return .unverified
-            }
-            unfinishedTransactions[transaction.id] = transaction
-            return .success(Self.evidence(from: verification, transaction: transaction))
+            return purchaseOutcome(from: verification)
         case .pending:
             return .pending
         case .userCancelled:
@@ -127,6 +120,16 @@ actor LiveManagedConnectionStoreKitClient: ManagedConnectionStoreKitClient {
         @unknown default:
             return .unverified
         }
+    }
+
+    func purchaseOutcome(from verification: VerificationResult<Transaction>) -> ManagedConnectionPurchaseOutcome {
+        guard case .verified(let transaction) = verification else {
+            return .unverified
+        }
+        // StoreKit 可能重放已过期的旧交易；过期不等于签名无效。
+        // 与交易监听保持一致，交给服务端判断权益，再结束已确认的交易。
+        unfinishedTransactions[transaction.id] = transaction
+        return .success(Self.evidence(from: verification, transaction: transaction))
     }
 
     func currentEntitlement(productID: String) async -> ManagedConnectionCurrentEntitlementOutcome {

--- a/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/ManagedConnectionSubscriptionView.swift
@@ -20,6 +20,7 @@ struct ManagedConnectionSubscriptionView: View {
     @EnvironmentObject private var themeStore: ThemeStore
     @State private var pendingRemoval: ManagedConnectionDevice?
     @State private var localError: String?
+    @State private var restoreResult: ManagedConnectionEntitlementStore.RestoreResult?
     @State private var isConnectingMac = false
     @State private var isChangingRoute = false
     @State private var managedRouteError: String?
@@ -55,6 +56,22 @@ struct ManagedConnectionSubscriptionView: View {
             await deviceStore.refreshDevices()
         }
         .onAppear(perform: configureManagedScanner)
+        .alert(
+            L10n.text("ui.restore_purchases"),
+            isPresented: Binding(
+                get: { restoreResult != nil },
+                set: { if !$0 { restoreResult = nil } }
+            ),
+            presenting: restoreResult
+        ) { _ in
+            Button(L10n.text("ui.got_it"), role: .cancel) {}
+        } message: { result in
+            Text(L10n.text(
+                result == .restored
+                    ? "ui.managed_subscription_restored"
+                    : "ui.managed_subscription_restore_empty"
+            ))
+        }
         // 托管页请求扫码时它自己是栈顶页面，Cover 必须挂在这里才会真正呈现。
         .fullScreenCover(
             item: qrScannerPresentation.presentationBinding(for: .managedConnection),
@@ -580,7 +597,7 @@ struct ManagedConnectionSubscriptionView: View {
     private var subscriptionInformationSection: some View {
         Section {
             Button(L10n.text("ui.restore_purchases")) {
-                Task { await entitlementStore.restorePurchases() }
+                Task { restoreResult = await entitlementStore.restorePurchases() }
             }
             .frame(minHeight: 44)
             .disabled(entitlementStore.isBusy)

--- a/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
@@ -21,7 +21,9 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
     }
 
     @Published private(set) var products: [ManagedConnectionProduct] = []
-    @Published private(set) var status: Status = .loading
+    @Published private(set) var status: Status = .loading {
+        didSet { stateRevision &+= 1 }
+    }
     @Published private(set) var currentGrant: ManagedConnectionEntitlementGrant?
     private(set) var currentEvidence: ManagedConnectionTransactionEvidence?
 
@@ -31,6 +33,10 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
     private let sleepUntil: @Sendable (Date) async throws -> Void
     private var operationGeneration = 0
     private var productGeneration = 0
+    // 操作开始序号不能识别同一操作稍后提交的结果；页面回滚还须检查状态版本。
+    private var stateRevision = 0
+    private var authoritativeGeneration: Int?
+    private var needsEntitlementRefresh = false
     // 购买等待期间仍须处理撤销事件，因此用计数覆盖这两个操作的重叠区间。
     @Published private var activeTransactionOperations = 0
 
@@ -56,15 +62,19 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         let previousGrant = usableCurrentGrant
         let previousStatus = status
         if activeTransactionOperations == 0 { status = .loading }
+        let revision = stateRevision
         do {
             try await reloadProducts()
-            guard isLatest(generation), activeTransactionOperations == 0 else { return }
+            guard isLatest(generation), stateRevision == revision,
+                  activeTransactionOperations == 0 else { return }
             await refreshEntitlement()
         } catch is CancellationError {
-            guard isLatest(generation), activeTransactionOperations == 0 else { return }
+            guard isLatest(generation), stateRevision == revision,
+                  activeTransactionOperations == 0 else { return }
             restoreAfterCancellation(previousGrant, previousStatus: previousStatus)
         } catch {
-            guard isLatest(generation), activeTransactionOperations == 0 else { return }
+            guard isLatest(generation), stateRevision == revision,
+                  activeTransactionOperations == 0 else { return }
             restore(previousGrant, otherwise: .failed(userFacingMessage(for: error)))
         }
     }
@@ -87,6 +97,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         let generation = productGeneration
         do {
             let loadedProducts = try await storeKit.products()
+            try Task.checkCancellation()
             guard generation == productGeneration else { return }
             products = loadedProducts
         } catch {
@@ -97,7 +108,10 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
 
     func refreshEntitlement() async {
         // 系统支付/恢复弹窗也会触发前台刷新；普通读取不能抢占交易处理。
-        guard activeTransactionOperations == 0 else { return }
+        guard activeTransactionOperations == 0 else {
+            needsEntitlementRefresh = true
+            return
+        }
         let generation = beginOperation()
         await refreshEntitlement(generation: generation)
     }
@@ -105,12 +119,25 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
     func observeTransactionUpdates() async {
         // Ask to Buy、另一设备购买等交易会在 App 运行期间异步完成。
         // 收到变化后仍走统一的服务端校验路径，监听器本身不直接授予权益。
+        // 单个商品任务合并重复通知，慢商品请求不会挡住撤销事件；监听结束时一起取消。
+        let refreshes = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let productRefresh = Task {
+            for await _ in refreshes.stream {
+                guard !Task.isCancelled else { return }
+                await refreshProducts()
+            }
+        }
+        defer {
+            refreshes.continuation.finish()
+            productRefresh.cancel()
+        }
         for await update in storeKit.transactionUpdates() {
             guard !Task.isCancelled else { return }
             switch update {
             case .verified(let evidence):
                 await resolveTransactionUpdate(evidence)
-                await refreshProducts()
+                await refreshDeferredEntitlement()
+                refreshes.continuation.yield(())
             case .unverified:
                 // 未验证事件本身不能改变权益；重新读取 Apple 当前已验证权益。
                 await refreshEntitlement()
@@ -159,6 +186,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
             guard isLatest(generation) else { return }
             currentGrant = grant
             currentEvidence = evidence
+            authoritativeGeneration = generation
             status = .entitled(grant.entitlement)
             await storeKit.finish(transactionID: evidence.transactionID)
         } catch is CancellationError {
@@ -187,6 +215,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
             case .unverified:
                 currentGrant = nil
                 currentEvidence = nil
+                authoritativeGeneration = generation
                 status = .failed(L10n.text("ui.managed_subscription_unverified"))
                 return
             case .verified(let evidence):
@@ -195,6 +224,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                     guard isLatest(generation) else { return }
                     currentGrant = grant
                     currentEvidence = evidence
+                    authoritativeGeneration = generation
                     status = .entitled(grant.entitlement)
                     await storeKit.finish(transactionID: evidence.transactionID)
                     return
@@ -212,6 +242,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
 
         currentGrant = nil
         currentEvidence = nil
+        authoritativeGeneration = generation
         status = .available
     }
 
@@ -219,6 +250,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         guard activeTransactionOperations == 0,
               ManagedConnectionProductID.all.contains(productID) else { return }
         await performPurchase(productID: productID)
+        await refreshDeferredEntitlement()
         await refreshProducts()
     }
 
@@ -248,6 +280,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                     guard isLatest(generation) else { return }
                     currentGrant = grant
                     currentEvidence = evidence
+                    authoritativeGeneration = generation
                     status = .entitled(grant.entitlement)
                     // 服务端是权益事实来源。只有它接受两份 JWS 后，才结束 StoreKit 交易。
                     await storeKit.finish(transactionID: evidence.transactionID)
@@ -271,6 +304,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
     func restorePurchases() async {
         guard activeTransactionOperations == 0 else { return }
         await performRestore()
+        await refreshDeferredEntitlement()
         await refreshProducts()
     }
 
@@ -293,6 +327,14 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
             guard isLatest(generation) else { return }
             restore(previousGrant, otherwise: .failed(userFacingMessage(for: error)))
         }
+    }
+
+    private func refreshDeferredEntitlement() async {
+        guard activeTransactionOperations == 0, needsEntitlementRefresh else { return }
+        needsEntitlementRefresh = false
+        // 当前操作已提交授权或拒绝时，不用旧的前台通知再次读取并覆盖它。
+        guard authoritativeGeneration != operationGeneration, !Task.isCancelled else { return }
+        await refreshEntitlement()
     }
 
     var isBusy: Bool {
@@ -410,6 +452,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         case .available, .expired, .revoked:
             currentGrant = nil
             currentEvidence = nil
+            authoritativeGeneration = operationGeneration
             status = failureStatus
         case .failed:
             if let apiError = error as? ManagedConnectionEntitlementAPIError,
@@ -418,6 +461,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
             {
                 currentGrant = nil
                 currentEvidence = nil
+                authoritativeGeneration = operationGeneration
                 status = failureStatus
             } else {
                 restore(fallbackGrant, otherwise: failureStatus)

--- a/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
@@ -331,10 +331,15 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
 
     private func refreshDeferredEntitlement() async {
         guard activeTransactionOperations == 0, needsEntitlementRefresh else { return }
-        needsEntitlementRefresh = false
-        // 当前操作已提交授权或拒绝时，不用旧的前台通知再次读取并覆盖它。
-        guard authoritativeGeneration != operationGeneration, !Task.isCancelled else { return }
-        await refreshEntitlement()
+        // 刷新由另一调用者请求，不能继承已取消的购买或恢复任务的取消状态。
+        await Task { @MainActor in
+            // 排队期间可能有新交易开始或提交结果，必须在实际消费前重新判断。
+            guard activeTransactionOperations == 0, needsEntitlementRefresh else { return }
+            needsEntitlementRefresh = false
+            // 当前操作已提交授权或拒绝时，不用旧的前台通知再次读取并覆盖它。
+            guard authoritativeGeneration != operationGeneration else { return }
+            await refreshEntitlement()
+        }.value
     }
 
     var isBusy: Bool {

--- a/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
+++ b/ios/MimiRemote/Sources/State/ManagedConnectionEntitlementStore.swift
@@ -9,6 +9,11 @@ struct ManagedConnectionPurchaseEvidence: Equatable, Sendable {
 
 @MainActor
 final class ManagedConnectionEntitlementStore: ObservableObject {
+    enum RestoreResult: Equatable {
+        case restored
+        case noActiveSubscription
+    }
+
     enum Status: Equatable {
         case loading
         case available
@@ -282,7 +287,7 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                     currentEvidence = evidence
                     authoritativeGeneration = generation
                     status = .entitled(grant.entitlement)
-                    // 服务端是权益事实来源。只有它接受两份 JWS 后，才结束 StoreKit 交易。
+                    // 服务端确认授权后结束交易；明确的失效决定在错误分支处理。
                     await storeKit.finish(transactionID: evidence.transactionID)
                 } catch is CancellationError {
                     guard isLatest(generation) else { return }
@@ -290,6 +295,10 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
                 } catch {
                     guard isLatest(generation) else { return }
                     applyFailure(error, fallbackGrant: previousGrant)
+                    if isTerminalServerDecision(error) {
+                        // 旧交易已被服务端确认失效，必须结束，否则后续购买仍可能重放它。
+                        await storeKit.finish(transactionID: evidence.transactionID)
+                    }
                 }
             }
         } catch is CancellationError {
@@ -301,14 +310,20 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         }
     }
 
-    func restorePurchases() async {
-        guard activeTransactionOperations == 0 else { return }
-        await performRestore()
+    @discardableResult
+    func restorePurchases() async -> RestoreResult? {
+        guard activeTransactionOperations == 0 else { return nil }
+        let result = await performRestore()
+        let generation = operationGeneration
+        let revision = stateRevision
         await refreshDeferredEntitlement()
         await refreshProducts()
+        // 等待商品期间的新交易决定优先，不能再弹出旧的恢复结果。
+        guard isLatest(generation), stateRevision == revision, !Task.isCancelled else { return nil }
+        return result
     }
 
-    private func performRestore() async {
+    private func performRestore() async -> RestoreResult? {
         activeTransactionOperations += 1
         defer { activeTransactionOperations -= 1 }
         let generation = beginOperation()
@@ -318,15 +333,27 @@ final class ManagedConnectionEntitlementStore: ObservableObject {
         do {
             // AppStore.sync 会弹出系统鉴权，只能由用户明确点击“恢复购买”触发。
             try await storeKit.syncPurchases()
-            guard isLatest(generation) else { return }
+            guard isLatest(generation) else { return nil }
             await refreshEntitlement(generation: generation)
+            // 校验取消或失败时不能把保留的旧状态误当成本次恢复成功。
+            guard isLatest(generation), authoritativeGeneration == generation,
+                  !Task.isCancelled else { return nil }
+            switch status {
+            case .entitled:
+                return .restored
+            case .available, .expired, .revoked:
+                return .noActiveSubscription
+            default:
+                return nil
+            }
         } catch is CancellationError {
-            guard isLatest(generation) else { return }
+            guard isLatest(generation) else { return nil }
             restoreAfterCancellation(previousGrant, previousStatus: previousStatus)
         } catch {
-            guard isLatest(generation) else { return }
+            guard isLatest(generation) else { return nil }
             restore(previousGrant, otherwise: .failed(userFacingMessage(for: error)))
         }
+        return nil
     }
 
     private func refreshDeferredEntitlement() async {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
@@ -4,6 +4,140 @@ import XCTest
 
 @MainActor
 final class ManagedConnectionEntitlementStoreTests: XCTestCase {
+    func testDeferredMaintenanceRefreshRenewsAfterPaymentExpiresAndIsCancelled() async {
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let initial = Self.grant(now: base)
+        let renewed = ManagedConnectionEntitlementGrant(
+            entitlement: initial.entitlement, token: "renewed-token",
+            tokenExpiresAt: base.addingTimeInterval(1_800)
+        )
+        var currentTime = base
+        let kit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(initial))
+        let sleeper = SleepUntilFake()
+        await kit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: kit, entitlementAPI: api, now: { currentTime },
+            sleepUntil: { try await sleeper.sleep(until: $0) }
+        )
+        await store.refreshEntitlement()
+        await api.setResult(.success(renewed))
+        await kit.pausePurchase()
+        let purchase = Task { await store.purchase(productID: ManagedConnectionProductID.annual) }
+        await waitUntil { await kit.isPurchasePaused }
+        let maintenance = Task { await store.maintainCurrentGrant() }
+        await waitUntil { await sleeper.hasWaiter }
+        currentTime = initial.tokenExpiresAt.addingTimeInterval(-60)
+        await sleeper.resume()
+        await waitUntil { await sleeper.scheduledDate == initial.tokenExpiresAt }
+        currentTime = initial.tokenExpiresAt.addingTimeInterval(1)
+        await sleeper.resume()
+        await maintenance.value
+        // 支付弹窗关闭的前台通知也可能先于购买回调；重复通知应合并。
+        await store.refreshEntitlement()
+        await kit.resumePurchase()
+        await purchase.value
+
+        let resolveCount = await api.resolveCount
+        let syncCount = await kit.syncCount
+        XCTAssertEqual(store.currentGrant, renewed)
+        XCTAssertEqual(store.status, .entitled(renewed.entitlement))
+        XCTAssertEqual(resolveCount, 2)
+        XCTAssertEqual(syncCount, 0)
+    }
+
+    func testDeferredRefreshRunsAfterCancelledRestore() async {
+        let kit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        await kit.pauseSync()
+        await kit.setSyncError(CancellationError())
+        let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+        let restore = Task { await store.restorePurchases() }
+        await waitUntil { await kit.isSyncPaused }
+        await store.refreshEntitlement()
+        await kit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        await kit.resumeSync()
+        await restore.value
+
+        let resolveCount = await api.resolveCount
+        XCTAssertEqual(store.currentGrant, Self.grant)
+        XCTAssertEqual(resolveCount, 1)
+    }
+
+    func testProductLoadFailureCannotUndoConcurrentServerDecision() async {
+        for error in [TestError.serverUnavailable as Error, CancellationError()] {
+            let kit = StoreKitFake()
+            let api = EntitlementAPIFake(result: .success(Self.grant))
+            await kit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+            let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+            await store.refreshEntitlement()
+            await api.pauseNextResolve()
+            await api.setResult(.failure(ManagedConnectionEntitlementAPIError.rejected(code: "revoked")))
+            let refresh = Task { await store.refreshEntitlement() }
+            await waitUntil { await api.isResolvePaused }
+            await kit.pauseNextProductLoad()
+            let load = Task { await store.load() }
+            await waitUntil { await kit.isProductLoadPaused }
+            await api.resumeResolve()
+            await refresh.value
+            XCTAssertEqual(store.status, .revoked)
+            await kit.setProductsError(error)
+            await kit.resumeProductLoad()
+            await load.value
+
+            XCTAssertEqual(store.status, .revoked)
+            XCTAssertNil(store.currentGrant)
+            XCTAssertNil(store.currentEvidence)
+        }
+    }
+
+    func testSlowProductRefreshDoesNotBlockRevocationAndCoalescesUpdates() async {
+        let kit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+        await store.load()
+        await kit.pauseNextProductLoad()
+        let observer = Task { await store.observeTransactionUpdates() }
+        await kit.sendTransactionUpdate(.verified(Self.evidence))
+        await waitUntil { await kit.isProductLoadPaused }
+        await api.setResult(.failure(ManagedConnectionEntitlementAPIError.rejected(code: "revoked")))
+        await kit.sendTransactionUpdate(.verified(Self.evidence))
+        await kit.sendTransactionUpdate(.verified(Self.evidence))
+        await waitUntil { await kit.finishedTransactionIDs.count == 3 }
+
+        XCTAssertEqual(store.status, .revoked)
+        XCTAssertNil(store.currentGrant)
+        let pausedCount = await kit.productsCount
+        XCTAssertEqual(pausedCount, 2)
+        await kit.setProducts([Self.updatedProduct])
+        await kit.resumeProductLoad()
+        await waitUntil { store.products == [Self.updatedProduct] }
+        observer.cancel()
+        await observer.value
+        let productsCount = await kit.productsCount
+        XCTAssertEqual(productsCount, 3)
+    }
+
+    func testStoppingTransactionObserverDiscardsPausedProductResult() async {
+        let kit = StoreKitFake()
+        let store = ManagedConnectionEntitlementStore(
+            storeKit: kit, entitlementAPI: EntitlementAPIFake(result: .success(Self.grant))
+        )
+        await kit.setProducts([Self.oldProduct])
+        await store.load()
+        await kit.setProducts([Self.updatedProduct])
+        await kit.pauseNextProductLoad()
+        let observer = Task { await store.observeTransactionUpdates() }
+        await kit.sendTransactionUpdate(.verified(Self.evidence))
+        await waitUntil { await kit.isProductLoadPaused }
+        observer.cancel()
+        await observer.value
+        await kit.resumeProductLoad()
+        // 刷新任务已取消，即使底层请求稍后返回，也不得提交商品结果。
+        for _ in 0..<100 { await Task.yield() }
+        XCTAssertEqual(store.products, [Self.oldProduct])
+    }
+
     func testForegroundRefreshAndPageLoadCannotDiscardPurchaseSuccess() async {
         let storeKit = StoreKitFake()
         await storeKit.setPurchase(.success(Self.evidence))
@@ -802,6 +936,7 @@ private actor StoreKitFake: ManagedConnectionStoreKitClient {
     private var syncError: Error?
     private var productsError: Error?
     private var purchaseError: Error?
+    private(set) var productsCount = 0
     private var productValues: [ManagedConnectionProduct] = []
     private var shouldPausePurchase = false
     private var purchaseContinuation: CheckedContinuation<Void, Never>?
@@ -850,12 +985,13 @@ private actor StoreKitFake: ManagedConnectionStoreKitClient {
     }
 
     func products() async throws -> [ManagedConnectionProduct] {
-        if let productsError { throw productsError }
+        productsCount += 1
         let result = productValues
         if shouldPauseProductLoad {
             shouldPauseProductLoad = false
             await withCheckedContinuation { productContinuation = $0 }
         }
+        if let productsError { throw productsError }
         return result
     }
 
@@ -930,6 +1066,11 @@ private actor SleepUntilFake {
 private actor EntitlementAPIFake: ManagedConnectionEntitlementAPIClient {
     private var result: Result<ManagedConnectionEntitlementGrant, Error>
     private(set) var resolveCount = 0
+    private var shouldPauseResolve = false
+    private var resolveContinuation: CheckedContinuation<Void, Never>?
+    var isResolvePaused: Bool { resolveContinuation != nil }
+    func pauseNextResolve() { shouldPauseResolve = true }
+    func resumeResolve() { resolveContinuation?.resume(); resolveContinuation = nil }
 
     init(result: Result<ManagedConnectionEntitlementGrant, Error>) {
         self.result = result
@@ -944,6 +1085,10 @@ private actor EntitlementAPIFake: ManagedConnectionEntitlementAPIClient {
         signedTransaction: String
     ) async throws -> ManagedConnectionEntitlementGrant {
         resolveCount += 1
+        if shouldPauseResolve {
+            shouldPauseResolve = false
+            await withCheckedContinuation { resolveContinuation = $0 }
+        }
         return try result.get()
     }
 }

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
@@ -4,6 +4,87 @@ import XCTest
 
 @MainActor
 final class ManagedConnectionEntitlementStoreTests: XCTestCase {
+    func testPurchaseFinishesOnlyTerminalServerDecisions() async {
+        for code in ["expired", "revoked", "no_current_entitlement", "unverified_transaction"] {
+            let kit = StoreKitFake()
+            let api = EntitlementAPIFake(result: .failure(
+                ManagedConnectionEntitlementAPIError.rejected(code: code)
+            ))
+            await kit.setPurchase(.success(Self.evidence))
+            let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+
+            await store.purchase(productID: ManagedConnectionProductID.monthly)
+
+            let finished = await kit.finishedTransactionIDs
+            let resolves = await api.resolveCount
+            XCTAssertEqual(resolves, 1)
+            XCTAssertEqual(finished, code == "unverified_transaction" ? [] : [Self.evidence.transactionID], code)
+            XCTAssertNil(store.currentGrant)
+            XCTAssertFalse(store.isBusy)
+        }
+    }
+
+    func testRestoreReportsNoActiveSubscriptionOnlyAfterCompletedVerification() async {
+        for rejection in [nil, "expired", "revoked", "no_current_entitlement"] as [String?] {
+            let kit = StoreKitFake()
+            let api = EntitlementAPIFake(result: .success(Self.grant))
+            if let rejection {
+                await kit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+                await api.setResult(.failure(ManagedConnectionEntitlementAPIError.rejected(code: rejection)))
+            }
+            let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+
+            let result = await store.restorePurchases()
+
+            XCTAssertEqual(result, .noActiveSubscription)
+            XCTAssertNil(store.currentGrant)
+            XCTAssertFalse(store.isBusy)
+            let syncs = await kit.syncCount
+            XCTAssertEqual(syncs, 1)
+        }
+    }
+
+    func testCancelledOrFailedRestoreDoesNotReportSuccessOrEmptyPurchases() async {
+        for phase in ["sync", "resolve"] {
+            for error in [CancellationError(), TestError.serverUnavailable] as [Error] {
+                let kit = StoreKitFake()
+                let api = EntitlementAPIFake(result: .success(Self.grant))
+                await kit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+                let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+                await store.refreshEntitlement()
+                if phase == "sync" {
+                    await kit.setSyncError(error)
+                } else {
+                    await api.setResult(.failure(error))
+                }
+
+                let result = await store.restorePurchases()
+
+                XCTAssertNil(result, phase)
+                XCTAssertEqual(store.currentGrant, Self.grant)
+                XCTAssertFalse(store.isBusy)
+            }
+        }
+    }
+
+    func testRestoreDoesNotReportOldEmptyResultAfterNewEntitlementArrives() async {
+        let kit = StoreKitFake()
+        let api = EntitlementAPIFake(result: .success(Self.grant))
+        let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+        await store.load()
+        await kit.pauseNextProductLoad()
+        let restore = Task { await store.restorePurchases() }
+        await waitUntil { await kit.isProductLoadPaused }
+        await kit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+        await store.refreshEntitlement()
+        await kit.resumeProductLoad()
+
+        let result = await restore.value
+
+        XCTAssertNil(result)
+        XCTAssertEqual(store.currentGrant, Self.grant)
+    }
+
     func testDeferredMaintenanceRefreshRenewsAfterPaymentExpiresAndIsCancelled() async {
         let base = Date(timeIntervalSince1970: 1_800_000_000)
         let initial = Self.grant(now: base)
@@ -468,10 +549,11 @@ final class ManagedConnectionEntitlementStoreTests: XCTestCase {
         let syncCountBeforeRestore = await storeKit.syncCount
         XCTAssertEqual(syncCountBeforeRestore, 0)
 
-        await store.restorePurchases()
+        let restoreResult = await store.restorePurchases()
         let syncCountAfterRestore = await storeKit.syncCount
         XCTAssertEqual(syncCountAfterRestore, 1)
         XCTAssertEqual(store.status, .entitled(Self.grant.entitlement))
+        XCTAssertEqual(restoreResult, .restored)
     }
 
     func testCurrentEntitlementFinishesOnlyAfterServerGrant() async {
@@ -806,7 +888,7 @@ final class ManagedConnectionEntitlementStoreTests: XCTestCase {
         let finishedTransactionIDs = await storeKit.finishedTransactionIDs
         XCTAssertEqual(store.status, .revoked)
         XCTAssertNil(store.currentGrant)
-        XCTAssertEqual(finishedTransactionIDs, [])
+        XCTAssertEqual(finishedTransactionIDs, [Self.evidence.transactionID])
     }
 
     func testOnlyFreeTrialOfferIsPresentedAsTrial() {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionEntitlementStoreTests.swift
@@ -64,6 +64,44 @@ final class ManagedConnectionEntitlementStoreTests: XCTestCase {
         XCTAssertEqual(resolveCount, 1)
     }
 
+    func testDeferredRefreshSurvivesCancellationOfPurchaseOrRestoreTask() async {
+        for operation in ["purchase", "restore"] {
+            let kit = StoreKitFake()
+            let api = EntitlementAPIFake(result: .success(Self.grant))
+            let store = ManagedConnectionEntitlementStore(storeKit: kit, entitlementAPI: api)
+            await kit.pausePurchase()
+            await kit.setPurchaseError(CancellationError())
+            await kit.pauseSync()
+            await kit.setSyncError(CancellationError())
+            let transaction = Task {
+                if operation == "purchase" {
+                    await store.purchase(productID: ManagedConnectionProductID.monthly)
+                } else {
+                    await store.restorePurchases()
+                }
+            }
+            await waitUntil {
+                if operation == "purchase" { return await kit.isPurchasePaused }
+                return await kit.isSyncPaused
+            }
+            // 另一调用者已请求刷新并返回；取消交易任务不能顺带取消该请求。
+            await store.refreshEntitlement()
+            await kit.setCurrent(.verified(Self.evidence), productID: ManagedConnectionProductID.monthly)
+            transaction.cancel()
+            if operation == "purchase" {
+                await kit.resumePurchase()
+            } else {
+                await kit.resumeSync()
+            }
+            await transaction.value
+
+            let resolveCount = await api.resolveCount
+            XCTAssertEqual(store.currentGrant, Self.grant, operation)
+            XCTAssertEqual(resolveCount, 1, operation)
+            XCTAssertFalse(store.isBusy, operation)
+        }
+    }
+
     func testProductLoadFailureCannotUndoConcurrentServerDecision() async {
         for error in [TestError.serverUnavailable as Error, CancellationError()] {
             let kit = StoreKitFake()
@@ -1084,6 +1122,7 @@ private actor EntitlementAPIFake: ManagedConnectionEntitlementAPIClient {
         signedAppTransaction: String,
         signedTransaction: String
     ) async throws -> ManagedConnectionEntitlementGrant {
+        try Task.checkCancellation()
         resolveCount += 1
         if shouldPauseResolve {
             shouldPauseResolve = false

--- a/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionStoreKitClientTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/ManagedConnectionStoreKitClientTests.swift
@@ -5,6 +5,49 @@ import XCTest
 
 @MainActor
 final class ManagedConnectionStoreKitClientTests: XCTestCase {
+    func testReplayedExpiredPurchaseRemainsVerifiedAndCanBeFinished() async throws {
+        let (session, client) = try await makeSessionAndClient()
+        session.timeRate = .oneRenewalEveryTwoSeconds
+        let transaction = try await session.buyProduct(identifier: ManagedConnectionProductID.monthly)
+        try session.disableAutoRenewForTransaction(identifier: UInt(transaction.id))
+        let expiresAt = try XCTUnwrap(transaction.expirationDate)
+        guard expiresAt.timeIntervalSinceNow < 10 else {
+            return XCTFail("StoreKit 未使用测试设置的加速续期时间")
+        }
+        // 保留同一笔已签名交易直到实际到期，不依赖 currentEntitlements 的缓存失效时机。
+        try await Task.sleep(for: .seconds(max(0, expiresAt.timeIntervalSinceNow) + 0.1))
+        var storedVerification: VerificationResult<Transaction>?
+        for await result in Transaction.all {
+            if case .verified(let value) = result, value.id == transaction.id {
+                storedVerification = result
+                break
+            }
+        }
+        let verification = try XCTUnwrap(storedVerification)
+        XCTAssertLessThanOrEqual(expiresAt, Date())
+
+        // 使用 StoreKit 产生的真实过期交易，复现真机 purchase 重放的返回值。
+        let outcome = await client.purchaseOutcome(from: verification)
+        guard case .success(let evidence) = outcome else {
+            return XCTFail("过期交易必须交给服务端确认，不能误报签名失败")
+        }
+        XCTAssertEqual(evidence.transactionID, transaction.id)
+        XCTAssertEqual(evidence.signedTransaction, verification.jwsRepresentation)
+        await client.finish(transactionID: evidence.transactionID)
+        let finishDeadline = Date().addingTimeInterval(10)
+        while Date() < finishDeadline {
+            var isUnfinished = false
+            for await unfinished in Transaction.unfinished {
+                if case .verified(let value) = unfinished, value.id == transaction.id {
+                    isUnfinished = true
+                }
+            }
+            if !isUnfinished { return }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        XCTFail("确认失效后 StoreKit 仍保留未完成的旧交易")
+    }
+
     func testProductsUseCompactChineseBillingUnits() async throws {
         let (session, client) = try await makeSessionAndClient()
         session.locale = Locale(identifier: "zh_CN")


### PR DESCRIPTION
修复订阅状态刷新与重新购买时的错误反馈。

- 商品加载失败不再恢复已撤销授权；支付期间跳过的权益刷新会合并补做，服务端新决定保持优先；商品刷新不会阻塞交易撤销。
- Apple 重放已过期的已验证交易时，交给服务端判断权益，不再显示“Apple 无法验证此交易”。服务端明确确认失效后结束旧交易；网络失败和验证失败仍保留交易。
- 恢复购买完成后显示“已恢复”或“未找到有效订阅”；取消、请求失败或新交易已改变状态时不显示旧结果。

验证：
- 41 项 ManagedConnectionEntitlementStoreTests 分批通过，包含原有 37 项与 4 项新增回归。
- ManagedConnectionStoreKitClientTests/testReplayedExpiredPurchaseRemainsVerifiedAndCanBeFinished 通过，使用 Transaction.all 返回的真实已验证过期交易，验证证据与交易结束。
- 本机 Xcode 27 beta 6，固定 M5 iPad Simulator。精确 XCTest 使用 scripts/ios-dev.sh test 执行。
- verify-change quick 的差异检查、源码行数检查通过；首次 App 编译被其他任务设备租约阻止，释放后仅重跑 ios-dev.sh build，编译通过。
- 修正版已通过真机构建、安装并启动。iPad mini 手工确认恢复购买显示无有效订阅。用户授权清除沙盒购买历史并重新登录后，月付重新出现 Apple 确认弹窗；用户完成 Touch ID 确认，Apple 显示 Sandbox 购买成功，Mimi 显示“订阅生效中”。真实 Sandbox 购买与权益生效通过。

运行态说明：此前 Apple Sandbox 反复返回同一批已过期交易。只读检查未发现明显商品配置缺项；经用户授权清除沙盒测试账号购买历史并重新登录后，新购买成功。未修改 App Store Connect 商品配置。不能据此把全部旧交易异常归因于 App 或 Apple 系统。有效订阅的恢复购买、完整回归与稳定 Xcode 的 PR Gate 尚未在本次验收，未发布。

Refs #373

