### PR TITLE
减少重复 Go 缓存与 Tailcat 框架无关重建

### DIFF
--- a/macos/MimiRemoteMac/Scripts/embed-agentd.sh
+++ b/macos/MimiRemoteMac/Scripts/embed-agentd.sh
@@ -82,16 +82,15 @@ for architecture in "${architectures[@]}"; do
       exit 1
       ;;
   esac
-  # 每个架构使用独立 Go 编译缓存和输出，既可复用又不会把交叉编译结果混在一起。
-  go_cache_root="$cache_root/go/$architecture"
-  mkdir -p "$go_cache_root/gocache"
-  output="$go_cache_root/agentd"
+  # 只隔离最终产物；Go 编译缓存沿用调用者环境或 Go 的全局默认值。
+  go_output_root="$cache_root/go/$architecture"
+  mkdir -p "$go_output_root"
+  output="$go_output_root/agentd"
   go_started_at=$SECONDS
-  log "构建 agentd：arch=${architecture} goarch=${go_arch} cache=${go_cache_root}"
+  log "构建 agentd：arch=${architecture} goarch=${go_arch} output=${output}"
   (
     cd "$project_root"
     CGO_ENABLED=0 GOOS=darwin GOARCH="$go_arch" GOTOOLCHAIN=local \
-      GOCACHE="$go_cache_root/gocache" \
       "$go_binary" build -trimpath \
       -ldflags "-s -w -X main.version=${agent_version}" \
       -o "$output" ./cmd/agentd
@@ -126,15 +125,14 @@ for architecture in "${architectures[@]}"; do
     arm64) go_arch=arm64 ;;
     x86_64) go_arch=amd64 ;;
   esac
-  tailcat_cache_root="$cache_root/tailcat-go/$architecture"
-  mkdir -p "$tailcat_cache_root/gocache"
-  output="$tailcat_cache_root/mimi-tailcat-experiment"
+  tailcat_output_root="$cache_root/tailcat-go/$architecture"
+  mkdir -p "$tailcat_output_root"
+  output="$tailcat_output_root/mimi-tailcat-experiment"
   tailcat_started_at=$SECONDS
   log "构建 Tailcat sidecar：arch=${architecture} goarch=${go_arch} go=${tailcat_go_version}"
   (
     cd "$tailcat_module"
     CGO_ENABLED=0 GOOS=darwin GOARCH="$go_arch" GOTOOLCHAIN=auto \
-      GOCACHE="$tailcat_cache_root/gocache" \
       "$go_binary" build -trimpath \
       -ldflags "-s -w -X main.version=${agent_version}" \
       -o "$output" ./cmd/mimi-tailcat-experiment

--- a/scripts/build-tailcat-mobile.sh
+++ b/scripts/build-tailcat-mobile.sh
@@ -107,10 +107,10 @@ source_fingerprint() (
   } | shasum -a 256 | awk '{ print $1 }'
 )
 
-prepare_tools() {
-  # 不同 Worktree 共用工具目录；安装与版本复查必须在同一把锁内完成。
+build_framework() {
+  # 不同 Worktree 可能要求不同工具版本；直到 bind 完成前都不能让另一构建替换工具。
   bash "$SCRIPT_DIR/development-cache-lock.sh" "$TOOL_DIR/install.lock" -- \
-    bash -euo pipefail -s -- "$GO_BIN" "$TOOL_DIR/bin" "$GOMOBILE_VERSION" <<'TOOLS'
+    bash -euo pipefail -s -- "$GO_BIN" "$TOOL_DIR/bin" "$GOMOBILE_VERSION" "$MODULE_DIR" "$1" <<'TOOLS'
 go_bin="$1"
 tool_bin="$2"
 expected_version="$3"
@@ -127,6 +127,11 @@ for tool in gomobile gobind; do
     tool_matches "$tool" || { echo "Tailcat 工具版本不匹配：$tool" >&2; exit 1; }
   fi
 done
+cd "$4"
+"$tool_bin/gomobile" bind \
+  -target=ios,iossimulator \
+  -o "$5" \
+  ./mobile/tailcatmobile
 TOOLS
 }
 
@@ -173,16 +178,10 @@ fi
 
 mkdir -p "$TOOL_DIR/bin" "$OUTPUT_DIR"
 export PATH="$TOOL_DIR/bin:$PATH"
-# Apple 环境由 bind 自行准备；init 还会清理全局 gomobile 目录并安装 gobind@latest。
-prepare_tools
-
 TEMPORARY_DIR="$(mktemp -d "$OUTPUT_DIR/.tailcat-mobile.XXXXXX")"
 TEMPORARY_OUTPUT="$TEMPORARY_DIR/TailcatMobile.xcframework"
-cd "$MODULE_DIR"
-"$TOOL_DIR/bin/gomobile" bind \
-  -target=ios,iossimulator \
-  -o "$TEMPORARY_OUTPUT" \
-  ./mobile/tailcatmobile
+# Apple 环境由 bind 自行准备；init 还会清理全局 gomobile 目录并安装 gobind@latest。
+build_framework "$TEMPORARY_OUTPUT"
 
 framework_is_complete "$TEMPORARY_OUTPUT" \
   || fail "生成的 XCFramework 缺少必要 slice、header 或原生符号"

--- a/scripts/build-tailcat-mobile.sh
+++ b/scripts/build-tailcat-mobile.sh
@@ -53,10 +53,42 @@ framework_is_complete() {
   done
 }
 
-source_fingerprint() {
+production_inputs() {
+  local architecture
+  local template='{{if and .Module .Module.Main}}{{$dir := .Dir}}
+{{range .GoFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .CgoFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .CFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .CXXFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .MFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .HFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .FFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .SFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .SysoFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{range .EmbedFiles}}{{printf "%s/%s\n" $dir .}}{{end}}
+{{end}}'
+  (
+    cd "$MODULE_DIR"
+    # 按 gomobile 的 iOS 构建标签枚举两个架构的依赖，避免测试和无关命令触发重建。
+    # 外部 module 由 go.mod/go.sum 锁定；本地 package 同时跟踪原生文件和 embed 资源。
+    for architecture in arm64 amd64; do
+      GOOS=ios GOARCH="$architecture" CGO_ENABLED=1 "$GO_BIN" list -mod=readonly -deps -tags=ios \
+        -f "$template" \
+        ./mobile/tailcatmobile || exit "$?"
+    done
+    printf '%s\n' "$MODULE_DIR/go.mod"
+    [[ ! -f "$MODULE_DIR/go.sum" ]] || printf '%s\n' "$MODULE_DIR/go.sum"
+  ) | LC_ALL=C sort -u
+}
+
+source_fingerprint() (
+  # 命令替换默认不继承 errexit；输入枚举或哈希失败时必须停止，不能复用不完整指纹。
+  set -e
   local source_file relative_path
+  local inputs
+  inputs="$(production_inputs)"
   {
-    printf 'schema=2\n'
+    printf 'schema=3\n'
     printf 'gomobile=%s\n' "$GOMOBILE_VERSION"
     "$GO_BIN" version
     (
@@ -66,16 +98,36 @@ source_fingerprint() {
     "$XCRUN_BIN" --sdk iphoneos --show-sdk-build-version
     "$XCRUN_BIN" --sdk iphonesimulator --show-sdk-build-version
     while IFS= read -r source_file; do
+      [[ -n "$source_file" ]] || continue
       relative_path="${source_file#"$MODULE_DIR"/}"
       printf 'file=%s\n' "$relative_path"
-      shasum -a 256 "$source_file"
-    done < <(
-      find "$MODULE_DIR" -type f \
-        \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) \
-        | LC_ALL=C sort
-    )
-    shasum -a 256 "$0"
+      shasum -a 256 < "$source_file"
+    done <<< "$inputs"
+    shasum -a 256 < "$0"
   } | shasum -a 256 | awk '{ print $1 }'
+)
+
+prepare_tools() {
+  # 不同 Worktree 共用工具目录；安装与版本复查必须在同一把锁内完成。
+  bash "$SCRIPT_DIR/development-cache-lock.sh" "$TOOL_DIR/install.lock" -- \
+    bash -euo pipefail -s -- "$GO_BIN" "$TOOL_DIR/bin" "$GOMOBILE_VERSION" <<'TOOLS'
+go_bin="$1"
+tool_bin="$2"
+expected_version="$3"
+tool_matches() {
+  [[ -x "$tool_bin/$1" ]] || return 1
+  local version
+  version="$("$go_bin" version -m "$tool_bin/$1" | awk '$1 == "mod" && $2 == "golang.org/x/mobile" { print $3 }')"
+  [[ "$version" == "$expected_version" ]]
+}
+mkdir -p "$tool_bin"
+for tool in gomobile gobind; do
+  if ! tool_matches "$tool"; then
+    GOBIN="$tool_bin" "$go_bin" install "golang.org/x/mobile/cmd/$tool@$expected_version"
+    tool_matches "$tool" || { echo "Tailcat 工具版本不匹配：$tool" >&2; exit 1; }
+  fi
+done
+TOOLS
 }
 
 acquire_lock() {
@@ -98,11 +150,13 @@ acquire_lock() {
   LOCK_HELD=1
 }
 
-for command_name in "$GO_BIN" "$XCRUN_BIN" "$NM_BIN" find shasum awk grep sort; do
+for command_name in "$GO_BIN" "$XCRUN_BIN" "$NM_BIN" shasum awk grep sort; do
   require_command "$command_name"
 done
 [[ -d "$MODULE_DIR" ]] || fail "缺少 Tailcat module：$MODULE_DIR"
 [[ -f "$BRIDGE_SOURCE" ]] || fail "缺少 iOS Tailcat bridge：$BRIDGE_SOURCE"
+# go list 返回规范化目录；先统一符号链接和重复斜杠，才能稳定剥离绝对路径。
+MODULE_DIR="$(cd "$MODULE_DIR" && pwd -P)"
 
 fingerprint="$(source_fingerprint)"
 if framework_is_complete && [[ "$(cat "$FINGERPRINT_FILE" 2>/dev/null || true)" == "$fingerprint" ]]; then
@@ -119,9 +173,8 @@ fi
 
 mkdir -p "$TOOL_DIR/bin" "$OUTPUT_DIR"
 export PATH="$TOOL_DIR/bin:$PATH"
-GOBIN="$TOOL_DIR/bin" "$GO_BIN" install "golang.org/x/mobile/cmd/gomobile@$GOMOBILE_VERSION"
-GOBIN="$TOOL_DIR/bin" "$GO_BIN" install "golang.org/x/mobile/cmd/gobind@$GOMOBILE_VERSION"
-"$TOOL_DIR/bin/gomobile" init
+# Apple 环境由 bind 自行准备；init 还会清理全局 gomobile 目录并安装 gobind@latest。
+prepare_tools
 
 TEMPORARY_DIR="$(mktemp -d "$OUTPUT_DIR/.tailcat-mobile.XXXXXX")"
 TEMPORARY_OUTPUT="$TEMPORARY_DIR/TailcatMobile.xcframework"

--- a/scripts/test-macos-local-cache.sh
+++ b/scripts/test-macos-local-cache.sh
@@ -5,10 +5,18 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mimi-macos-local-cache.XXXXXX")"
 trap 'rm -rf "$TEMP_DIR"' EXIT
 fixture="$TEMP_DIR/repo"
-mkdir -p "$fixture/scripts" "$fixture/macos/MimiRemoteMac/Scripts" "$TEMP_DIR/bin"
+mkdir -p \
+  "$fixture/scripts" \
+  "$fixture/experiments/tailcat" \
+  "$fixture/macos/MimiRemoteMac/Scripts" \
+  "$fixture/macos/MimiRemoteMac/Resources/LaunchAgents" \
+  "$TEMP_DIR/bin" \
+  "$TEMP_DIR/go-root/bin"
 cp "$ROOT_DIR/scripts/development-cache-"*.sh "$fixture/scripts/"
-cp "$ROOT_DIR/macos/MimiRemoteMac/Scripts/"{build-local,install-local}.sh \
+cp "$ROOT_DIR/macos/MimiRemoteMac/Scripts/"{build-local,embed-agentd,install-local}.sh \
   "$fixture/macos/MimiRemoteMac/Scripts/"
+cp "$ROOT_DIR/macos/MimiRemoteMac/Resources/LaunchAgents/com.gaixianggeng.mimi.mac.agentd.plist" \
+  "$fixture/macos/MimiRemoteMac/Resources/LaunchAgents/"
 
 export PATH="$TEMP_DIR/bin:$PATH"
 export MIMI_DEVELOPMENT_CACHE_REPO_ROOT="$ROOT_DIR"
@@ -19,6 +27,8 @@ export MACOS_DEVELOPMENT_CACHE_LOCK="$TEMP_DIR/build.lock"
 export FIXTURE_LOCK_SCRIPT="$ROOT_DIR/scripts/development-cache-lock.sh"
 export FIXTURE_BUILD_LOG="$TEMP_DIR/build.log"
 export FIXTURE_REVISION="current-worktree"
+export FIXTURE_GO_BUILD_LOG="$TEMP_DIR/go-build.log"
+export FIXTURE_GO_ROOT="$TEMP_DIR/go-root"
 
 # 仅替换外部构建工具，不启动真实 App，也不改动用户已安装的 App。
 cat > "$TEMP_DIR/bin/xcodegen" <<'STUB'
@@ -53,7 +63,72 @@ cat > "$TEMP_DIR/bin/pgrep" <<'STUB'
 #!/usr/bin/env bash
 exit 1
 STUB
-chmod +x "$TEMP_DIR/bin/"*
+cat > "$TEMP_DIR/bin/go" <<'STUB'
+#!/usr/bin/env bash
+exec "$FIXTURE_GO_ROOT/bin/go" "$@"
+STUB
+cat > "$TEMP_DIR/go-root/bin/go" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == env && "${2:-}" == GOROOT ]]; then
+  printf '%s\n' "$FIXTURE_GO_ROOT"
+  exit 0
+fi
+if [[ "${1:-}" == env && "${2:-}" == GOVERSION ]]; then
+  if [[ "$PWD" == */experiments/tailcat ]]; then
+    printf 'go1.27.0\n'
+  else
+    printf 'go1.25.0\n'
+  fi
+  exit 0
+fi
+[[ "${1:-}" == build ]] || { echo "未预期的 go 调用：$*" >&2; exit 1; }
+output=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+[[ -n "$output" ]] || { echo "go build 缺少 -o" >&2; exit 1; }
+printf '%s\t%s\n' "${GOCACHE-<unset>}" "$output" >> "$FIXTURE_GO_BUILD_LOG"
+mkdir -p "$(dirname "$output")"
+cp /usr/bin/true "$output"
+chmod +x "$output"
+STUB
+cat > "$TEMP_DIR/bin/cargo" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+target=""
+target_dir=""
+profile="debug"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      target="$2"
+      shift 2
+      ;;
+    --target-dir)
+      target_dir="$2"
+      shift 2
+      ;;
+    --release)
+      profile="release"
+      shift
+      ;;
+    *) shift ;;
+  esac
+done
+[[ -n "$target" && -n "$target_dir" ]] || { echo "cargo 缺少目标目录" >&2; exit 1; }
+output="$target_dir/$target/$profile/alleycat-claude-bridge"
+mkdir -p "$(dirname "$output")"
+cp /usr/bin/true "$output"
+chmod +x "$output"
+STUB
+chmod +x "$TEMP_DIR/bin/"* "$TEMP_DIR/go-root/bin/go"
 
 old_app="$MACOS_DERIVED_DATA_PATH/Build/Products/Release/Mimi Remote Mac.app"
 mkdir -p "$old_app"
@@ -68,4 +143,32 @@ bash "$fixture/macos/MimiRemoteMac/Scripts/install-local.sh" "$destination"
 [[ "$(cat "$destination/revision")" == updated-worktree ]]
 [[ "$(wc -l < "$FIXTURE_BUILD_LOG" | tr -d ' ')" == 2 ]]
 [[ "$(cat "$TEMP_DIR/installed/"Mimi\ Remote\ Mac.backup-*.app/revision)" == current-worktree ]]
-echo "Mac 安装使用当前 Worktree 增量构建，并在共享缓存锁内暂存的自测通过。"
+
+embed_env=(
+  "SRCROOT=$fixture/macos/MimiRemoteMac"
+  "TARGET_BUILD_DIR=$TEMP_DIR/embed-build"
+  "CONTENTS_FOLDER_PATH=Mimi Remote Mac.app/Contents"
+  "ARCHS=arm64"
+  "CONFIGURATION=Debug"
+  "MACOS_EMBED_CACHE_DIR=$TEMP_DIR/embed"
+  "CODE_SIGNING_ALLOWED=NO"
+)
+embed_script="$fixture/macos/MimiRemoteMac/Scripts/embed-agentd.sh"
+env -u GOCACHE "${embed_env[@]}" bash "$embed_script" >/dev/null
+
+agentd_intermediate="$TEMP_DIR/embed/Debug/go/arm64/agentd"
+tailcat_intermediate="$TEMP_DIR/embed/Debug/tailcat-go/arm64/mimi-tailcat-experiment"
+[[ "$(sed -n '1p' "$FIXTURE_GO_BUILD_LOG")" == $'<unset>\t'"$agentd_intermediate" ]]
+[[ "$(sed -n '2p' "$FIXTURE_GO_BUILD_LOG")" == $'<unset>\t'"$tailcat_intermediate" ]]
+[[ ! -e "$TEMP_DIR/embed/Debug/go/arm64/gocache" ]]
+[[ ! -e "$TEMP_DIR/embed/Debug/tailcat-go/arm64/gocache" ]]
+[[ -x "$TEMP_DIR/embed-build/Mimi Remote Mac.app/Contents/Resources/agentd" ]]
+[[ -x "$TEMP_DIR/embed/Debug/rust/debug/aarch64-apple-darwin/aarch64-apple-darwin/debug/alleycat-claude-bridge" ]]
+
+caller_go_cache="$TEMP_DIR/caller-gocache"
+: > "$FIXTURE_GO_BUILD_LOG"
+env "GOCACHE=$caller_go_cache" "${embed_env[@]}" bash "$embed_script" >/dev/null
+[[ "$(sed -n '1p' "$FIXTURE_GO_BUILD_LOG")" == "$caller_go_cache"$'\t'"$agentd_intermediate" ]]
+[[ "$(sed -n '2p' "$FIXTURE_GO_BUILD_LOG")" == "$caller_go_cache"$'\t'"$tailcat_intermediate" ]]
+
+echo "Mac 安装锁、内嵌产物隔离和 Go 全局缓存继承自测通过。"

--- a/scripts/test-tailcat-mobile-build.sh
+++ b/scripts/test-tailcat-mobile-build.sh
@@ -18,16 +18,25 @@ assert_equal() {
   [[ "$actual" == "$expected" ]] || fail "${label}：期望 '$expected'，实际 '$actual'"
 }
 
-module_dir="$TEMP_DIR/module"
+module_dir="$TEMP_DIR/module with spaces"
 output_dir="$TEMP_DIR/output"
 tool_dir="$TEMP_DIR/tools"
 bridge_source="$TEMP_DIR/MimiTailcatBridge.m"
 gomobile_log="$TEMP_DIR/gomobile.log"
-mkdir -p "$module_dir/mobile/tailcatmobile"
-printf 'module example.invalid/tailcat\n\ngo 1.26\n' > "$module_dir/go.mod"
-printf 'package tailcatmobile\n' > "$module_dir/mobile/tailcatmobile/tailcatmobile.go"
+install_log="$TEMP_DIR/install.log"
+real_go="$(command -v go)"
+builder_script="$ROOT_DIR/scripts/build-tailcat-mobile.sh"
+mkdir -p "$module_dir/mobile/tailcatmobile" "$module_dir/internal/tunnel" "$module_dir/cmd/unrelated"
+printf 'module example.invalid/tailcat\n\ngo 1.25\n' > "$module_dir/go.mod"
+printf 'package tailcatmobile\nimport "example.invalid/tailcat/internal/tunnel"\nvar Value = tunnel.Value\n' \
+  > "$module_dir/mobile/tailcatmobile/tailcatmobile.go"
+printf 'package tunnel\nimport _ "embed"\n//go:embed value.txt\nvar Value string\n' \
+  > "$module_dir/internal/tunnel/tunnel.go"
+printf 'initial value\n' > "$module_dir/internal/tunnel/value.txt"
+printf 'package main\nfunc main() {}\n' > "$module_dir/cmd/unrelated/main.go"
 printf '#import "MimiTailcatBridge.h"\n' > "$bridge_source"
 : > "$gomobile_log"
+: > "$install_log"
 
 run_builder() {
   TAILCAT_MOBILE_MODULE_DIR="$module_dir" \
@@ -39,11 +48,18 @@ run_builder() {
   TAILCAT_MOBILE_NM_BIN="$FIXTURE_DIR/fake-nm.sh" \
   TAILCAT_TEST_FAKE_GOMOBILE="$FIXTURE_DIR/fake-gomobile.sh" \
   TAILCAT_TEST_GOMOBILE_LOG="$gomobile_log" \
-  bash "$ROOT_DIR/scripts/build-tailcat-mobile.sh"
+  TAILCAT_TEST_INSTALL_LOG="$install_log" \
+  TAILCAT_TEST_REAL_GO="$real_go" \
+  MIMI_DEVELOPMENT_CACHE_REPO_ROOT="$ROOT_DIR" \
+  bash "$builder_script"
 }
 
 bind_count() {
   awk '$0 == "bind" { count += 1 } END { print count + 0 }' "$gomobile_log"
+}
+
+install_count() {
+  wc -l < "$install_log" | tr -d ' '
 }
 
 run_builder >/dev/null
@@ -51,17 +67,66 @@ assert_equal "1" "$(bind_count)" "首次执行必须生成 XCFramework"
 [[ -f "$output_dir/.tailcat-mobile-fingerprint" ]] || fail "首次执行缺少源码指纹"
 [[ -x "$tool_dir/bin/gomobile" ]] || fail "首次执行没有安装固定版本的 gomobile"
 [[ -x "$tool_dir/bin/gobind" ]] || fail "首次执行没有安装固定版本的 gobind"
+assert_equal "2" "$(install_count)" "首次执行只安装两个固定版本工具"
 
 run_builder >/dev/null
 assert_equal "1" "$(bind_count)" "源码未变化时必须复用缓存"
 
+printf 'package tunnel\n// new test\n' > "$module_dir/internal/tunnel/tunnel_test.go"
+printf '// unrelated command changed\n' >> "$module_dir/cmd/unrelated/main.go"
+run_builder >/dev/null
+assert_equal "1" "$(bind_count)" "测试和无关命令变化不得重建框架"
+
+cp -R "$module_dir" "$TEMP_DIR/relocated module"
+module_dir="$TEMP_DIR/relocated module"
+mkdir -p "$TEMP_DIR/relocated repo/scripts"
+cp "$builder_script" "$ROOT_DIR/scripts/development-cache-path.sh" \
+  "$ROOT_DIR/scripts/development-cache-lock.sh" "$TEMP_DIR/relocated repo/scripts/"
+builder_script="$TEMP_DIR/relocated repo/scripts/build-tailcat-mobile.sh"
+run_builder >/dev/null
+assert_equal "1" "$(bind_count)" "相同源码与脚本移动目录后必须复用框架"
+
 printf '// source changed\n' >> "$module_dir/mobile/tailcatmobile/tailcatmobile.go"
 run_builder >/dev/null
 assert_equal "2" "$(bind_count)" "Tailcat 源码变化后必须重新生成"
+assert_equal "2" "$(install_count)" "框架失效不得重复安装已有工具"
+
+printf '// dependency changed\n' >> "$module_dir/internal/tunnel/tunnel.go"
+run_builder >/dev/null
+assert_equal "3" "$(bind_count)" "生产依赖变化必须重建"
+printf 'changed embedded value\n' > "$module_dir/internal/tunnel/value.txt"
+run_builder >/dev/null
+assert_equal "4" "$(bind_count)" "embed 输入变化必须重建"
+printf '// module changed\n' >> "$module_dir/go.mod"
+run_builder >/dev/null
+assert_equal "5" "$(bind_count)" "module 输入变化必须重建"
+
+export TAILCAT_TEST_SDK_VERSION=next-sdk
+run_builder >/dev/null
+assert_equal "6" "$(bind_count)" "SDK 变化必须重建"
+export TAILCAT_TEST_GO_VERSION=go1.27.0
+run_builder >/dev/null
+assert_equal "7" "$(bind_count)" "Go 工具链变化必须重建"
+assert_equal "2" "$(install_count)" "SDK 和编译工具链变化无需重装同版本 mobile 工具"
+
+printf 'wrong-version\n' > "$tool_dir/bin/gobind.version"
+printf '// rebuild with repaired tool\n' >> "$module_dir/internal/tunnel/tunnel.go"
+run_builder >/dev/null
+assert_equal "8" "$(bind_count)" "修复工具版本后正常构建"
+assert_equal "3" "$(install_count)" "仅重装版本不符的工具"
+rm "$tool_dir/bin/gomobile"
 
 rm -f "$output_dir/TailcatMobile.xcframework/ios-arm64/TailcatMobile.framework/Headers/TailcatMobile.h"
 run_builder >/dev/null
-assert_equal "3" "$(bind_count)" "缓存缺少 header 时必须重新生成"
+assert_equal "9" "$(bind_count)" "缓存缺少 header 时必须重新生成"
+assert_equal "4" "$(install_count)" "仅重装缺失的工具"
+
+set +e
+TAILCAT_TEST_LIST_EXIT_CODE=92 run_builder >"$TEMP_DIR/failed-inputs.log" 2>&1
+input_status=$?
+set -e
+assert_equal "92" "$input_status" "输入枚举失败必须中止"
+assert_equal "9" "$(bind_count)" "输入枚举失败不得开始构建"
 
 fingerprint_before="$(cat "$output_dir/.tailcat-mobile-fingerprint")"
 binary_before="$(cat "$output_dir/TailcatMobile.xcframework/ios-arm64/TailcatMobile.framework/TailcatMobile")"
@@ -76,5 +141,19 @@ assert_equal "$fingerprint_before" "$(cat "$output_dir/.tailcat-mobile-fingerpri
 assert_equal "$binary_before" \
   "$(cat "$output_dir/TailcatMobile.xcframework/ios-arm64/TailcatMobile.framework/TailcatMobile")" \
   "失败构建不得破坏最后一个有效 XCFramework"
+
+run_builder >/dev/null
+before="$(bind_count)"
+printf '// existing test changed\n' >> "$module_dir/internal/tunnel/tunnel_test.go"
+printf 'package tunnel\nconst LinuxOnly = true\n' > "$module_dir/internal/tunnel/extra_linux.go"
+run_builder >/dev/null
+assert_equal "$before" "$(bind_count)" "修改测试和非 iOS 输入不得重建"
+
+printf 'package tunnel\nconst SimulatorOnly = true\n' > "$module_dir/internal/tunnel/extra_amd64.go"
+run_builder >/dev/null
+assert_equal "$((before + 1))" "$(bind_count)" "amd64 模拟器专用生产输入必须重建"
+printf '\n' > "$module_dir/go.sum"
+run_builder >/dev/null
+assert_equal "$((before + 2))" "$(bind_count)" "go.sum 输入变化必须重建"
 
 echo "Tailcat iOS 框架生成、缓存失效和失败保留检查通过。"

--- a/scripts/test-tailcat-mobile-build.sh
+++ b/scripts/test-tailcat-mobile-build.sh
@@ -4,7 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURE_DIR="$ROOT_DIR/scripts/testdata/tailcat-mobile"
 TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mimi-tailcat-mobile-build.XXXXXX")"
-trap 'rm -rf "$TEMP_DIR"' EXIT
+build_pid=""
+cleanup() {
+  if [[ -n "$build_pid" ]]; then
+    touch "$TEMP_DIR/bind-release"
+    wait "$build_pid" || true
+  fi
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
 
 fail() {
   echo "Tailcat iOS 构建缓存测试失败：$1" >&2
@@ -155,5 +163,41 @@ assert_equal "$((before + 1))" "$(bind_count)" "amd64 模拟器专用生产输�
 printf '\n' > "$module_dir/go.sum"
 run_builder >/dev/null
 assert_equal "$((before + 2))" "$(bind_count)" "go.sum 输入变化必须重建"
+
+# 两个 Worktree 使用不同工具版本和不同产物目录，但必须共用整段 bind 的工具锁。
+version_a="$(cat "$tool_dir/bin/gomobile.version")"
+version_b="v0.0.0-20260909000000-test-version"
+output_dir="$TEMP_DIR/concurrent-a"
+TAILCAT_TEST_BIND_STARTED="$TEMP_DIR/bind-started" \
+TAILCAT_TEST_BIND_RELEASE="$TEMP_DIR/bind-release" \
+TAILCAT_TEST_EXPECTED_VERSION="$version_a" \
+  run_builder >"$TEMP_DIR/concurrent-a.log" 2>&1 &
+build_pid=$!
+for attempt in {1..400}; do
+  [[ -f "$TEMP_DIR/bind-started" ]] && break
+  sleep 0.05
+done
+[[ -f "$TEMP_DIR/bind-started" ]] || fail "第一个构建未进入 bind"
+
+sed "s/^GOMOBILE_VERSION=.*/GOMOBILE_VERSION=\"$version_b\"/" "$builder_script" \
+  > "$TEMP_DIR/relocated repo/scripts/build-version-b.sh"
+builder_script="$TEMP_DIR/relocated repo/scripts/build-version-b.sh"
+output_dir="$TEMP_DIR/concurrent-b"
+installs_before="$(install_count)"
+set +e
+MIMI_DEVELOPMENT_CACHE_LOCK_WAIT_SECONDS=0 TAILCAT_TEST_EXPECTED_VERSION="$version_b" \
+  run_builder >"$TEMP_DIR/concurrent-b-busy.log" 2>&1
+busy_status=$?
+set -e
+assert_equal "75" "$busy_status" "另一个版本的构建必须等待正在 bind 的工具锁"
+assert_equal "$installs_before" "$(install_count)" "bind 期间不能安装其他版本工具"
+
+touch "$TEMP_DIR/bind-release"
+wait "$build_pid" || fail "第一个构建未能始终使用自己的工具版本"
+build_pid=""
+TAILCAT_TEST_EXPECTED_VERSION="$version_b" run_builder >/dev/null
+assert_equal "$((installs_before + 2))" "$(install_count)" "锁释放后才能安装另一个版本并构建"
+[[ -f "$TEMP_DIR/concurrent-a/.tailcat-mobile-fingerprint" ]] || fail "第一个构建缺少有效指纹"
+[[ -f "$TEMP_DIR/concurrent-b/.tailcat-mobile-fingerprint" ]] || fail "第二个构建缺少有效指纹"
 
 echo "Tailcat iOS 框架生成、缓存失效和失败保留检查通过。"

--- a/scripts/testdata/tailcat-mobile/fake-go.sh
+++ b/scripts/testdata/tailcat-mobile/fake-go.sh
@@ -3,14 +3,29 @@ set -euo pipefail
 
 case "${1:-}" in
   version)
-    echo "go version go1.26.0 darwin/arm64"
+    if [[ "${2:-}" == -m ]]; then
+      [[ -f "$3.version" ]] || exit 1
+      printf '\tmod\tgolang.org/x/mobile\t%s\tfake-hash\n' "$(cat "$3.version")"
+    else
+      echo "go version ${TAILCAT_TEST_GO_VERSION:-go1.26.0} darwin/arm64"
+    fi
     ;;
   env)
-    printf 'go1.26.0\ndarwin\narm64\n'
+    printf '%s\ndarwin\narm64\n' "${TAILCAT_TEST_GO_VERSION:-go1.26.0}"
+    ;;
+  list)
+    [[ "${TAILCAT_TEST_LIST_EXIT_CODE:-0}" == 0 ]] || exit "$TAILCAT_TEST_LIST_EXIT_CODE"
+    # 使用真实 Go 解析夹具依赖，防止假工具把错误的输入范围也判为通过。
+    exec "${TAILCAT_TEST_REAL_GO:?}" "$@"
     ;;
   install)
     [[ -n "${GOBIN:-}" ]] || exit 64
+    [[ "$2" != *@latest ]] || exit 65
+    printf '%s\n' "$2" >> "${TAILCAT_TEST_INSTALL_LOG:?}"
     mkdir -p "$GOBIN"
+    tool="${2%%@*}"
+    tool="${tool##*/}"
+    printf '%s\n' "${2#*@}" > "$GOBIN/$tool.version"
     case "${2:-}" in
       golang.org/x/mobile/cmd/gomobile@*)
         cp "${TAILCAT_TEST_FAKE_GOMOBILE:?}" "$GOBIN/gomobile"

--- a/scripts/testdata/tailcat-mobile/fake-gomobile.sh
+++ b/scripts/testdata/tailcat-mobile/fake-gomobile.sh
@@ -11,6 +11,23 @@ case "$command_name" in
     exit 66
     ;;
   bind)
+    if [[ -n "${TAILCAT_TEST_BIND_STARTED:-}" ]]; then
+      touch "$TAILCAT_TEST_BIND_STARTED"
+      for attempt in {1..400}; do
+        [[ -f "$TAILCAT_TEST_BIND_RELEASE" ]] && break
+        sleep 0.05
+      done
+      [[ -f "$TAILCAT_TEST_BIND_RELEASE" ]] || exit 67
+    fi
+    if [[ -n "${TAILCAT_TEST_EXPECTED_VERSION:-}" ]]; then
+      tool_bin="$(dirname "$0")"
+      for tool in gomobile gobind; do
+        [[ "$(cat "$tool_bin/$tool.version")" == "$TAILCAT_TEST_EXPECTED_VERSION" ]] || {
+          echo "bind 使用了其他 Worktree 的 $tool 版本" >&2
+          exit 68
+        }
+      done
+    fi
     command -v gobind >/dev/null 2>&1 || {
       echo "gobind was not found" >&2
       exit 65

--- a/scripts/testdata/tailcat-mobile/fake-gomobile.sh
+++ b/scripts/testdata/tailcat-mobile/fake-gomobile.sh
@@ -7,7 +7,8 @@ command_name="${1:-}"
 
 case "$command_name" in
   init)
-    exit 0
+    echo "iOS bind 不应执行会安装 latest 的 gomobile init" >&2
+    exit 66
     ;;
   bind)
     command -v gobind >/dev/null 2>&1 || {

--- a/scripts/testdata/tailcat-mobile/fake-xcrun.sh
+++ b/scripts/testdata/tailcat-mobile/fake-xcrun.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 case "$*" in
-  "--sdk iphoneos --show-sdk-build-version") echo "23F81a" ;;
-  "--sdk iphonesimulator --show-sdk-build-version") echo "23F81a" ;;
+  "--sdk iphoneos --show-sdk-build-version") echo "${TAILCAT_TEST_SDK_VERSION:-23F81a}" ;;
+  "--sdk iphonesimulator --show-sdk-build-version") echo "${TAILCAT_TEST_SDK_VERSION:-23F81a}" ;;
   *) exit 64 ;;
 esac


### PR DESCRIPTION
Mac 内嵌构建不再按 agentd/Tailcat、架构和配置重复划分 Go 编译缓存，默认使用 Go 全局缓存，并保留调用者显式设置及最终产物隔离。

Tailcat iOS 框架按实际生产依赖计算指纹，排除测试、无关命令和非 iOS 输入，同时跟踪 embed 资源、模块依赖、SDK 与工具版本。相同输入不受目录搬迁影响。gomobile/gobind 只在缺失或版本不符时安装，取消会安装 gobind@latest 的 gomobile init，版本检查、按需安装及整个 gomobile bind 在同一把共享锁内完成，防止另一个 Worktree 在构建期间替换工具。

Refs #407

验证：

- `bash scripts/check-source-size.sh` 通过。
- 两个不同工具版本、不同输出目录的并发构建回归通过：bind 期间另一版本不能安装，释放锁后可继续构建；该用例在旧实现上可复现失败。
- `bash scripts/verify-change.sh --plan` 与 quick 通过：7 项检查，包含流程自测、真实 Mac 编译和 69 个单测。
- 通过 `IOS_TARGET_MODE=simulator bash scripts/ios-dev.sh build` 完成固定 M5 Simulator 上的真实构建对照：无修改 5.41 秒、仅修改测试 7.92 秒，两者均复用框架；相关生产源码变化正确触发重建。
- 无修改对照中的全局 Go 编译缓存增量为 0 KiB，仅测试变化对照为 4 KiB；所有 iOS 对照中的固定版本工具二进制 hash 均未变化。
- 真实 Mac 构建没有再创建两个组件的私有 gocache 目录。

本次不清理已有缓存，不改变 Go 1.25/1.27 约束或发布架构。源码变化仍会产生正常缓存增量；上述数据为本机观测，不承诺全局缓存零增长。未执行 full、真机专项或发布验证。


