### PR TITLE
覆盖安装后 Mac App 几秒内识别 launchd 拉起失败并立即重新登记后台服务

### DIFF
--- a/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
+++ b/macos/MimiRemoteMac/Sources/Features/MenuBar/MenuBarContentView.swift
@@ -25,6 +25,7 @@ struct MenuBarContentView: View {
         VStack(alignment: .leading, spacing: 0) {
             MenuStatusHeader(
                 lifecycle: store.lifecycle,
+                startingDetail: store.startingDetail,
                 isRefreshing: store.isRefreshingStatus || store.isBusy,
                 refresh: refreshStatus
             )
@@ -249,6 +250,7 @@ struct MenuBarContentView: View {
 
 private struct MenuStatusHeader: View {
     let lifecycle: HostLifecycleState
+    var startingDetail: String? = nil
     let isRefreshing: Bool
     let refresh: () -> Void
 
@@ -318,7 +320,7 @@ private struct MenuStatusHeader: View {
         case .loading: "正在读取服务和连接状态。"
         case .notConfigured: "选择代码目录后即可配对移动设备。"
         case .migrationRequired: "可安全迁移，现有配置和配对都会保留。"
-        case .starting: "移动设备连接会在服务就绪后自动恢复。"
+        case .starting: startingDetail ?? "移动设备连接会在服务就绪后自动恢复。"
         case .ready: "Mac 端服务运行正常。"
         case .degraded(let message), .failed(let message): message
         case .stopped: "打开 App 或重新登录后可以再次启动。"

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
@@ -147,13 +147,19 @@ extension ServiceManagementClient {
         if let pid, !pid.isEmpty, pid != "0" { return nil }
         if state == "running" { return nil }
         let neverExited = lastExitCode == nil || lastExitCode == "(never exited)"
+        // launchctl 输出形如 `78`、`78: EX_CONFIG` 或 `0`。KeepAlive 服务有序退出后、
+        // 下一次拉起前同样没有 pid；退出码 0 本身不算失败，只有反复拉起才算循环。
+        let exitCode = lastExitCode.flatMap { value -> Int? in
+            Int(value.prefix { $0 == "-" || $0.isNumber })
+        }
+        let abnormalExit = !neverExited && exitCode != 0
         let repeatedRuns = (runs ?? 0) >= 2
-        guard repeatedRuns || !neverExited else { return nil }
+        guard repeatedRuns || abnormalExit else { return nil }
         var detail = "launchd 无法启动 agentd"
         if let runs, runs >= 2 {
             detail += "，已连续尝试 \(runs) 次"
         }
-        if !neverExited, let lastExitCode {
+        if abnormalExit, let lastExitCode {
             detail += "，最近退出码 \(lastExitCode)"
         }
         if let state, !state.isEmpty {

--- a/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
+++ b/macos/MimiRemoteMac/Sources/Infrastructure/ServiceManagementClient.swift
@@ -14,6 +14,9 @@ struct ServiceManagementClient {
     var markAgentRegistrationCurrent: @MainActor () -> Void
     var registerAgent: @MainActor () throws -> Void
     var unregisterAgent: @MainActor () async throws -> Void
+    /// launchd 是否正卡在反复拉起却启动不了 agentd 的循环里（例如覆盖安装后
+    /// BTM 复用了旧 App 的 Launch Constraint）。返回非空即表示需要立即换代登记。
+    var agentLaunchFailure: @MainActor () async -> String?
     var mainAppStatus: @MainActor () -> ServiceRegistrationState
     var registerMainApp: @MainActor () throws -> Void
     var unregisterMainApp: @MainActor () async throws -> Void
@@ -22,8 +25,10 @@ struct ServiceManagementClient {
 
 extension ServiceManagementClient {
     @MainActor
-    static var live: ServiceManagementClient {
+    static func live(executor: ProcessExecutor = .shared) -> ServiceManagementClient {
         let registrationRevision = currentAgentRegistrationRevision()
+        let launchctl = URL(filePath: "/bin/launchctl")
+        let environment = ProcessEnvironment.userTooling
         return ServiceManagementClient(
             agentStatus: {
                 registrationState(for: agentService.status)
@@ -56,6 +61,24 @@ extension ServiceManagementClient {
                 // 使用异步 API 等待系统真正终止旧进程；回调完成后才可安全重新注册。
                 try await service.unregister()
             },
+            agentLaunchFailure: {
+                // SMAppService 在 launchd 拉不起进程时仍报告 enabled，只有 launchd
+                // 自己的 job 记录能看出 spawn 失败与重试次数。这里只读取，不改动。
+                let target = "gui/\(getuid())/\(agentLabel)"
+                guard let result = try? await executor.run(
+                    executable: launchctl,
+                    arguments: ["print", target],
+                    timeout: .seconds(3),
+                    outputLimit: 256 * 1024,
+                    environment: environment
+                ) else {
+                    return nil
+                }
+                return launchFailureDescription(
+                    fromLaunchctlOutput: result.stdoutText,
+                    exitStatus: result.status
+                )
+            },
             mainAppStatus: {
                 registrationState(for: SMAppService.mainApp.status)
             },
@@ -84,7 +107,60 @@ extension ServiceManagementClient {
     private static let agentRegistrationRevisionKey =
         "MimiRemoteMac.agentRegistrationRevision"
 
-    private static let agentPlistName = "com.gaixianggeng.mimi.mac.agentd.plist"
+    private static let agentLabel = "com.gaixianggeng.mimi.mac.agentd"
+
+    private static let agentPlistName = "\(agentLabel).plist"
+
+    /// 解析 `launchctl print gui/<uid>/<label>` 的输出。只有 job 存在、当前没有
+    /// 运行中的进程，且 launchd 已经至少重试过一次或记录了异常退出码时，才判定为
+    /// “拉起失败循环”。正在运行（有 pid）或刚刚首次派生的 job 都返回 nil，避免把
+    /// 正常的慢启动误判成失败。
+    static func launchFailureDescription(
+        fromLaunchctlOutput output: String,
+        exitStatus: Int32 = 0
+    ) -> String? {
+        guard exitStatus == 0 else { return nil }
+        var state: String?
+        var pid: String?
+        var runs: Int?
+        var lastExitCode: String?
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard let separator = line.range(of: " = ") else { continue }
+            let key = line[..<separator.lowerBound].trimmingCharacters(in: .whitespaces)
+            let value = line[separator.upperBound...].trimmingCharacters(in: .whitespaces)
+            switch key {
+            case "state" where state == nil:
+                // 顶层 job 的 state 先于内部 endpoint/子项出现，只取第一条。
+                state = value
+            case "pid" where pid == nil:
+                pid = value
+            case "runs" where runs == nil:
+                runs = Int(value)
+            case "last exit code" where lastExitCode == nil:
+                lastExitCode = value
+            default:
+                continue
+            }
+        }
+        guard state != nil || runs != nil || lastExitCode != nil else { return nil }
+        if let pid, !pid.isEmpty, pid != "0" { return nil }
+        if state == "running" { return nil }
+        let neverExited = lastExitCode == nil || lastExitCode == "(never exited)"
+        let repeatedRuns = (runs ?? 0) >= 2
+        guard repeatedRuns || !neverExited else { return nil }
+        var detail = "launchd 无法启动 agentd"
+        if let runs, runs >= 2 {
+            detail += "，已连续尝试 \(runs) 次"
+        }
+        if !neverExited, let lastExitCode {
+            detail += "，最近退出码 \(lastExitCode)"
+        }
+        if let state, !state.isEmpty {
+            detail += "，当前状态 \(state)"
+        }
+        return detail
+    }
 
     /// `.notFound` 只表示 ServiceManagement 没找到服务记录，不能据此判断安装包漏文件。
     /// 这里直接核对包内 plist 与 BundleProgram，只有资源真的损坏时才要求重新安装。

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -30,6 +30,10 @@ final class HostStore {
     private(set) var startingDetail: String?
     var lastError: String?
     @ObservationIgnored private var pairingRefreshGeneration = 0
+    /// 启动等待期间的 status 轮询只用来判断是否就绪。未就绪的结果不能把生命周期
+    /// 写成 degraded/stopped，否则菜单栏会在"正在启动"阶段先闪出"服务需要处理"，
+    /// 让用户误以为启动已经失败。真正的失败由等待结束后的 fail() 给出。
+    @ObservationIgnored private var isAwaitingServiceStart = false
 
     var canRestoreHomebrew: Bool {
         owner == .macApp && homebrew.installedAgentBinary() != nil
@@ -910,6 +914,8 @@ final class HostStore {
     }
 
     private func waitForClaudeRuntime(enabled: Bool) async throws {
+        isAwaitingServiceStart = true
+        defer { isAwaitingServiceStart = false }
         for attempt in 0..<12 {
             try Task.checkCancellation()
             if let current = try? await fetchAndApplyLatestStatus() {
@@ -958,6 +964,8 @@ final class HostStore {
     }
 
     private func waitForMacAgentReady() async throws {
+        isAwaitingServiceStart = true
+        defer { isAwaitingServiceStart = false }
         var lastStatus: AgentStatus?
         for _ in 0..<15 {
             try Task.checkCancellation()
@@ -992,8 +1000,8 @@ final class HostStore {
             }
 
             let initialError = error
-            // 换代期间仍属于启动阶段：轮询 status 可能已把生命周期落成 stopped，
-            // 这里恢复 starting 并给出说明，避免菜单栏在自动修复时显示“服务已停止”。
+            // 换代期间仍属于启动阶段：保持 starting 并给出说明，
+            // 避免菜单栏在自动修复时显示"服务已停止"。
             lifecycle = .starting
             startingDetail = "覆盖安装后正在重新登记后台服务…"
             defer { startingDetail = nil }
@@ -1171,6 +1179,9 @@ final class HostStore {
         readinessFailureStartedAt = nil
         if resolved.serviceOK {
             lifecycle = .ready
+        } else if isAwaitingServiceStart {
+            // 启动闭环还在等待就绪；保持"正在启动"，把 degraded/stopped 留给稳态监控。
+            lifecycle = .starting
         } else if resolved.processOK {
             lifecycle = .degraded(
                 resolved.serviceError ?? firstBlockingIssue(in: resolved.doctor)
@@ -1267,6 +1278,8 @@ final class HostStore {
     /// 常驻监控始终以 healthz 作为进程探针；readiness 和完整 runtime 状态按不同频率读取。
     /// 保持该入口为 internal，测试可以直接推进 tick，无需真实等待五分钟。
     func performMonitoringTick(_ tick: Int, now: Date) async {
+        // 启动闭环自己在轮询 status；监控此时不得把未就绪写成 degraded。
+        guard !isAwaitingServiceStart else { return }
         guard owner != .none, let endpoint = status?.endpoint else { return }
         guard await health.check(endpoint) else {
             await refresh()

--- a/macos/MimiRemoteMac/Sources/State/HostStore.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStore.swift
@@ -25,6 +25,9 @@ final class HostStore {
     private(set) var isUpdatingTailcat = false
     private(set) var tailcatError: String?
     private(set) var tailcatNotice: String?
+    /// 启动阶段的补充说明，例如覆盖安装后正在重新登记后台服务。只在
+    /// `.starting` 期间有值，进入其它生命周期状态时清空。
+    private(set) var startingDetail: String?
     var lastError: String?
     @ObservationIgnored private var pairingRefreshGeneration = 0
 
@@ -169,7 +172,7 @@ final class HostStore {
     static func live() -> HostStore {
         HostStore(
             agent: .live(),
-            services: .live,
+            services: .live(),
             homebrew: .live(),
             health: .live,
             logs: .live,
@@ -962,9 +965,15 @@ final class HostStore {
                 lastStatus = current
                 if current.serviceOK { return }
             }
+            // 覆盖安装后 BTM 可能沿用旧 App 的 Launch Constraint，launchd 会每 3 秒
+            // 重试却始终拉不起进程。等满整轮再修复会白白浪费近一分钟；一旦 launchd
+            // 自己已经报告反复 spawn 失败，就立即交给上层做一次有界换代。
+            if let launchFailure = await services.agentLaunchFailure() {
+                throw ServiceLifecycleError.agentSpawnFailed(launchFailure)
+            }
             try await Task.sleep(for: .seconds(1))
         }
-        let detail = lastStatus?.serviceError ?? "服务在 15 秒内没有通过就绪检查。"
+        let detail = lastStatus?.serviceError ?? "服务在有限等待内没有通过就绪检查。"
         throw AgentClientError.commandFailed(detail)
     }
 
@@ -983,6 +992,11 @@ final class HostStore {
             }
 
             let initialError = error
+            // 换代期间仍属于启动阶段：轮询 status 可能已把生命周期落成 stopped，
+            // 这里恢复 starting 并给出说明，避免菜单栏在自动修复时显示“服务已停止”。
+            lifecycle = .starting
+            startingDetail = "覆盖安装后正在重新登记后台服务…"
+            defer { startingDetail = nil }
             do {
                 // register 已落入 enabled 但进程未就绪时，完整换代一次以刷新 BTM
                 // 的 Launch Constraint；递归调用关闭修复开关，保证最多只重试一次。
@@ -1380,6 +1394,7 @@ final class HostStore {
     private func fail(_ error: Error) {
         lastError = error.localizedDescription
         lifecycle = .failed(error.localizedDescription)
+        startingDetail = nil
     }
 
     private func validateMacAgentConfiguration() throws {
@@ -1527,6 +1542,7 @@ final class HostStore {
             markAgentRegistrationCurrent: {},
             registerAgent: {},
             unregisterAgent: {},
+            agentLaunchFailure: { nil },
             mainAppStatus: { .enabled }, registerMainApp: {}, unregisterMainApp: {},
             openLoginItemsSettings: {}
         )

--- a/macos/MimiRemoteMac/Sources/State/HostStoreControlErrors.swift
+++ b/macos/MimiRemoteMac/Sources/State/HostStoreControlErrors.swift
@@ -6,6 +6,7 @@ enum ServiceLifecycleError: LocalizedError {
     case stopTimedOut
     case requiresApproval
     case agentRegistrationFailed(String)
+    case agentSpawnFailed(String)
     case automaticRepairFailed(initial: String, recovery: String)
 
     var errorDescription: String? {
@@ -20,6 +21,8 @@ enum ServiceLifecycleError: LocalizedError {
             "请先在系统设置的登录项中允许 Mimi Remote Mac。"
         case .agentRegistrationFailed(let detail):
             "系统没有找到原服务记录，自动重新登记失败：\(detail)。请运行诊断并重试。"
+        case .agentSpawnFailed(let detail):
+            "macOS 无法启动后台服务（\(detail)），后台服务记录可能已过期。"
         case .automaticRepairFailed(let initial, let recovery):
             "服务首次启动失败（\(initial)），自动重新登记仍未恢复（\(recovery)）。请运行诊断。"
         }

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -402,6 +402,186 @@ final class HostStoreTests: XCTestCase {
         XCTAssertNil(store.lastError)
     }
 
+    /// 覆盖安装后 launchd 可能沿用旧 Launch Constraint，每 3 秒 spawn 失败一次。
+    /// 只要 launchd 自己已报告反复失败，就应在少量轮询后立即换代，而不是等满整轮。
+    func testLaunchdSpawnFailureTriggersImmediateReregistration() async {
+        let events = EventRecorder()
+        let statusCalls = CallCounter()
+        let launchFailureCalls = CallCounter()
+        let registrationAttempts = CallCounter()
+        var registrationState = ServiceRegistrationState.notRegistered
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            status: {
+                _ = statusCalls.increment()
+                return registrationAttempts.current >= 2 ? Self.readyStatus : Self.stoppedStatus
+            },
+            registerAgent: {
+                let attempt = registrationAttempts.increment()
+                events.append("register-\(attempt)")
+                registrationState = .enabled
+            },
+            unregisterAgent: {
+                events.append("unregister-mac")
+                registrationState = .notRegistered
+            },
+            agentLaunchFailure: {
+                _ = launchFailureCalls.increment()
+                return registrationAttempts.current == 1
+                    ? "launchd 无法启动 agentd，已连续尝试 3 次，最近退出码 78"
+                    : nil
+            },
+            healthCheck: { _ in false }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, ["register-1", "unregister-mac", "register-2"])
+        XCTAssertEqual(registrationAttempts.current, 2)
+        // 第一次登记只轮询一次 status 就发现 launchd 已在失败循环里，随后换代成功。
+        XCTAssertEqual(statusCalls.current, 2)
+        XCTAssertEqual(launchFailureCalls.current, 1)
+        XCTAssertEqual(store.owner, .macApp)
+        XCTAssertEqual(store.lifecycle, .ready)
+        XCTAssertNil(store.startingDetail)
+        XCTAssertNil(store.lastError)
+    }
+
+    /// 进程存活但尚未就绪的慢启动不会被误判：launchd 没有报告失败时继续等待，
+    /// 不做多余的注销与重新登记。
+    func testSlowStartWithoutLaunchdFailureKeepsWaitingWithoutRepair() async {
+        let events = EventRecorder()
+        let statusCalls = CallCounter()
+        var registrationState = ServiceRegistrationState.notRegistered
+        let store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            status: {
+                statusCalls.increment() >= 3 ? Self.readyStatus : Self.stoppedStatus
+            },
+            registerAgent: {
+                events.append("register-mac")
+                registrationState = .enabled
+            },
+            unregisterAgent: {
+                events.append("unregister-mac")
+                registrationState = .notRegistered
+            },
+            agentLaunchFailure: { nil },
+            healthCheck: { _ in false }
+        )
+
+        await store.bootstrap()
+
+        XCTAssertEqual(events.values, ["register-mac"])
+        XCTAssertEqual(statusCalls.current, 3)
+        XCTAssertEqual(store.lifecycle, .ready)
+        XCTAssertNil(store.startingDetail)
+    }
+
+    /// 自动换代期间菜单栏应显示正在重新登记的说明，而不是“服务已停止”。
+    func testAutomaticRepairExposesStartingDetailWhileReregistering() async {
+        let observed = EventRecorder()
+        let registrationAttempts = CallCounter()
+        var registrationState = ServiceRegistrationState.notRegistered
+        var store: HostStore?
+        let capture = { @MainActor in
+            observed.append("\(store?.lifecycle == .starting)|\(store?.startingDetail ?? "nil")")
+        }
+        store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            status: {
+                registrationAttempts.current >= 2 ? Self.readyStatus : Self.stoppedStatus
+            },
+            registerAgent: {
+                _ = registrationAttempts.increment()
+                registrationState = .enabled
+            },
+            unregisterAgent: {
+                await capture()
+                registrationState = .notRegistered
+            },
+            agentLaunchFailure: {
+                registrationAttempts.current == 1 ? "launchd 无法启动 agentd，已连续尝试 2 次" : nil
+            },
+            healthCheck: { _ in false }
+        )
+
+        await store?.bootstrap()
+
+        XCTAssertEqual(observed.values, ["true|覆盖安装后正在重新登记后台服务…"])
+        XCTAssertEqual(store?.lifecycle, .ready)
+        XCTAssertNil(store?.startingDetail)
+    }
+
+    func testLaunchFailureDescriptionIgnoresRunningJob() {
+        let output = """
+        gui/501/com.gaixianggeng.mimi.mac.agentd = {
+        \tactive count = 1
+        \tpath = /Applications/Mimi Remote Mac.app/Contents/Library/LaunchAgents/com.gaixianggeng.mimi.mac.agentd.plist
+        \tstate = running
+        \tparent bundle identifier = com.gaixianggeng.mimi.mac
+        \truns = 1
+        \tpid = 3856
+        \tlast exit code = (never exited)
+        \tendpoints = {
+        \t\t"com.gaixianggeng.mimi.mac.agentd" = {
+        \t\t\tstate = active
+        \t\t}
+        \t}
+        \tjob state = running
+        }
+        """
+        XCTAssertNil(ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: output))
+    }
+
+    func testLaunchFailureDescriptionDetectsSpawnFailureLoop() throws {
+        let output = """
+        gui/501/com.gaixianggeng.mimi.mac.agentd = {
+        \tactive count = 0
+        \tstate = spawn scheduled
+        \tparent bundle identifier = com.gaixianggeng.mimi.mac
+        \truns = 17
+        \tlast exit code = 78
+        \tendpoints = {
+        \t\t"com.gaixianggeng.mimi.mac.agentd" = {
+        \t\t\tstate = active
+        \t\t}
+        \t}
+        \tjob state = spawn scheduled
+        }
+        """
+        let detail = try XCTUnwrap(
+            ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: output)
+        )
+        XCTAssertTrue(detail.contains("17 次"), detail)
+        XCTAssertTrue(detail.contains("78"), detail)
+        XCTAssertEqual(
+            ServiceLifecycleError.agentSpawnFailed(detail).errorDescription?.contains("后台服务记录可能已过期"),
+            true
+        )
+    }
+
+    func testLaunchFailureDescriptionIgnoresFirstSpawnAndMissingJob() {
+        let firstSpawn = """
+        gui/501/com.gaixianggeng.mimi.mac.agentd = {
+        \tstate = spawn scheduled
+        \truns = 1
+        \tlast exit code = (never exited)
+        }
+        """
+        XCTAssertNil(ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: firstSpawn))
+        XCTAssertNil(
+            ServiceManagementClient.launchFailureDescription(
+                fromLaunchctlOutput: "Could not find service \"com.gaixianggeng.mimi.mac.agentd\" in domain for login: 100015",
+                exitStatus: 113
+            )
+        )
+        XCTAssertNil(ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: ""))
+    }
+
     func testAgentConfigurationValidatorChecksPlistAndExecutable() throws {
         let fileManager = FileManager.default
         let bundleURL = fileManager.temporaryDirectory
@@ -1293,6 +1473,7 @@ final class HostStoreTests: XCTestCase {
         },
         registerAgent: @escaping @MainActor () throws -> Void = {},
         unregisterAgent: @escaping @MainActor () async throws -> Void = {},
+        agentLaunchFailure: @escaping @MainActor () async -> String? = { nil },
         homebrewStart: @escaping @Sendable () async throws -> Void = {},
         homebrewStop: @escaping @Sendable () async throws -> Void = {},
         configureClaude: @escaping @Sendable (
@@ -1355,6 +1536,7 @@ final class HostStoreTests: XCTestCase {
             markAgentRegistrationCurrent: markAgentRegistrationCurrent,
             registerAgent: registerAgent,
             unregisterAgent: unregisterAgent,
+            agentLaunchFailure: agentLaunchFailure,
             mainAppStatus: { .enabled },
             registerMainApp: {},
             unregisterMainApp: {},

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -516,6 +516,71 @@ final class HostStoreTests: XCTestCase {
         XCTAssertNil(store?.startingDetail)
     }
 
+    /// 启动等待期间每轮 status 都可能返回"未就绪"。这些结果只用于判断是否继续等，
+    /// 不能把菜单栏从"正在启动"改成"服务需要处理"或"服务已停止"。
+    func testStartupWaitKeepsStartingLifecycleUntilReady() async {
+        let observed = EventRecorder()
+        let statusCalls = CallCounter()
+        var registrationState = ServiceRegistrationState.notRegistered
+        var store: HostStore?
+        let capture = { @MainActor in
+            observed.append(store?.lifecycle.title ?? "nil")
+        }
+        store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            status: {
+                await capture()
+                return statusCalls.increment() >= 3 ? Self.readyStatus : Self.stoppedStatus
+            },
+            registerAgent: { registrationState = .enabled },
+            healthCheck: { _ in false }
+        )
+
+        await store?.bootstrap()
+
+        XCTAssertEqual(statusCalls.current, 3)
+        XCTAssertEqual(observed.values, ["正在启动", "正在启动", "正在启动"])
+        XCTAssertEqual(store?.lifecycle, .ready)
+    }
+
+    /// 自动换代后仍拉不起进程时，结果必须是明确的"启动失败"，而不是停留在
+    /// 启动中，也不是被轮询结果写成"服务已停止"。
+    func testStartupRepairFailureEndsInFailedLifecycle() async {
+        let observed = EventRecorder()
+        let registrationAttempts = CallCounter()
+        var registrationState = ServiceRegistrationState.notRegistered
+        var store: HostStore?
+        let capture = { @MainActor in
+            observed.append(store?.lifecycle.title ?? "nil")
+        }
+        store = makeStore(
+            configExists: true,
+            agentStatus: { registrationState },
+            status: {
+                await capture()
+                return Self.stoppedStatus
+            },
+            registerAgent: {
+                _ = registrationAttempts.increment()
+                registrationState = .enabled
+            },
+            unregisterAgent: { registrationState = .notRegistered },
+            agentLaunchFailure: { "launchd 无法启动 agentd，已连续尝试 2 次，最近退出码 78" },
+            healthCheck: { _ in false }
+        )
+
+        await store?.bootstrap()
+
+        XCTAssertEqual(registrationAttempts.current, 2)
+        XCTAssertEqual(observed.values, ["正在启动", "正在启动"])
+        guard case .failed(let message)? = store?.lifecycle else {
+            return XCTFail("换代后仍失败应进入 failed，实际 \(String(describing: store?.lifecycle))")
+        }
+        XCTAssertTrue(message.contains("自动重新登记仍未恢复"), message)
+        XCTAssertNil(store?.startingDetail)
+    }
+
     func testLaunchFailureDescriptionIgnoresRunningJob() {
         let output = """
         gui/501/com.gaixianggeng.mimi.mac.agentd = {

--- a/macos/MimiRemoteMac/Tests/HostStoreTests.swift
+++ b/macos/MimiRemoteMac/Tests/HostStoreTests.swift
@@ -647,6 +647,44 @@ final class HostStoreTests: XCTestCase {
         XCTAssertNil(ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: ""))
     }
 
+    /// KeepAlive 服务有序退出（退出码 0）后到下一次拉起之间也没有 pid；只跑过一次时
+    /// 不能当成失败循环，否则会把一次正常退出变成不必要的注销与重新登记。
+    func testLaunchFailureDescriptionIgnoresSingleCleanExit() throws {
+        let cleanExit = """
+        gui/501/com.gaixianggeng.mimi.mac.agentd = {
+        \tstate = not running
+        \truns = 1
+        \tlast exit code = 0
+        }
+        """
+        XCTAssertNil(ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: cleanExit))
+
+        let abnormalFirstExit = """
+        gui/501/com.gaixianggeng.mimi.mac.agentd = {
+        \tstate = spawn scheduled
+        \truns = 1
+        \tlast exit code = 78: EX_CONFIG
+        }
+        """
+        let detail = try XCTUnwrap(
+            ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: abnormalFirstExit)
+        )
+        XCTAssertTrue(detail.contains("78"), detail)
+
+        let cleanExitLoop = """
+        gui/501/com.gaixianggeng.mimi.mac.agentd = {
+        \tstate = spawn scheduled
+        \truns = 4
+        \tlast exit code = 0
+        }
+        """
+        let loopDetail = try XCTUnwrap(
+            ServiceManagementClient.launchFailureDescription(fromLaunchctlOutput: cleanExitLoop)
+        )
+        XCTAssertTrue(loopDetail.contains("4 次"), loopDetail)
+        XCTAssertFalse(loopDetail.contains("退出码"), loopDetail)
+    }
+
     func testAgentConfigurationValidatorChecksPlistAndExecutable() throws {
         let fileManager = FileManager.default
         let bundleURL = fileManager.temporaryDirectory


### PR DESCRIPTION
## 目标

覆盖安装（或先「停止服务并退出」再重装）后第一次打开 Mimi Remote Mac，后台服务应在几秒内起来；自动修复期间菜单栏要说明它在做什么，而不是近一分钟停在「正在启动」。

Refs #431

## 根因

统一日志显示：新版 App 完成 `SMAppService.register()` 后，launchd 立刻以 `OS_REASON_CODESIGNING | Launch Constraint Violation` 拉起 agentd 失败（BTM 复用了旧 App 留下的 launch item 记录），随后每 3 秒重试一次并持续失败。App 端 `waitForMacAgentReady` 要轮询满 15 轮（约 51 秒）才走到既有的 unregister → register 自动修复；第二次登记后 launchd 立即成功，agentd 不到 1 秒就 `listening`。也就是说这一分钟全部耗在“launchd 拉不起进程”＋“App 发现得太晚”，与 agentd 自身无关。

## 改动

- `ServiceManagementClient` 新增 `agentLaunchFailure`：读取 `launchctl print gui/<uid>/com.gaixianggeng.mimi.mac.agentd`，用纯函数 `launchFailureDescription(fromLaunchctlOutput:exitStatus:)` 判断 job 是否处于“无 pid、已重试 ≥ 2 次或记录了异常退出码”的失败循环；正在运行、首次派生、job 不存在都返回 nil。
- `HostStore.waitForMacAgentReady` 每轮 status 未就绪后询问一次 launchd；一旦确认失败循环立即抛出新的 `ServiceLifecycleError.agentSpawnFailed`，交给既有的一次性有界换代修复，不再等满整轮。
- 自动换代期间把生命周期恢复为 `.starting` 并暴露 `startingDetail`（「覆盖安装后正在重新登记后台服务…」），菜单栏用它替换泛用副标题；修复结束或失败时清空。
- 修正原先“15 秒内没有通过就绪检查”的误导文案。

## 验证

- `bash ./scripts/check-source-size.sh`：通过。
- `bash ./scripts/test-macos-app.sh`（真实 Scheme 编译 + XCTest）：75 个测试全部通过（含 6 个新增用例）。
- `bash ./scripts/verify-change.sh --plan` / `bash ./scripts/verify-change.sh`（quick）：4 项全部通过（diff --check ×3 + Mac App 无签名编译测试）。
- 新增单测：launchd spawn 失败在一次 status 轮询后即触发换代并最终就绪；无 launchd 失败的慢启动不做多余修复；换代期间 `startingDetail` 可见且结束后清空；`launchctl print` 解析覆盖运行中、失败循环、首次派生、job 不存在四种样本。

## 延后到真机的验收

- 需要在真实 Mac 上再走一次「停止服务并退出 → 覆盖安装 → 打开」流程，确认从打开到就绪不超过约 10 秒且菜单栏能看到重新登记的说明。本机当前的 agentd 正被其它会话和手机使用，本 PR 未在本机做覆盖安装验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYyfJr9QtZw85ZmpTHsF7B
