### PR TITLE
修复首次连接未打开工作区时会话页持续加载

### DIFF
--- a/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
+++ b/ios/MimiRemote/Sources/Features/Sessions/SessionListView.swift
@@ -75,7 +75,8 @@ enum SessionListPresentationState: Equatable {
         isFiltering: Bool,
         isNetworkUnavailable: Bool,
         errorMessage: String?,
-        connectionStatus: ConnectionStatus
+        connectionStatus: ConnectionStatus,
+        hasLoadedWorkspaceCatalog: Bool = false
     ) -> Self {
         guard !hasVisibleSessions else { return .content }
 
@@ -93,7 +94,10 @@ enum SessionListPresentationState: Equatable {
             return .loading
         }
         switch connectionStatus {
-        case .idle, .testing:
+        case .idle:
+            // 未打开目录时不会触发会话连接；目录已加载即可显示空态，不能等待连接检测。
+            if !hasLoadedWorkspaceCatalog { return .loading }
+        case .testing:
             return .loading
         case .connected, .failed:
             break
@@ -593,7 +597,8 @@ struct SessionListView: View {
             isFiltering: sessionStore.isSessionSearchActive || selectedWorkspaceID != "all" || selectedStatus != .all,
             isNetworkUnavailable: sessionStore.isNetworkUnavailable,
             errorMessage: sessionStore.errorMessage,
-            connectionStatus: appStore.connectionStatus
+            connectionStatus: appStore.connectionStatus,
+            hasLoadedWorkspaceCatalog: sessionStore.loadedWorkspaceCatalogScope == appStore.activeHostScope
         )
     }
 

--- a/ios/MimiRemote/Sources/State/SessionStore.swift
+++ b/ios/MimiRemote/Sources/State/SessionStore.swift
@@ -127,6 +127,8 @@ final class SessionStore: ObservableObject {
     @Published var expandedProjectIDs: Set<String> = []
     @Published var showingAllSessionProjectIDs: Set<String> = []
     @Published var isLoading = false
+    // 加载完成只属于当前主机代次，切换主机后不能沿用旧目录的空态判断。
+    @Published var loadedWorkspaceCatalogScope: HostScope?
     @Published var webSocketStatus: WebSocketStatus = .disconnected
     @Published var connectionTermination: ConnectionTerminationStatus? {
         didSet {

--- a/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
+++ b/ios/MimiRemote/Sources/State/SessionStoreLifecycleWorkspaces.swift
@@ -567,6 +567,7 @@ extension SessionStore {
             recordCarStatusHostObservation(at: sessionListNow())
             setProjectsIfChanged(fetchedProjects)
             reloadRecentWorkspaces()
+            loadedWorkspaceCatalogScope = appStore.activeHostScope
             if let requestedProjectID,
                sidebarProjectsByID[requestedProjectID] == nil,
                let project = projectsByID[requestedProjectID] {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SessionListPresentationTests.swift
@@ -5,6 +5,78 @@ import XCTest
 @testable import MimiRemote
 
 final class SessionListPresentationTests: XCTestCase {
+    @MainActor
+    func testFirstConnectionWithoutOpenedWorkspaceFinishesLoading() async {
+        let appStore = makeIsolatedAppStore()
+        let candidate = makeProject(id: "unopened-candidate")
+        let client = MockSessionStoreClient(projects: [candidate], sessions: [])
+        let store = SessionStore(
+            appStore: appStore,
+            conversationStore: ConversationStore(),
+            logStore: LogStore(),
+            recentWorkspaceStore: makeRecentWorkspaceStore(workspaces: [], endpoint: appStore.endpoint),
+            clientFactory: { client }
+        )
+        func presentation() -> SessionListPresentationState {
+            SessionListPresentationState.resolve(
+                hasVisibleSessions: !store.sessions.isEmpty,
+                hasOpenedWorkspace: !store.sidebarProjects.isEmpty,
+                isLoading: store.isLoading,
+                isSearching: false,
+                isFiltering: false,
+                isNetworkUnavailable: store.isNetworkUnavailable,
+                errorMessage: store.errorMessage,
+                connectionStatus: appStore.connectionStatus,
+                hasLoadedWorkspaceCatalog: store.loadedWorkspaceCatalogScope == appStore.activeHostScope
+            )
+        }
+
+        XCTAssertEqual(presentation(), .loading)
+        await store.refreshAll(autoAttach: true)
+
+        XCTAssertEqual(appStore.connectionStatus, .idle)
+        XCTAssertFalse(store.isLoading)
+        XCTAssertTrue(store.sidebarProjects.isEmpty, "后端候选目录不应自动成为已打开工作区")
+        XCTAssertEqual(presentation(), .needsWorkspace)
+
+        _ = store.ensureWorkspaceForKnownProjectID(candidate.id)
+        await store.refreshAll(autoAttach: true)
+        XCTAssertFalse(store.sidebarProjects.isEmpty)
+        XCTAssertEqual(presentation(), .noSessions)
+    }
+
+    func testLoadedWorkspaceCatalogPreservesLoadingErrorsAndContent() {
+        func state(
+            loading: Bool = false,
+            connection: ConnectionStatus = .idle,
+            error: String? = nil,
+            offline: Bool = false,
+            visible: Bool = false,
+            catalogLoaded: Bool = true
+        ) -> SessionListPresentationState {
+            SessionListPresentationState.resolve(
+                hasVisibleSessions: visible,
+                hasOpenedWorkspace: false,
+                isLoading: loading,
+                isSearching: false,
+                isFiltering: false,
+                isNetworkUnavailable: offline,
+                errorMessage: error,
+                connectionStatus: connection,
+                hasLoadedWorkspaceCatalog: catalogLoaded
+            )
+        }
+
+        XCTAssertEqual(state(), .needsWorkspace)
+        XCTAssertEqual(state(catalogLoaded: false), .loading)
+        XCTAssertEqual(state(loading: true), .loading)
+        XCTAssertEqual(state(connection: .testing), .loading)
+        XCTAssertEqual(state(connection: .failed("unavailable")), .runtimeUnavailable("unavailable"))
+        XCTAssertEqual(state(error: "load failed"), .loadFailed("load failed"))
+        XCTAssertEqual(state(offline: true), .networkUnavailable)
+        XCTAssertEqual(state(visible: true), .content)
+    }
+
     func testDateBucketsPreferTodayAndYesterdayAtLocalMidnight() {
         let calendar = makeCalendar(timeZone: "Asia/Shanghai")
         let now = makeDate(calendar, year: 2025, month: 6, day: 2, hour: 0, minute: 15)


### PR DESCRIPTION
首次连接且尚未打开工作区文件夹时，目录加载已完成，但会话页仍将 idle 连接状态当成加载中，导致持续转圈。

记录当前主机代次的目录加载完成状态，让该场景显示已有的打开工作区引导。保留加载、连接检测和错误提示的优先级，切换主机后不复用旧主机的加载完成状态。

Refs #393

验证：固定 iPad Pro 13-inch (M5) Simulator 上两项定向 XCTest 通过，覆盖首次空工作区、后续打开目录及加载/错误/内容优先级。源码体积与差异检查通过。quick 的 App 编译最初因其他任务占用设备而退出，释放后单独补跑该项，App 编译通过。

尚未进行真机界面验收、完整回归或发布。
