### PR TITLE
修复新会话短回复回放并减少刷新期间的正文延迟

### DIFF
--- a/internal/httpapi/appserver_gateway_list_latency_test.go
+++ b/internal/httpapi/appserver_gateway_list_latency_test.go
@@ -1,0 +1,183 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/gaixianggeng/mimi-remote/internal/config"
+	"github.com/gaixianggeng/mimi-remote/internal/projects"
+)
+
+func TestGlobalThreadListDoesNotRepeatGitBeforeQueuedReply(t *testing.T) {
+	browseRoot := t.TempDir()
+	var listPayload []byte
+	reply := []byte(`{"method":"item/agentMessage/delta","params":{"threadId":"thread-0","itemId":"reply","delta":"OK"}}`)
+	sent := make(chan time.Time, 1)
+	upstreamURL, _, _ := fakeAppServerUpstream(t, func(conn *websocket.Conn, _ int, _ []byte) {
+		sent <- time.Now()
+		_ = conn.WriteMessage(websocket.TextMessage, listPayload)
+		_ = conn.WriteMessage(websocket.TextMessage, reply)
+	})
+	handler, projectDir := appServerGatewayRouterFixtureWithConfig(t, upstreamURL, func(cfg *config.Config) {
+		cfg.BrowseRoots = []string{browseRoot}
+		cfg.WorktreesRoot = t.TempDir()
+	})
+	runGitTestCommand(t, projectDir, "init")
+	runGitTestCommand(t, projectDir, "-c", "user.email=test@example.invalid", "-c", "user.name=Test", "commit", "--allow-empty", "-m", "initial")
+	worktreeDir := filepath.Join(browseRoot, "worktree")
+	runGitTestCommand(t, projectDir, "worktree", "add", "--detach", worktreeDir)
+	listPayload = globalListLatencyPayload(t, worktreeDir, 30)
+	gitCalls := countGlobalListGitCalls(t)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialAuthedGateway(t, server.URL)
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"id":1,"method":"thread/list","params":{"limit":50}}`)); err != nil {
+		t.Fatal(err)
+	}
+	list := readGatewayRaw(t, conn)
+	if !bytes.Contains(list, []byte(`"thread-29"`)) {
+		t.Fatalf("正文前的列表必须完整返回：%s", list)
+	}
+	if got := readGatewayRaw(t, conn); !bytes.Equal(got, reply) {
+		t.Fatalf("紧跟列表的正文必须原样转发：%s", got)
+	}
+	t.Logf("上游正文已就绪至客户端收到：%s，Git 调用：%d", time.Since(<-sent), gitCalls())
+	if got := gitCalls(); got != 2 {
+		t.Fatalf("正文不能等待逐任务重复的 Git 查询：calls=%d", got)
+	}
+}
+
+func TestGlobalThreadListDoesNotProbeGitForKnownProjects(t *testing.T) {
+	projectDir := newCommittedGitRepo(t)
+	policy := globalListLatencyPolicy(t, projectDir, t.TempDir())
+	gitCalls := countGlobalListGitCalls(t)
+	for _, count := range []int{0, 30} {
+		_, allowed, err := policy.sanitizeGlobalThreadListResponse(
+			globalListLatencyPayload(t, projectDir, count),
+			appServerGatewayPendingThreadRequest{},
+		)
+		if err != nil || len(allowed) != count {
+			t.Fatalf("已配置项目的任务列表应完整保留：count=%d allowed=%d err=%v", count, len(allowed), err)
+		}
+	}
+	if got := gitCalls(); got != 0 {
+		t.Fatalf("已知项目和空列表不应扫描 Git，避免阻塞同一连接的正文：calls=%d", got)
+	}
+}
+
+func TestGlobalThreadListDoesNotScanProjectsForNonRepository(t *testing.T) {
+	projectDir := newCommittedGitRepo(t)
+	browseRoot := t.TempDir()
+	policy := globalListLatencyPolicy(t, projectDir, browseRoot)
+	gitCalls := countGlobalListGitCalls(t)
+	_, allowed, err := policy.sanitizeGlobalThreadListResponse(
+		globalListLatencyPayload(t, browseRoot, 30), appServerGatewayPendingThreadRequest{},
+	)
+	if err != nil || len(allowed) != 0 {
+		t.Fatalf("普通目录不能通过 Git 归属获得全局发现权限：allowed=%d err=%v", len(allowed), err)
+	}
+	if got := gitCalls(); got != 1 {
+		t.Fatalf("目录不属于 Git 仓库时不应继续扫描项目：calls=%d", got)
+	}
+}
+
+func TestGlobalThreadListResolvesRepeatedWorkspaceOncePerPage(t *testing.T) {
+	projectDir := newCommittedGitRepo(t)
+	browseRoot := t.TempDir()
+	worktreeDir := filepath.Join(browseRoot, "worktree")
+	runGitTestCommand(t, projectDir, "worktree", "add", "--detach", worktreeDir)
+	policy := globalListLatencyPolicy(t, projectDir, browseRoot)
+	gitCalls := countGlobalListGitCalls(t)
+	payload := globalListLatencyPayload(t, worktreeDir, 30)
+	started := time.Now()
+	_, allowed, err := policy.sanitizeGlobalThreadListResponse(payload, appServerGatewayPendingThreadRequest{})
+	t.Logf("30 条同目录任务的列表处理耗时：%s，Git 调用：%d", time.Since(started), gitCalls())
+	if err != nil || len(allowed) != 30 {
+		t.Fatalf("同仓外部 Worktree 的任务应完整保留：allowed=%d err=%v", len(allowed), err)
+	}
+	for _, thread := range allowed {
+		if !thread.readOnly || thread.canAcceptDirectInput {
+			t.Fatalf("外部 Worktree 仍必须只读：%+v", thread)
+		}
+	}
+	if got := gitCalls(); got != 2 {
+		t.Errorf("每页只需查询主项目和外部 Worktree 各一次：calls=%d", got)
+	}
+
+	// 归属只在当前响应内复用。目录不再属于原仓库时，下一页必须重新判定。
+	marker := filepath.Join(worktreeDir, ".git")
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+	_, allowed, err = policy.sanitizeGlobalThreadListResponse(payload, appServerGatewayPendingThreadRequest{})
+	if err != nil || len(allowed) != 0 {
+		t.Fatalf("下一次响应不能沿用失效的仓库归属：allowed=%d err=%v", len(allowed), err)
+	}
+	if got := gitCalls(); got != 3 {
+		t.Errorf("未匹配目录也只在本页查询一次：total calls=%d", got)
+	}
+}
+
+func globalListLatencyPolicy(t *testing.T, projectDir, browseRoot string) *appServerGatewayPolicy {
+	t.Helper()
+	registry, err := projects.NewRegistry([]config.ProjectConfig{{ID: "project", Name: "Project", Path: projectDir}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &appServerGatewayPolicy{runtimeID: "codex", router: &Router{
+		projects: registry,
+		cfg:      config.Config{BrowseRoots: []string{browseRoot}, WorktreesRoot: t.TempDir()},
+	}}
+}
+
+func globalListLatencyPayload(t *testing.T, cwd string, count int) []byte {
+	t.Helper()
+	items := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		items = append(items, map[string]any{"id": fmt.Sprintf("thread-%d", i), "cwd": cwd, "canAcceptDirectInput": true})
+	}
+	data, err := json.Marshal(map[string]any{"id": 1, "result": map[string]any{"data": items, "nextCursor": nil}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func countGlobalListGitCalls(t *testing.T) func() int {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Git 调用计数使用 POSIX wrapper；权限行为另由跨平台全局发现测试覆盖")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "calls")
+	script := "#!/bin/sh\nprintf 'call\\n' >> \"$MIMI_LIST_GIT_LOG\"\nexec \"$MIMI_LIST_REAL_GIT\" \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MIMI_LIST_GIT_LOG", logPath)
+	t.Setenv("MIMI_LIST_REAL_GIT", realGit)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return func() int {
+		data, err := os.ReadFile(logPath)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		return strings.Count(string(data), "\n")
+	}
+}

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -555,7 +555,8 @@ func (p *appServerGatewayPolicy) sanitizeGlobalThreadListResponse(
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	projectByCommonDir := p.authorizedProjectsByGitCommonDir(ctx)
+	var projectByCommonDir map[string]projects.Project
+	projectByPath := map[string]projects.Project{}
 	safeItems := make([]map[string]any, 0, min(len(rawItems), int(limit)))
 	allowedThreads := make([]appServerGatewayAllowedThread, 0, cap(safeItems))
 	for _, rawItem := range rawItems {
@@ -582,8 +583,23 @@ func (p *appServerGatewayPolicy) sanitizeGlobalThreadListResponse(
 		if err != nil || !info.IsDir() {
 			continue
 		}
-		project, ok := projectForGlobalThread(ctx, scope, projectByCommonDir)
-		if !ok {
+		project := scope.project
+		if strings.TrimSpace(project.ID) == "" && scope.browse {
+			// 列表和正文共用接收通道。只在外部目录需要归属时扫描项目，
+			// 同一响应内的重复目录（含未匹配目录）只查询一次，避免逐条启动 Git 阻塞正文。
+			var resolved bool
+			project, resolved = projectByPath[scope.realPath]
+			if !resolved {
+				if commonDir, ok := gitCommonDirectory(ctx, scope.realPath); ok {
+					if projectByCommonDir == nil {
+						projectByCommonDir = p.authorizedProjectsByGitCommonDir(ctx)
+					}
+					project = projectByCommonDir[commonDir]
+				}
+				projectByPath[scope.realPath] = project
+			}
+		}
+		if strings.TrimSpace(project.ID) == "" {
 			continue
 		}
 
@@ -773,25 +789,6 @@ func selectAuthorizedProjectForGitCommonDir(commonDir string, candidates []proje
 		return projects.Project{}, false
 	}
 	return primary, true
-}
-
-func projectForGlobalThread(
-	ctx context.Context,
-	scope gatewayScope,
-	projectByCommonDir map[string]projects.Project,
-) (projects.Project, bool) {
-	if strings.TrimSpace(scope.project.ID) != "" {
-		return scope.project, true
-	}
-	if !scope.browse {
-		return projects.Project{}, false
-	}
-	commonDir, ok := gitCommonDirectory(ctx, scope.realPath)
-	if !ok {
-		return projects.Project{}, false
-	}
-	project, ok := projectByCommonDir[commonDir]
-	return project, ok
 }
 
 func copyGatewayRawFields(src map[string]json.RawMessage, keys ...string) map[string]any {

--- a/internal/httpapi/appserver_subagent_discovery_test.go
+++ b/internal/httpapi/appserver_subagent_discovery_test.go
@@ -70,11 +70,11 @@ func TestAuthorizedProjectsByGitCommonDirUsesUniquePrimaryProject(t *testing.T) 
 	defer cancel()
 
 	projectByCommonDir := policy.authorizedProjectsByGitCommonDir(ctx)
-	got, ok := projectForGlobalThread(ctx, gatewayScope{
-		id:       workspaceIDForRealPath(externalWorktree),
-		realPath: externalWorktree,
-		browse:   true,
-	}, projectByCommonDir)
+	commonDir, ok := gitCommonDirectory(ctx, externalWorktree)
+	if !ok {
+		t.Fatal("外部 Worktree 应能解析 Git 共享目录")
+	}
+	got, ok := projectByCommonDir[commonDir]
 	if !ok || got.ID != "root" {
 		t.Fatalf("同仓多个 Project 必须稳定映射到唯一主工作树项目，got=%+v ok=%v", got, ok)
 	}

--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D2FB93E7A0367E66B84AF7CD /* NewSessionBufferedReplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EDD5D8A884DB855281E9ED /* NewSessionBufferedReplyTests.swift */; };
 		230F001AAABBBCCC00000001 /* WorkspacePullRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230F001AAABBBCCC00000002 /* WorkspacePullRefreshTests.swift */; platformFilters = (ios, ); };
 		0209F743D168F03B03894AB0 /* FileAttachmentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55F20982430C816BB70A7F5 /* FileAttachmentModelsTests.swift */; };
 		037B9C95E0087324B0B93B82 /* CodexAppServerApprovalProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D536A7DD9FA51261421A61A /* CodexAppServerApprovalProjection.swift */; };
@@ -408,6 +409,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		29EDD5D8A884DB855281E9ED /* NewSessionBufferedReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionBufferedReplyTests.swift; sourceTree = "<group>"; };
 		230F001AAABBBCCC00000002 /* WorkspacePullRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePullRefreshTests.swift; sourceTree = "<group>"; };
 		00BF9FE4AEE49C6DD13873AA /* testComposerStatusTrayCrowdedCompactWidth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testComposerStatusTrayCrowdedCompactWidth.1.png; sourceTree = "<group>"; };
 		023D47371A66B1C8E92BB3D4 /* testSessionLibraryDensityAndAccessibilityLayouts.iphone-390-light.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSessionLibraryDensityAndAccessibilityLayouts.iphone-390-light.png"; sourceTree = "<group>"; };
@@ -987,6 +989,7 @@
 				4CAF352234E74EEAF7B023AE /* ManagedPairingContractTests.swift */,
 				24B74985F9E77EEE70BC1856 /* MarkdownRenderingTests.swift */,
 				81FDFD00533B31F16F861BFB /* MimiInteractionFeedbackTests.swift */,
+				29EDD5D8A884DB855281E9ED /* NewSessionBufferedReplyTests.swift */,
 				61B287032A29ABBC9D670E94 /* NewSessionPresentationSourceTests.swift */,
 				8EABFF317C695883ECE910D0 /* PairingLinkTests.swift */,
 				EF8E25B79CBECB1CB0EDBD5B /* ProtocolContractTests.swift */,
@@ -1862,6 +1865,7 @@
 				7FCF7AE789CFBC4E2148BCD3 /* ManagedPairingContractTests.swift in Sources */,
 				4DDCF6949E6DDCC9ABEBE709 /* MarkdownRenderingTests.swift in Sources */,
 				20D78099D1CE0CC7A660BFA1 /* MimiInteractionFeedbackTests.swift in Sources */,
+				D2FB93E7A0367E66B84AF7CD /* NewSessionBufferedReplyTests.swift in Sources */,
 				B3BE80D2693D4982B46A4924 /* NewSessionPresentationSourceTests.swift in Sources */,
 				89DCEF26CCF404A369DFDE80 /* PairingLinkTests.swift in Sources */,
 				E321385031CD0951AABBF21C /* ProtocolContractTests.swift in Sources */,

--- a/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreHistory.swift
@@ -287,7 +287,12 @@ extension SessionStore {
             if let responseSelectionLease,
                isSelectionLeaseCurrent(responseSelectionLease) {
                 let shouldReplayBufferedEvents = resume == nil || !didLoadInitialHistory
-                connectWebSocket(responseSession, replayBufferedEvents: shouldReplayBufferedEvents)
+                // 短首轮可能在 ACK 前已被上游卸载；仍须接入并回放缓存回复，不能只订阅 running。
+                connectWebSocket(
+                    responseSession,
+                    replayBufferedEvents: shouldReplayBufferedEvents,
+                    allowNonRunning: resume == nil && !payload.isEmpty
+                )
                 // 恢复反馈属于页面生命周期状态，不是服务端 transcript 内容，避免它参与历史排序。
                 setStatusMessage(resume == nil ? L10n.text("ui.session_started") : L10n.text("ui.this_historical_conversation_has_been_continued"))
                 setErrorMessage(nil)

--- a/ios/MimiRemote/Tests/MimiRemoteTests/NewSessionBufferedReplyTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/NewSessionBufferedReplyTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import MimiRemote
+
+@MainActor
+final class NewSessionBufferedReplyTests: XCTestCase {
+    func testCompletedFirstTurnBeforeAckReplaysAfterNotLoaded() async throws {
+        try await verifyFirstReply(status: "notLoaded")
+    }
+
+    func testCompletedFirstTurnBeforeAckReplaysAfterIdle() async throws {
+        try await verifyFirstReply(status: "idle")
+    }
+
+    private func verifyFirstReply(status: String) async throws {
+        let project = AgentProject(id: "proj_store_direct", name: "Store Direct", path: "/tmp/store-direct")
+        let config = makeDirectAppServerConfig(project: project)
+        let transport = FakeCodexAppServerTransport()
+        let runtime = CodexAppServerSessionRuntime(
+            endpoint: "http://127.0.0.1:8787",
+            token: "outer-token",
+            transportFactory: { transport },
+            configProvider: { config }
+        )
+        let client = CodexAppServerSessionAPIClient(runtime: runtime)
+        let suiteName = "ConversationDataFlowTests.StoreDirect.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let profile = ConnectionProfile(
+            id: "store-direct",
+            displayName: "Store Direct",
+            endpoint: "http://127.0.0.1:8787",
+            lastSuccessfulAt: nil
+        )
+        defaults.set(try JSONEncoder().encode([profile]), forKey: "agentd.connectionProfiles.v1")
+        defaults.set(profile.id, forKey: "agentd.activeConnectionProfileID.v1")
+        defaults.set(profile.endpoint, forKey: "agentd.endpoint")
+        let keychain = TestKeychainOperations()
+        keychain.setData(Data("test-token".utf8), account: "agentd-profile.\(profile.id)")
+        let appStore = AppStore(defaults: defaults, tokenStore: TokenStore(keychain: keychain))
+        let conversationStore = ConversationStore()
+        let logStore = LogStore()
+        let contextStore = SessionContextStore()
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: conversationStore,
+            logStore: logStore,
+            contextStore: contextStore,
+            clientFactory: { client },
+            webSocketFactory: { CodexAppServerSessionWebSocketClient(runtime: runtime) },
+            webSocketReconnectDelayNanoseconds: { _ in 1_000_000 }
+        )
+
+        store.selectedProjectID = project.id
+        let refreshTask = Task { await store.refreshAll(autoAttach: false) }
+        let initializeMessages = try await waitForFakeAppServerMessages(transport, count: 1)
+        let initialize = try decodeAppServerRequest(initializeMessages[0])
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: initialize.id)),"result":{"userAgent":"fake-codex","platformFamily":"macos"}}"#)
+        let listMessages = try await waitForFakeAppServerMessages(transport, count: 3)
+        let listRequest = try decodeAppServerRequest(listMessages[2])
+        XCTAssertEqual(listRequest.method, "thread/list")
+        // 主动刷新先查索引；空页还需普通扫描确认，之后才能进入新会话的 model/list 链路。
+        XCTAssertEqual(listRequest.params?.objectValue?["useStateDbOnly"]?.boolValue, true)
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: listRequest.id)),"result":{"data":[],"nextCursor":null,"backwardsCursor":null}}"#)
+        let verifiedListMessages = try await waitForFakeAppServerMessages(transport, count: 4)
+        let verifiedListRequest = try decodeAppServerRequest(verifiedListMessages[3])
+        XCTAssertEqual(verifiedListRequest.method, "thread/list")
+        XCTAssertEqual(verifiedListRequest.params?.objectValue?["useStateDbOnly"]?.boolValue, false)
+        transportResponse(transport, id: verifiedListRequest.id, result: #"{"data":[],"nextCursor":null}"#)
+        await refreshTask.value
+        XCTAssertEqual(store.selectedProjectID, project.id)
+
+        let sendTask = Task { await store.sendPrompt("帮我验收 direct Store") }
+        let threadMessages = try await waitForFakeAppServerMessages(transport, count: 5)
+        let modelList = try decodeAppServerRequest(threadMessages[4])
+        XCTAssertEqual(modelList.method, "model/list")
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: modelList.id)),"result":{"models":[{"id":"gpt-store-default","name":"Store Default","provider":"openai","isDefault":true}]}}"#)
+
+        let threadStartMessages = try await waitForFakeAppServerMessages(transport, count: 6)
+        let threadStart = try decodeAppServerRequest(threadStartMessages[5])
+        XCTAssertEqual(threadStart.method, "thread/start")
+        XCTAssertNil(threadStart.params?.objectValue?["model"]?.stringValue)
+        XCTAssertNil(threadStart.params?.objectValue?["modelProvider"])
+        transport.enqueue(#"{"id":\#(try jsonFragment(for: threadStart.id)),"result":{"thread":{"id":"thr_store_direct","sessionId":"thr_store_direct","preview":"帮我验收 direct Store","ephemeral":false,"modelProvider":"openai","createdAt":1780490100,"updatedAt":1780490101,"status":{"type":"idle"},"path":null,"cwd":"/tmp/store-direct","cliVersion":"0.0.0","source":"appServer","threadSource":"user","name":"Store 直连","turns":[]}}}"#)
+
+        let turnMessages = try await waitForFakeAppServerMessages(transport, count: 7)
+        let turnStart = try decodeAppServerRequest(turnMessages[6])
+        XCTAssertEqual(turnStart.method, "turn/start")
+        XCTAssertEqual(turnStart.params?.objectValue?["model"]?.stringValue, "gpt-store-default")
+        let collaborationMode = try XCTUnwrap(turnStart.params?.objectValue?["collaborationMode"]?.objectValue)
+        XCTAssertEqual(collaborationMode["mode"]?.stringValue, "default")
+        XCTAssertEqual(collaborationMode["settings"]?.objectValue?["model"]?.stringValue, "gpt-store-default")
+        // 首轮完整回复、终态和空闲状态均先于发送确认，复现快速任务的接入窗口。
+        transport.enqueue(#"{"method":"item/completed","params":{"threadId":"thr_store_direct","turnId":"turn_store_direct","item":{"type":"agentMessage","id":"assistant_store","text":"最终回答"}}}"#)
+        transport.enqueue(#"{"method":"turn/completed","params":{"threadId":"thr_store_direct","turnId":"turn_store_direct"}}"#)
+        transport.enqueue(#"{"method":"thread/status/changed","params":{"threadId":"thr_store_direct","status":{"type":"\#(status)"}}}"#)
+        transportResponse(transport, id: turnStart.id, result: #"{"turn":{"id":"turn_store_direct","items":[],"status":"inProgress","error":null}}"#)
+        let didSend = await sendTask.value
+        XCTAssertTrue(didSend)
+        XCTAssertEqual(store.selectedSessionID, "thr_store_direct")
+        XCTAssertEqual(store.connectedSessionID, "thr_store_direct", "已完成的首轮仍需接入缓存事件流")
+        defer { store.disconnectWebSocket() }
+        let messages = try await waitForConversationMessages(in: conversationStore, sessionID: "thr_store_direct") {
+            $0.contains { $0.role == .assistant && $0.content == "最终回答" }
+                && store.selectedForegroundActivity == nil
+        }
+        XCTAssertEqual(messages.filter { $0.role == .assistant }.count, 1)
+        XCTAssertEqual(messages.filter { $0.role == .user }.count, 1)
+        XCTAssertNil(store.selectedForegroundActivity, "迟到 ACK 不能留下等待回复状态")
+        XCTAssertNil(store.selectedSession?.activeTurnID)
+        let requests = await transport.sentMessages().compactMap { try? decodeAppServerRequest($0) }
+        XCTAssertFalse(requests.contains { ["thread/read", "thread/turns/list", "thread/resume"].contains($0.method) }, "首轮应直接回放；只读空闲线程不额外获取 writer 或补拉历史")
+    }
+}

--- a/scripts/test-conversation-regressions.sh
+++ b/scripts/test-conversation-regressions.sh
@@ -81,6 +81,7 @@ bash "$ROOT_DIR/scripts/ios-dev.sh" test \
   -only-testing:MimiRemoteTests/CodexAppServerProtocolTests \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAppServerFakeSmokeCoversThreadTurnAndApproval \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testSessionStoreConsumesDirectAppServerEventsWithoutMobileProtocolConversion \
+  -only-testing:MimiRemoteTests/NewSessionBufferedReplyTests \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAuthoritativeFirstPageReadsFreshIndexIncludingExternalUnarchive \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testCodexAuthoritativeEmptyIndexFallsBackToHistoryScan \
   -only-testing:MimiRemoteTests/ConversationDataFlowTests/testExternalArchiveDoesNotPermanentlyDisableDirectoryIndex \


### PR DESCRIPTION
短回复存在两种显示延迟：新会话首轮在发送确认前结束并进入 `notLoaded` 时，客户端跳过事件订阅；后台全局任务列表与正文共用接收通道，列表逐条执行 Git 查询会阻塞已到达的正文。

本 PR 让带首条输入的新会话接入并回放原有事件流。同时按目录复用当前列表响应内的 Git 归属结果，只在外部 Git 仓库需要匹配时扫描项目。已配置项目、空列表和非 Git 目录不再触发无关的全项目扫描。归属结果不跨响应保存，外部 Worktree 的只读规则和目录过滤保持原有行为。

验证：
- iOS 原修复：修改前复现提前完成后未订阅；修改后固定 M5 的 4 项定向 XCTest 通过。原提交的 PR Gate 已通过。本轮没有追加 iOS 产品改动。
- 新增 4 项 Go 回归：列表后紧跟正文、已知项目/空列表、非 Git 目录、重复外部 Worktree 及下一次响应归属失效；已有多项目共仓、只读与分页过滤回归通过。
- 30 条同目录任务的 Git 调用从 31 次降为 2 次。完整 WebSocket 对照中，已就绪正文等待列表处理的时间从约 674 毫秒降至最终一次约 214 毫秒。计时受本机负载影响，回归以查询次数、正文内容及权限结果为判定条件。
- 对同一份上游原始 50 条真实任务响应回放：处理时间从 2.151 秒降至 1.615 秒，均保留 42 条。除连接级随机 cursor 外，规范化响应内容的 SHA-256 完全相同。原始数据仅保存在本机。
- 最后一次代码修改后执行了 `verify-change.sh --plan` 和 quick：前 7 项通过，包括完整 `internal/httpapi` package 测试、源码体积、差异及回归映射检查。末项 App 编译因固定 M5 被其他任务占用而退出 75；本轮此前相同 iOS 源码的 App 编译已成功，但不将最后一次 quick 表述为全绿。

限制：开发中的真实 Spark 对照仍出现约 10.77 秒的首轮正文等待，主要耗时仍在 Codex 上游准备阶段。本 PR 减少中转额外阻塞，不能作为“首轮已降至 2–3 秒”的验收。临时中转已关闭；没有替换正在运行的 Mac 服务，没有重新发布 iPad 版本。完整 PR Gate 和真机/Tailcat 端到端验收另行确认。

Refs #388
