### PR TITLE
Tailcat 配对按操作区分超时并把辅助程序日志收进 agentd

### DIFF
--- a/experiments/tailcat/internal/managed/manager.go
+++ b/experiments/tailcat/internal/managed/manager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -358,7 +359,16 @@ func (m *Manager) pairHandler(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
+	// 首次配对要等中继授权临时节点，耗时不稳定。写到 stderr 由 agentd 收进日志，
+	// 排查时能看到是节点启动慢还是控制通道慢。
+	started := time.Now()
 	status, err := m.StartPairing(10 * time.Minute)
+	elapsed := time.Since(started).Round(time.Millisecond)
+	if err != nil {
+		log.Printf("pair: 短期配对节点启动失败（耗时 %s）：%v", elapsed, err)
+	} else {
+		log.Printf("pair: 短期配对节点启动耗时 %s", elapsed)
+	}
 	writeResult(w, status, err)
 }
 

--- a/internal/httpapi/tailcat_sidecar.go
+++ b/internal/httpapi/tailcat_sidecar.go
@@ -36,6 +36,9 @@ const (
 	// 节点其实已经生成，却被报成失败。CLI 与 Mac App 各给 25 秒，这里留 20 秒
 	// 让辅助程序把结果交回来。
 	tailcatPairCallTimeout = 20 * time.Second
+	// 取回超时后建好的配对节点时，剩余有效期（辅助程序给 10 分钟）至少要这么长；
+	// 再短的话用户扫码前可能就过期了，宁可重新生成。
+	tailcatPairReuseMinRemaining = 5 * time.Minute
 )
 
 type tailcatStatus struct {
@@ -82,6 +85,8 @@ type tailcatSidecarSupervisor struct {
 	// 零值表示使用上面的默认超时；测试用短超时驱动。
 	controlTimeout time.Duration
 	pairTimeout    time.Duration
+	// 上一次 /pair 超时、辅助程序可能还在把那个节点建完。受 operationMu 保护。
+	pairTimedOut bool
 }
 
 func (s *tailcatSidecarSupervisor) controlCallTimeout() time.Duration {
@@ -342,23 +347,62 @@ func (s *tailcatSidecarSupervisor) Pair(ctx context.Context) (tailcatStatus, err
 	}
 	s.operationMu.Lock()
 	defer s.operationMu.Unlock()
-	var status tailcatStatus
 	timeout := s.pairCallTimeout()
+	if s.pairTimedOut {
+		if status, reused, err := s.reclaimTimedOutPair(ctx, timeout); reused || err != nil {
+			s.applyConfigurationToStatus(&status)
+			return status, err
+		}
+	}
+	var status tailcatStatus
 	started := time.Now()
 	err := s.call(ctx, timeout, http.MethodPost, "/pair", nil, &status)
 	elapsed := time.Since(started).Round(time.Millisecond)
+	s.pairTimedOut = false
 	switch {
 	case err == nil:
 		log.Printf("tailcat pair: 辅助程序 %s 内生成配对节点", elapsed)
 	case errors.Is(err, context.DeadlineExceeded):
-		// 辅助程序不看请求是否还在，配对节点会继续生成完；此时重试通常立即成功。
+		// 辅助程序不看请求是否还在，配对节点会继续建完；下一次配对先取回它，不能重发 /pair。
 		log.Printf("tailcat pair: 辅助程序 %s 内未返回配对结果", elapsed)
-		err = fmt.Errorf("Tailcat 配对节点仍在等待中继授权，%s 内未完成；节点可能已经生成，请稍后重试一次", timeout)
+		s.pairTimedOut = true
+		err = tailcatPairPendingError(timeout)
 	default:
 		log.Printf("tailcat pair: 辅助程序返回失败（耗时 %s）：%v", elapsed, err)
 	}
 	s.applyConfigurationToStatus(&status)
 	return status, err
+}
+
+// reclaimTimedOutPair 取回上一次超时的配对。辅助程序的 StartPairing 会先销毁现有节点再重建，
+// 直接重发 /pair 会把刚建好的节点拆掉、再走一遍慢授权，可能一直超时下去。辅助程序在配对
+// 期间持有状态锁，这里读 /status 会等到那次配对结束。返回 reused=false 且 err 为空时，
+// 由调用方按正常流程重新生成。
+func (s *tailcatSidecarSupervisor) reclaimTimedOutPair(
+	ctx context.Context,
+	timeout time.Duration,
+) (tailcatStatus, bool, error) {
+	var status tailcatStatus
+	err := s.call(ctx, timeout, http.MethodGet, "/status", nil, &status)
+	if errors.Is(err, context.DeadlineExceeded) {
+		log.Printf("tailcat pair: 上一次的配对节点仍未建好")
+		return status, false, tailcatPairPendingError(timeout)
+	}
+	s.pairTimedOut = false
+	if err != nil || strings.TrimSpace(status.PairAddress) == "" {
+		// 上一次最终失败、已过期，或辅助程序已重启：重新生成。
+		return tailcatStatus{}, false, nil
+	}
+	expiresAt, parseErr := time.Parse(time.RFC3339Nano, status.PairExpiresAt)
+	if parseErr != nil || time.Until(expiresAt) < tailcatPairReuseMinRemaining {
+		return tailcatStatus{}, false, nil
+	}
+	log.Printf("tailcat pair: 复用上一次超时后建好的配对节点（剩余 %s）", time.Until(expiresAt).Round(time.Second))
+	return status, true, nil
+}
+
+func tailcatPairPendingError(timeout time.Duration) error {
+	return fmt.Errorf("Tailcat 配对节点仍在等待中继授权，%s 内未完成；节点可能已经生成，请稍后重试一次", timeout)
 }
 
 func (s *tailcatSidecarSupervisor) AllowClient(ctx context.Context, publicKey string) (tailcatStatus, error) {

--- a/internal/httpapi/tailcat_sidecar.go
+++ b/internal/httpapi/tailcat_sidecar.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -29,6 +30,12 @@ const (
 	TailcatLocalControlHeader = "X-Mimi-Tailcat-Local-Control"
 	tailcatSidecarBinary      = "mimi-tailcat-experiment"
 	defaultTailcatPort        = 8787
+	// 普通控制调用只读内存状态或改白名单，5 秒足够。
+	tailcatControlCallTimeout = 5 * time.Second
+	// 配对要先向中继完成临时节点授权。agentd 重启后的第一次配对实测超过 5 秒，
+	// 节点其实已经生成，却被报成失败。CLI 与 Mac App 各给 25 秒，这里留 20 秒
+	// 让辅助程序把结果交回来。
+	tailcatPairCallTimeout = 20 * time.Second
 )
 
 type tailcatStatus struct {
@@ -72,6 +79,53 @@ type tailcatSidecarSupervisor struct {
 	starting    bool
 	closing     bool
 	lastError   string
+	// 零值表示使用上面的默认超时；测试用短超时驱动。
+	controlTimeout time.Duration
+	pairTimeout    time.Duration
+}
+
+func (s *tailcatSidecarSupervisor) controlCallTimeout() time.Duration {
+	if s.controlTimeout > 0 {
+		return s.controlTimeout
+	}
+	return tailcatControlCallTimeout
+}
+
+func (s *tailcatSidecarSupervisor) pairCallTimeout() time.Duration {
+	if s.pairTimeout > 0 {
+		return s.pairTimeout
+	}
+	return tailcatPairCallTimeout
+}
+
+// tailcatSidecarLogWriter 把辅助程序的 stderr 按行转进 agentd 日志。辅助程序只在
+// 失败退出和配对计时时写 stderr；此前一律丢弃，进程为何退出、配对慢在哪一步都看不到。
+type tailcatSidecarLogWriter struct {
+	mu      sync.Mutex
+	pending []byte
+}
+
+func (w *tailcatSidecarLogWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.pending = append(w.pending, p...)
+	for {
+		index := bytes.IndexByte(w.pending, '\n')
+		if index < 0 {
+			break
+		}
+		line := strings.TrimRight(string(w.pending[:index]), "\r")
+		w.pending = append([]byte(nil), w.pending[index+1:]...)
+		if strings.TrimSpace(line) != "" {
+			log.Printf("tailcat sidecar: %s", line)
+		}
+	}
+	// 没有换行的超长输出不无限积压，直接整段落盘。
+	if len(w.pending) > 8<<10 {
+		log.Printf("tailcat sidecar: %s", strings.TrimSpace(string(w.pending)))
+		w.pending = nil
+	}
+	return len(p), nil
 }
 
 func newTailcatSidecarSupervisor(cfg config.Config, configPath string) *tailcatSidecarSupervisor {
@@ -149,7 +203,7 @@ func (s *tailcatSidecarSupervisor) start(ctx context.Context) error {
 	}
 	cmd := exec.Command(bin, args...)
 	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
+	cmd.Stderr = &tailcatSidecarLogWriter{}
 	if err := cmd.Start(); err != nil {
 		err = fmt.Errorf("启动 Tailcat sidecar：%w", err)
 		s.finishStart(nil, err)
@@ -266,7 +320,7 @@ func (s *tailcatSidecarSupervisor) Status(ctx context.Context) tailcatStatus {
 		return status
 	}
 	if running {
-		if err := s.call(ctx, http.MethodGet, "/status", nil, &status); err == nil {
+		if err := s.call(ctx, s.controlCallTimeout(), http.MethodGet, "/status", nil, &status); err == nil {
 			status.Enabled = true
 			status.DERPMapURL = derpMapURL
 			return status
@@ -289,7 +343,20 @@ func (s *tailcatSidecarSupervisor) Pair(ctx context.Context) (tailcatStatus, err
 	s.operationMu.Lock()
 	defer s.operationMu.Unlock()
 	var status tailcatStatus
-	err := s.call(ctx, http.MethodPost, "/pair", nil, &status)
+	timeout := s.pairCallTimeout()
+	started := time.Now()
+	err := s.call(ctx, timeout, http.MethodPost, "/pair", nil, &status)
+	elapsed := time.Since(started).Round(time.Millisecond)
+	switch {
+	case err == nil:
+		log.Printf("tailcat pair: 辅助程序 %s 内生成配对节点", elapsed)
+	case errors.Is(err, context.DeadlineExceeded):
+		// 辅助程序不看请求是否还在，配对节点会继续生成完；此时重试通常立即成功。
+		log.Printf("tailcat pair: 辅助程序 %s 内未返回配对结果", elapsed)
+		err = fmt.Errorf("Tailcat 配对节点仍在等待中继授权，%s 内未完成；节点可能已经生成，请稍后重试一次", timeout)
+	default:
+		log.Printf("tailcat pair: 辅助程序返回失败（耗时 %s）：%v", elapsed, err)
+	}
 	s.applyConfigurationToStatus(&status)
 	return status, err
 }
@@ -301,7 +368,7 @@ func (s *tailcatSidecarSupervisor) AllowClient(ctx context.Context, publicKey st
 	s.operationMu.Lock()
 	defer s.operationMu.Unlock()
 	var status tailcatStatus
-	err := s.call(ctx, http.MethodPost, "/allow", map[string]string{"public_key": publicKey}, &status)
+	err := s.call(ctx, s.controlCallTimeout(), http.MethodPost, "/allow", map[string]string{"public_key": publicKey}, &status)
 	s.applyConfigurationToStatus(&status)
 	return status, err
 }
@@ -318,6 +385,7 @@ func (s *tailcatSidecarSupervisor) ReplaceManagedClients(
 	var status tailcatStatus
 	err := s.call(
 		ctx,
+		s.controlCallTimeout(),
 		http.MethodPut,
 		"/managed-clients",
 		map[string][]string{"public_keys": publicKeys},
@@ -334,7 +402,7 @@ func (s *tailcatSidecarSupervisor) Reset(ctx context.Context) (tailcatStatus, er
 	s.operationMu.Lock()
 	defer s.operationMu.Unlock()
 	var status tailcatStatus
-	err := s.call(ctx, http.MethodPost, "/reset", nil, &status)
+	err := s.call(ctx, s.controlCallTimeout(), http.MethodPost, "/reset", nil, &status)
 	s.applyConfigurationToStatus(&status)
 	return status, err
 }
@@ -510,7 +578,7 @@ func (s *tailcatSidecarSupervisor) waitUntilReady(ctx context.Context) error {
 	defer ticker.Stop()
 	for {
 		var status tailcatStatus
-		if err := s.call(ctx, http.MethodGet, "/status", nil, &status); err == nil && status.Running {
+		if err := s.call(ctx, s.controlCallTimeout(), http.MethodGet, "/status", nil, &status); err == nil && status.Running {
 			return nil
 		}
 		s.mu.Lock()
@@ -527,9 +595,23 @@ func (s *tailcatSidecarSupervisor) waitUntilReady(ctx context.Context) error {
 	}
 }
 
-func (s *tailcatSidecarSupervisor) call(ctx context.Context, method string, path string, payload any, result any) error {
+// call 按操作给定超时。超时错误原样返回（可用 errors.Is 判 context.DeadlineExceeded），
+// 由调用方决定怎么向用户解释。
+func (s *tailcatSidecarSupervisor) call(
+	ctx context.Context,
+	timeout time.Duration,
+	method string,
+	path string,
+	payload any,
+	result any,
+) error {
 	if s == nil || s.controlPath == "" {
 		return errors.New("Tailcat 控制通道不可用")
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
 	}
 	var body io.Reader
 	if payload != nil {
@@ -552,7 +634,7 @@ func (s *tailcatSidecarSupervisor) call(ctx context.Context, method string, path
 		},
 	}
 	defer transport.CloseIdleConnections()
-	client := http.Client{Transport: transport, Timeout: 5 * time.Second}
+	client := http.Client{Transport: transport}
 	response, err := client.Do(req)
 	if err != nil {
 		return err

--- a/internal/httpapi/tailcat_sidecar_test.go
+++ b/internal/httpapi/tailcat_sidecar_test.go
@@ -1,0 +1,130 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startFakeTailcatControl 在临时 unix socket 上起一个假辅助程序控制接口。
+func startFakeTailcatControl(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	// macOS 的 unix socket 路径上限约 104 字节，t.TempDir() 太长；用系统临时目录。
+	dir, err := os.MkdirTemp("", "tailcat-ctl-")
+	if err != nil {
+		t.Fatalf("创建临时目录失败：%v", err)
+	}
+	socket := filepath.Join(dir, "control.sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("监听 unix socket 失败：%v", err)
+	}
+	server := &http.Server{Handler: handler}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = os.RemoveAll(dir)
+	})
+	return socket
+}
+
+func slowTailcatControl(delay time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		time.Sleep(delay)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"running":      true,
+			"pair_address": "pair.example.invalid",
+		})
+	})
+}
+
+func TestTailcatSupervisorPairWaitsLongerThanControlCalls(t *testing.T) {
+	socket := startFakeTailcatControl(t, slowTailcatControl(150*time.Millisecond))
+	supervisor := &tailcatSidecarSupervisor{
+		controlPath:    socket,
+		controlTimeout: 40 * time.Millisecond,
+		pairTimeout:    2 * time.Second,
+	}
+
+	status, err := supervisor.Pair(context.Background())
+	if err != nil {
+		t.Fatalf("配对应等到辅助程序返回，而不是按普通控制超时失败：%v", err)
+	}
+	if status.PairAddress != "pair.example.invalid" {
+		t.Fatalf("配对结果未透传：%+v", status)
+	}
+
+	var probe tailcatStatus
+	err = supervisor.call(context.Background(), supervisor.controlCallTimeout(), http.MethodGet, "/status", nil, &probe)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("普通控制调用仍应受短超时约束，got %v", err)
+	}
+}
+
+func TestTailcatSupervisorPairTimeoutExplainsRetry(t *testing.T) {
+	socket := startFakeTailcatControl(t, slowTailcatControl(300*time.Millisecond))
+	supervisor := &tailcatSidecarSupervisor{
+		controlPath: socket,
+		pairTimeout: 50 * time.Millisecond,
+	}
+
+	_, err := supervisor.Pair(context.Background())
+	if err == nil {
+		t.Fatal("超过配对超时应返回错误")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "稍后重试") || !strings.Contains(message, "中继授权") {
+		t.Fatalf("超时错误应说明授权未完成、可重试，got %q", message)
+	}
+	if strings.Contains(message, "context deadline exceeded") || strings.Contains(message, "tailcat.local") {
+		t.Fatalf("超时错误不应把底层 HTTP 细节交给用户，got %q", message)
+	}
+}
+
+func TestTailcatSupervisorPairKeepsSidecarFailureMessage(t *testing.T) {
+	socket := startFakeTailcatControl(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "启动短期 Tailcat 配对服务：中继拒绝"})
+	}))
+	supervisor := &tailcatSidecarSupervisor{controlPath: socket}
+
+	_, err := supervisor.Pair(context.Background())
+	if err == nil || err.Error() != "启动短期 Tailcat 配对服务：中继拒绝" {
+		t.Fatalf("辅助程序的明确失败应原样返回，got %v", err)
+	}
+}
+
+func TestTailcatSidecarLogWriterForwardsCompleteLines(t *testing.T) {
+	var captured bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&captured)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	writer := &tailcatSidecarLogWriter{}
+	if _, err := writer.Write([]byte("Tailcat 实验失败：中继不可达\r\npair: 短期")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write([]byte("配对节点启动耗时 6.2s\n\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captured.String()
+	for _, want := range []string{
+		"tailcat sidecar: Tailcat 实验失败：中继不可达",
+		"tailcat sidecar: pair: 短期配对节点启动耗时 6.2s",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("缺少日志行 %q，实际输出：%q", want, output)
+		}
+	}
+	if got := strings.Count(output, "tailcat sidecar:"); got != 2 {
+		t.Fatalf("空行不应产生日志，且半行要等到换行再写；实际 %d 行：%q", got, output)
+	}
+}

--- a/internal/httpapi/tailcat_sidecar_test.go
+++ b/internal/httpapi/tailcat_sidecar_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -86,6 +89,104 @@ func TestTailcatSupervisorPairTimeoutExplainsRetry(t *testing.T) {
 	}
 	if strings.Contains(message, "context deadline exceeded") || strings.Contains(message, "tailcat.local") {
 		t.Fatalf("超时错误不应把底层 HTTP 细节交给用户，got %q", message)
+	}
+}
+
+// fakePairingSidecar 模拟辅助程序的配对语义：每次 /pair 都生成新节点；配对期间持有状态锁，
+// 所以 /status 会等到那次配对结束（与 managed.Manager.StartPairing 一致）。
+type fakePairingSidecar struct {
+	mu        sync.Mutex
+	delay     time.Duration
+	ttl       time.Duration
+	pairCalls atomic.Int32
+	address   string
+	expiresAt time.Time
+}
+
+func (f *fakePairingSidecar) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	switch req.URL.Path {
+	case "/pair":
+		call := f.pairCalls.Add(1)
+		f.mu.Lock()
+		time.Sleep(f.delay)
+		f.address = fmt.Sprintf("pair-%d.example.invalid", call)
+		f.expiresAt = time.Now().Add(f.ttl)
+		status := f.statusLocked()
+		f.mu.Unlock()
+		writeJSON(w, http.StatusOK, status)
+	case "/status":
+		f.mu.Lock()
+		status := f.statusLocked()
+		f.mu.Unlock()
+		writeJSON(w, http.StatusOK, status)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func (f *fakePairingSidecar) statusLocked() map[string]any {
+	status := map[string]any{"running": true}
+	if f.address != "" && time.Now().Before(f.expiresAt) {
+		status["pair_address"] = f.address
+		status["pair_expires_at"] = f.expiresAt.UTC().Format(time.RFC3339Nano)
+	}
+	return status
+}
+
+// PR #428 评审：超时后按提示重试时，重发 /pair 会先销毁辅助程序刚建好的节点、再走一遍慢授权。
+// 重试必须取回那次配对的结果。
+func TestTailcatSupervisorPairRetryReclaimsNodeFinishedAfterTimeout(t *testing.T) {
+	fake := &fakePairingSidecar{delay: 500 * time.Millisecond, ttl: 10 * time.Minute}
+	socket := startFakeTailcatControl(t, fake)
+	supervisor := &tailcatSidecarSupervisor{controlPath: socket, pairTimeout: 60 * time.Millisecond}
+
+	if _, err := supervisor.Pair(context.Background()); err == nil {
+		t.Fatal("首次配对应按配对超时返回")
+	}
+	// 立刻重试：那次配对仍在进行，/status 等不到结果，继续提示稍后重试，不能重发 /pair。
+	if _, err := supervisor.Pair(context.Background()); err == nil || !strings.Contains(err.Error(), "稍后重试") {
+		t.Fatalf("配对仍在进行时应继续提示稍后重试，got %v", err)
+	}
+	if got := fake.pairCalls.Load(); got != 1 {
+		t.Fatalf("配对进行中不应重发 /pair：calls=%d", got)
+	}
+
+	time.Sleep(600 * time.Millisecond)
+	status, err := supervisor.Pair(context.Background())
+	if err != nil {
+		t.Fatalf("那次配对建好后，重试应直接取回：%v", err)
+	}
+	if status.PairAddress != "pair-1.example.invalid" {
+		t.Fatalf("应复用超时后建好的节点，got %q", status.PairAddress)
+	}
+	if got := fake.pairCalls.Load(); got != 1 {
+		t.Fatalf("取回时不应重发 /pair 拆掉刚建好的节点：calls=%d", got)
+	}
+
+	// 取回之后恢复正常语义：再次配对（刷新二维码）生成新节点。
+	supervisor.pairTimeout = 2 * time.Second
+	status, err = supervisor.Pair(context.Background())
+	if err != nil || status.PairAddress != "pair-2.example.invalid" || fake.pairCalls.Load() != 2 {
+		t.Fatalf("取回后的下一次配对应生成新节点：status=%+v err=%v calls=%d", status, err, fake.pairCalls.Load())
+	}
+}
+
+func TestTailcatSupervisorPairRetryRegeneratesWhenReclaimedNodeNearlyExpired(t *testing.T) {
+	fake := &fakePairingSidecar{delay: 200 * time.Millisecond, ttl: time.Minute}
+	socket := startFakeTailcatControl(t, fake)
+	supervisor := &tailcatSidecarSupervisor{controlPath: socket, pairTimeout: 60 * time.Millisecond}
+
+	if _, err := supervisor.Pair(context.Background()); err == nil {
+		t.Fatal("首次配对应按配对超时返回")
+	}
+	time.Sleep(300 * time.Millisecond)
+	supervisor.pairTimeout = 2 * time.Second
+	status, err := supervisor.Pair(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.PairAddress != "pair-2.example.invalid" || fake.pairCalls.Load() != 2 {
+		t.Fatalf("剩余有效期不足时应重新生成：status=%+v calls=%d", status, fake.pairCalls.Load())
 	}
 }
 


### PR DESCRIPTION
Refs #422

## 问题

agentd 重启后第一次在 Mac「配对设备 → Tailcat」生成配对信息会报 `Post "http://tailcat.local/pair": context deadline exceeded`。链路是 Mac App（25 秒）→ `agentd tailcat pair`（HTTP 25 秒）→ agentd 调辅助程序 `/pair`，最后一跳用的是固定 `http.Client{Timeout: 5s}`。首次配对要先向中继完成临时节点授权，实测超过 5 秒；辅助程序其实已经把 `pair.address` / `pair.private.json` 写好了，agentd 却按超时报失败，用户重试才成功。

## 改动

**agentd（`internal/httpapi/tailcat_sidecar.go`）**
- 控制通道调用改为按操作给超时：`/status`、`/allow`、`/managed-clients`、`/reset` 仍 5 秒，`/pair` 20 秒，留在 CLI 与 Mac App 各自 25 秒之内。
- 配对超时时不再把底层 HTTP 错误交给用户，改为「Tailcat 配对节点仍在等待中继授权，20s 内未完成；节点可能已经生成，请稍后重试一次」。
- 超时后的重试先取回上一次的结果（评审 P1）：辅助程序的 `StartPairing` 会先销毁现有节点再重建，直接重发 `/pair` 会把刚建好的节点拆掉、再走一遍慢授权。现在 agentd 记住上一次超时，重试先读 `/status`（辅助程序配对期间持锁，会等到那次配对结束）：节点建好且剩余有效期不少于 5 分钟就复用；还没建好继续提示稍后重试；失败、过期或辅助程序重启才重新生成。
- 配对耗时与结果写进 agentd 日志（`tailcat pair: 辅助程序 6.2s 内生成配对节点`）。
- 辅助程序 stderr 此前一律丢弃，现在按行转进 agentd 日志（前缀 `tailcat sidecar:`）；进程为何退出、配对慢在哪一步都能看到。

**辅助程序（`experiments/tailcat/internal/managed/manager.go`）**
- `/pair` 记录短期配对节点启动耗时，走 stderr 进 agentd 日志。

不改 DERP / 中继授权协议，不改配对安全边界，CLI 与 Mac App 的超时不变。

## 验证

- 新增 `internal/httpapi/tailcat_sidecar_test.go` 6 个用例：配对等待长于普通控制超时、超时错误文案、辅助程序明确失败原样透传、stderr 按行转日志、超时后重试取回已建好的节点（进行中不重发 /pair、建好后复用、之后正常生成新节点）、剩余有效期不足时重建。`go test ./internal/httpapi -run Tailcat -race` 通过；quick 在评审修正后重跑 7/7 通过。
- Tailcat 独立 module `go build`、`go vet`、`go test ./internal/managed/` 通过。
- `bash ./scripts/verify-change.sh --plan` 与 quick 通过（7 项：差异检查、源码行数、`go test ./internal/httpapi`、Tailcat module 测试、固定 M5 Simulator App 编译）。
- 运行态：从源码重装 Mac App、agentd 重启约 7 分钟后做首次 Tailcat 配对，用户验收正常。日志记录辅助程序 2.51 s 生成配对节点、返回 200。本次没有超过原 5 秒上限，所以超时与可重试文案路径在真机上没有触发，由单测覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013curpUwnTehH1y1VHi4tYd