### PR TITLE
Mac App 检查更新并保护升级后的服务启动

### DIFF
--- a/macos/MimiRemoteMac/MimiRemoteMac.xcodeproj/project.pbxproj
+++ b/macos/MimiRemoteMac/MimiRemoteMac.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		11399EBAD3569F1EA7DC3A55 /* MenuBarWindowPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFC2080963A6433B43217 /* MenuBarWindowPlacementTests.swift */; };
 		1A8CB50439D0E08A8514EA5B /* BrandColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252E87DED48E48439FF3A75F /* BrandColors.swift */; };
 		24DB015A7182EFD4401ABED1 /* SystemPrivacySettingsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3D35758B7D2B2638A2334 /* SystemPrivacySettingsClient.swift */; };
+		28EBD25B9A113B0FD13FE90E /* AppUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C59B0505460DB90B25BDCDE /* AppUpdateTests.swift */; };
 		2D3D7AD1F48F6D665E50089E /* AgentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B97C2451CBB1E2B78D009C /* AgentModelsTests.swift */; };
 		2D88E2B17C680EC02E71EAB5 /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F22A0DD397F37B0B0E8849 /* HostStoreTests.swift */; };
 		2F6C3092D9D2A6993F9C62B0 /* ExperimentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97938E4BFF530423DDA33CDC /* ExperimentsView.swift */; };
@@ -32,9 +33,11 @@
 		AD199C3299AE46CEBBFBD8F4 /* MenuRuntimePresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */; };
 		B0007C75D28B779DE9DE6270 /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE170A943EDB5164E2CD95 /* PairingView.swift */; };
 		B4E72BE5C26B15E8255D9F2B /* HealthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF645CF76E8BD94261F54A9 /* HealthClient.swift */; };
+		D336EA8131545784B5D56A67 /* AppUpdateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A55B52C00DCCF1CB58B745 /* AppUpdateView.swift */; };
 		D888FADCD970DD7E91DBFF45 /* AgentCommandClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BFD44EAEE64300C32946C4 /* AgentCommandClient.swift */; };
 		DE712EF3822095AC7465834A /* MacSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8B42F16AE872A2164A2C14 /* MacSettingsView.swift */; };
 		E315A720A10E9DC2DEC52514 /* AgentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7976BAA1C4222A9CE0CF24 /* AgentModels.swift */; };
+		E69A1AE53A6D6F073F9718B0 /* AppUpdateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD370321E5A2003E97312162 /* AppUpdateStore.swift */; };
 		EB40EB38AC0DD1E7C9C3B21E /* MenuRuntimePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78765A951C28D21B18CCFAF /* MenuRuntimePresentation.swift */; };
 		F0B1F99A2045339CB960772E /* AgentCommandClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA410B972FDE86680731233 /* AgentCommandClientTests.swift */; };
 		F496A4E680E86AEC0F3AB5E9 /* MimiRemoteMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0665418B45A53032B38134E3 /* MimiRemoteMacApp.swift */; };
@@ -60,6 +63,7 @@
 		14513EDAFE3A09C6F7A08CC1 /* ExperimentPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPresentationTests.swift; sourceTree = "<group>"; };
 		252E87DED48E48439FF3A75F /* BrandColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandColors.swift; sourceTree = "<group>"; };
 		38BFD44EAEE64300C32946C4 /* AgentCommandClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCommandClient.swift; sourceTree = "<group>"; };
+		3C59B0505460DB90B25BDCDE /* AppUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateTests.swift; sourceTree = "<group>"; };
 		414A74A2A5A2877C1A9CB604 /* MenuBarContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContentView.swift; sourceTree = "<group>"; };
 		420B2B044A245D8F755DB795 /* HostStoreControlErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStoreControlErrors.swift; sourceTree = "<group>"; };
 		425D1AFDB58612825840CB62 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
@@ -77,11 +81,13 @@
 		97938E4BFF530423DDA33CDC /* ExperimentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentsView.swift; sourceTree = "<group>"; };
 		A14C8D785FAF772A76606A4A /* MenuRuntimePresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRuntimePresentationTests.swift; sourceTree = "<group>"; };
 		A1A62A4B02D2D4B3685ED5AD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A8A55B52C00DCCF1CB58B745 /* AppUpdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateView.swift; sourceTree = "<group>"; };
 		B78765A951C28D21B18CCFAF /* MenuRuntimePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRuntimePresentation.swift; sourceTree = "<group>"; };
 		C187C502CDCBC251CB35D863 /* MimiRemoteMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MimiRemoteMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9C3D35758B7D2B2638A2334 /* SystemPrivacySettingsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPrivacySettingsClient.swift; sourceTree = "<group>"; };
 		CC34FFFDD49F996F5FB064A2 /* AgentLogClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLogClient.swift; sourceTree = "<group>"; };
 		DC7976BAA1C4222A9CE0CF24 /* AgentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentModels.swift; sourceTree = "<group>"; };
+		DD370321E5A2003E97312162 /* AppUpdateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateStore.swift; sourceTree = "<group>"; };
 		DFA410B972FDE86680731233 /* AgentCommandClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCommandClientTests.swift; sourceTree = "<group>"; };
 		F9B97C2451CBB1E2B78D009C /* AgentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentModelsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -154,6 +160,7 @@
 				95A7A7AE02B2D68F286356EA /* Onboarding */,
 				4582ED716415B96BA7CE71B0 /* Pairing */,
 				4851EC28A741A7D1F86397E2 /* Settings */,
+				E9FAD288DC80A977A92B9FE8 /* Updates */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -163,6 +170,7 @@
 			children = (
 				DFA410B972FDE86680731233 /* AgentCommandClientTests.swift */,
 				F9B97C2451CBB1E2B78D009C /* AgentModelsTests.swift */,
+				3C59B0505460DB90B25BDCDE /* AppUpdateTests.swift */,
 				14513EDAFE3A09C6F7A08CC1 /* ExperimentPresentationTests.swift */,
 				01F22A0DD397F37B0B0E8849 /* HostStoreTests.swift */,
 				95CEFC2080963A6433B43217 /* MenuBarWindowPlacementTests.swift */,
@@ -236,6 +244,15 @@
 				A1A62A4B02D2D4B3685ED5AD /* Assets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		E9FAD288DC80A977A92B9FE8 /* Updates */ = {
+			isa = PBXGroup;
+			children = (
+				DD370321E5A2003E97312162 /* AppUpdateStore.swift */,
+				A8A55B52C00DCCF1CB58B745 /* AppUpdateView.swift */,
+			);
+			path = Updates;
 			sourceTree = "<group>";
 		};
 		F4A24875542B877ABFF93DB0 /* Products */ = {
@@ -380,6 +397,8 @@
 				D888FADCD970DD7E91DBFF45 /* AgentCommandClient.swift in Sources */,
 				7DA4ACD2AA9E502238AC5228 /* AgentLogClient.swift in Sources */,
 				E315A720A10E9DC2DEC52514 /* AgentModels.swift in Sources */,
+				E69A1AE53A6D6F073F9718B0 /* AppUpdateStore.swift in Sources */,
+				D336EA8131545784B5D56A67 /* AppUpdateView.swift in Sources */,
 				1A8CB50439D0E08A8514EA5B /* BrandColors.swift in Sources */,
 				78843D42483895178C480F25 /* DashboardView.swift in Sources */,
 				0CA331176F893C656E0CCDA1 /* DiagnosticsView.swift in Sources */,
@@ -410,6 +429,7 @@
 			files = (
 				F0B1F99A2045339CB960772E /* AgentCommandClientTests.swift in Sources */,
 				2D3D7AD1F48F6D665E50089E /* AgentModelsTests.swift in Sources */,
+				28EBD25B9A113B0FD13FE90E /* AppUpdateTests.swift in Sources */,
 				A1A08305F933F264072454B6 /* ExperimentPresentationTests.swift in Sources */,
 				2D88E2B17C680EC02E71EAB5 /* HostStoreTests.swift in Sources */,
 				11399EBAD3569F1EA7DC3A55 /* MenuBarWindowPlacementTests.swift in Sources */,

--- a/macos/MimiRemoteMac/README.md
+++ b/macos/MimiRemoteMac/README.md
@@ -4,7 +4,7 @@
 
 把原本隐藏在终端和 Homebrew service 后面的 Mac 端能力，收敛为一个轻量菜单栏 App。App 负责状态、设置、配对、诊断与系统服务生命周期；Go `agentd` 继续负责协议、安全边界和 Codex / Claude Runtime，不重复实现后端。
 
-源码开发需要 macOS 26、Xcode 27、XcodeGen 和 Go 1.25。正式 Release 通过 GitHub Actions 生成 universal DMG，对 App、内嵌 `agentd` 和磁盘镜像使用 Developer ID 签名，并完成 Apple Notarization；自动更新暂不进入首个安装包闭环。
+源码开发需要 macOS 26、Xcode 27、XcodeGen 和 Go 1.25。正式 Release 通过 GitHub Actions 生成 universal DMG，对 App、内嵌 `agentd` 和磁盘镜像使用 Developer ID 签名，并完成 Apple Notarization；App 提供新版本检查与下载入口，安装仍由用户通过 DMG 完成。
 
 ## 方案
 
@@ -114,4 +114,9 @@ bash scripts/check-macos-installer.sh \
 - 文件浏览范围默认覆盖当前用户 Home，配对 Token 是远程读取文件的安全边界；项目扫描仍只遍历用户选择的代码目录。
 - `SMAppService` 的 `.requiresApproval` 不能由 App 绕过；界面会引导用户打开“系统设置 → 通用 → 登录项与扩展”。
 - App 被移走或删除前，应先在 App 内恢复 Homebrew 或停止服务，避免系统仍保留指向旧 bundle 的注册记录。
-- 首个 DMG 不带自动更新；升级时下载新 DMG 覆盖 App，`agentd` 配置和配对数据保存在用户 Application Support 中，不随 App 覆盖。
+- 菜单栏的“检查更新…”会打开设置并查询 GitHub 最新正式 Release。设置页显示当前 App 版本、检查结果、新版 DMG 下载和更新说明。
+- App 启动时自动检查，持续运行期间每 24 小时检查一次。只认可已上传完成的 `Mimi-Remote-Mac.dmg`；检查失败不会弹窗。
+- 发现新版后显示菜单栏更新标记和菜单内提示。“稍后”会记住该版本并隐藏自动提示，仍可从设置中下载；发布更高版本后重新提示。
+- 下载后退出 Mimi Remote Mac，用 DMG 中的 App 覆盖原 App，再重新打开。退出期间移动端连接会中断；`agentd` 配置和配对数据保存在用户 Application Support 中，不随 App 覆盖。不会静默安装或强制重启。
+- 检查更新会向 GitHub 发起公开版本查询，不发送配置、配对数据或日志。无法联网时可手动重试或打开发布页面。
+- 0.3.13 等尚未包含此功能的安装包仍需手动下载升级，无法追溯增加提示入口。

--- a/macos/MimiRemoteMac/README.md
+++ b/macos/MimiRemoteMac/README.md
@@ -117,6 +117,7 @@ bash scripts/check-macos-installer.sh \
 - 菜单栏的“检查更新…”会打开设置并查询 GitHub 最新正式 Release。设置页显示当前 App 版本、检查结果、新版 DMG 下载和更新说明。
 - App 启动时自动检查，持续运行期间每 24 小时检查一次。只认可已上传完成的 `Mimi-Remote-Mac.dmg`；检查失败不会弹窗。
 - 发现新版后显示菜单栏更新标记和菜单内提示。“稍后”会记住该版本并隐藏自动提示，仍可从设置中下载；发布更高版本后重新提示。
-- 下载后退出 Mimi Remote Mac，用 DMG 中的 App 覆盖原 App，再重新打开。退出期间移动端连接会中断；`agentd` 配置和配对数据保存在用户 Application Support 中，不随 App 覆盖。不会静默安装或强制重启。
+- 下载后退出 Mimi Remote Mac，在 Finder 中把 DMG 里的 App 拖入「应用程序」并替换，再从「应用程序」打开。不要直接运行 DMG 中的副本；命令行复制不能替代 Finder 的安装验收。退出期间移动端连接会中断；`agentd` 配置和配对数据保存在用户 Application Support 中，不随 App 覆盖。不会静默安装或强制重启。
+- 从 macOS 临时隔离路径或只读磁盘映像启动时，App 只显示安装指引并退出，不登记登录项、不注销或接管已有服务。正式升级验收需检查实际进程位于安装目录，且 `agentd status --json` 中 `service_ok=true`、`version` 与 `server_version` 一致。
 - 检查更新会向 GitHub 发起公开版本查询，不发送配置、配对数据或日志。无法联网时可手动重试或打开发布页面。
 - 0.3.13 等尚未包含此功能的安装包仍需手动下载升级，无法追溯增加提示入口。

--- a/macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
+++ b/macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
@@ -15,6 +15,7 @@ enum MimiRemoteMacMain {
 
 struct MimiRemoteMacApp: App {
     @State private var store: HostStore
+    @State private var updates: AppUpdateStore
 
     init() {
 #if DEBUG
@@ -25,21 +26,31 @@ struct MimiRemoteMacApp: App {
         let store = HostStore.live()
 #endif
         _store = State(initialValue: store)
+        let updates = AppUpdateStore()
+        _updates = State(initialValue: updates)
 #if DEBUG
         guard !usesSeedUI else { return }
 #endif
         Task { @MainActor in
             await store.bootstrap()
         }
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+            Task { await updates.runAutomaticChecks() }
+        }
     }
 
     var body: some Scene {
         MenuBarExtra {
-            MenuBarContentView(store: store)
+            MenuBarContentView(store: store, updates: updates)
         } label: {
             // 菜单栏使用稳定的品牌标记，服务状态交由弹窗内的语义图标表达。
-            MimiMenuBarMark()
-                .accessibilityLabel("Mimi Remote Mac：\(store.lifecycle.title)")
+            HStack(spacing: 2) {
+                MimiMenuBarMark()
+                if updates.showsUpdateNotice {
+                    Image(systemName: "arrow.down.circle")
+                }
+            }
+            .accessibilityLabel("Mimi Remote Mac：\(store.lifecycle.title)\(updates.showsUpdateNotice ? "，有新版本可更新" : "")")
         }
         .menuBarExtraStyle(.window)
 
@@ -64,7 +75,7 @@ struct MimiRemoteMacApp: App {
         .defaultSize(width: 500, height: 680)
 
         Settings {
-            MacSettingsView(store: store)
+            MacSettingsView(store: store, updates: updates)
         }
     }
 }

--- a/macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
+++ b/macos/MimiRemoteMac/Sources/App/MimiRemoteMacApp.swift
@@ -1,12 +1,26 @@
+import AppKit
 import SwiftUI
 
 /// Mimi Remote Mac 只运行菜单栏 App；后台 Codex App Server 由 agentd 托管。
 @main
 enum MimiRemoteMacMain {
+    @MainActor
     static func main() {
         // 覆盖升级后，旧 LaunchAgent 可能仍带着该参数启动新二进制。
         // 这里只退出，绝不恢复已移除的共享 daemon，也不误开第二个菜单栏 App。
         if CommandLine.arguments.contains("--codex-daemon-supervisor") {
+            return
+        }
+        if let error = ServiceManagementClient.installationLocationError() {
+            // 必须先于 Store/bootstrap：隔离副本连登录项和已有服务的注销都不能执行。
+            let app = NSApplication.shared
+            app.setActivationPolicy(.accessory)
+            let alert = NSAlert()
+            alert.messageText = "请先安装 Mimi Remote Mac"
+            alert.informativeText = error
+            alert.addButton(withTitle: "退出")
+            app.activate(ignoringOtherApps: true)
+            alert.runModal()
             return
         }
         MimiRemoteMacApp.main()

--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -17,6 +17,7 @@ private enum MenuBarLayout {
 
 struct MenuBarContentView: View {
     let store: HostStore
+    let updates: AppUpdateStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
@@ -28,6 +29,8 @@ struct MenuBarContentView: View {
                 isRefreshing: store.isRefreshingStatus || store.isBusy,
                 refresh: refreshStatus
             )
+
+            AppUpdateNotice(updates: updates)
 
             if let status = store.status {
                 Divider()
@@ -104,6 +107,21 @@ struct MenuBarContentView: View {
                     // 菜单首层只导航，不直接切换实验开关：配置执行需要保留
                     // HostStore 的单 writer、确认和重启语义，避免误触改变服务状态。
                     presentWindow(.experiments)
+                }
+
+                Divider()
+                    .opacity(MenuBarLayout.actionDividerOpacity)
+                    .padding(.leading, MenuBarLayout.textColumnLeading)
+
+                MenuActionRow(
+                    title: updates.isChecking ? "正在检查更新…" : "检查更新…",
+                    systemImage: "arrow.down.circle",
+                    isEnabled: !updates.isChecking,
+                    isWorking: updates.isChecking
+                ) {
+                    openSettings()
+                    activateApplication()
+                    Task { await updates.check(manual: true) }
                 }
 
                 Divider()
@@ -1124,10 +1142,10 @@ private final class MenuBarWindowProbeView: NSView {
 
 #if DEBUG
     #Preview("菜单栏 · 等待迁移") {
-        MenuBarContentView(store: .preview(.migrationRequired))
+        MenuBarContentView(store: .preview(.migrationRequired), updates: AppUpdateStore())
     }
 
     #Preview("菜单栏 · 服务可用") {
-        MenuBarContentView(store: .preview(.ready))
+        MenuBarContentView(store: .preview(.ready), updates: AppUpdateStore())
     }
 #endif

--- a/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Settings/MacSettingsView.swift
@@ -2,11 +2,16 @@ import SwiftUI
 
 struct MacSettingsView: View {
     let store: HostStore
+    let updates: AppUpdateStore
     @Environment(\.openWindow) private var openWindow
     @State private var confirmsRestore = false
 
     var body: some View {
         Form {
+            Section("软件更新") {
+                AppUpdateView(updates: updates)
+            }
+
             Section("启动") {
                 Toggle("登录 Mac 时启动菜单栏和服务", isOn: Binding(
                     get: { store.launchesAtLogin },

--- a/macos/MimiRemoteMac/Sources/Features/Updates/AppUpdateStore.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Updates/AppUpdateStore.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Observation
+
+/// 正式安装包只使用 X.Y.Z；按数值比较，避免把 0.3.9 排在 0.3.13 后面。
+struct AppReleaseVersion: Comparable {
+    let components: [Int]
+
+    init?(_ value: String) {
+        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              parts.allSatisfy({ !$0.isEmpty && $0.utf8.allSatisfy { (48...57).contains($0) } })
+        else { return nil }
+        let numbers = parts.compactMap { Int($0) }
+        guard numbers.count == 3 else { return nil }
+        components = numbers
+    }
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.components.lexicographicallyPrecedes(rhs.components)
+    }
+}
+
+struct MacAppRelease: Equatable {
+    let version: String
+    let downloadURL: URL
+    let releaseURL: URL
+
+    static func decode(_ data: Data) throws -> Self {
+        let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
+        guard !release.draft, !release.prerelease,
+              release.tag_name.hasPrefix("v"),
+              AppReleaseVersion(String(release.tag_name.dropFirst())) != nil
+        else { throw AppUpdateError.invalidRelease }
+        let base = "https://github.com/gaixianggeng/mimi-remote/releases"
+        let download = "\(base)/download/\(release.tag_name)/Mimi-Remote-Mac.dmg"
+        // 同一 Release 也含 Windows/Linux 产物。只有正式 Mac DMG 上传完成才提供更新。
+        // 固定仓库及版本路径，避免把响应中的任意链接交给系统打开。
+        guard release.assets.contains(where: {
+            $0.name == "Mimi-Remote-Mac.dmg" && $0.state == "uploaded"
+                && $0.browser_download_url == download
+        }) else { throw AppUpdateError.invalidRelease }
+        return Self(
+            version: String(release.tag_name.dropFirst()),
+            downloadURL: URL(string: download)!,
+            releaseURL: URL(string: "\(base)/tag/\(release.tag_name)")!
+        )
+    }
+
+    private struct GitHubRelease: Decodable {
+        let tag_name: String
+        let draft: Bool
+        let prerelease: Bool
+        let assets: [Asset]
+
+        struct Asset: Decodable {
+            let name: String
+            let state: String
+            let browser_download_url: String
+        }
+    }
+}
+
+enum AppUpdateError: LocalizedError {
+    case invalidRelease
+    case invalidCurrentVersion
+    case requestFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRelease: "暂时无法获取可用的 Mac 正式安装包，请稍后重试。"
+        case .invalidCurrentVersion: "无法识别当前 App 版本，请前往发布页面查看。"
+        case .requestFailed: "无法连接更新服务，请检查网络后重试。"
+        }
+    }
+}
+
+struct AppUpdateClient {
+    var latestRelease: () async throws -> MacAppRelease
+
+    static func live(session: URLSession = .shared) -> Self {
+        Self {
+            let url = URL(string: "https://api.github.com/repos/gaixianggeng/mimi-remote/releases/latest")!
+            var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 20)
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+            request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+            let (data, response) = try await session.data(for: request)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+                throw AppUpdateError.requestFailed
+            }
+            return try MacAppRelease.decode(data)
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class AppUpdateStore {
+    let currentVersion: String
+    private(set) var isChecking = false
+    private(set) var availableRelease: MacAppRelease?
+    private(set) var statusMessage: String?
+    private(set) var errorMessage: String?
+    private(set) var deferredVersion: String?
+    private var lastAttempt: Date?
+    private let client: AppUpdateClient
+    private let defaults: UserDefaults
+    private static let deferredVersionKey = "appUpdate.deferredVersion"
+    static let checkInterval: TimeInterval = 24 * 60 * 60
+
+    init(
+        currentVersion: String = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "未知",
+        client: AppUpdateClient = .live(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.currentVersion = currentVersion
+        self.client = client
+        self.defaults = defaults
+        deferredVersion = defaults.string(forKey: Self.deferredVersionKey)
+    }
+
+    var showsUpdateNotice: Bool {
+        guard let availableRelease else { return false }
+        return availableRelease.version != deferredVersion
+    }
+
+    func deferUpdate() {
+        deferredVersion = availableRelease?.version
+        defaults.set(deferredVersion, forKey: Self.deferredVersionKey)
+    }
+
+    func check(manual: Bool, now: Date = Date()) async {
+        guard !isChecking else { return }
+        if !manual, let lastAttempt, now.timeIntervalSince(lastAttempt) < Self.checkInterval {
+            return
+        }
+        isChecking = true
+        lastAttempt = now
+        if manual {
+            errorMessage = nil
+            statusMessage = nil
+        }
+        defer { isChecking = false }
+        do {
+            guard let current = AppReleaseVersion(currentVersion) else {
+                throw AppUpdateError.invalidCurrentVersion
+            }
+            let release = try await client.latestRelease()
+            try Task.checkCancellation()
+            guard let latest = AppReleaseVersion(release.version) else {
+                throw AppUpdateError.invalidRelease
+            }
+            availableRelease = latest > current ? release : nil
+            errorMessage = nil
+            statusMessage = nil
+            if manual, latest == current {
+                statusMessage = "当前已是最新正式版（\(currentVersion)）。"
+            } else if manual, latest < current {
+                statusMessage = "当前版本高于最新正式版，无需更新。"
+            }
+        } catch is CancellationError {
+            // App 退出取消检查时，不生成失败提示。
+        } catch {
+            if manual, !Task.isCancelled {
+                errorMessage = (error as? AppUpdateError)?.errorDescription
+                    ?? AppUpdateError.requestFailed.errorDescription
+            }
+        }
+    }
+
+    func runAutomaticChecks() async {
+        // 任务由 App 持有，与菜单弹窗和后台服务状态无关；关闭菜单后仍会检查。
+        // 启动时检查一次，持续运行期间每 24 小时检查；“稍后”按版本跨重启保留。
+        while !Task.isCancelled {
+            await check(manual: false)
+            do {
+                // 手动检查也会刷新时间；下一轮等待剩余间隔，避免直接再跳过一整天。
+                let elapsed = lastAttempt.map { Date().timeIntervalSince($0) } ?? 0
+                try await Task.sleep(for: .seconds(max(1, Self.checkInterval - elapsed)))
+            } catch { return }
+        }
+    }
+}

--- a/macos/MimiRemoteMac/Sources/Features/Updates/AppUpdateView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Updates/AppUpdateView.swift
@@ -11,7 +11,7 @@ struct AppUpdateView: View {
                 Link("下载 Mac 更新", destination: release.downloadURL)
                 Link("查看更新说明", destination: release.releaseURL)
             }
-            Text("下载后退出 Mimi Remote Mac，用 DMG 中的 App 替换原 App，再重新打开。配置和配对数据会保留。")
+            Text("下载后退出 Mimi Remote Mac，在 Finder 中把 DMG 里的 App 拖入「应用程序」并替换，再从「应用程序」打开。配置和配对数据会保留。")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -46,7 +46,7 @@ struct AppUpdateNotice: View {
                     Spacer()
                     Button("稍后") { updates.deferUpdate() }
                 }
-                Text("下载后退出 App 并覆盖安装，配置和配对数据会保留。")
+                Text("下载后退出 App，在 Finder 中拖入「应用程序」并替换，再从「应用程序」打开。")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/macos/MimiRemoteMac/Sources/Features/Updates/AppUpdateView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/Updates/AppUpdateView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct AppUpdateView: View {
+    let updates: AppUpdateStore
+
+    var body: some View {
+        LabeledContent("当前 App 版本", value: updates.currentVersion)
+        if let release = updates.availableRelease {
+            Label("新版本 \(release.version) 已发布", systemImage: "arrow.down.circle")
+            HStack {
+                Link("下载 Mac 更新", destination: release.downloadURL)
+                Link("查看更新说明", destination: release.releaseURL)
+            }
+            Text("下载后退出 Mimi Remote Mac，用 DMG 中的 App 替换原 App，再重新打开。配置和配对数据会保留。")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        Button(updates.isChecking ? "正在检查…" : "检查更新") {
+            Task { await updates.check(manual: true) }
+        }
+        .disabled(updates.isChecking)
+        if let error = updates.errorMessage {
+            Text(error)
+                .foregroundStyle(.secondary)
+            Link("打开发布页面", destination: URL(string: "https://github.com/gaixianggeng/mimi-remote/releases/latest")!)
+        } else if let message = updates.statusMessage {
+            Text(message)
+                .foregroundStyle(.secondary)
+        }
+        Text("启动时自动检查，运行期间每 24 小时检查一次。")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+}
+
+struct AppUpdateNotice: View {
+    let updates: AppUpdateStore
+
+    var body: some View {
+        if updates.showsUpdateNotice, let release = updates.availableRelease {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("新版本 \(release.version) 已发布", systemImage: "arrow.down.circle")
+                    .font(.headline)
+                HStack {
+                    Link("下载 Mac 更新", destination: release.downloadURL)
+                    Spacer()
+                    Button("稍后") { updates.deferUpdate() }
+                }
+                Text("下载后退出 App 并覆盖安装，配置和配对数据会保留。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 10)
+            Divider()
+        }
+    }
+}

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
@@ -86,6 +86,15 @@ extension ServiceManagementClient {
 
     private static let agentPlistName = "com.gaixianggeng.mimi.mac.agentd.plist"
 
+    static func installationLocationError(bundleURL: URL = Bundle.main.bundleURL) -> String? {
+        let location = bundleURL.resolvingSymlinksInPath()
+        let isReadOnly = (try? location.resourceValues(forKeys: [.volumeIsReadOnlyKey]))?.volumeIsReadOnly == true
+        // 隔离副本或 DMG 内的 App 不能作为持久后台服务的所有者。签名有效也不代表
+        // 该位置可登记；先阻止接管，避免注销正在工作的服务后留下无效的启动约束。
+        guard location.pathComponents.contains("AppTranslocation") || isReadOnly else { return nil }
+        return "请退出此副本，在 Finder 中把 DMG 里的 Mimi Remote Mac 拖入「应用程序」并替换原 App，再从「应用程序」打开。"
+    }
+
     /// `.notFound` 只表示 ServiceManagement 没找到服务记录，不能据此判断安装包漏文件。
     /// 这里直接核对包内 plist 与 BundleProgram，只有资源真的损坏时才要求重新安装。
     static func validateAgentConfiguration(
@@ -93,6 +102,7 @@ extension ServiceManagementClient {
         fileManager: FileManager = .default,
         signingIdentityProvider: ((URL) -> CodeSigningIdentity?)? = nil
     ) -> String? {
+        if let error = installationLocationError(bundleURL: bundleURL) { return error }
         let plistURL = bundleURL
             .appending(path: "Contents/Library/LaunchAgents", directoryHint: .isDirectory)
             .appending(path: agentPlistName, directoryHint: .notDirectory)

--- a/macos/MimiRemoteMac/Tests/AppUpdateTests.swift
+++ b/macos/MimiRemoteMac/Tests/AppUpdateTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import MimiRemoteMac
+
+final class AppReleaseTests: XCTestCase {
+    func testVersionsCompareNumericallyAndRejectNonReleaseStrings() {
+        XCTAssertLessThan(AppReleaseVersion("0.3.9")!, AppReleaseVersion("0.3.13")!)
+        XCTAssertLessThan(AppReleaseVersion("0.9.99")!, AppReleaseVersion("0.10.0")!)
+        XCTAssertLessThan(AppReleaseVersion("0.99.99")!, AppReleaseVersion("1.0.0")!)
+        XCTAssertEqual(AppReleaseVersion("0.3.13"), AppReleaseVersion("0.3.13"))
+        for value in ["", "v0.3.13", "0.3", "0.3.13-beta.1", "0.3.13+dev", "-1.3.0", "1..0"] {
+            XCTAssertNil(AppReleaseVersion(value), value)
+        }
+    }
+
+    func testOnlyUploadedOfficialMacAssetIsAccepted() throws {
+        let release = try MacAppRelease.decode(releaseData())
+        XCTAssertEqual(release.version, "0.3.14")
+        XCTAssertEqual(release.downloadURL.absoluteString, Self.download)
+        for overrides: [String: Any] in [
+            ["prerelease": true], ["draft": true], ["tag_name": "v0.3.14-beta.1"],
+            ["assets": []],
+            ["assets": [["name": "Mimi-Remote-Mac.dmg", "state": "new", "browser_download_url": Self.download]]],
+            ["assets": [["name": "Mimi-Remote-Mac.dmg", "state": "uploaded", "browser_download_url": "https://example.com/app.dmg"]]],
+            ["assets": [["name": "windows.exe", "state": "uploaded", "browser_download_url": Self.download]]]
+        ] {
+            XCTAssertThrowsError(try MacAppRelease.decode(releaseData(overrides: overrides)))
+        }
+    }
+
+    func testMalformedResponseIsRejected() {
+        XCTAssertThrowsError(try MacAppRelease.decode(Data("{}".utf8)))
+    }
+
+    private static let download = "https://github.com/gaixianggeng/mimi-remote/releases/download/v0.3.14/Mimi-Remote-Mac.dmg"
+
+    private func releaseData(overrides: [String: Any] = [:]) -> Data {
+        var object: [String: Any] = [
+            "tag_name": "v0.3.14", "draft": false, "prerelease": false,
+            "assets": [["name": "Mimi-Remote-Mac.dmg", "state": "uploaded", "browser_download_url": Self.download]]
+        ]
+        object.merge(overrides) { _, new in new }
+        return try! JSONSerialization.data(withJSONObject: object)
+    }
+}
+
+@MainActor
+final class AppUpdateStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suite: String!
+
+    override func setUp() async throws {
+        suite = "AppUpdateStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suite)!
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suite)
+    }
+
+    func testManualCheckOffersNewerVersionAndDoesNotOfferDowngrade() async {
+        for (installed, hasUpdate) in [("0.3.9", true), ("0.3.14", false), ("0.4.0", false)] {
+            let store = makeStore(currentVersion: installed)
+            await store.check(manual: true)
+            XCTAssertEqual(store.availableRelease != nil, hasUpdate)
+            XCTAssertEqual(store.showsUpdateNotice, hasUpdate)
+            XCTAssertEqual(store.statusMessage == nil, hasUpdate)
+            XCTAssertNil(store.errorMessage)
+            XCTAssertFalse(store.isChecking)
+        }
+    }
+
+    func testAutomaticCheckIsThrottledButManualCheckCanRetry() async {
+        var calls = 0
+        let store = makeStore(client: AppUpdateClient {
+            calls += 1
+            throw AppUpdateError.requestFailed
+        })
+        let start = Date(timeIntervalSince1970: 100_000)
+        await store.check(manual: false, now: start)
+        await store.check(manual: false, now: start.addingTimeInterval(60))
+        XCTAssertEqual(calls, 1)
+        XCTAssertNil(store.errorMessage)
+        await store.check(manual: true, now: start.addingTimeInterval(120))
+        XCTAssertEqual(calls, 2)
+        XCTAssertNotNil(store.errorMessage)
+        await store.check(manual: false, now: start.addingTimeInterval(120 + AppUpdateStore.checkInterval))
+        XCTAssertEqual(calls, 3)
+    }
+
+    func testDeferredVersionSurvivesRestartAndNewVersionShowsAgain() async {
+        let first = makeStore()
+        await first.check(manual: false)
+        first.deferUpdate()
+        XCTAssertFalse(first.showsUpdateNotice)
+        XCTAssertNotNil(first.availableRelease)
+        let restarted = makeStore()
+        await restarted.check(manual: true)
+        XCTAssertFalse(restarted.showsUpdateNotice)
+        XCTAssertNotNil(restarted.availableRelease, "稍后不应移除手动下载入口")
+        let next = makeStore(client: AppUpdateClient { Self.release("0.3.15") })
+        await next.check(manual: false)
+        XCTAssertTrue(next.showsUpdateNotice)
+    }
+
+    func testFailurePreservesKnownUpdateAndSuccessClearsError() async {
+        var fail = false
+        let store = makeStore(client: AppUpdateClient {
+            if fail { throw AppUpdateError.requestFailed }
+            return Self.release("0.3.14")
+        })
+        await store.check(manual: true)
+        fail = true
+        await store.check(manual: true)
+        XCTAssertNotNil(store.availableRelease)
+        XCTAssertNotNil(store.errorMessage)
+        fail = false
+        await store.check(manual: true)
+        XCTAssertNil(store.errorMessage)
+    }
+
+    func testUnknownCurrentVersionDoesNotClaimUpToDate() async {
+        let store = makeStore(currentVersion: "dev")
+        await store.check(manual: true)
+        XCTAssertNil(store.statusMessage)
+        XCTAssertNil(store.availableRelease)
+        XCTAssertNotNil(store.errorMessage)
+    }
+
+    func testOverlappingChecksOnlyMakeOneRequest() async {
+        var continuation: CheckedContinuation<MacAppRelease, Error>?
+        let store = makeStore(client: AppUpdateClient {
+            try await withCheckedThrowingContinuation { continuation = $0 }
+        })
+        let task = Task { await store.check(manual: true) }
+        while continuation == nil { await Task.yield() }
+        XCTAssertTrue(store.isChecking)
+        await store.check(manual: true)
+        continuation?.resume(returning: Self.release("0.3.14"))
+        await task.value
+        XCTAssertFalse(store.isChecking)
+        XCTAssertTrue(store.showsUpdateNotice)
+    }
+
+    private func makeStore(currentVersion: String = "0.3.13", client: AppUpdateClient? = nil) -> AppUpdateStore {
+        AppUpdateStore(
+            currentVersion: currentVersion,
+            client: client ?? AppUpdateClient { Self.release("0.3.14") },
+            defaults: defaults
+        )
+    }
+
+    private static func release(_ version: String) -> MacAppRelease {
+        MacAppRelease(
+            version: version,
+            downloadURL: URL(string: "https://github.com/gaixianggeng/mimi-remote/releases/download/v\(version)/Mimi-Remote-Mac.dmg")!,
+            releaseURL: URL(string: "https://github.com/gaixianggeng/mimi-remote/releases/tag/v\(version)")!
+        )
+    }
+}
+
+final class AppUpdateClientTests: XCTestCase {
+    func testHTTPErrorWithReleaseShapedBodyIsNotAccepted() async {
+        let session = makeSession(status: 403)
+        defer { session.invalidateAndCancel() }
+        do {
+            _ = try await AppUpdateClient.live(session: session).latestRelease()
+            XCTFail("HTTP 403 不应提供更新")
+        } catch {
+            XCTAssertTrue(error is AppUpdateError)
+        }
+    }
+
+    func testPublicRequestUsesCorrectEndpointAndNoCredentials() async throws {
+        let session = makeSession(status: 200)
+        defer { session.invalidateAndCancel() }
+        let release = try await AppUpdateClient.live(session: session).latestRelease()
+        XCTAssertEqual(release.version, "0.3.14")
+    }
+
+    private func makeSession(status: Int) -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [UpdateURLProtocol.self]
+        config.httpAdditionalHeaders = ["X-Test-Status": String(status)]
+        return URLSession(configuration: config)
+    }
+}
+
+private final class UpdateURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        XCTAssertEqual(request.url?.absoluteString, "https://api.github.com/repos/gaixianggeng/mimi-remote/releases/latest")
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/vnd.github+json")
+        let status = Int(request.value(forHTTPHeaderField: "X-Test-Status") ?? "200")!
+        let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+        let body = """
+        {"tag_name":"v0.3.14","draft":false,"prerelease":false,"assets":[
+          {"name":"Mimi-Remote-Mac.dmg","state":"uploaded",
+           "browser_download_url":"https://github.com/gaixianggeng/mimi-remote/releases/download/v0.3.14/Mimi-Remote-Mac.dmg"}
+        ]}
+        """
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -1574,3 +1574,24 @@ private final class SuspendedStatusGate: @unchecked Sendable {
         condition.unlock()
     }
 }
+
+final class MacInstallationLocationTests: XCTestCase {
+    func testTranslocatedCopyIsRejectedBeforeSigningOrServiceWork() {
+        let bundle = URL(filePath: "/private/var/folders/test/T/AppTranslocation/test-id/d/Mimi Remote Mac.app")
+        let message = ServiceManagementClient.installationLocationError(bundleURL: bundle)
+        XCTAssertTrue(message?.contains("Finder") == true)
+        XCTAssertEqual(ServiceManagementClient.validateAgentConfiguration(
+            bundleURL: bundle,
+            signingIdentityProvider: { _ in
+                XCTFail("临时副本不应继续签名和服务检查")
+                return nil
+            }
+        ), message)
+    }
+
+    func testWritableDevelopmentAndApplicationsLocationsRemainAllowed() {
+        for path in ["/Applications/Mimi Remote Mac.app", "/tmp/DerivedData/Build/Products/Release/Mimi Remote Mac.app", "/tmp/AppTranslocationNotes/Mimi Remote Mac.app"] {
+            XCTAssertNil(ServiceManagementClient.installationLocationError(bundleURL: URL(filePath: path)))
+        }
+    }
+}


### PR DESCRIPTION
Mac 用户现在可以从菜单栏检查更新，并在设置中下载 GitHub 正式 Release 的 Mac DMG。启动时及持续运行每 24 小时自动检查；发现新版后显示标记，“稍后”按版本保留选择。后台检查失败不弹窗，手动检查可重试。只接受本仓库对应正式版本、上传完成的 Mac DMG。

升级排查中复现了另一条故障链：App 从 macOS 临时隔离路径运行，后台服务启动被系统签名约束拒绝，随后服务登记失效。现在 App 在创建 Store 和操作服务前检查启动位置。从临时隔离路径或只读磁盘映像启动时，仅显示 Finder 安装指引，避免注销或接管已有服务。下载区同步说明通过 Finder 拖入「应用程序」替换并从安装目录打开。

用户仍手动安装。现有配置和配对数据保存在 App 外；旧安装包必须先手动升级才能获得新功能及保护。

验证：
- `bash ./scripts/check-source-size.sh`、`bash ./scripts/verify-change.sh --plan` 和 `bash ./scripts/verify-change.sh` 通过；Mac Debug arm64 编译及 82 项测试零失败。
- 更新测试覆盖版本比较、附件筛选、HTTP 错误、自动节流、稍后跨实例保留及重复检查合并；新增临时隔离路径提前拒绝和正常安装/开发目录放行测试。
- 本地低版本启动与手动检查均发现正式 v0.3.13；实际点击下载完成，官方 DMG 校验和、签名及 Gatekeeper 公证评估通过。
- 将修复版放入只读磁盘映像并启动，进程采样确认停在入口安装提示；原后台服务保持健康，配置未变化。
- 本地签名构建 0.3.13 (833) 覆盖安装后，App 从安装目录运行；process_ok、service_ok、doctor_ok 均为 true，version 与 server_version 同为 0.3.13+mac.833，配置字节比对一致。

边界：此前用命令行复制官方包后触发了临时隔离故障，不能据此认定正常 Finder 安装也会失败。尚未完成 Finder 驱动的正式版到正式版覆盖升级验收，也未发布新 DMG。未运行 iOS/Go 全仓回归。

Refs #390
