### PR TITLE
「发送下载链接」改为显式呈现系统分享面板

### DIFF
--- a/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
+++ b/ios/MimiRemote/MimiRemote.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		9B9483D073425EF469DF701D /* testUnconfiguredConnectionSettingsOnWideWidthInDarkAppearance.unconfigured-wide-dark.png in Resources */ = {isa = PBXBuildFile; fileRef = 06541D01185FB619F3F3FFF7 /* testUnconfiguredConnectionSettingsOnWideWidthInDarkAppearance.unconfigured-wide-dark.png */; };
 		9BB164C3CFDE5A1120D2A096 /* ProfileRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302CD30CD51E926987FAD6C3 /* ProfileRootView.swift */; };
 		9CDA4F02261EE4460043EC2B /* testRichMarkdownConversationRendering.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 2ACC589478ECDD4A4FB9BEB0 /* testRichMarkdownConversationRendering.1.png */; };
+		9D3D4A255AB0F15B7F50A691 /* HostInstallerShareUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD620F635B06B43ECF89C60 /* HostInstallerShareUITests.swift */; };
 		9DB7FDC4C6AB0FBB1DE2DC8D /* testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5F6590638B16083675339655 /* testLongMultiSelectFormKeepsBottomActionsVisibleOnIPhone.1.png */; };
 		9E36F9EC5868CB3E87DA8E8E /* PushTicketStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE88D00CEBE53EE77A7DBB7 /* PushTicketStore.swift */; };
 		9F08EDD6695137214ECF7A7B /* testSkillInvocationCardLightAppearance.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 8AE76E723980EA82E7BBD4A8 /* testSkillInvocationCardLightAppearance.1.png */; };
@@ -569,6 +570,7 @@
 		3D416A89FB3388B3E36769E5 /* ConversationDirectRuntimeHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectRuntimeHistoryTests.swift; sourceTree = "<group>"; };
 		3DA20088DF3CC377CBB6D7B4 /* HostConnectionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConnectionSupport.swift; sourceTree = "<group>"; };
 		3DA86790E2FD08AE5C651FEC /* SessionStoreSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreSupport.swift; sourceTree = "<group>"; };
+		3DD620F635B06B43ECF89C60 /* HostInstallerShareUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostInstallerShareUITests.swift; sourceTree = "<group>"; };
 		3E158542D6C09FD5FCDDA6DE /* WorkspacePullRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePullRefreshTests.swift; sourceTree = "<group>"; };
 		3E5219F30FB1F37F4EE868FF /* SessionListPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListPresentationTests.swift; sourceTree = "<group>"; };
 		3F85208D350D6CD02FE29067 /* testSingleConnectedComputerOnCompactWidth.single-connected-compact.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSingleConnectedComputerOnCompactWidth.single-connected-compact.png"; sourceTree = "<group>"; };
@@ -1557,6 +1559,7 @@
 			isa = PBXGroup;
 			children = (
 				EF8D7333529B1DA4AEEADE91 /* DeviceSettingsNavigationUITests.swift */,
+				3DD620F635B06B43ECF89C60 /* HostInstallerShareUITests.swift */,
 				EC0864CB07EFB2FEBFFC91BA /* MimiRemotePhysicalSmokeUITests.swift */,
 			);
 			name = MimiRemoteUITests;
@@ -2004,6 +2007,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				989EAAF180B2EC736E7D8725 /* DeviceSettingsNavigationUITests.swift in Sources */,
+				9D3D4A255AB0F15B7F50A691 /* HostInstallerShareUITests.swift in Sources */,
 				1F58506B5DEC82FF40AE7060 /* MimiRemotePhysicalSmokeUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/MimiRemote/Sources/Features/Settings/HostInstallationSetupView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/HostInstallationSetupView.swift
@@ -160,7 +160,13 @@ struct HostInstallationSetupView: View {
                 .accessibilityHint(L10n.text("ui.github_release_accessibility_hint"))
                 .accessibilityIdentifier("settings.hostInstaller.githubRelease")
 
-                ShareLink(item: transientPreferences.hostInstallationPlatform.installerURL) {
+                // 不用 ShareLink：它在这一行里点了没有任何反应（#424，模拟器与真机都复现，
+                // 原因未定位）。分享面板改由连接分组的 Section 呈现，这里只登记请求。
+                Button {
+                    transientPreferences.hostInstallerShareRequest = HostInstallerShareRequest(
+                        url: transientPreferences.hostInstallationPlatform.installerURL
+                    )
+                } label: {
                     ConnectionActionLabel(
                         title: transientPreferences.hostInstallationPlatform.shareTitle,
                         systemImage: "square.and.arrow.up"
@@ -185,6 +191,22 @@ struct HostInstallationSetupView: View {
             .listRowSeparator(.hidden, edges: .top)
         }
     }
+}
+
+struct HostInstallerShareRequest: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+/// 系统分享面板。与 ShareJourneyActivityView 相同的包装，只是分享的是安装包链接。
+struct HostInstallerActivityView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 /// 图标与文字作为一个整体居中，避免宽窗口中两者分散到按钮两端。

--- a/ios/MimiRemote/Sources/Features/Settings/HostInstallationSetupView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/HostInstallationSetupView.swift
@@ -161,7 +161,7 @@ struct HostInstallationSetupView: View {
                 .accessibilityIdentifier("settings.hostInstaller.githubRelease")
 
                 // 不用 ShareLink：它在这一行里点了没有任何反应（#424，模拟器与真机都复现，
-                // 原因未定位）。分享面板改由连接分组的 Section 呈现，这里只登记请求。
+                // 原因未定位）。分享面板由连接页整页呈现，这里只登记请求。
                 Button {
                     transientPreferences.hostInstallerShareRequest = HostInstallerShareRequest(
                         url: transientPreferences.hostInstallationPlatform.installerURL
@@ -196,6 +196,17 @@ struct HostInstallationSetupView: View {
 struct HostInstallerShareRequest: Identifiable {
     let id = UUID()
     let url: URL
+}
+
+/// 连接页整页持有分享面板的 presenter；只观察这一个对象，登记请求时不会让整页重算。
+struct HostInstallerSharePresenter: ViewModifier {
+    @ObservedObject var preferences: SettingsTransientPreferences
+
+    func body(content: Content) -> some View {
+        content.sheet(item: $preferences.hostInstallerShareRequest) { request in
+            HostInstallerActivityView(url: request.url)
+        }
+    }
 }
 
 /// 系统分享面板。与 ShareJourneyActivityView 相同的包装，只是分享的是安装包链接。

--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -176,7 +176,9 @@ struct InitialConnectionSettingsSections: View {
     @ScaledMetric(relativeTo: .subheadline) private var profileDetailPointSize = 15.0
 
     @ObservedObject var draft: ConnectionSettingsDraft
-    let transientPreferences: SettingsTransientPreferences
+    // 观察它是为了在 Section 级呈现「发送下载链接」的分享面板；只拿引用的话，
+    // 请求写进去了这里也不会重算 body，sheet 永远不会打开。
+    @ObservedObject var transientPreferences: SettingsTransientPreferences
     var prioritizesConnectionStatus = false
 
     private var endpoint: String {
@@ -581,6 +583,11 @@ struct InitialConnectionSettingsSections: View {
             }
         } message: { confirmation in
             Text(confirmation.message)
+        }
+        // 「发送下载链接」的系统分享面板。安装说明行里的 ShareLink 点了没有任何反应（#424，
+        // 原因未定位）；改为行里登记请求、这里和删除确认一样由 Section 统一呈现。
+        .sheet(item: $transientPreferences.hostInstallerShareRequest) { request in
+            HostInstallerActivityView(url: request.url)
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/InitialConnectionSettingsSections.swift
@@ -176,9 +176,7 @@ struct InitialConnectionSettingsSections: View {
     @ScaledMetric(relativeTo: .subheadline) private var profileDetailPointSize = 15.0
 
     @ObservedObject var draft: ConnectionSettingsDraft
-    // 观察它是为了在 Section 级呈现「发送下载链接」的分享面板；只拿引用的话，
-    // 请求写进去了这里也不会重算 body，sheet 永远不会打开。
-    @ObservedObject var transientPreferences: SettingsTransientPreferences
+    let transientPreferences: SettingsTransientPreferences
     var prioritizesConnectionStatus = false
 
     private var endpoint: String {
@@ -583,11 +581,6 @@ struct InitialConnectionSettingsSections: View {
             }
         } message: { confirmation in
             Text(confirmation.message)
-        }
-        // 「发送下载链接」的系统分享面板。安装说明行里的 ShareLink 点了没有任何反应（#424，
-        // 原因未定位）；改为行里登记请求、这里和删除确认一样由 Section 统一呈现。
-        .sheet(item: $transientPreferences.hostInstallerShareRequest) { request in
-            HostInstallerActivityView(url: request.url)
         }
     }
 

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsDashboardViews.swift
@@ -76,6 +76,9 @@ struct ConnectionSettingsView: View {
                 try appStore.renameConnectionProfile(id: route.profileID, displayName: displayName)
             }
         }
+        // 「发送下载链接」的分享面板同理挂在整页上。挂在 Form.Section 上时，启动后第一次
+        // 点击会弹出又立刻收回（#424 真机验收）。
+        .modifier(HostInstallerSharePresenter(preferences: navigation.transientPreferences))
     }
 
     private var profileRenameRouteBinding: Binding<ConnectionProfileRenameRoute?> {

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsTransientPreferences.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsTransientPreferences.swift
@@ -7,9 +7,10 @@ final class SettingsTransientPreferences: ObservableObject {
     /// 不在 onAppear 里播种默认值：那发生在首次布局之后，会让依赖内容高度的居中
     /// 多等一轮，快照只跑两个 layout pass 就会录到没收敛的中间态。
     @Published var hostInstallationExpansionOverride: Bool?
-    /// 「发送下载链接」的分享面板由连接分组的 Section 统一呈现（见 connectionPresentationSection）。
-    /// 这一行里的 `ShareLink` 点了没有任何反应也没有日志（iOS 26.5 / 27.0 模拟器和 iOS 27 真机
-    /// 都复现，#424），原因没有定位；改为行里登记请求、Section 级显式呈现。
+    /// 「发送下载链接」的分享请求。安装说明行里的 `ShareLink` 点了没有任何反应也没有日志
+    /// （iOS 26.5 / 27.0 模拟器和 iOS 27 真机都复现，#424），原因没有定位；改为行里登记请求，
+    /// 由连接页整页的 `HostInstallerSharePresenter` 呈现。挂在 Form.Section 上会在启动后第一次
+    /// 点击时弹出又立刻收回。
     @Published var hostInstallerShareRequest: HostInstallerShareRequest?
     @Published var speedTestRoute: ConnectionTestRoute = .tailscale
     @Published var didSelectInitialSpeedTestRoute = false

--- a/ios/MimiRemote/Sources/Features/Settings/SettingsTransientPreferences.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/SettingsTransientPreferences.swift
@@ -7,6 +7,10 @@ final class SettingsTransientPreferences: ObservableObject {
     /// 不在 onAppear 里播种默认值：那发生在首次布局之后，会让依赖内容高度的居中
     /// 多等一轮，快照只跑两个 layout pass 就会录到没收敛的中间态。
     @Published var hostInstallationExpansionOverride: Bool?
+    /// 「发送下载链接」的分享面板由连接分组的 Section 统一呈现（见 connectionPresentationSection）。
+    /// 这一行里的 `ShareLink` 点了没有任何反应也没有日志（iOS 26.5 / 27.0 模拟器和 iOS 27 真机
+    /// 都复现，#424），原因没有定位；改为行里登记请求、Section 级显式呈现。
+    @Published var hostInstallerShareRequest: HostInstallerShareRequest?
     @Published var speedTestRoute: ConnectionTestRoute = .tailscale
     @Published var didSelectInitialSpeedTestRoute = false
     @Published var recordsBenchmarkSamples = false

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/HostInstallerShareUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/HostInstallerShareUITests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+/// 「Mac 连接」页的「发送下载链接」必须真的弹出系统分享面板。
+/// 此前的 UI 测试只检查按钮存在，从没点过它，所以 #424 一直没有被拦住。
+final class HostInstallerShareUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+        app = XCUIApplication()
+        // --debug-skip-pairing 不写 endpoint，干净模拟器上是首次连接态，「首次安装」默认展开。
+        // --debug-open-mac-connection 直达连接页，避开 Tab 导航在 UI 测试里的时序抖动。
+        app.launchArguments = [
+            "--debug-skip-pairing", "--debug-seed-ui",
+            "--debug-open-mac-connection", "-app.language", "zh-Hans",
+        ]
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 25))
+    }
+
+    override func tearDownWithError() throws {
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "\(name)-final"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+        XCUIDevice.shared.orientation = .portrait
+        app.terminate()
+    }
+
+    func testShareDownloadLinkPresentsActivitySheet() throws {
+        let platform = element("settings.hostInstaller.platform")
+        if !platform.waitForExistence(timeout: 3) {
+            // 只有没展开时才点标题；已展开时再点反而会把内容收起。
+            let disclosure = element("settings.hostInstaller.disclosure")
+            XCTAssertTrue(disclosure.waitForExistence(timeout: 10), "连接页应提供「首次安装」入口")
+            scrollTo(disclosure)
+            disclosure.tap()
+            XCTAssertTrue(platform.waitForExistence(timeout: 5), "展开后应出现平台选择器")
+        }
+
+        let share = element("settings.hostInstaller.share")
+        XCTAssertTrue(share.waitForExistence(timeout: 5), "展开后应出现「发送下载链接」按钮")
+        scrollTo(share)
+        share.tap()
+
+        let activitySheet = app.otherElements["ActivityListView"]
+        XCTAssertTrue(
+            activitySheet.waitForExistence(timeout: 8),
+            "点击「发送下载链接」后应弹出系统分享面板；当前元素树：\(app.debugDescription.prefix(4000))"
+        )
+    }
+
+    private func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    private func scrollTo(_ item: XCUIElement) {
+        if item.waitForExistence(timeout: 2), item.isHittable { return }
+        let list = app.collectionViews.firstMatch
+        for _ in 0..<10 {
+            if item.exists, item.isHittable { return }
+            if list.exists { list.swipeUp() } else { app.swipeUp() }
+        }
+        XCTAssertTrue(item.exists && item.isHittable, "应能滚动到 \(item.identifier)")
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteUITests/HostInstallerShareUITests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteUITests/HostInstallerShareUITests.swift
@@ -49,6 +49,10 @@ final class HostInstallerShareUITests: XCTestCase {
             activitySheet.waitForExistence(timeout: 8),
             "点击「发送下载链接」后应弹出系统分享面板；当前元素树：\(app.debugDescription.prefix(4000))"
         )
+        // 真机上启动后的第一次点击会「弹出又立刻收回」（#424 验收反馈）。只看出现过
+        // 不够，必须确认面板停住了。
+        Thread.sleep(forTimeInterval: 2.5)
+        XCTAssertTrue(activitySheet.exists, "分享面板弹出后不应自行收回")
     }
 
     private func element(_ identifier: String) -> XCUIElement {


### PR DESCRIPTION
Refs #424

## 问题

「Mac 连接」页展开「首次安装」后，点「发送下载链接到 Mac」（或 Windows 下载页面）没有任何反应，也没有日志。

## 排查

在 iPhone 17 Pro 模拟器（iOS 27.0，`--debug-open-mac-connection` 直达连接页）用 UI 测试复现，对照了几种写法：

| 写法 | 结果 |
| --- | --- |
| 同一行里的普通 `Button` | 能收到点按 |
| 现有带修饰符的 `ShareLink` | 不弹 |
| 去掉全部修饰符的裸 `ShareLink` | 不弹 |
| 给行挂 `.sheet(isPresented: .constant(false))` | 仍不弹 |
| `Button` + `.sheet(item:)` + `UIActivityViewController` | 弹 |

`ShareLink` 在这一行里为什么失效没有定位到。iOS 26.5 模拟器同样复现；真机 iOS 27 由用户手动复现。

## 改动

- 行里改为普通 `Button`，只往 `SettingsTransientPreferences.hostInstallerShareRequest` 登记请求；按钮外观、`accessibilityIdentifier` 不变。
- 分享面板由 `ConnectionSettingsView` 整页上的 `HostInstallerSharePresenter` 呈现（只观察 `SettingsTransientPreferences` 的 ViewModifier，登记请求时整页不重算），和同页的扫码 Cover、重命名 sheet 在同一层。
- 新增 `HostInstallerShareUITests.testShareDownloadLinkPresentsActivitySheet`：真的点按钮，等待 `ActivityListView` 出现，并断言 2.5 秒后仍在。此前的 UI 测试只检查按钮存在。

**第一版（`5236b886`）把 sheet 挂在 `Form.Section` 上是错的**：真机验收时，启动后第一次点击会弹出又立刻收回，之后正常，重开 App 必现。原因是登记请求时 Section 重建、presenter 被销毁，和 MIM-63 是同一个坑。第一版测试只断言面板「出现过」，所以没拦住；加上「停住」断言后，旧写法在模拟器上稳定失败。`783d6b64` 改为挂整页。

不动「命令行安装」「手动连接」展开后的系统缩进，那不在本 PR 范围。

## 验证

- `HostInstallerShareUITests`（含「停住」断言）在 iPhone 17 Pro（iOS 27.0）模拟器通过；Section 版在同一测试上稳定失败。
- `ConnectionSettingsSnapshotTests`（7）与 `SettingsConnectionCardSnapshotTests`（5）在固定 M5 Simulator 上：第一版与 `783d6b64` 均 12/12 通过，基线未重录。
- `check-source-size.sh` 通过；`verify-change.sh` quick 5/5（第一版时）。
- 真机：修复版已部署到 iPhone（iOS 27.0），等用户手动验收。真机 UI 自动化目前跑不起来（runner 退出码 74）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013curpUwnTehH1y1VHi4tYd