### PR TITLE
从 Claude CLI 动态读取模型目录与思考强度

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/handlers/model.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/model.rs
@@ -1,27 +1,14 @@
-//! `model/list`.
-//!
-//! Claude has no introspection API for available models, so the bridge ships
-//! a hand-curated list. Four concrete model ids (fable plus the latest
-//! opus/sonnet/haiku) and the three established short aliases
-//! (`opus`/`sonnet`/`haiku`) the `claude` CLI accepts via `--model`. Fable uses
-//! its full id so the list also works with older CLI builds that predate its alias.
-//!
-//! Default is opus — the remote app defaults to the most capable model for
-//! agentic coding; the picker still lets the user drop to sonnet/haiku.
+//! `model/list` 使用当前 Claude CLI 的 SDK 初始化目录。
 
 use std::sync::Arc;
 
 use alleycat_codex_proto as p;
 use serde_json::json;
 
+use crate::pool::model_catalog::ClaudeModelInfo;
 use crate::state::ConnectionState;
 
 pub const MODEL_PROVIDER: &str = "anthropic";
-
-pub const FABLE_MODEL: &str = "claude-fable-5-1";
-pub const OPUS_MODEL: &str = "claude-opus-5";
-pub const SONNET_MODEL: &str = "claude-sonnet-4-6";
-pub const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
 
 pub fn normalize_claude_model_id(model: &str) -> String {
     let model = model.trim();
@@ -36,73 +23,137 @@ pub fn normalize_claude_model(model: Option<String>) -> Option<String> {
 }
 
 pub async fn handle_model_list(
-    _state: &Arc<ConnectionState>,
+    state: &Arc<ConnectionState>,
     _params: p::ModelListParams,
 ) -> p::ModelListResponse {
-    let data = vec![
-        // Concrete model ids first.
-        build_model(
-            FABLE_MODEL,
-            "Claude Fable 5.1",
-            "Anthropic's most capable generally available model for the hardest, longest-running agentic work.",
-            false,
-            p::ReasoningEffort::High,
-            true,
-        ),
-        build_model(
-            OPUS_MODEL,
-            "Claude Opus 5",
-            "Anthropic's most capable model. Best for hard reasoning, deep refactors, multi-step planning.",
-            true,
-            p::ReasoningEffort::High,
-            true,
-        ),
-        build_model(
-            SONNET_MODEL,
-            "Claude Sonnet 4.6",
-            "Balanced model for everyday coding work — fast, capable, lower cost than Opus.",
-            false,
-            p::ReasoningEffort::High,
-            true,
-        ),
-        build_model(
-            HAIKU_MODEL,
-            "Claude Haiku 4.5",
-            "Lightest, fastest model. Best for quick edits, small tasks, low-latency interactions.",
-            false,
-            p::ReasoningEffort::None,
-            false,
-        ),
-        // Short aliases the `claude` CLI accepts directly.
-        build_model(
-            "opus",
-            "Claude Opus (alias)",
-            "Alias resolved by the claude CLI to the latest Opus revision.",
-            false,
-            p::ReasoningEffort::High,
-            true,
-        ),
-        build_model(
-            "sonnet",
-            "Claude Sonnet (alias)",
-            "Alias resolved by the claude CLI to the latest Sonnet revision.",
-            false,
-            p::ReasoningEffort::High,
-            true,
-        ),
-        build_model(
-            "haiku",
-            "Claude Haiku (alias)",
-            "Alias resolved by the claude CLI to the latest Haiku revision.",
-            false,
-            p::ReasoningEffort::None,
-            false,
-        ),
-    ];
+    let data = match state.claude_pool().discover_models().await {
+        Ok(models) => models
+            .into_iter()
+            .filter_map(convert_model)
+            .collect::<Vec<_>>(),
+        // 不把 CLI 初始化响应或账号信息写入错误日志；失败只使用无版本的 alias。
+        Err(_) => Vec::new(),
+    };
     p::ModelListResponse {
-        data,
+        data: if data.is_empty() {
+            fallback_models()
+        } else {
+            data
+        },
         next_cursor: None,
     }
+}
+
+fn convert_model(info: ClaudeModelInfo) -> Option<p::Model> {
+    if info.value.trim().is_empty() {
+        return None;
+    }
+    let efforts = if info.supports_effort == Some(false) {
+        Vec::new()
+    } else if let Some(levels) = &info.supported_effort_levels {
+        levels
+            .iter()
+            .filter_map(|level| serde_json::from_value(json!(level)).ok())
+            .collect()
+    } else if info.supports_effort == Some(true) {
+        // 旧 CLI 只声明支持 effort 时保留默认 high，不猜测它支持 Max 等额外档位。
+        vec![p::ReasoningEffort::High]
+    } else {
+        Vec::new()
+    };
+    let title = if info.value == "default" {
+        info.display_name.clone()
+    } else {
+        info.resolved_model
+            .as_deref()
+            .or(Some(info.value.as_str()))
+            .and_then(model_version_title)
+            .unwrap_or_else(|| info.display_name.clone())
+    };
+    let mut model = build_model(
+        &info.value,
+        &title,
+        &info.description,
+        info.value == "default",
+        efforts,
+    );
+    if model.display_name.trim().is_empty() {
+        model.display_name = info.value;
+    }
+    Some(model)
+}
+
+// resolvedModel 是 CLI 解析出的实际版本。只格式化常规 Claude ID；第三方/未来未知
+// 命名仍使用 CLI 的 displayName，不按模型家族维护版本表，也不修改发送给 CLI 的 value。
+fn model_version_title(id: &str) -> Option<String> {
+    let (id, context) = match id.split_once('[') {
+        Some((id, context)) => (id, Some(context.strip_suffix(']')?)),
+        None => (id, None),
+    };
+    let parts: Vec<_> = id.strip_prefix("claude-")?.split('-').collect();
+    let version_start = parts
+        .iter()
+        .position(|part| part.chars().all(|ch| ch.is_ascii_digit()))?;
+    if version_start == 0 {
+        return None;
+    }
+    let mut version = Vec::new();
+    for part in &parts[version_start..] {
+        if part.len() == 8 && part.chars().all(|ch| ch.is_ascii_digit()) {
+            break;
+        }
+        if part.is_empty() || !part.chars().all(|ch| ch.is_ascii_digit()) {
+            return None;
+        }
+        version.push(*part);
+    }
+    if version.is_empty() {
+        return None;
+    }
+    let name = parts[..version_start]
+        .iter()
+        .map(|part| {
+            let mut chars = part.chars();
+            chars
+                .next()
+                .map(|first| first.to_uppercase().to_string() + chars.as_str())
+        })
+        .collect::<Option<Vec<_>>>()?
+        .join(" ");
+    let mut title = format!("Claude {name} {}", version.join("."));
+    if let Some(context) = context {
+        title.push_str(&format!(" ({})", context.to_uppercase()));
+    }
+    Some(title)
+}
+
+fn fallback_models() -> Vec<p::Model> {
+    // CLI 不支持目录查询或暂不可用时，基础 alias 仍由 CLI 自己解析，名称不承诺版本。
+    [
+        ("opus", "Claude Opus"),
+        ("sonnet", "Claude Sonnet"),
+        ("haiku", "Claude Haiku"),
+    ]
+    .into_iter()
+    .map(|(id, title)| {
+        build_model(
+            id,
+            title,
+            "Claude CLI alias; model catalog unavailable.",
+            id == "opus",
+            if id == "haiku" {
+                Vec::new()
+            } else {
+                vec![
+                    p::ReasoningEffort::Medium,
+                    p::ReasoningEffort::High,
+                    p::ReasoningEffort::XHigh,
+                    p::ReasoningEffort::Max,
+                ]
+            },
+        )
+    })
+    .collect()
 }
 
 fn build_model(
@@ -110,9 +161,13 @@ fn build_model(
     display_name: &str,
     description: &str,
     is_default: bool,
-    default_effort: p::ReasoningEffort,
-    supports_native_effort: bool,
+    efforts: Vec<p::ReasoningEffort>,
 ) -> p::Model {
+    let default_reasoning_effort = if efforts.contains(&p::ReasoningEffort::High) {
+        p::ReasoningEffort::High
+    } else {
+        efforts.first().copied().unwrap_or(p::ReasoningEffort::None)
+    };
     p::Model {
         id: model_id.to_string(),
         model: model_id.to_string(),
@@ -122,175 +177,90 @@ fn build_model(
         display_name: display_name.to_string(),
         description: description.to_string(),
         hidden: false,
-        supported_reasoning_efforts: if supports_native_effort {
-            reasoning_options()
-        } else {
-            Vec::new()
-        },
-        default_reasoning_effort: default_effort,
+        supported_reasoning_efforts: efforts
+            .into_iter()
+            .map(|effort| p::ReasoningEffortOption {
+                reasoning_effort: effort,
+                description: String::new(),
+            })
+            .collect(),
+        default_reasoning_effort,
         input_modalities: vec![json!("text"), json!("image")],
         supports_personality: false,
         additional_speed_tiers: Vec::new(),
-        service_tiers: standard_service_tiers(),
+        service_tiers: vec![p::ModelServiceTier {
+            id: "standard".to_string(),
+            name: "Standard".to_string(),
+            description: "Default bridge service tier".to_string(),
+        }],
         is_default,
     }
-}
-
-fn standard_service_tiers() -> Vec<p::ModelServiceTier> {
-    vec![p::ModelServiceTier {
-        id: "standard".to_string(),
-        name: "Standard".to_string(),
-        description: "Default bridge service tier".to_string(),
-    }]
-}
-
-fn reasoning_options() -> Vec<p::ReasoningEffortOption> {
-    vec![
-        p::ReasoningEffortOption {
-            reasoning_effort: p::ReasoningEffort::Medium,
-            description: "Balanced native Claude effort".to_string(),
-        },
-        p::ReasoningEffortOption {
-            reasoning_effort: p::ReasoningEffort::High,
-            description: "High native Claude effort (default)".to_string(),
-        },
-        p::ReasoningEffortOption {
-            reasoning_effort: p::ReasoningEffort::XHigh,
-            description: "Extended native Claude effort".to_string(),
-        },
-        p::ReasoningEffortOption {
-            reasoning_effort: p::ReasoningEffort::Max,
-            description: "Maximum native Claude effort".to_string(),
-        },
-    ]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::ClaudeSessionRef;
-    use crate::pool::ClaudePool;
-    use crate::state::{ConnectionState, ThreadDefaults};
-    use std::path::PathBuf;
 
-    struct NoopIndex;
-
-    #[async_trait::async_trait]
-    impl alleycat_bridge_core::ThreadIndexHandle<ClaudeSessionRef> for NoopIndex {
-        async fn lookup(&self, _: &str) -> Option<crate::state::IndexEntry> {
-            None
-        }
-        async fn insert(&self, _: crate::state::IndexEntry) -> anyhow::Result<()> {
-            Ok(())
-        }
-        async fn set_archived(&self, _: &str, _: bool) -> anyhow::Result<bool> {
-            Ok(false)
-        }
-        async fn set_name(&self, _: &str, _: Option<String>) -> anyhow::Result<bool> {
-            Ok(false)
-        }
-        async fn update_preview_and_updated_at(
-            &self,
-            _: &str,
-            _: String,
-            _: chrono::DateTime<chrono::Utc>,
-        ) -> anyhow::Result<()> {
-            Ok(())
-        }
-        async fn list(
-            &self,
-            _: &crate::state::ListFilter,
-            _: crate::state::ListSort,
-            _: Option<&str>,
-            _: Option<u32>,
-        ) -> anyhow::Result<crate::state::ListPage<ClaudeSessionRef>> {
-            Ok(crate::state::ListPage::<ClaudeSessionRef> {
-                data: Vec::new(),
-                next_cursor: None,
-            })
-        }
-        async fn loaded_thread_ids(&self) -> Vec<String> {
-            Vec::new()
-        }
-    }
-
-    fn dummy_state() -> Arc<ConnectionState> {
-        let (state, _rx) = ConnectionState::for_test(
-            Arc::new(ClaudePool::new(PathBuf::from("/usr/bin/false"))),
-            Arc::new(NoopIndex),
-            ThreadDefaults::default(),
-        );
-        state
-    }
-
-    #[tokio::test]
-    async fn lists_four_concrete_models_plus_established_aliases_with_opus_default() {
-        let state = dummy_state();
-        let resp = handle_model_list(&state, p::ModelListParams::default()).await;
-        assert_eq!(resp.data.len(), 7);
-
-        let by_id: std::collections::HashMap<_, _> =
-            resp.data.iter().map(|m| (m.model.as_str(), m)).collect();
-
-        // 同时锁定显示名和真正传给 CLI 的 ID，避免只升级文案。
-        let fable = by_id["claude-fable-5-1"];
-        assert_eq!(fable.id, "claude-fable-5-1");
-        assert_eq!(fable.display_name, "Claude Fable 5.1");
-        assert!(!by_id.contains_key("claude-fable-5"));
-        assert!(by_id.contains_key(OPUS_MODEL));
-        assert!(by_id.contains_key(SONNET_MODEL));
-        assert!(by_id.contains_key(HAIKU_MODEL));
-        assert!(by_id.contains_key("opus"));
-        assert!(by_id.contains_key("sonnet"));
-        assert!(by_id.contains_key("haiku"));
-
-        let opus = by_id[OPUS_MODEL];
-        assert!(opus.is_default);
-        assert_eq!(opus.id, OPUS_MODEL);
-        assert!(matches!(
-            opus.default_reasoning_effort,
-            p::ReasoningEffort::High
-        ));
-        assert_eq!(opus.supported_reasoning_efforts.len(), 4);
+    #[test]
+    fn future_models_use_cli_ids_versions_and_capabilities() {
+        let info = serde_json::from_value(json!({
+            "value": "fable", "resolvedModel": "claude-fable-9-2", "displayName": "Fable",
+            "description": "Runtime model", "supportsEffort": true,
+            "supportedEffortLevels": ["medium", "max", "future-effort"]
+        }))
+        .unwrap();
+        let model = convert_model(info).unwrap();
+        assert_eq!(model.id, "fable");
+        assert_eq!(model.model, "fable");
+        assert_eq!(model.display_name, "Claude Fable 9.2");
+        assert_eq!(model.description, "Runtime model");
         assert_eq!(
-            opus.supported_reasoning_efforts
+            model
+                .supported_reasoning_efforts
                 .iter()
-                .map(|option| option.reasoning_effort)
+                .map(|e| e.reasoning_effort)
                 .collect::<Vec<_>>(),
-            vec![
-                p::ReasoningEffort::Medium,
-                p::ReasoningEffort::High,
-                p::ReasoningEffort::XHigh,
-                p::ReasoningEffort::Max,
-            ]
+            vec![p::ReasoningEffort::Medium, p::ReasoningEffort::Max]
         );
-        assert!(
-            by_id[HAIKU_MODEL].supported_reasoning_efforts.is_empty(),
-            "Haiku 4.5 不支持 Claude 原生 effort"
-        );
-        assert!(matches!(
-            by_id[HAIKU_MODEL].default_reasoning_effort,
-            p::ReasoningEffort::None
-        ));
-
-        // The other concrete models are no longer the default.
-        assert!(!by_id[SONNET_MODEL].is_default);
-
-        // Only one default across the entire list.
-        let defaults: Vec<_> = resp.data.iter().filter(|m| m.is_default).collect();
-        assert_eq!(defaults.len(), 1);
+        assert_eq!(model.default_reasoning_effort, p::ReasoningEffort::Medium);
     }
 
-    #[tokio::test]
-    async fn ids_are_plain_claude_cli_model_values() {
-        let state = dummy_state();
-        let resp = handle_model_list(&state, p::ModelListParams::default()).await;
-        for m in &resp.data {
-            assert!(
-                !m.id.contains('/'),
-                "id {} should be a plain claude CLI model value, not provider-prefixed",
-                m.id
-            );
-        }
+    #[test]
+    fn defaults_unknown_names_and_missing_capabilities_are_not_invented() {
+        let info = serde_json::from_value(json!({
+            "value": "default", "resolvedModel": "vendor:new", "displayName": "Vendor Latest",
+            "description": "Chosen by CLI"
+        }))
+        .unwrap();
+        let model = convert_model(info).unwrap();
+        assert!(model.is_default);
+        assert_eq!(model.display_name, "Vendor Latest");
+        assert!(model.supported_reasoning_efforts.is_empty());
+        assert_eq!(model.default_reasoning_effort, p::ReasoningEffort::None);
+        assert_eq!(
+            model_version_title("claude-haiku-4-5-20251001").as_deref(),
+            Some("Claude Haiku 4.5")
+        );
+        assert_eq!(
+            model_version_title("claude-opus-9[1m]").as_deref(),
+            Some("Claude Opus 9 (1M)")
+        );
+    }
+
+    #[test]
+    fn fallback_only_contains_unversioned_cli_aliases() {
+        let models = fallback_models();
+        assert_eq!(
+            models.iter().map(|m| m.model.as_str()).collect::<Vec<_>>(),
+            vec!["opus", "sonnet", "haiku"]
+        );
+        assert_eq!(
+            models
+                .iter()
+                .map(|m| m.display_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Claude Opus", "Claude Sonnet", "Claude Haiku"]
+        );
+        assert!(models[0].is_default);
     }
 }

--- a/bridges/claude/crates/claude-bridge/src/handlers/model.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/model.rs
@@ -18,7 +18,7 @@ use crate::state::ConnectionState;
 
 pub const MODEL_PROVIDER: &str = "anthropic";
 
-pub const FABLE_MODEL: &str = "claude-fable-5";
+pub const FABLE_MODEL: &str = "claude-fable-5-1";
 pub const OPUS_MODEL: &str = "claude-opus-5";
 pub const SONNET_MODEL: &str = "claude-sonnet-4-6";
 pub const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
@@ -43,7 +43,7 @@ pub async fn handle_model_list(
         // Concrete model ids first.
         build_model(
             FABLE_MODEL,
-            "Claude Fable 5",
+            "Claude Fable 5.1",
             "Anthropic's most capable generally available model for the hardest, longest-running agentic work.",
             false,
             p::ReasoningEffort::High,
@@ -232,7 +232,11 @@ mod tests {
         let by_id: std::collections::HashMap<_, _> =
             resp.data.iter().map(|m| (m.model.as_str(), m)).collect();
 
-        assert!(by_id.contains_key(FABLE_MODEL));
+        // 同时锁定显示名和真正传给 CLI 的 ID，避免只升级文案。
+        let fable = by_id["claude-fable-5-1"];
+        assert_eq!(fable.id, "claude-fable-5-1");
+        assert_eq!(fable.display_name, "Claude Fable 5.1");
+        assert!(!by_id.contains_key("claude-fable-5"));
         assert!(by_id.contains_key(OPUS_MODEL));
         assert!(by_id.contains_key(SONNET_MODEL));
         assert!(by_id.contains_key(HAIKU_MODEL));

--- a/bridges/claude/crates/claude-bridge/src/pool/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/mod.rs
@@ -19,6 +19,7 @@
 //! to re-implement the eviction / capacity loop.
 
 pub mod claude_protocol;
+pub mod model_catalog;
 pub mod process;
 
 use std::path::{Path, PathBuf};
@@ -138,6 +139,10 @@ impl ClaudePool {
     /// Path of the claude binary this pool spawns.
     pub fn claude_bin(&self) -> &Path {
         &self.claude_bin
+    }
+
+    pub async fn discover_models(&self) -> anyhow::Result<Vec<model_catalog::ClaudeModelInfo>> {
+        model_catalog::discover(self.launcher.as_ref(), &self.claude_bin).await
     }
 
     /// Spawn a fresh claude process for a brand-new codex thread, mint a

--- a/bridges/claude/crates/claude-bridge/src/pool/model_catalog.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/model_catalog.rs
@@ -1,0 +1,229 @@
+//! 通过 CLI 的 SDK initialize 控制请求读取目录，不发送 user 消息。
+
+use std::path::Path;
+use std::time::Duration;
+
+use alleycat_bridge_core::{ProcessLauncher, ProcessSpec, StdioMode};
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::json;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeModelInfo {
+    pub value: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub resolved_model: Option<String>,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub supports_effort: Option<bool>,
+    #[serde(default)]
+    pub supported_effort_levels: Option<Vec<String>>,
+}
+
+pub(super) async fn discover(
+    launcher: &dyn ProcessLauncher,
+    claude_bin: &Path,
+) -> Result<Vec<ClaudeModelInfo>> {
+    discover_with_timeout(launcher, claude_bin, Duration::from_secs(10)).await
+}
+
+async fn discover_with_timeout(
+    launcher: &dyn ProcessLauncher,
+    claude_bin: &Path,
+    timeout: Duration,
+) -> Result<Vec<ClaudeModelInfo>> {
+    let mut spec = ProcessSpec::new(claude_bin);
+    // 查询独立于会话进程，避免 initialize 干扰正在运行的 turn。
+    // 保留 CLI 的账号/模型配置，但关闭工具、MCP 和用户 hooks，且不写会话历史。
+    spec.args = [
+        "-p",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--tools",
+        "",
+        "--strict-mcp-config",
+        "--no-session-persistence",
+        "--settings",
+        r#"{"disableAllHooks":true}"#,
+    ]
+    .into_iter()
+    .map(Into::into)
+    .collect();
+    spec.stderr = StdioMode::Null;
+    let mut child = tokio::time::timeout(timeout, launcher.launch(spec)).await??;
+    let result = tokio::time::timeout(timeout, async {
+        let mut stdin = child.take_stdin().context("missing CLI stdin")?;
+        let stdout = child.take_stdout().context("missing CLI stdout")?;
+        let request = json!({
+            "type": "control_request",
+            "request_id": "model-catalog",
+            "request": { "subtype": "initialize" },
+        });
+        stdin.write_all(format!("{request}\n").as_bytes()).await?;
+        stdin.flush().await?;
+        // initialize 还会返回 commands 等信息；限定总读取量，防止异常输出无限占用内存。
+        let mut lines = BufReader::new(stdout.take(1024 * 1024)).lines();
+        while let Some(line) = lines.next_line().await? {
+            let Ok(frame) = serde_json::from_str::<serde_json::Value>(&line) else {
+                continue;
+            };
+            if frame["type"] != "control_response"
+                || frame["response"]["request_id"] != "model-catalog"
+            {
+                continue;
+            }
+            if frame["response"]["subtype"] != "success" {
+                // CLI 错误可能带账号信息；只返回固定诊断，不透传原始响应。
+                bail!("CLI rejected model catalog initialization");
+            }
+            return serde_json::from_value(frame["response"]["response"]["models"].clone())
+                .context("invalid CLI model catalog");
+        }
+        bail!("CLI exited without a model catalog")
+    })
+    .await
+    .context("CLI model catalog timed out")
+    .and_then(|result| result);
+    // stdin 在上面的查询完成/取消时关闭。无论成功还是超时，都回收短命查询进程。
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alleycat_bridge_core::launcher::{ChildProcess, ChildStderr, ChildStdin, ChildStdout};
+    use futures::future::BoxFuture;
+    use std::sync::{Arc, Mutex};
+
+    struct FakeLauncher {
+        output: String,
+        hang: bool,
+        events: Arc<Mutex<Vec<&'static str>>>,
+        request: Arc<Mutex<String>>,
+    }
+
+    struct FakeChild {
+        stdin: Mutex<Option<ChildStdin>>,
+        stdout: Mutex<Option<ChildStdout>>,
+        task: tokio::task::JoinHandle<()>,
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl ProcessLauncher for FakeLauncher {
+        fn launch(
+            &self,
+            spec: ProcessSpec,
+        ) -> BoxFuture<'_, std::io::Result<Box<dyn ChildProcess>>> {
+            Box::pin(async move {
+                let args: Vec<_> = spec.args.iter().map(|s| s.to_string_lossy()).collect();
+                assert!(args.contains(&"--no-session-persistence".into()));
+                assert!(args.contains(&"--strict-mcp-config".into()));
+                assert!(args.contains(&r#"{"disableAllHooks":true}"#.into()));
+                assert!(args.windows(2).any(|pair| pair == ["--tools", ""]));
+                let (stdin, read_request) = tokio::io::duplex(4096);
+                let (mut write_response, stdout) = tokio::io::duplex(4096);
+                let output = self.output.clone();
+                let request = self.request.clone();
+                let hang = self.hang;
+                let task = tokio::spawn(async move {
+                    let mut line = String::new();
+                    BufReader::new(read_request)
+                        .read_line(&mut line)
+                        .await
+                        .unwrap();
+                    *request.lock().unwrap() = line;
+                    if hang {
+                        std::future::pending::<()>().await;
+                    }
+                    write_response.write_all(output.as_bytes()).await.unwrap();
+                });
+                Ok(Box::new(FakeChild {
+                    stdin: Mutex::new(Some(Box::new(stdin))),
+                    stdout: Mutex::new(Some(Box::new(stdout))),
+                    task,
+                    events: self.events.clone(),
+                }) as Box<dyn ChildProcess>)
+            })
+        }
+    }
+
+    impl ChildProcess for FakeChild {
+        fn take_stdin(&mut self) -> Option<ChildStdin> {
+            self.stdin.get_mut().unwrap().take()
+        }
+        fn take_stdout(&mut self) -> Option<ChildStdout> {
+            self.stdout.get_mut().unwrap().take()
+        }
+        fn take_stderr(&mut self) -> Option<ChildStderr> {
+            None
+        }
+        fn id(&self) -> Option<u32> {
+            None
+        }
+        fn kill(&mut self) -> BoxFuture<'_, std::io::Result<()>> {
+            Box::pin(async move {
+                self.events.lock().unwrap().push("kill");
+                self.task.abort();
+                Ok(())
+            })
+        }
+        fn wait(&mut self) -> BoxFuture<'_, std::io::Result<std::process::ExitStatus>> {
+            Box::pin(async move {
+                self.events.lock().unwrap().push("wait");
+                Err(std::io::Error::other("fake exit"))
+            })
+        }
+    }
+
+    async fn query(output: String, hang: bool) -> Result<Vec<ClaudeModelInfo>> {
+        let launcher = FakeLauncher {
+            output,
+            hang,
+            events: Arc::default(),
+            request: Arc::default(),
+        };
+        let result =
+            discover_with_timeout(&launcher, Path::new("claude"), Duration::from_millis(100)).await;
+        assert_eq!(*launcher.events.lock().unwrap(), vec!["kill", "wait"]);
+        let request: serde_json::Value =
+            serde_json::from_str(&launcher.request.lock().unwrap()).unwrap();
+        assert_eq!(
+            request,
+            json!({"type":"control_request","request_id":"model-catalog","request":{"subtype":"initialize"}})
+        );
+        result
+    }
+
+    #[tokio::test]
+    async fn catalog_is_fresh_and_only_matching_initialize_response_is_used() {
+        for version in ["claude-fable-9-1", "claude-fable-9-2"] {
+            let response = json!({"type":"control_response","response":{"subtype":"success","request_id":"model-catalog","response":{"models":[{"value":version,"displayName":"Future"}]}}});
+            let models = query(
+                format!("noise\n{{\"type\":\"system\"}}\n{response}\n"),
+                false,
+            )
+            .await
+            .unwrap();
+            assert_eq!(models[0].value, version);
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_empty_and_timed_out_queries_reap_the_process() {
+        assert!(query(String::new(), false).await.is_err());
+        let response = json!({"type":"control_response","response":{"subtype":"error","request_id":"model-catalog","error":"private account"}});
+        let error = query(format!("{response}\n"), false).await.unwrap_err();
+        assert!(!error.to_string().contains("private account"));
+        let error = query(String::new(), true).await.unwrap_err();
+        assert!(error.to_string().contains("timed out"));
+    }
+}

--- a/internal/httpapi/appserver_gateway_policy.go
+++ b/internal/httpapi/appserver_gateway_policy.go
@@ -82,10 +82,7 @@ func (p *appServerGatewayPolicy) validateClientFrameContext(ctx context.Context,
 		p.forgetPending(frame.ID)
 		return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
 	}
-	runtimeID := normalizeAppServerRuntimeID(p.runtimeID)
-	tracksClientResponse := (runtimeID == "claude" && method == "model/list") ||
-		(runtimeID == "codex" && method == "account/usage/read")
-	if frame.ID != nil && tracksClientResponse {
+	if frame.ID != nil && normalizeAppServerRuntimeID(p.runtimeID) == "codex" && method == "account/usage/read" {
 		if err := p.rememberPendingClientRequest(frame.ID, method); err != nil {
 			return nil, &appServerGatewayPolicyError{id: frame.ID, message: err.Error()}
 		}

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -288,7 +288,11 @@ func TestClaudeGatewayStartsBridgeAndProxiesJSONLines(t *testing.T) {
 	bridge := writeTestBridge(t, fmt.Sprintf(`#!/bin/sh
 IFS= read -r line
 printf '%%s\n' "$line" > %q
-printf '{"jsonrpc":"2.0","id":99,"result":{"models":[]}}\n'
+printf '{"jsonrpc":"2.0","id":99,"result":{"data":[{"id":"claude-future-9","model":"claude-future-9","displayName":"Claude Future 9 Preview","supportedReasoningEfforts":[{"reasoningEffort":"adaptive","description":"Bridge-defined adaptive effort","futureEffortField":{"budget":123}}],"defaultReasoningEffort":"adaptive","futureModelField":{"contextWindow":123456}}],"nextCursor":"future-page-2","futureResultField":{"source":"cli-initialize"}},"futureEnvelopeField":"keep-me"}\n'
+IFS= read -r line
+printf '{"jsonrpc":"2.0","id":100,"result":{"data":[],"nextCursor":null,"futureResultField":"empty-kept"}}\n'
+IFS= read -r line
+printf '{"jsonrpc":"2.0","id":101,"error":{"code":-32042,"message":"CLI initialize failed","data":{"source":"initialize","retryable":true}},"futureEnvelopeField":"error-kept"}\n'
 while IFS= read -r line; do :; done
 `, receivedPath))
 	upstreamURL, _, _ := fakeAppServerUpstream(t, nil)
@@ -306,15 +310,25 @@ while IFS= read -r line; do :; done
 	if err := conn.WriteMessage(websocket.TextMessage, pretty); err != nil {
 		t.Fatal(err)
 	}
-	raw := readGatewayRaw(t, conn)
-	if !bytes.Contains(raw, []byte(`"id":99`)) ||
-		!bytes.Contains(raw, []byte(`"model":"claude-fable-5-1"`)) ||
-		!bytes.Contains(raw, []byte(`"model":"sonnet"`)) ||
-		!bytes.Contains(raw, []byte(`"model":"opus"`)) ||
-		!bytes.Contains(raw, []byte(`"Claude Fable 5.1"`)) ||
-		!bytes.Contains(raw, []byte(`"Claude Opus 5"`)) ||
-		bytes.Contains(raw, []byte(`"models":[]`)) {
-		t.Fatalf("Claude model/list 应由 gateway 覆盖成当前模型目录：%s", raw)
+	want := []byte(`{"jsonrpc":"2.0","id":99,"result":{"data":[{"id":"claude-future-9","model":"claude-future-9","displayName":"Claude Future 9 Preview","supportedReasoningEfforts":[{"reasoningEffort":"adaptive","description":"Bridge-defined adaptive effort","futureEffortField":{"budget":123}}],"defaultReasoningEffort":"adaptive","futureModelField":{"contextWindow":123456}}],"nextCursor":"future-page-2","futureResultField":{"source":"cli-initialize"}},"futureEnvelopeField":"keep-me"}`)
+	if raw := readGatewayRaw(t, conn); !bytes.Equal(raw, want) {
+		t.Fatalf("Claude model/list 必须原样转发 bridge 的动态目录：\ngot =%s\nwant=%s", raw, want)
+	}
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":100,"method":"model/list","params":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+	want = []byte(`{"jsonrpc":"2.0","id":100,"result":{"data":[],"nextCursor":null,"futureResultField":"empty-kept"}}`)
+	if raw := readGatewayRaw(t, conn); !bytes.Equal(raw, want) {
+		t.Fatalf("Claude model/list 空目录必须原样转发，不能伪造固定模型：\ngot =%s\nwant=%s", raw, want)
+	}
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":101,"method":"model/list","params":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+	want = []byte(`{"jsonrpc":"2.0","id":101,"error":{"code":-32042,"message":"CLI initialize failed","data":{"source":"initialize","retryable":true}},"futureEnvelopeField":"error-kept"}`)
+	if raw := readGatewayRaw(t, conn); !bytes.Equal(raw, want) {
+		t.Fatalf("Claude model/list 错误必须原样转发，不能伪造固定模型：\ngot =%s\nwant=%s", raw, want)
 	}
 	received, err := os.ReadFile(receivedPath)
 	if err != nil {

--- a/internal/httpapi/appserver_gateway_test.go
+++ b/internal/httpapi/appserver_gateway_test.go
@@ -308,10 +308,10 @@ while IFS= read -r line; do :; done
 	}
 	raw := readGatewayRaw(t, conn)
 	if !bytes.Contains(raw, []byte(`"id":99`)) ||
-		!bytes.Contains(raw, []byte(`"model":"claude-fable-5"`)) ||
+		!bytes.Contains(raw, []byte(`"model":"claude-fable-5-1"`)) ||
 		!bytes.Contains(raw, []byte(`"model":"sonnet"`)) ||
 		!bytes.Contains(raw, []byte(`"model":"opus"`)) ||
-		!bytes.Contains(raw, []byte(`"Claude Fable 5"`)) ||
+		!bytes.Contains(raw, []byte(`"Claude Fable 5.1"`)) ||
 		!bytes.Contains(raw, []byte(`"Claude Opus 5"`)) ||
 		bytes.Contains(raw, []byte(`"models":[]`)) {
 		t.Fatalf("Claude model/list 应由 gateway 覆盖成当前模型目录：%s", raw)

--- a/internal/httpapi/claude_gateway.go
+++ b/internal/httpapi/claude_gateway.go
@@ -727,8 +727,8 @@ func claudeCurrentModelList() []map[string]any {
 	// 短 alias 的旧 CLI，Fable 使用官方完整 ID；展示名仍表达当前推荐代际。
 	return []map[string]any{
 		claudeModelOption(
-			"claude-fable-5",
-			"Claude Fable 5",
+			"claude-fable-5-1",
+			"Claude Fable 5.1",
 			"Anthropic's most capable generally available model for the hardest, longest-running agentic work.",
 			false,
 			"high",

--- a/internal/httpapi/claude_gateway.go
+++ b/internal/httpapi/claude_gateway.go
@@ -277,7 +277,6 @@ func (r *Router) appServerClaudeGatewayWS(w http.ResponseWriter, req *http.Reque
 		router:                r,
 		runtimeID:             "claude",
 		pendingThreads:        map[string]appServerGatewayPendingThreadRequest{},
-		pendingClientRequests: map[string]appServerGatewayPendingClientRequest{},
 		pendingServerRequests: map[string]appServerGatewayPendingServerRequest{},
 		activeServerTurns:     map[string]struct{}{},
 		allowedThreads:        map[string]appServerGatewayAllowedThread{},
@@ -611,9 +610,6 @@ func forwardClaudeBridgeFrame(payload []byte, client *websocket.Conn, clientWrit
 		return "", false
 	}
 	frame := append([]byte(nil), forwardPayload...)
-	if rewritten, ok := rewriteClaudeModelListResponse(policy, frame); ok {
-		frame = rewritten
-	}
 	writeStart := time.Now()
 	if err := writeWebSocketFrame(client, clientWriteMu, websocket.TextMessage, frame); err != nil {
 		return gatewayCloseReason("client_write", err), true
@@ -689,107 +685,6 @@ func compactJSONLine(payload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("JSON-RPC frame 重编码失败：%w", err)
 	}
 	return compacted, nil
-}
-
-func rewriteClaudeModelListResponse(policy *appServerGatewayPolicy, payload []byte) ([]byte, bool) {
-	if policy == nil {
-		return nil, false
-	}
-	var frame appServerGatewayFrame
-	if err := json.Unmarshal(payload, &frame); err != nil || !gatewayFrameIsResponse(&frame) {
-		return nil, false
-	}
-	pending, ok := policy.consumePendingClientRequest(frame.ID)
-	if !ok || pending.method != "model/list" || len(frame.Error) > 0 {
-		return nil, false
-	}
-	var object map[string]any
-	decoder := json.NewDecoder(bytes.NewReader(payload))
-	decoder.UseNumber()
-	if err := decoder.Decode(&object); err != nil {
-		return nil, false
-	}
-	object["result"] = map[string]any{
-		"data":       claudeCurrentModelList(),
-		"nextCursor": nil,
-	}
-	delete(object, "error")
-	rewritten, err := json.Marshal(object)
-	if err != nil {
-		return nil, false
-	}
-	return rewritten, true
-}
-
-func claudeCurrentModelList() []map[string]any {
-	// Claude CLI 的具体模型 ID 会比产品命名更频繁变化；这里用 CLI alias 作为真正发送的
-	// model，避免新名字尚未进入本机 metadata 时触发 fallback warning。为兼容尚不识别 `fable`
-	// 短 alias 的旧 CLI，Fable 使用官方完整 ID；展示名仍表达当前推荐代际。
-	return []map[string]any{
-		claudeModelOption(
-			"claude-fable-5-1",
-			"Claude Fable 5.1",
-			"Anthropic's most capable generally available model for the hardest, longest-running agentic work.",
-			false,
-			"high",
-			true,
-		),
-		claudeModelOption(
-			"opus",
-			"Claude Opus 5",
-			"Alias resolved by the Claude CLI to the latest available Opus model; best for complex agentic coding and deep reasoning.",
-			true,
-			"high",
-			true,
-		),
-		claudeModelOption(
-			"sonnet",
-			"Claude Sonnet 5",
-			"Alias resolved by the Claude CLI to the latest available Sonnet model; default balanced model for everyday coding work.",
-			false,
-			"high",
-			true,
-		),
-		claudeModelOption(
-			"haiku",
-			"Claude Haiku 4.5",
-			"Alias resolved by the Claude CLI to the latest available Haiku model; fastest choice for quick edits and small tasks.",
-			false,
-			"none",
-			false,
-		),
-	}
-}
-
-func claudeModelOption(modelID string, displayName string, description string, isDefault bool, defaultEffort string, supportsNativeEffort bool) map[string]any {
-	supportedEfforts := []map[string]string{}
-	if supportsNativeEffort {
-		// 与 Claude bridge 的原生 effort 档位保持一致；iPad 只会启用这里声明的格子。
-		supportedEfforts = claudeReasoningEffortOptions()
-	}
-	return map[string]any{
-		"id":                        modelID,
-		"model":                     modelID,
-		"displayName":               displayName,
-		"description":               description,
-		"hidden":                    false,
-		"supportedReasoningEfforts": supportedEfforts,
-		"defaultReasoningEffort":    defaultEffort,
-		"inputModalities":           []string{"text", "image"},
-		"supportsPersonality":       false,
-		"additionalSpeedTiers":      []any{},
-		"serviceTiers":              []map[string]string{{"id": "standard", "name": "Standard", "description": "Default bridge service tier"}},
-		"isDefault":                 isDefault,
-	}
-}
-
-func claudeReasoningEffortOptions() []map[string]string {
-	return []map[string]string{
-		{"reasoningEffort": "medium", "description": "Balanced native Claude effort"},
-		{"reasoningEffort": "high", "description": "High native Claude effort (default)"},
-		{"reasoningEffort": "xhigh", "description": "Extended native Claude effort"},
-		{"reasoningEffort": "max", "description": "Maximum native Claude effort"},
-	}
 }
 
 func pingClientGateway(ctx context.Context, client *websocket.Conn, clientWriteMu *sync.Mutex) {

--- a/internal/httpapi/claude_gateway_test.go
+++ b/internal/httpapi/claude_gateway_test.go
@@ -4,43 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"reflect"
 	"strings"
 	"testing"
 )
-
-func TestClaudeCurrentModelListMatchesNativeEffortCapabilities(t *testing.T) {
-	models := claudeCurrentModelList()
-	if len(models) != 4 {
-		t.Fatalf("Claude 模型数量异常：got=%d want=4", len(models))
-	}
-
-	wantEfforts := []string{"medium", "high", "xhigh", "max"}
-	for _, model := range models {
-		modelID, _ := model["model"].(string)
-		options, ok := model["supportedReasoningEfforts"].([]map[string]string)
-		if !ok {
-			t.Fatalf("模型 %q 的 effort 能力格式异常：%T", modelID, model["supportedReasoningEfforts"])
-		}
-		if modelID == "haiku" {
-			if len(options) != 0 || model["defaultReasoningEffort"] != "none" {
-				t.Fatalf("Haiku 不应声明原生 effort：options=%v default=%v", options, model["defaultReasoningEffort"])
-			}
-			continue
-		}
-
-		gotEfforts := make([]string, 0, len(options))
-		for _, option := range options {
-			gotEfforts = append(gotEfforts, option["reasoningEffort"])
-		}
-		if !reflect.DeepEqual(gotEfforts, wantEfforts) {
-			t.Fatalf("模型 %q 的 effort 能力异常：got=%v want=%v", modelID, gotEfforts, wantEfforts)
-		}
-		if model["defaultReasoningEffort"] != "high" {
-			t.Fatalf("模型 %q 默认应为 high：got=%v", modelID, model["defaultReasoningEffort"])
-		}
-	}
-}
 
 // 超大单帧必须被丢弃而不是撕掉连接：正常帧照常返回，超限帧返回 oversize=true 且不残留内容，
 // 其后的正常帧仍能继续读取。这是 Claude 通道断线循环兜底的核心保证。

--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -1288,8 +1288,8 @@ struct CodexAppServerModelOption: Codable, Hashable, Identifiable {
 
     static let builtInClaudeFallback: [CodexAppServerModelOption] = [
         CodexAppServerModelOption(
-            id: "claude-fable-5",
-            title: "Claude Fable 5",
+            id: "claude-fable-5-1",
+            title: "Claude Fable 5.1",
             provider: "anthropic",
             runtimeProvider: "claude",
             description: "Anthropic's most capable generally available model for the hardest, longest-running agentic work.",

--- a/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
+++ b/ios/MimiRemote/Sources/Core/Models/SessionAPIModels.swift
@@ -1288,39 +1288,30 @@ struct CodexAppServerModelOption: Codable, Hashable, Identifiable {
 
     static let builtInClaudeFallback: [CodexAppServerModelOption] = [
         CodexAppServerModelOption(
-            id: "claude-fable-5-1",
-            title: "Claude Fable 5.1",
-            provider: "anthropic",
-            runtimeProvider: "claude",
-            description: "Anthropic's most capable generally available model for the hardest, longest-running agentic work.",
-            supportedReasoningEfforts: ["medium", "high", "xhigh", "max"],
-            defaultReasoningEffort: "high"
-        ),
-        CodexAppServerModelOption(
             id: "opus",
-            title: "Claude Opus 5",
+            title: "Claude Opus",
             provider: "anthropic",
             runtimeProvider: "claude",
-            description: "Claude CLI alias resolved to the latest available Opus model.",
+            description: "Stable Claude CLI alias for Opus.",
             isDefault: true,
             supportedReasoningEfforts: ["medium", "high", "xhigh", "max"],
             defaultReasoningEffort: "high"
         ),
         CodexAppServerModelOption(
             id: "sonnet",
-            title: "Claude Sonnet 5",
+            title: "Claude Sonnet",
             provider: "anthropic",
             runtimeProvider: "claude",
-            description: "Claude CLI alias resolved to the latest available Sonnet model.",
+            description: "Stable Claude CLI alias for Sonnet.",
             supportedReasoningEfforts: ["medium", "high", "xhigh", "max"],
             defaultReasoningEffort: "high"
         ),
         CodexAppServerModelOption(
             id: "haiku",
-            title: "Claude Haiku 4.5",
+            title: "Claude Haiku",
             provider: "anthropic",
             runtimeProvider: "claude",
-            description: "Claude CLI alias resolved to the latest available Haiku model."
+            description: "Stable Claude CLI alias for Haiku."
         )
     ]
 

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
@@ -308,7 +308,7 @@ extension ComposerView {
         composerState.updateTurnOptions { options in
             if runtimeChanged || unsupportedModel {
                 // 切换 runtime 或目录刷新淘汰旧模型时，使用设置里的对应默认值；
-                // 没有自定义设置时回到 Codex GPT-6/medium、Claude Opus/high。
+                // 没有自定义设置时使用目录默认项，目录不可用才使用内置稳定 alias。
                 applyPreferredDefaultModel(runtimeProvider: runtimeProvider, to: &options)
             } else if unsupportedEffort {
                 options.reasoningEffort = normalizedEffort
@@ -323,7 +323,7 @@ extension ComposerView {
         runtimeProvider: String,
         to options: inout CodexAppServerTurnOptions
     ) {
-        // 默认模型统一从本机设置读取；没有保存配置时使用 GPT-6/medium、Opus/high。
+        // 默认模型统一从本机设置读取；没有保存配置时使用当前目录默认项。
         DefaultModelPreferences.applyDefault(
             for: runtimeProvider,
             allOptions: modelOptionsForMenu,

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerModelSelection.swift
@@ -273,6 +273,7 @@ extension ComposerView {
     }
 
     func clampModelSelectionToSelectedSessionRuntime() {
+        composerState.updateTurnOptions { ComposerModelSelectionCompatibility.apply(to: &$0) }
         guard let runtimeProvider = selectedSessionRuntimeProviderForModelMenu else {
             return
         }
@@ -350,6 +351,7 @@ extension ComposerView {
     func normalizeModelControlsForStandardComposer(
         _ options: inout CodexAppServerTurnOptions
     ) {
+        ComposerModelSelectionCompatibility.apply(to: &options)
         let modelID = ModelReasoningGridCatalog.effectiveModelID(
             selectedModelID: options.model,
             options: modelOptionsForMenu

--- a/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ComposerState.swift
@@ -164,6 +164,31 @@ struct ComposerDraftCache {
     }
 }
 
+enum ComposerModelSelectionCompatibility {
+    static func modelID(_ modelID: String?, runtimeProvider: String?) -> String? {
+        // 目录升级不能把用户明确选择的 Fable 静默改为服务端默认的 Opus。
+        guard CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider) == "claude",
+              modelID == "claude-fable-5" else { return modelID }
+        return "claude-fable-5-1"
+    }
+
+    static func apply(to options: inout CodexAppServerTurnOptions) {
+        options.model = modelID(options.model, runtimeProvider: options.runtimeProvider)
+    }
+
+    static func optionID(_ optionID: String?, runtimeProvider: String) -> String? {
+        guard CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider) == "claude",
+              let optionID else { return optionID }
+        // 设置保存的是 runtime@model@provider，历史版本也可能只保存裸模型 ID。
+        var components = optionID.components(separatedBy: "@")
+        if components.count >= 2, components[0] == "claude" {
+            components[1] = modelID(components[1], runtimeProvider: runtimeProvider)!
+            return components.joined(separator: "@")
+        }
+        return modelID(optionID, runtimeProvider: runtimeProvider)
+    }
+}
+
 struct ComposerModelSelectionSnapshot: Equatable {
     var runtimeProvider: String?
     var model: String?
@@ -173,7 +198,7 @@ struct ComposerModelSelectionSnapshot: Equatable {
 
     init(options: CodexAppServerTurnOptions) {
         runtimeProvider = options.runtimeProvider
-        model = options.model
+        model = ComposerModelSelectionCompatibility.modelID(options.model, runtimeProvider: options.runtimeProvider)
         modelProvider = options.modelProvider
         reasoningEffort = options.reasoningEffort
         serviceTier = options.serviceTier
@@ -181,7 +206,8 @@ struct ComposerModelSelectionSnapshot: Equatable {
 
     func apply(to options: inout CodexAppServerTurnOptions) {
         options.runtimeProvider = runtimeProvider
-        options.model = model
+        // 恢复时也做兼容处理，覆盖目录刷新前已经留在会话缓存里的快照。
+        options.model = ComposerModelSelectionCompatibility.modelID(model, runtimeProvider: runtimeProvider)
         options.modelProvider = modelProvider
         options.reasoningEffort = reasoningEffort
         options.serviceTier = serviceTier
@@ -268,9 +294,15 @@ enum DefaultModelPreferences {
         for runtimeProvider: String,
         in defaults: UserDefaults = .standard
     ) -> String? {
-        defaults.string(forKey: modelOptionIDKey(for: runtimeProvider))?
+        let key = modelOptionIDKey(for: runtimeProvider)
+        let storedID = defaults.string(forKey: key)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .appServerNilIfEmpty
+        let migratedID = ComposerModelSelectionCompatibility.optionID(storedID, runtimeProvider: runtimeProvider)
+        if migratedID != storedID {
+            defaults.set(migratedID, forKey: key)
+        }
+        return migratedID
     }
 
     static func storedReasoningEffort(
@@ -290,7 +322,15 @@ enum DefaultModelPreferences {
     ) -> DefaultModelSelection? {
         let candidates = options(for: runtimeProvider, allOptions: allOptions)
         let option = storedModelOptionID(for: runtimeProvider, in: defaults)
-            .flatMap { storedID in candidates.first { $0.id == storedID } }
+            .flatMap { storedID in
+                if let exact = candidates.first(where: { $0.id == storedID }) { return exact }
+                // 裸 Fable ID 升级后绑定到实际目录的 option ID，设置和提交共用同一项。
+                guard CodexAppServerSessionRuntime.normalizedRuntimeProvider(runtimeProvider) == "claude",
+                      storedID == "claude-fable-5-1",
+                      let migrated = candidates.first(where: { $0.model == storedID }) else { return nil }
+                defaults.set(migrated.id, forKey: modelOptionIDKey(for: runtimeProvider))
+                return migrated
+            }
             ?? ModelReasoningGridCatalog.preferredDefaultOption(
                 runtimeProvider: runtimeProvider,
                 options: candidates

--- a/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
+++ b/ios/MimiRemote/Sources/Features/Conversation/ModelReasoningGridPicker.swift
@@ -145,25 +145,14 @@ enum ModelReasoningGridCatalog {
             : CodexAppServerModelOption.builtInFallback
         let candidates = runtimeOptions.isEmpty ? fallbackOptions : runtimeOptions
 
-        if normalizedRuntime == "claude" {
-            // Bridge 可能返回稳定 alias `opus`，也可能返回带版本的 canonical id。
-            // 以产品名 Opus 5 匹配，避免服务端把其他模型标成默认后改变新会话体验。
-            if let opus = candidates.first(where: { option in
-                let model = option.model.lowercased()
-                let title = option.title.lowercased()
-                return model == "opus" ||
-                    model.contains("opus-5") ||
-                    title.contains("opus 5")
-            }) {
-                return opus
-            }
-        } else if let astra = candidates.first(where: {
+        if normalizedRuntime != "claude", let astra = candidates.first(where: {
             $0.model.caseInsensitiveCompare("gpt-6-astra") == .orderedSame
         }) {
             return astra
         }
 
-        // 账号尚未获得目标模型时不能发送目录外 ID；退回该 runtime 的可用默认项。
+        // Claude 的动态目录以运行时标记的默认项为准；目录不可用时
+        // built-in fallback 会用稳定 alias 提供默认项。
         return candidates.first(where: \.isDefault) ?? candidates.first
     }
 

--- a/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/CodexAppServerProtocolTests.swift
@@ -1602,11 +1602,11 @@ final class CodexAppServerProtocolTests: XCTestCase {
         )
     }
 
-    func testPreferredClaudeDefaultUsesCanonicalOpus5High() throws {
+    func testPreferredClaudeDefaultUsesServerDefaultForUnknownFutureModel() throws {
         let options = [
             CodexAppServerModelOption(
-                id: "claude-fable-5",
-                title: "Claude Fable 5",
+                id: "claude-future-model",
+                title: "Claude Future Model",
                 runtimeProvider: "claude",
                 isDefault: true,
                 supportedReasoningEfforts: ["medium", "high", "xhigh", "max"]
@@ -1628,7 +1628,7 @@ final class CodexAppServerProtocolTests: XCTestCase {
         )
         let layout = ModelReasoningGridCatalog.layout(runtimeProvider: "claude", options: options)
 
-        XCTAssertEqual(option.model, "claude-opus-5")
+        XCTAssertEqual(option.model, "claude-future-model")
         XCTAssertEqual(
             ModelReasoningGridCatalog.preferredDefaultEffort(
                 runtimeProvider: "claude",
@@ -1651,6 +1651,11 @@ final class CodexAppServerProtocolTests: XCTestCase {
             options: CodexAppServerModelOption.builtInClaudeFallback
         )
 
+        XCTAssertEqual(CodexAppServerModelOption.builtInClaudeFallback.map(\.model), ["opus", "sonnet", "haiku"])
+        XCTAssertEqual(
+            CodexAppServerModelOption.builtInClaudeFallback.map(\.title),
+            ["Claude Opus", "Claude Sonnet", "Claude Haiku"]
+        )
         XCTAssertEqual(option.model, "opus")
         XCTAssertTrue(option.isDefault)
         XCTAssertEqual(option.defaultReasoningEffort, "high")

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
@@ -9,6 +9,29 @@ private let codex56SnapshotModels = CodexAppServerModelOption.builtInFallback.fi
     $0.model.hasPrefix("gpt-5.6-")
 }
 
+// 图片基线验证服务端返回的版本化标题布局，不依赖产品的无版本 fallback。
+private let claudeCatalogSnapshotModels = [
+    CodexAppServerModelOption(
+        id: "claude-fable-5",
+        title: "Claude Fable 5",
+        runtimeProvider: "claude",
+        supportedReasoningEfforts: ["medium", "high", "xhigh", "max"]
+    ),
+    CodexAppServerModelOption(
+        id: "claude-opus-5",
+        title: "Claude Opus 5",
+        runtimeProvider: "claude",
+        isDefault: true,
+        supportedReasoningEfforts: ["medium", "high", "xhigh", "max"]
+    ),
+    CodexAppServerModelOption(
+        id: "claude-sonnet-5",
+        title: "Claude Sonnet 5",
+        runtimeProvider: "claude",
+        supportedReasoningEfforts: ["medium", "high", "xhigh", "max"]
+    )
+]
+
 @MainActor
 final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
     func testEffectiveModelUsesExplicitSelectionBeforeServerDefault() {
@@ -101,14 +124,14 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
 
         XCTAssertTrue(codexLayout.contains(modelID: nonGridModelID))
         XCTAssertTrue(claudeLayout.contains(modelID: claudeModelID))
-        XCTAssertEqual(claudeLayout.models.map(\.model), ["claude-fable-5-1", "opus", "sonnet"])
+        XCTAssertEqual(claudeLayout.models.map(\.model), ["opus", "sonnet", "haiku"])
         XCTAssertEqual(
             claudeLayout.models.map { ModelReasoningGridCatalog.shortTitle(for: $0, kind: .claude) },
-            ["Claude Fable 5.1", "Claude Opus 5", "Claude Sonnet 5"]
+            ["Claude Opus", "Claude Sonnet", "Claude Haiku"]
         )
         XCTAssertEqual(
             ModelReasoningGridCatalog.compactTriggerTitle(for: "opus", layout: claudeLayout),
-            "Opus 5"
+            "Opus"
         )
         XCTAssertEqual(claudeLayout.efforts, [.medium, .high, .xhigh, .max])
         XCTAssertEqual(ModelReasoningGridCatalog.effortTitle(.low), "Light")
@@ -445,8 +468,8 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
                 colorScheme: .dark,
                 horizontalSizeClass: .regular,
                 runtimeProvider: "claude",
-                options: CodexAppServerModelOption.builtInClaudeFallback,
-                selection: ModelReasoningGridSelection(modelID: "opus", effort: .high)
+                options: claudeCatalogSnapshotModels,
+                selection: ModelReasoningGridSelection(modelID: "claude-opus-5", effort: .high)
             ),
             as: .image(
                 precision: 0.98,

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
@@ -34,6 +34,78 @@ private let claudeCatalogSnapshotModels = [
 
 @MainActor
 final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
+    func testSavedFable5DefaultMigratesWithoutSelectingOpus() throws {
+        let suite = "FableSelectionMigration.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("claude-fable-5", forKey: DefaultModelPreferences.claudeModelOptionIDKey)
+        defaults.set("high", forKey: DefaultModelPreferences.claudeReasoningEffortKey)
+        let catalog = [
+            CodexAppServerModelOption(id: "opus", title: "Opus", runtimeProvider: "claude", isDefault: true),
+            CodexAppServerModelOption(
+                id: "claude-fable-5-1", title: "Fable 5.1", provider: "anthropic", runtimeProvider: "claude",
+                supportedReasoningEfforts: ["medium", "high", "max"]
+            )
+        ]
+
+        for legacyID in ["claude-fable-5", "claude@claude-fable-5@anthropic"] {
+            defaults.set(legacyID, forKey: DefaultModelPreferences.claudeModelOptionIDKey)
+            let selection = try XCTUnwrap(DefaultModelPreferences.resolvedSelection(
+                for: "claude", allOptions: catalog, defaults: defaults
+            ))
+            XCTAssertEqual(selection.option.model, "claude-fable-5-1")
+            XCTAssertEqual(selection.effort, .high)
+            XCTAssertEqual(defaults.string(forKey: DefaultModelPreferences.claudeModelOptionIDKey), catalog[1].id)
+            var submitted = CodexAppServerTurnOptions.default
+            DefaultModelPreferences.applyDefault(for: "claude", allOptions: catalog, defaults: defaults, to: &submitted)
+            XCTAssertEqual(submitted.model, "claude-fable-5-1")
+            XCTAssertEqual(submitted.runtimeProvider, "claude")
+            XCTAssertEqual(submitted.reasoningEffort, .high)
+        }
+    }
+
+    func testCachedFable5SelectionMigratesOnSessionRestore() throws {
+        var options = CodexAppServerTurnOptions.default
+        options.runtimeProvider = "claude"
+        options.model = "claude-fable-5"
+        options.modelProvider = "anthropic"
+        options.reasoningEffort = .high
+        var legacy = ComposerModelSelectionSnapshot(options: options)
+        XCTAssertEqual(legacy.model, "claude-fable-5-1")
+        // 模拟兼容处理前已存在的快照，验证恢复入口，而非只验证新快照。
+        legacy.model = "claude-fable-5"
+        var cache = ComposerModelSelectionCache()
+        cache.save(legacy, for: .session("legacy-fable-session"))
+        let restored = try XCTUnwrap(cache.snapshot(for: .session("legacy-fable-session")))
+        var submitted = CodexAppServerTurnOptions.default
+        restored.apply(to: &submitted)
+        XCTAssertEqual(submitted.model, "claude-fable-5-1")
+        XCTAssertEqual(submitted.runtimeProvider, "claude")
+        XCTAssertEqual(submitted.modelProvider, "anthropic")
+        XCTAssertEqual(submitted.reasoningEffort, .high)
+    }
+
+    func testFableMigrationKeepsOtherRuntimesAndExplicitServerDefault() {
+        for runtime in [nil, "codex", "claude"] as [String?] {
+            for model in [nil, "custom-model", "claude-fable-5-1", "claude-fable-5"] as [String?] {
+                var options = CodexAppServerTurnOptions.default
+                options.runtimeProvider = runtime
+                options.model = model
+                options.reasoningEffort = .high
+                let original = options
+                ComposerModelSelectionCompatibility.apply(to: &options)
+                if runtime == "claude", model == "claude-fable-5" {
+                    XCTAssertEqual(options.model, "claude-fable-5-1")
+                } else {
+                    XCTAssertEqual(options, original)
+                }
+                let once = options
+                ComposerModelSelectionCompatibility.apply(to: &options)
+                XCTAssertEqual(options, once)
+            }
+        }
+    }
+
     func testEffectiveModelUsesExplicitSelectionBeforeServerDefault() {
         let options = [
             CodexAppServerModelOption(id: "gpt-5.6-sol", title: "GPT-5.6 Sol", isDefault: true),

--- a/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
+++ b/ios/MimiRemote/Tests/MimiRemoteTests/SkillModelPickerSnapshotTests.swift
@@ -101,10 +101,10 @@ final class SkillModelPickerSnapshotTests: SimplifiedChineseSnapshotTestCase {
 
         XCTAssertTrue(codexLayout.contains(modelID: nonGridModelID))
         XCTAssertTrue(claudeLayout.contains(modelID: claudeModelID))
-        XCTAssertEqual(claudeLayout.models.map(\.model), ["claude-fable-5", "opus", "sonnet"])
+        XCTAssertEqual(claudeLayout.models.map(\.model), ["claude-fable-5-1", "opus", "sonnet"])
         XCTAssertEqual(
             claudeLayout.models.map { ModelReasoningGridCatalog.shortTitle(for: $0, kind: .claude) },
-            ["Claude Fable 5", "Claude Opus 5", "Claude Sonnet 5"]
+            ["Claude Fable 5.1", "Claude Opus 5", "Claude Sonnet 5"]
         )
         XCTAssertEqual(
             ModelReasoningGridCatalog.compactTriggerTitle(for: "opus", layout: claudeLayout),


### PR DESCRIPTION
Claude 模型目录改为读取当前 Claude CLI 的 SDK initialize 响应。模型 ID、版本名称和思考强度来自 CLI；Go 网关原样转发，iOS 尊重运行时默认项。

查询不发送聊天消息，关闭工具、MCP、用户 hooks 和会话持久化，设置超时并回收查询进程。失败时使用 opus/sonnet/haiku 无版本 alias。保留前三项快捷网格和完整菜单，沿用现有 5 分钟目录缓存。动态内容取决于当前 CLI 版本与配置。

Refs #440

### 验证

- 实际新 bridge 的 initialize → model/list 返回 5 项，包含 Fable 5.1；版本与思考强度来自 CLI，未发送推理请求。
- Rust 三个相关 crate 测试通过，Claude bridge 234 项单元测试通过。
- Go 网关 package 测试、go vet ./...、Rust 格式、源码体积、差异检查、完整 Git 历史安全扫描和固定 Codex CLI 0.151.0 协议检查通过。
- iOS 4 个精确 XCTest（含图片快照）通过。
- 最新提交 a12d49d7 的远端 PR Gate 已通过：9 successful、3 skipped，包含 Go、Rust 和 iOS conversation-regressions。

### 本地完整验证限制

已执行 verify-change.sh --plan、quick 与 --full，不能将本地结果表述为全部通过：

- Go 全仓登录诊断 TestProbeClaudeAuthStatusDoesNotTurnTimeoutIntoSignedOut 失败，精确重跑失败；先前在未修改 main 上已复现。推送票据测试偶发失败，精确重跑通过；两个 package 均未修改。
- quick 在 Go 测试成功后因全局缓存目录缺失退出；缓存恢复后 Go 网关重跑通过。独立 App build 被其他任务的固定 M5 租约阻挡；App/测试包已由通过的精确 XCTest 编译验证。
- 完整 iOS 回归长时间停在异步等待，采样后手动中断。结果包记录 230 通过、3 跳过；LockScreenApprovalTests/testDisableWithoutPreviousHostRevokesAtProviderAndClearsBinding 标记 Testing was canceled。未扩大修改通知逻辑。远端同一提交的 iOS 回归已通过。

尚未合并、安装日常 App 或发布。本机 Claude CLI 未登录，真实账号推理仍待验收。已保存的模型 ID 若不在运行时目录，沿用现有默认项回退规则，不维护固定版本迁移表。