### PR TITLE
之前绑定消息提醒的电脑已重装或不可用时，允许直接换绑到当前电脑或关闭

### DIFF
--- a/internal/pushbridge/client.go
+++ b/internal/pushbridge/client.go
@@ -19,7 +19,8 @@ const (
 	providerUserAgent = "mimi-agentd-push/1"
 )
 
-// ErrDeviceUnregistered 表示 APNs 已确认该设备 Token 失效，调用方应删除本地设备。
+// ErrDeviceUnregistered 表示 APNs 已确认该设备 Token 失效，或 Provider 确认这张
+// Ticket 已被撤销；两种情况下本机注册都不可能再投递成功，调用方应删除本地设备。
 var ErrDeviceUnregistered = errors.New("设备 Token 已失效")
 
 type Notification struct {
@@ -129,6 +130,12 @@ func (c *Client) post(ctx context.Context, path string, body any, target any) er
 	if resp.StatusCode == http.StatusGone {
 		return ErrDeviceUnregistered
 	}
+	if resp.StatusCode == http.StatusForbidden && providerReason(raw) == providerReasonTicketRevoked {
+		// 手机把消息提醒换绑到另一台电脑时，旧 Ticket 在 Provider 被撤销，而这台电脑
+		// 可能根本没被联系到。Provider 以 ticket_revoked 拒绝后按设备失效处理，
+		// 避免之后每次审批都拿同一张死 Ticket 重试。
+		return ErrDeviceUnregistered
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// 只回状态码与 Provider 的固定错误枚举，绝不把响应体原样带进日志。
 		return fmt.Errorf("push provider %s 返回 %d (%s)", path, resp.StatusCode, providerReason(raw))
@@ -138,6 +145,9 @@ func (c *Client) post(ctx context.Context, path string, body any, target any) er
 	}
 	return json.Unmarshal(raw, target)
 }
+
+// providerReasonTicketRevoked 是 Provider 对已撤销 Ticket 返回的固定错误枚举。
+const providerReasonTicketRevoked = "ticket_revoked"
 
 func providerReason(raw []byte) string {
 	var body struct {

--- a/internal/pushbridge/client_test.go
+++ b/internal/pushbridge/client_test.go
@@ -25,6 +25,38 @@ func TestNotifyMapsGoneToDeviceUnregistered(t *testing.T) {
 	}
 }
 
+// 手机把消息提醒换绑到另一台电脑后，旧 Ticket 在 Provider 被撤销；这台电脑
+// 收到 ticket_revoked 必须删除设备，而不是之后每次审批都重试同一张死 Ticket。
+func TestNotifyMapsRevokedTicketToDeviceUnregistered(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "ticket_revoked"})
+	}))
+	t.Cleanup(server.Close)
+
+	err := NewClient(server.URL).Notify(context.Background(), Notification{})
+	if !errors.Is(err, ErrDeviceUnregistered) {
+		t.Fatalf("Provider ticket_revoked 必须让 agentd 删除设备，got=%v", err)
+	}
+}
+
+// 其它 403 不代表 Ticket 永久失效，不能据此删除设备。
+func TestNotifyKeepsDeviceForOtherForbiddenReasons(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "forbidden"})
+	}))
+	t.Cleanup(server.Close)
+
+	err := NewClient(server.URL).Notify(context.Background(), Notification{})
+	if err == nil {
+		t.Fatal("Provider 403 不能被当成投递成功")
+	}
+	if errors.Is(err, ErrDeviceUnregistered) {
+		t.Fatalf("非 ticket_revoked 的 403 不能让 agentd 删除设备，got=%v", err)
+	}
+}
+
 func TestNotifyKeepsDeviceForConfigurationRejection(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/pushbridge/devices.go
+++ b/internal/pushbridge/devices.go
@@ -147,6 +147,23 @@ func (s *DeviceStore) Remove(deviceID string) (Device, bool, error) {
 	return device, true, nil
 }
 
+// RemoveIfTicket 只在本地记录仍是这张 Ticket 时删除。投递失败回报的是发出请求时的
+// 快照；期间手机可能已用新 Ticket 重新注册同一个设备 ID，不能把新注册一并删掉。
+func (s *DeviceStore) RemoveIfTicket(deviceID string, ticket string) (Device, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	device, ok := s.devices[deviceID]
+	if !ok || device.Ticket != ticket {
+		return Device{}, false, nil
+	}
+	delete(s.devices, deviceID)
+	if err := s.saveLocked(); err != nil {
+		s.devices[deviceID] = device
+		return Device{}, false, err
+	}
+	return device, true, nil
+}
+
 func (s *DeviceStore) Get(deviceID string) (Device, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/pushbridge/devices_test.go
+++ b/internal/pushbridge/devices_test.go
@@ -1,0 +1,45 @@
+package pushbridge
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// 投递失败回报的是发请求时的 Ticket 快照。期间手机已用新 Ticket 重新注册同一设备时，
+// 旧 Ticket 的失效回报不能把新注册删掉；只有记录仍是那张 Ticket 才删除并落盘。
+func TestDeviceStoreRemoveIfTicketKeepsNewerRegistration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "push-devices.json")
+	store, err := NewDeviceStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ticket := range []string{"ticket-old", "ticket-new"} {
+		if _, err := store.Register(Device{
+			ID: "device-a", Ticket: ticket, ExpiresAt: time.Now().Add(24 * time.Hour),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, removed, err := store.RemoveIfTicket("device-a", "ticket-old"); err != nil || removed {
+		t.Fatalf("旧 Ticket 的回报不能删除新注册：removed=%v err=%v", removed, err)
+	}
+	if device, ok := store.Get("device-a"); !ok || device.Ticket != "ticket-new" {
+		t.Fatalf("新注册应原样保留：ok=%v device=%+v", ok, device)
+	}
+
+	if _, removed, err := store.RemoveIfTicket("device-a", "ticket-new"); err != nil || !removed {
+		t.Fatalf("当前 Ticket 失效时应删除：removed=%v err=%v", removed, err)
+	}
+	reloaded, err := NewDeviceStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reloaded.Get("device-a"); ok {
+		t.Fatal("删除必须落盘，重启后不能复活")
+	}
+	if _, removed, err := reloaded.RemoveIfTicket("device-missing", "ticket"); err != nil || removed {
+		t.Fatalf("不存在的设备不应报错也不应删除：removed=%v err=%v", removed, err)
+	}
+}

--- a/internal/pushbridge/manager.go
+++ b/internal/pushbridge/manager.go
@@ -308,7 +308,7 @@ func (m *Manager) fanout(ctx context.Context, action Action, event string, devic
 			}
 			if err := m.notifyer(deviceCtx, notification); err != nil {
 				if errors.Is(err, ErrDeviceUnregistered) {
-					if _, removed, removeErr := m.devices.Remove(device.ID); removeErr != nil {
+					if _, removed, removeErr := m.devices.RemoveIfTicket(device.ID, device.Ticket); removeErr != nil {
 						log.Printf("push bridge 删除失效设备失败 err=%v", removeErr)
 					} else if removed {
 						m.actions.RevokeDevice(device.ID)

--- a/ios/MimiRemote/Resources/Localizable.xcstrings
+++ b/ios/MimiRemote/Resources/Localizable.xcstrings
@@ -21729,6 +21729,108 @@
         }
       }
     },
+    "ui.push_previous_host_unavailable": {
+      "comment": "Shown when the push binding belongs to another computer that cannot be reached (reinstalled, removed from the app, offline or token rejected).",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The previously linked computer can't be reached. It may have been reinstalled, removed, or be offline. You can move notifications to this computer."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "之前绑定的电脑无法连接，可能已重装、已删除或离线。可以直接换绑到这台电脑。"
+          }
+        }
+      }
+    },
+    "ui.push_rebind_to_this_computer": {
+      "comment": "Button and confirmation action that moves the push binding to the current computer without contacting the previous one.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Notifications Here"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接换绑到这台电脑"
+          }
+        }
+      }
+    },
+    "ui.push_rebind_confirm_title": {
+      "comment": "Confirmation alert title before moving the push binding to the current computer.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move notifications to this computer?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "换绑到这台电脑？"
+          }
+        }
+      }
+    },
+    "ui.push_rebind_confirm_message": {
+      "comment": "Confirmation alert message before moving the push binding to the current computer.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications from the previous computer will stop, and this computer will start receiving them."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "旧电脑上的消息提醒会失效，这台电脑将开始接收提醒。"
+          }
+        }
+      }
+    },
+    "ui.push_previous_binding_revoke_failed": {
+      "comment": "Shown when the push service could not revoke the previous computer's ticket; the old binding is kept unchanged.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't revoke the previous computer's binding. Check your network and try again."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法撤销旧电脑的绑定，请检查网络后重试。"
+          }
+        }
+      }
+    },
+    "ui.push_turn_off_previous_binding": {
+      "comment": "Secondary action that turns off notifications bound to an unreachable previous computer by revoking its ticket, without binding this computer.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Just Turn Off Previous Notifications"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅关闭旧电脑的消息提醒"
+          }
+        }
+      }
+    },
     "ui.push_switch_to_registered_mac": {
       "comment": "Return to the previously bound Mac before enabling approval notifications for a different Mac.",
       "localizations": {

--- a/ios/MimiRemote/Sources/Features/Settings/LockScreenApprovalSettingsView.swift
+++ b/ios/MimiRemote/Sources/Features/Settings/LockScreenApprovalSettingsView.swift
@@ -13,6 +13,9 @@ struct LockScreenApprovalSettingsView: View {
     @AppStorage("agentd.developerMode") private var developerModeEnabled = false
     @State private var isBusy = false
     @State private var showsConsent = false
+    @State private var showsRebindConfirmation = false
+    /// 换绑前先补披露同意时记住意图，同意后直接以换绑模式继续，不让用户点两次。
+    @State private var takeOverAfterConsent = false
 
     var body: some View {
         let tokens = themeStore.tokens(for: colorScheme)
@@ -55,6 +58,40 @@ struct LockScreenApprovalSettingsView: View {
                     .accessibilityIdentifier("settings.lockScreenApproval.hostNotice")
                 }
             }
+
+			if showsRebindOptions {
+				// 旧绑定所在的电脑联系不上（已删、已重装、离线或 Token 被拒）。
+				// 这里给出唯一的出口：以 Provider 撤销为准换绑到当前电脑，或者只关掉。
+				Section {
+					Label {
+						Text(L10n.text("ui.push_previous_host_unavailable"))
+							.font(themeStore.uiFont(.subheadline))
+							.foregroundStyle(tokens.secondaryText)
+							.fixedSize(horizontal: false, vertical: true)
+					} icon: {
+						Image(systemName: "exclamationmark.triangle")
+							.foregroundStyle(tokens.accent)
+					}
+					.padding(.vertical, 6)
+					.accessibilityIdentifier("settings.lockScreenApproval.previousHostNotice")
+					Button {
+						showsRebindConfirmation = true
+					} label: {
+						Label(L10n.text("ui.push_rebind_to_this_computer"), systemImage: "arrow.left.arrow.right")
+					}
+					.settingsRow()
+					.disabled(isBusy || !store.hostSupportsPush(for: appStore.activeConnectionProfileID))
+					.accessibilityIdentifier("settings.lockScreenApproval.rebind")
+					Button(role: .destructive) {
+						Task { await disablePreviousBindingWithoutHost() }
+					} label: {
+						Label(L10n.text("ui.push_turn_off_previous_binding"), systemImage: "bell.slash")
+					}
+					.settingsRow()
+					.disabled(isBusy)
+					.accessibilityIdentifier("settings.lockScreenApproval.turnOffPrevious")
+				}
+			}
 
             Section {
                 ForEach(LockScreenApprovalDisclosure.leavesDeviceKeys, id: \.self) { key in
@@ -120,12 +157,38 @@ struct LockScreenApprovalSettingsView: View {
                 onAgree: {
                     showsConsent = false
 					store.recordConsent(for: appStore.activeConnectionProfileID)
-                    Task { await enable() }
+					let takeOver = takeOverAfterConsent
+					takeOverAfterConsent = false
+                    Task { await enable(takeOverPreviousBinding: takeOver) }
                 },
-                onCancel: { showsConsent = false }
+                onCancel: {
+					takeOverAfterConsent = false
+					showsConsent = false
+				}
             )
         }
+		.alert(
+			L10n.text("ui.push_rebind_confirm_title"),
+			isPresented: $showsRebindConfirmation
+		) {
+			Button(L10n.text("ui.push_rebind_to_this_computer"), role: .destructive) {
+				rebindToCurrentComputer()
+			}
+			Button(L10n.text("ui.cancel"), role: .cancel) {}
+		} message: {
+			Text(L10n.text("ui.push_rebind_confirm_message"))
+		}
     }
+
+	/// 只有绑定确实属于另一台联系不上的电脑时才露出换绑入口。
+	private var showsRebindOptions: Bool {
+		guard case .previousHostUnavailable = store.status,
+		      store.isEnabled,
+		      let registeredProfileID = store.registeredProfileID else {
+			return false
+		}
+		return registeredProfileID != appStore.activeConnectionProfileID
+	}
 
     private var toggleBinding: Binding<Bool> {
 		Binding(
@@ -146,16 +209,18 @@ struct LockScreenApprovalSettingsView: View {
         )
     }
 
-	private func enable() async {
+	private func enable(takeOverPreviousBinding: Bool = false) async {
         isBusy = true
         defer { isBusy = false }
 		guard let client = try? appStore.client(),
 			  let profileID = appStore.activeConnectionProfileID else { return }
 		let previousClient: AgentAPIClient?
 		let previousClientProfileID: String?
-		if let previousProfileID = store.registeredProfileID,
+		if !takeOverPreviousBinding,
+		   let previousProfileID = store.registeredProfileID,
 		   previousProfileID != profileID {
-			// Store 会在 B 注册前注销 A；构造失败时传 nil，Store 保留 A 的本地绑定并报错。
+			// Store 会在 B 注册前注销 A；构造失败时传 nil，Store 保留 A 的本地绑定，
+			// 并把状态置为“旧电脑联系不上”，由下方的换绑入口接手。
 			previousClient = try? await LockScreenApprovalRouting.client(
 				profileID: previousProfileID,
 				appStore: appStore
@@ -169,27 +234,58 @@ struct LockScreenApprovalSettingsView: View {
 			client: client,
 			profileID: profileID,
 			previousClient: previousClient,
-			previousClientProfileID: previousClientProfileID
+			previousClientProfileID: previousClientProfileID,
+			takeOverPreviousBinding: takeOverPreviousBinding
 		)
+	}
+
+	/// 用户在弹窗里确认换绑后才到这里。没同意过当前收件主机就先弹披露，同意后继续换绑。
+	private func rebindToCurrentComputer() {
+		guard !isBusy else { return }
+		if store.hasConsented(for: appStore.activeConnectionProfileID) {
+			Task { await enable(takeOverPreviousBinding: true) }
+		} else {
+			takeOverAfterConsent = true
+			showsConsent = true
+		}
 	}
 
 	private func disable() async {
 		isBusy = true
 		defer { isBusy = false }
 		let client: AgentAPIClient?
+		var previousHostUnavailable = false
 		let registeredProfileID = store.registeredProfileID
 		if let profileID = registeredProfileID,
 		   profileID != appStore.activeConnectionProfileID {
 			client = try? await LockScreenApprovalRouting.client(profileID: profileID, appStore: appStore)
+			// 旧档案已删或凭据缺失时构造不出 client；关闭只能靠 Provider 撤销来保证。
+			previousHostUnavailable = client == nil
 		} else {
 			client = try? appStore.client()
 		}
-		await store.disable(client: client, profileID: registeredProfileID)
+		await store.disable(
+			client: client,
+			profileID: registeredProfileID,
+			previousHostUnavailable: previousHostUnavailable
+		)
+	}
+
+	/// 旧电脑已经确认联系不上：不再尝试它的 agentd，直接撤销 Provider Ticket 并清理本地绑定。
+	private func disablePreviousBindingWithoutHost() async {
+		guard !isBusy else { return }
+		isBusy = true
+		defer { isBusy = false }
+		await store.disable(
+			client: nil,
+			profileID: store.registeredProfileID,
+			previousHostUnavailable: true
+		)
 	}
 
     private var statusIsProblem: Bool {
         switch store.status {
-        case .notificationsDenied, .failed, .unavailableOnHost:
+        case .notificationsDenied, .failed, .unavailableOnHost, .previousHostUnavailable:
             return true
         case .off, .registering, .active:
             return false
@@ -214,6 +310,8 @@ struct LockScreenApprovalSettingsView: View {
             return L10n.format("ui.push_status_active_until_value", Self.expiryFormatter.string(from: expiresAt))
         case .failed(let message):
             return message
+        case .previousHostUnavailable:
+            return L10n.text("ui.push_previous_host_unavailable")
         }
     }
 

--- a/ios/MimiRemote/Sources/State/LockScreenApprovalStore.swift
+++ b/ios/MimiRemote/Sources/State/LockScreenApprovalStore.swift
@@ -345,8 +345,9 @@ final class LockScreenApprovalStore: ObservableObject {
 			}
 			if takeOverPreviousBinding {
 				// 旧电脑联系不上时不再要求它先注销：真正决定投递的是 Provider 手里的
-				// Ticket，撤销成功即旧绑定失效，旧 agentd 收到 410 后会自行清理设备。
-				// 撤销必须成功；失败就原样保留旧绑定，绝不制造两边都注册的窗口。
+				// Ticket。撤销成功后 Provider 以 ticket_revoked 拒绝旧 agentd 的投递，
+				// 旧 agentd 据此删除这台设备。撤销必须成功；失败就原样保留旧绑定，
+				// 绝不制造两边都注册的窗口。
 				status = .registering
 				do {
 					try await providerClientFactory(previousProviderURL).revokeTicket(previousTicket)
@@ -363,6 +364,11 @@ final class LockScreenApprovalStore: ObservableObject {
 					previousClient: nil,
 					previousClientProfileID: nil
 				)
+				if !isEnabled {
+					// 旧绑定已撤销、新注册没成功：此刻功能就是关闭态。按关闭路径清掉标题缓存、
+					// 远程通知注册和残留的锁屏卡片，保留 performEnable 给出的失败状态。
+					await clearOffStateArtifacts()
+				}
 				return
 			}
 			if needsProfileSwitch,
@@ -575,7 +581,12 @@ final class LockScreenApprovalStore: ObservableObject {
 			defaults.removeObject(forKey: key)
 		}
 		status = .off
-		// 关闭后不会再有推送命中缓存；标题副本随功能一起清掉。
+		await clearOffStateArtifacts()
+	}
+
+	/// 功能进入关闭态后的本地清理：不会再有推送命中缓存，标题副本随功能一起清掉；
+	/// 注销远程通知，并移走已经送达的审批卡片。
+	private func clearOffStateArtifacts() async {
 		clearNotificationTitleCache()
 		#if canImport(UIKit)
 		UIApplication.shared.unregisterForRemoteNotifications()

--- a/ios/MimiRemote/Sources/State/LockScreenApprovalStore.swift
+++ b/ios/MimiRemote/Sources/State/LockScreenApprovalStore.swift
@@ -24,24 +24,39 @@ final class LockScreenApprovalStore: ObservableObject {
         case registering
         case active(expiresAt: Date)
         case failed(message: String)
+        /// 绑定还在另一台电脑上，而那台电脑联系不上（档案已删、已重装、离线或
+        /// Token 被拒）。旧绑定原样保留；UI 据此提供“直接换绑到这台电脑”的出口。
+        case previousHostUnavailable
     }
 
     private enum BindingError: LocalizedError {
         case previousClientUnavailable
         case previousProviderUnavailable
 		case providerChanged
+		/// 旧 agentd 的注销请求失败。无论是 401、404 还是网络错误，对用户来说都是
+		/// “旧电脑联系不上”；具体原因不影响下一步（Provider 撤销后换绑）。
+		case previousHostUnreachable
+		/// 换绑或关闭时 Provider 没能撤销旧 Ticket；旧绑定必须原样保留。
+		case previousBindingRevokeFailed
 
         var errorDescription: String? {
 			switch self {
 			case .providerChanged:
 				return L10n.text("ui.push_consent_required")
-			case .previousClientUnavailable:
-                return L10n.text("ui.push_switch_to_registered_mac")
+			case .previousClientUnavailable, .previousHostUnreachable:
+                return L10n.text("ui.push_previous_host_unavailable")
+			case .previousBindingRevokeFailed:
+				return L10n.text("ui.push_previous_binding_revoke_failed")
             case .previousProviderUnavailable:
 				return L10n.text("ui.push_approval_result_unknown")
 			}
         }
     }
+
+	/// 测试需要替换 Provider 与系统通知授权：前者用 URLProtocol 桩，后者不能真的弹
+	/// 系统对话框。生产路径保持默认值。
+	typealias ProviderClientFactory = (String) -> PushProviderClient
+	typealias NotificationAuthorizationRequest = () async throws -> Bool
 
 	private enum Key {
         static let enabled = "lockScreenApproval.enabled"
@@ -80,6 +95,8 @@ final class LockScreenApprovalStore: ObservableObject {
 	/// 关闭提醒时同步删除 App Group 里的会话标题缓存（gh-418）；功能关掉后
 	/// 设备上不该留着一份没有用途的标题副本。测试可注入替身。
 	private let clearNotificationTitleCache: () -> Void
+	private let providerClientFactory: ProviderClientFactory
+	private let requestAuthorization: NotificationAuthorizationRequest
 	private let identity: PushInstallationIdentity?
 	private var deviceTokenContinuations: [CheckedContinuation<String, Error>] = []
 	private var cachedDeviceToken: String?
@@ -94,13 +111,19 @@ final class LockScreenApprovalStore: ObservableObject {
         ticketStore: PushTicketStore = PushTicketStore(),
 		identityStore: PushInstallationIdentityStore = PushInstallationIdentityStore(),
         environment: PushEnvironment = .current(),
-		clearNotificationTitleCache: @escaping () -> Void = { NotificationTitleCache.clear() }
+		clearNotificationTitleCache: @escaping () -> Void = { NotificationTitleCache.clear() },
+		providerClientFactory: @escaping ProviderClientFactory = { PushProviderClient(baseURL: $0) },
+		requestAuthorization: NotificationAuthorizationRequest? = nil
     ) {
         self.defaults = defaults
         self.center = center
         self.ticketStore = ticketStore
         self.environment = environment
 		self.clearNotificationTitleCache = clearNotificationTitleCache
+		self.providerClientFactory = providerClientFactory
+		self.requestAuthorization = requestAuthorization ?? {
+			try await center.requestAuthorization(options: [.alert, .sound, .badge])
+		}
 		do {
 			let resolution = try Self.resolveIdentity(
 				defaults: defaults,
@@ -219,12 +242,16 @@ final class LockScreenApprovalStore: ObservableObject {
 		defaults.removeObject(forKey: Key.consentedHost)
 	}
 
+	/// `takeOverPreviousBinding` 只在旧绑定属于另一台电脑且那台电脑联系不上时使用：
+	/// 跳过旧 agentd 的注销，以 Provider 撤销旧 Ticket 为准，再为当前电脑重新注册。
+	/// 必须由用户在设置页显式确认后才传 true。
 	func enable(
 		client: AgentAPIClient,
 		profileID: String,
 		providerURL: String? = nil,
 		previousClient: AgentAPIClient? = nil,
-		previousClientProfileID: String? = nil
+		previousClientProfileID: String? = nil,
+		takeOverPreviousBinding: Bool = false
 	) async {
 		await withBindingOperation {
 			await performEnableUntilCurrentDeviceToken(
@@ -232,7 +259,8 @@ final class LockScreenApprovalStore: ObservableObject {
 				profileID: profileID,
 				providerURL: providerURL,
 				previousClient: previousClient,
-				previousClientProfileID: previousClientProfileID
+				previousClientProfileID: previousClientProfileID,
+				takeOverPreviousBinding: takeOverPreviousBinding
 			)
 		}
 	}
@@ -242,14 +270,16 @@ final class LockScreenApprovalStore: ObservableObject {
 		profileID: String,
 		providerURL: String?,
 		previousClient: AgentAPIClient?,
-		previousClientProfileID: String?
+		previousClientProfileID: String?,
+		takeOverPreviousBinding: Bool = false
 	) async {
 		await performEnable(
 			client: client,
 			profileID: profileID,
 			providerURL: providerURL,
 			previousClient: previousClient,
-			previousClientProfileID: previousClientProfileID
+			previousClientProfileID: previousClientProfileID,
+			takeOverPreviousBinding: takeOverPreviousBinding
 		)
 		// APNs 可能在上一次注册已经读取 cachedDeviceToken 后回调新 Token。
 		// 每次成功后重新比较，直到远端绑定与当前缓存一致。
@@ -275,7 +305,8 @@ final class LockScreenApprovalStore: ObservableObject {
 		profileID: String,
 		providerURL: String?,
 		previousClient: AgentAPIClient?,
-		previousClientProfileID: String?
+		previousClientProfileID: String?,
+		takeOverPreviousBinding: Bool = false
 	) async {
 		guard let identity else {
 			status = .failed(message: L10n.text("ui.push_approval_result_unknown"))
@@ -300,24 +331,44 @@ final class LockScreenApprovalStore: ObservableObject {
 		}
 		let needsProviderSwitch = previousProviderURL != nil && previousProviderURL != baseURL
 		let needsBindingSwitch = needsProfileSwitch || needsProviderSwitch
-		let provider = PushProviderClient(baseURL: baseURL)
+		let provider = providerClientFactory(baseURL)
 		guard defaults.string(forKey: Key.consentedProviderURL) == baseURL else {
 			status = .failed(message: L10n.text("ui.push_consent_required"))
 			return
 		}
 		if needsBindingSwitch {
-			guard previousTicket != nil,
-			      previousExpiry != nil else {
+			guard let previousTicket,
+			      previousExpiry != nil,
+			      let previousProviderURL else {
 				status = .failed(message: BindingError.previousProviderUnavailable.localizedDescription)
 				return
 			}
-			if previousProviderURL == nil {
-				status = .failed(message: BindingError.previousProviderUnavailable.localizedDescription)
+			if takeOverPreviousBinding {
+				// 旧电脑联系不上时不再要求它先注销：真正决定投递的是 Provider 手里的
+				// Ticket，撤销成功即旧绑定失效，旧 agentd 收到 410 后会自行清理设备。
+				// 撤销必须成功；失败就原样保留旧绑定，绝不制造两边都注册的窗口。
+				status = .registering
+				do {
+					try await providerClientFactory(previousProviderURL).revokeTicket(previousTicket)
+				} catch {
+					status = .failed(message: BindingError.previousBindingRevokeFailed.localizedDescription)
+					return
+				}
+				clearStoredBinding()
+				// 旧绑定已经不存在，剩下的就是一次干净的首次开启；中途失败留下的也是关闭态。
+				await performEnable(
+					client: client,
+					profileID: profileID,
+					providerURL: providerURL,
+					previousClient: nil,
+					previousClientProfileID: nil
+				)
 				return
 			}
 			if needsProfileSwitch,
 			   previousClient == nil || previousClientProfileID != previousProfileID {
-				status = .failed(message: BindingError.previousClientUnavailable.localizedDescription)
+				// 旧档案已删、Tailcat 档案非当前或缺少凭据：没有网络请求可发。
+				status = .previousHostUnavailable
 				return
 			}
 		}
@@ -357,7 +408,13 @@ final class LockScreenApprovalStore: ObservableObject {
 				}
 				// 同一安装只允许一个绑定。先撤销旧 agentd 注册，再提交新 Profile。
 				previousUnregistrationAttempted = true
-				try await previousClient.unregisterPushDevice(deviceID: identity.deviceID)
+				do {
+					try await previousClient.unregisterPushDevice(deviceID: identity.deviceID)
+				} catch {
+					// 401、404、超时或断网在这里都是同一个结论：旧电脑联系不上。
+					// 具体错误不改变下一步，用户可以在确认后走 Provider 撤销换绑。
+					throw BindingError.previousHostUnreachable
+				}
 			}
 
 			try ticketStore.save(ticket.value)
@@ -377,7 +434,7 @@ final class LockScreenApprovalStore: ObservableObject {
 			   let previousTicket,
 			   let previousProviderURL {
 				// 新注册确认后再撤销旧 Ticket；撤销失败会进入下方回滚，避免静默双活。
-				try await PushProviderClient(baseURL: previousProviderURL).revokeTicket(previousTicket)
+				try await providerClientFactory(previousProviderURL).revokeTicket(previousTicket)
 			}
 
 			defaults.set(true, forKey: Key.enabled)
@@ -391,7 +448,7 @@ final class LockScreenApprovalStore: ObservableObject {
 			if !needsBindingSwitch,
 			   let previousTicket,
 			   previousTicket != ticket.value {
-				try? await PushProviderClient(baseURL: previousProviderURL ?? baseURL)
+				try? await providerClientFactory(previousProviderURL ?? baseURL)
 					.revokeTicket(previousTicket)
 			}
 		} catch {
@@ -432,19 +489,47 @@ final class LockScreenApprovalStore: ObservableObject {
 				try? await provider.revokeTicket(issuedTicket)
 			}
 			defaults.set(wasEnabled, forKey: Key.enabled)
-			status = .failed(message: error.localizedDescription)
+			switch error as? BindingError {
+			case .previousClientUnavailable?, .previousHostUnreachable?:
+				// 旧绑定原样保留；由 UI 提供“直接换绑到这台电脑”的出口。
+				status = .previousHostUnavailable
+			default:
+				status = .failed(message: error.localizedDescription)
+			}
+		}
+	}
+
+	/// 把本地绑定彻底清成关闭态：Ticket、注册记录和 Token 指纹都不保留。
+	/// 只在 Provider 已经撤销旧 Ticket 之后调用。
+	private func clearStoredBinding() {
+		try? ticketStore.delete()
+		defaults.set(false, forKey: Key.enabled)
+		for key in [Key.ticketExpiresAt, Key.registeredProfileID, Key.registeredProviderURL, Key.deviceTokenFingerprint] {
+			defaults.removeObject(forKey: key)
 		}
 	}
 
 	/// 关闭等价于撤销：删除本地 Ticket、让 agentd 忘记这台设备、请求 Provider
 	/// 把 Ticket ID 加入撤销表，并注销远程通知。
-	func disable(client: AgentAPIClient?, profileID: String?) async {
+	func disable(
+		client: AgentAPIClient?,
+		profileID: String?,
+		previousHostUnavailable: Bool = false
+	) async {
 		await withBindingOperation {
-			await performDisable(client: client, profileID: profileID)
+			await performDisable(
+				client: client,
+				profileID: profileID,
+				previousHostUnavailable: previousHostUnavailable
+			)
 		}
 	}
 
-	private func performDisable(client: AgentAPIClient?, profileID: String?) async {
+	private func performDisable(
+		client: AgentAPIClient?,
+		profileID: String?,
+		previousHostUnavailable: Bool
+	) async {
 		guard let identity else {
 			status = .failed(message: L10n.text("ui.push_approval_result_unknown"))
 			return
@@ -455,7 +540,7 @@ final class LockScreenApprovalStore: ObservableObject {
 			status = .failed(message: L10n.text("ui.push_approval_result_unknown"))
 			return
 		}
-		guard let client else {
+		guard client != nil || previousHostUnavailable else {
 			// 没有来源 client 时不能确认 agentd 已注销；保留全部绑定状态，
 			// 让用户恢复连接后重试，而不是只清理本地痕迹。
 			status = .failed(message: L10n.text("ui.push_approval_result_unknown"))
@@ -468,9 +553,17 @@ final class LockScreenApprovalStore: ObservableObject {
 			return
 		}
 		do {
-			try await client.unregisterPushDevice(deviceID: identity.deviceID)
+			if let client {
+				try await client.unregisterPushDevice(deviceID: identity.deviceID)
+			}
+			// 旧电脑联系不上时（client 为 nil），Provider 撤销就是关闭的全部保证：
+			// 撤销失败必须保留绑定，只清本地痕迹会让 Provider 继续持有一张有效 Ticket。
 			if let ticket, let registeredProviderURL {
-				try await PushProviderClient(baseURL: registeredProviderURL).revokeTicket(ticket)
+				do {
+					try await providerClientFactory(registeredProviderURL).revokeTicket(ticket)
+				} catch where client == nil {
+					throw BindingError.previousBindingRevokeFailed
+				}
 			}
 			try ticketStore.delete()
 		} catch {
@@ -758,7 +851,7 @@ final class LockScreenApprovalStore: ObservableObject {
     // MARK: - 内部
 
     private func requestNotificationAuthorization() async throws -> Bool {
-        try await center.requestAuthorization(options: [.alert, .sound, .badge])
+        try await requestAuthorization()
     }
 
     private func obtainDeviceToken() async throws -> String {

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LockScreenApprovalTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LockScreenApprovalTests.swift
@@ -771,3 +771,333 @@ extension LockScreenApprovalTests {
         ))), "类型对不上时不删")
     }
 }
+
+// MARK: - 旧电脑联系不上时的换绑与关闭（gh-432）
+
+extension LockScreenApprovalTests {
+    private struct RebindFixture {
+        let defaults: UserDefaults
+        let suite: String
+        let session: URLSession
+        let store: LockScreenApprovalStore
+        let tickets: PushTicketStore
+        let newClient: AgentAPIClient
+        let oldClient: AgentAPIClient
+
+        func tearDown() {
+            defaults.removePersistentDomain(forName: suite)
+            RebindURLProtocol.reset()
+        }
+    }
+
+    /// 绑定在 profile-old 上，当前电脑是 profile-new；两台电脑共用同一个 Provider。
+    @MainActor
+    private func makeRebindFixture() async throws -> RebindFixture {
+        let suite = "LockScreenApprovalTests.Rebind.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        RebindURLProtocol.reset()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RebindURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let keychain = TestKeychainOperations()
+        let identityStore = PushInstallationIdentityStore(keychain: keychain)
+        try identityStore.save(.make())
+        let tickets = PushTicketStore(keychain: keychain)
+        try tickets.save("ticket-old")
+        defaults.set(true, forKey: "lockScreenApproval.enabled")
+        defaults.set("profile-old", forKey: "lockScreenApproval.registeredProfileID")
+        defaults.set(RebindURLProtocol.providerURL, forKey: "lockScreenApproval.registeredProviderURL")
+        defaults.set(Date().addingTimeInterval(86400), forKey: "lockScreenApproval.ticketExpiresAt")
+        let store = LockScreenApprovalStore(
+            defaults: defaults,
+            ticketStore: tickets,
+            identityStore: identityStore,
+            clearNotificationTitleCache: {},
+            providerClientFactory: { PushProviderClient(baseURL: $0, session: session) },
+            requestAuthorization: { true }
+        )
+        let newClient = AgentAPIClient(endpoint: "https://profile-new.example", token: "new", session: session)
+        let oldClient = AgentAPIClient(endpoint: "https://profile-old.example", token: "old", session: session)
+        await store.refreshHostSupport(client: newClient, profileID: "profile-new")
+        store.recordConsent(for: "profile-new")
+        XCTAssertTrue(store.hasConsented(for: "profile-new"))
+        store.handleDeviceToken(Data([0xAB, 0xCD, 0xEF]))
+        RebindURLProtocol.clearRecordedRequests()
+        return RebindFixture(
+            defaults: defaults,
+            suite: suite,
+            session: session,
+            store: store,
+            tickets: tickets,
+            newClient: newClient,
+            oldClient: oldClient
+        )
+    }
+
+    /// 旧档案已删或凭据缺失时构造不出旧 client：不发任何请求，旧绑定原样保留，
+    /// 状态明确告诉 UI“旧电脑联系不上”，而不是要求用户回到一台不存在的电脑。
+    @MainActor
+    func testEnableWithoutPreviousClientReportsPreviousHostUnavailableWithoutRequests() async throws {
+        let fixture = try await makeRebindFixture()
+        defer { fixture.tearDown() }
+
+        await fixture.store.enable(client: fixture.newClient, profileID: "profile-new")
+
+        XCTAssertEqual(fixture.store.status, .previousHostUnavailable)
+        XCTAssertEqual(RebindURLProtocol.recordedRequests, [])
+        XCTAssertTrue(fixture.store.isEnabled)
+        XCTAssertEqual(fixture.store.registeredProfileID, "profile-old")
+        XCTAssertEqual(try fixture.tickets.loadRequired(), "ticket-old")
+    }
+
+    /// 旧 agentd 拒绝注销（重装后 Token 失效的典型表现）：撤销刚签发的新 Ticket、
+    /// 保留旧绑定，并进入“旧电脑联系不上”状态，而不是把 401 原样丢给用户。
+    @MainActor
+    func testPreviousHostRejectingUnregisterRollsBackAndReportsPreviousHostUnavailable() async throws {
+        let fixture = try await makeRebindFixture()
+        defer { fixture.tearDown() }
+        RebindURLProtocol.fail("DELETE profile-old.example /api/push/devices", status: 401)
+
+        await fixture.store.enable(
+            client: fixture.newClient,
+            profileID: "profile-new",
+            previousClient: fixture.oldClient,
+            previousClientProfileID: "profile-old"
+        )
+
+        XCTAssertEqual(fixture.store.status, .previousHostUnavailable)
+        XCTAssertTrue(fixture.store.isEnabled)
+        XCTAssertEqual(fixture.store.registeredProfileID, "profile-old")
+        XCTAssertEqual(try fixture.tickets.loadRequired(), "ticket-old")
+        let requests = RebindURLProtocol.recordedRequests
+        XCTAssertTrue(requests.contains("DELETE profile-old.example /api/push/devices"), "\(requests)")
+        XCTAssertFalse(requests.contains("POST profile-new.example /api/push/devices"), "新电脑不应被注册：\(requests)")
+        XCTAssertEqual(RebindURLProtocol.revokedTickets, ["ticket-new"], "只能撤销刚签发的新 Ticket")
+    }
+
+    /// 用户确认换绑：不再联系旧 agentd，先在 Provider 撤销旧 Ticket，再为当前电脑注册。
+    @MainActor
+    func testTakeoverRevokesOldTicketAtProviderThenRegistersCurrentComputer() async throws {
+        let fixture = try await makeRebindFixture()
+        defer { fixture.tearDown() }
+
+        await fixture.store.enable(
+            client: fixture.newClient,
+            profileID: "profile-new",
+            takeOverPreviousBinding: true
+        )
+
+        guard case .active = fixture.store.status else {
+            return XCTFail("换绑后应处于 active，实际：\(fixture.store.status)")
+        }
+        XCTAssertTrue(fixture.store.isEnabled)
+        XCTAssertEqual(fixture.store.registeredProfileID, "profile-new")
+        XCTAssertEqual(fixture.store.registeredProviderURL, RebindURLProtocol.providerURL)
+        XCTAssertEqual(try fixture.tickets.loadRequired(), "ticket-new")
+        XCTAssertEqual(RebindURLProtocol.revokedTickets, ["ticket-old"])
+        XCTAssertEqual(
+            RebindURLProtocol.recordedRequests,
+            [
+                "POST provider.example /mimi-push/v1/ticket/revoke",
+                "POST provider.example /mimi-push/v1/ticket",
+                "POST profile-new.example /api/push/devices",
+            ]
+        )
+    }
+
+    /// Provider 撤销失败时必须原样保留旧绑定：不签发新 Ticket、不注册新电脑、不清本地。
+    @MainActor
+    func testTakeoverKeepsOldBindingWhenProviderRevokeFails() async throws {
+        let fixture = try await makeRebindFixture()
+        defer { fixture.tearDown() }
+        RebindURLProtocol.fail("POST provider.example /mimi-push/v1/ticket/revoke", status: 503)
+
+        await fixture.store.enable(
+            client: fixture.newClient,
+            profileID: "profile-new",
+            takeOverPreviousBinding: true
+        )
+
+        XCTAssertEqual(
+            fixture.store.status,
+            .failed(message: L10n.text("ui.push_previous_binding_revoke_failed"))
+        )
+        XCTAssertTrue(fixture.store.isEnabled)
+        XCTAssertEqual(fixture.store.registeredProfileID, "profile-old")
+        XCTAssertEqual(try fixture.tickets.loadRequired(), "ticket-old")
+        XCTAssertEqual(
+            RebindURLProtocol.recordedRequests,
+            ["POST provider.example /mimi-push/v1/ticket/revoke"]
+        )
+    }
+
+    /// 旧电脑联系不上时也能关闭：Provider 撤销成功后清掉本地绑定，不再要求旧 agentd 注销。
+    @MainActor
+    func testDisableWithoutPreviousHostRevokesAtProviderAndClearsBinding() async throws {
+        let fixture = try await makeRebindFixture()
+        defer { fixture.tearDown() }
+
+        await fixture.store.disable(client: nil, profileID: "profile-old", previousHostUnavailable: true)
+
+        XCTAssertEqual(fixture.store.status, .off)
+        XCTAssertFalse(fixture.store.isEnabled)
+        XCTAssertNil(fixture.store.registeredProfileID)
+        XCTAssertNil(fixture.store.registeredProviderURL)
+        XCTAssertNil(fixture.tickets.load())
+        XCTAssertEqual(RebindURLProtocol.revokedTickets, ["ticket-old"])
+        XCTAssertEqual(
+            RebindURLProtocol.recordedRequests,
+            ["POST provider.example /mimi-push/v1/ticket/revoke"]
+        )
+    }
+
+    /// 没有旧 client 且没有明确标记“旧电脑联系不上”时仍然 fail closed，行为不变。
+    @MainActor
+    func testDisableWithoutClientStillFailsClosedUnlessPreviousHostFlagged() async throws {
+        let fixture = try await makeRebindFixture()
+        defer { fixture.tearDown() }
+        RebindURLProtocol.fail("POST provider.example /mimi-push/v1/ticket/revoke", status: 503)
+
+        await fixture.store.disable(client: nil, profileID: "profile-old")
+        guard case .failed = fixture.store.status else {
+            return XCTFail("未标记旧电脑不可达时不能只清本地痕迹")
+        }
+        XCTAssertEqual(RebindURLProtocol.recordedRequests, [])
+
+        await fixture.store.disable(client: nil, profileID: "profile-old", previousHostUnavailable: true)
+        XCTAssertEqual(
+            fixture.store.status,
+            .failed(message: L10n.text("ui.push_previous_binding_revoke_failed"))
+        )
+        XCTAssertTrue(fixture.store.isEnabled)
+        XCTAssertEqual(fixture.store.registeredProfileID, "profile-old")
+        XCTAssertEqual(try fixture.tickets.loadRequired(), "ticket-old")
+    }
+
+    func testRebindLocalizationKeysExist() {
+        let keys = [
+            "ui.push_previous_host_unavailable",
+            "ui.push_rebind_to_this_computer",
+            "ui.push_rebind_confirm_title",
+            "ui.push_rebind_confirm_message",
+            "ui.push_previous_binding_revoke_failed",
+            "ui.push_turn_off_previous_binding",
+        ]
+        for key in keys {
+            XCTAssertNotEqual(L10n.text(key, language: .simplifiedChinese), key, "缺少中文文案：\(key)")
+            XCTAssertNotEqual(L10n.text(key, language: .english), key, "缺少英文文案：\(key)")
+        }
+    }
+}
+
+/// 同时扮演两台 agentd 和一个 Provider：按“方法 主机 路径”记录请求，并可让指定请求失败。
+private final class RebindURLProtocol: URLProtocol {
+    static let providerURL = "https://provider.example/mimi-push"
+
+    private static let lock = NSLock()
+    private static var requests: [String] = []
+    private static var revoked: [String] = []
+    private static var failures: [String: Int] = [:]
+
+    static var recordedRequests: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    static var revokedTickets: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return revoked
+    }
+
+    static func fail(_ key: String, status: Int) {
+        lock.lock()
+        failures[key] = status
+        lock.unlock()
+    }
+
+    static func clearRecordedRequests() {
+        lock.lock()
+        requests.removeAll()
+        revoked.removeAll()
+        lock.unlock()
+    }
+
+    static func reset() {
+        lock.lock()
+        requests.removeAll()
+        revoked.removeAll()
+        failures.removeAll()
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url, let host = url.host else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        let method = request.httpMethod ?? "GET"
+        let key = "\(method) \(host) \(url.path)"
+        let body = Self.readBody(of: request)
+        Self.lock.lock()
+        Self.requests.append(key)
+        if url.path.hasSuffix("/v1/ticket/revoke"),
+           let body,
+           let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+           let ticket = object["ticket"] as? String {
+            Self.revoked.append(ticket)
+        }
+        let failure = Self.failures[key]
+        Self.lock.unlock()
+
+        let status = failure ?? 200
+        let payload: String
+        switch url.path {
+        case let path where path.hasSuffix("/api/push/status"):
+            payload = #"{"enabled":true,"provider_configured":true,"provider_url":"\#(Self.providerURL)"}"#
+        case let path where path.hasSuffix("/api/push/devices") && method == "POST":
+            payload = #"{"device_id":"dev","expires_at":"2099-01-01T00:00:00Z","needs_refresh":false}"#
+        case let path where path.hasSuffix("/api/push/devices"):
+            payload = #"{"removed":true}"#
+        case let path where path.hasSuffix("/v1/ticket/revoke"):
+            payload = "{}"
+        case let path where path.hasSuffix("/v1/ticket"):
+            payload = #"{"ticket":"ticket-new","expires_at":"2099-01-01T00:00:00Z"}"#
+        default:
+            payload = "{}"
+        }
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data((status == 200 ? payload : #"{"error":"stubbed failure"}"#).utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(of request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/ios/MimiRemote/Tests/MimiRemoteTests/LockScreenApprovalTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/LockScreenApprovalTests.swift
@@ -792,7 +792,9 @@ extension LockScreenApprovalTests {
 
     /// 绑定在 profile-old 上，当前电脑是 profile-new；两台电脑共用同一个 Provider。
     @MainActor
-    private func makeRebindFixture() async throws -> RebindFixture {
+    private func makeRebindFixture(
+        clearTitleCache: @escaping () -> Void = {}
+    ) async throws -> RebindFixture {
         let suite = "LockScreenApprovalTests.Rebind.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
         RebindURLProtocol.reset()
@@ -812,7 +814,7 @@ extension LockScreenApprovalTests {
             defaults: defaults,
             ticketStore: tickets,
             identityStore: identityStore,
-            clearNotificationTitleCache: {},
+            clearNotificationTitleCache: clearTitleCache,
             providerClientFactory: { PushProviderClient(baseURL: $0, session: session) },
             requestAuthorization: { true }
         )
@@ -929,6 +931,32 @@ extension LockScreenApprovalTests {
             RebindURLProtocol.recordedRequests,
             ["POST provider.example /mimi-push/v1/ticket/revoke"]
         )
+    }
+
+    /// 旧 Ticket 已撤销、新电脑注册失败：结果就是关闭态，必须和正常关闭一样清掉
+    /// 标题缓存与残留卡片，并撤销刚签发的新 Ticket，不留下半开的绑定。
+    @MainActor
+    func testTakeoverCleansUpOffStateWhenNewRegistrationFails() async throws {
+        final class Counter { var value = 0 }
+        let clears = Counter()
+        let fixture = try await makeRebindFixture(clearTitleCache: { clears.value += 1 })
+        defer { fixture.tearDown() }
+        RebindURLProtocol.fail("POST profile-new.example /api/push/devices", status: 500)
+
+        await fixture.store.enable(
+            client: fixture.newClient,
+            profileID: "profile-new",
+            takeOverPreviousBinding: true
+        )
+
+        guard case .failed = fixture.store.status else {
+            return XCTFail("新注册失败应给出失败状态，实际：\(fixture.store.status)")
+        }
+        XCTAssertFalse(fixture.store.isEnabled)
+        XCTAssertNil(fixture.store.registeredProfileID)
+        XCTAssertNil(fixture.tickets.load())
+        XCTAssertEqual(clears.value, 1, "关闭态必须清掉通知标题缓存")
+        XCTAssertEqual(RebindURLProtocol.revokedTickets, ["ticket-old", "ticket-new"])
     }
 
     /// 旧电脑联系不上时也能关闭：Provider 撤销成功后清掉本地绑定，不再要求旧 agentd 注销。


### PR DESCRIPTION
Refs #432

## 目标

之前绑定消息提醒（锁屏审批推送）的电脑已经重装、在手机上被删除或暂时连不上时，用户仍然可以把消息提醒换绑到当前电脑，或者直接关闭它，而不是被「请先返回已绑定的电脑关闭消息提醒」卡死。

## 根因

- `LockScreenApprovalStore.performEnable` 在绑定属于另一台电脑时，要求先拿到旧 Profile 的 `AgentAPIClient` 去 `unregisterPushDevice`。旧档案已删、Tailcat 档案非当前、凭据缺失时构造不出 client；旧 agentd 已被重装（安装身份变化、旧 Token 401）时调用失败。两种情况都直接报「请先返回已绑定的电脑」，而那台电脑已经回不去。
- `performDisable` 同样要求旧 client 可用，否则「结果未知」失败，所以也关不掉。
- 真正决定投递的是 Provider 手里的 Ticket；旧 agentd 上的注册只是清理项（agentd 收到 Provider 410 后会自行删除失效设备，见 `internal/pushbridge/manager.go`）。

## 改动

- **Store**（`LockScreenApprovalStore.swift`）
  - 新增 `Status.previousHostUnavailable`：旧 client 构造不出，或旧 agentd 注销失败（401/404/超时/断网）时回滚刚签发的新 Ticket、原样保留旧绑定并进入该状态，不再把原始错误丢给用户。
  - `enable(takeOverPreviousBinding:)`：用户显式确认后跳过旧 agentd，先在旧 Provider 撤销旧 Ticket（必须成功，否则保持旧绑定不动并提示重试），清掉本地绑定，再按首次开启为当前电脑签发并注册新 Ticket。
  - `disable(previousHostUnavailable:)`：没有旧 client 但已确认旧电脑不可达时，以 Provider 撤销为准清理本地绑定；撤销失败保持绑定不动。未标记时行为不变（fail closed）。
  - Provider client 与系统通知授权改为可注入（`providerClientFactory` / `requestAuthorization`），生产默认值不变。
- **设置页**（`LockScreenApprovalSettingsView.swift`）：处于该状态时展示原因，并提供「直接换绑到这台电脑」（二次确认弹窗；没同意过当前收件主机就先弹披露，同意后继续换绑）和「仅关闭旧电脑的消息提醒」两个出口。`disable()` 在旧档案构造不出 client 时走 Provider 撤销路径。
- **文案**：新增 6 条 `ui.push_*` 中英文案。
- Provider 接口与 agentd 未改动；正常路径（旧电脑可达）仍保持「先注销旧绑定再注册新绑定」的顺序。

## 验证

- `bash ./scripts/ios-dev.sh test -only-testing:MimiRemoteTests/LockScreenApprovalTests`（iPad Pro 13-inch (M5) Simulator）：`Executed 37 tests, with 0 failures`，xcresulttool 确认 LockScreenApprovalTests 执行 37 个用例、0 个未通过（30 个原有 + 7 个新增：无旧 client 报 previousHostUnavailable 且零请求、旧 agentd 401 回滚、换绑先撤销后注册、撤销失败保留旧绑定、无旧主机关闭、未标记时仍 fail closed、新文案 key 存在）。
- `bash ./scripts/check-ios-localization.sh` 通过。
- `bash ./scripts/check-source-size.sh` 通过。
- `bash ./scripts/verify-change.sh --plan` / `bash ./scripts/verify-change.sh`（quick，5 项）通过，iOS App 在 M5 Simulator 编译成功。

## 延后验收

- 真机换绑：旧 Mac 重装（安装身份变化）后在手机上作为新电脑配对，进入「消息提醒」确认换绑，验证新电脑推送正常、旧电脑不再投递；以及删除旧档案后「仅关闭旧电脑的消息提醒」。由用户在真机执行。
- 完整 iOS 回归延后到 PR Gate。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYyfJr9QtZw85ZmpTHsF7B
