### PR TITLE
修复 Linux 安装脚本在 bash 3.2 下展开空数组导致正式发布失败

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -309,6 +309,8 @@ main() {
   local was_active="0"
   local created_config="0"
   local app_server_ssh_target="${AGENTD_APP_SERVER_SSH_TARGET:-}"
+  # 只有显式 SSH 远端时才有元素；展开处用 ${arr[@]+"${arr[@]}"}，因为 bash 3.2
+  # 在 set -u 下把空数组当作未绑定变量（Release 的 macOS 校验用的就是 /bin/bash 3.2）。
   local setup_transport_args=()
   if [[ -n "$app_server_ssh_target" ]]; then
     require_command ssh
@@ -366,7 +368,7 @@ main() {
     --scan-root "$HOME" \
     --browse-root "$HOME" \
     --listen 127.0.0.1:8787 \
-    "${setup_transport_args[@]}" \
+    ${setup_transport_args[@]+"${setup_transport_args[@]}"} \
     2>&1)"; then
     echo "Codex App Server 预检诊断：" >&2
     print_bounded_redacted_lines "$preflight_output" 12 "（agentd setup 没有返回诊断）" >&2
@@ -419,7 +421,7 @@ main() {
     "$destination_binary" setup \
       --scan-root "$HOME/code" \
       --browse-root "$HOME" \
-      "${setup_transport_args[@]}" \
+      ${setup_transport_args[@]+"${setup_transport_args[@]}"} \
       >/dev/null
   fi
   "$destination_binary" doctor --fix


### PR DESCRIPTION
Refs #426

## 问题

v0.3.14 正式发布在 Release workflow 的 macOS `verify` job 失败，失败步骤是 `Check packaging sources`，没有任何输出。原因是 `scripts/install-linux.sh` 的 `setup_transport_args` 为空数组时，`set -u` 下 bash 3.2 报 `unbound variable`；`test-install-linux.sh` 把安装输出存进变量后断言失败，外层因此不打印原因。只有 Release 的 macOS verify 用 `/bin/bash` 3.2，PR Gate 在 Ubuntu 的 bash 5 上跑，所以合并时没有暴露。Linux 用户使用 bash 5，不受影响。

## 改动

- 两处展开改为 `${setup_transport_args[@]+"${setup_transport_args[@]}"}`，数组为空时不展开，有元素时与原来一致。

## 验证

- 全新 clone，用 macOS `/bin/bash` 3.2、只含系统工具和 ripgrep 的 PATH、UTF-8 locale、Go 1.25.0 运行 `verify-release.sh`：打包门禁与发布产物门禁均通过。修复前同样条件下 `check-packaging.sh` 退出码 1，可稳定复现。
- 正常环境 bash 5 下 `check-packaging.sh` 通过。
- Release macOS verify 执行的脚本中，v0.3.13 之后只有 `check-packaging.sh` 与 `check-release-artifacts.sh` 有改动，均已在上述环境通过。其他脚本中的空数组写法不在发布路径上，本 PR 不动。
- 说明：用 `env -i` 清空 locale 时，`check-release-prerequisites.sh` 的 `ruby -e` 会报 `invalid multibyte char`。这段代码自 v0.3.13 起未改，而 v0.3.13 在 CI 上通过同一步骤，说明 runner 是 UTF-8，属于模拟环境造成，不是问题。

## 发布

合并后以新 tag `v0.3.15` 重新触发发布。`v0.3.14` 按仓库规则不可移动或删除，保留为没有 Release 的 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MNwQdU2NHtwUpV3J7CcBB
