### PR TITLE
补齐工作区下拉后新会话进入列表的回归验证

### DIFF
--- a/ios/MimiRemote/Tests/MimiRemoteTests/WorkspacePullRefreshTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/WorkspacePullRefreshTests.swift
@@ -105,9 +105,13 @@ final class WorkspacePullRefreshTests: XCTestCase {
         ) {
             !refreshControl.isRefreshing
         }
-        // 只断言“下拉确实拉了会话”。会话如何合并进 Store 由 Store 侧用例负责；
-        // 把整条会话管线绑进这个 UI 用例，正是这个文件先前反复失败的来源。
         XCTAssertGreaterThan(client.sessionPageCallCount, sessionRequestCountBeforePull, "下拉应发出会话请求")
+        // 请求成功不等于刷新成功；同时检查 canonical Store 和实际列表使用的目录成员。
+        try await waitForRefreshUI("刷新响应未提交：sessions=\(store.sessionsByID.keys.sorted())") {
+            store.sessionsByID[refreshedSession.id] != nil
+                && store.directoryScopedSessions(workspaceID: project.id, runtimeProvider: "codex")
+                    .contains { $0.id == refreshedSession.id }
+        }
 
         // 目录同步是下拉的附属工作，退到指示器之后仍然要跑；Git 摘要则一次都不能发。
         try await waitForRefreshUI(


### PR DESCRIPTION
工作区下拉刷新的现有测试只检查会话请求次数，无法发现“返回了新会话，但 Store 和列表没有更新”。恢复结果断言后，一次真实 UIRefreshControl action 必须让新会话同时进入 `sessionsByID` 和列表使用的 `directoryScopedSessions`。

在已合入 PR #382 的 `main@175049db` 上，这条原复现场景已通过。因此本 PR 只补回回归保护，不重复修改业务逻辑，也不依据旧 Issue 推断当前仍有同样缺陷。

验证：
- 固定 M5 Simulator 上 `WorkspacePullRefreshTests/testPullRefreshPublishesSessionsWithoutRequestingWorkspaceGitSummaries` 通过（1/1）。覆盖新会话入列、刷新指示器结束、后台目录同步、下拉与恢复前台不增加 Git 摘要请求。
- 用例由 fake API 返回新页，并驱动生产 SwiftUI 页面及真实 UIKit refresh action；不是实际服务器或真机网络验收。
- `verify-change.sh --plan` 已执行。quick 前 4 项静态检查通过；最后的 App 编译首次因设备争用退出 75，随后只补跑该阶段并成功，全部收尾检查已补齐。
- 原 selector 已在 PR Gate 中，无需额外注册。

Refs #379
