### PR TITLE
减少重复验证与模型等待，汇总本地检查并明确 CI 收尾

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,17 +98,24 @@
 ## 分层验证执行规范
 
 - 开发过程中只运行与当前行为直接相关的最小检查。Go 优先运行变更 package 的测试；iOS 优先运行精确 XCTest selector、相关快照或静态检查。不要在每次微调后运行 quick、完整 XCTest 或全仓测试。
-- 完成最后一次代码修改后，交付或 push 前执行一轮：
-  - `bash ./scripts/verify-change.sh --plan`
-  - `bash ./scripts/verify-change.sh`
+- 完成最后一次代码修改后，交付或 push 前先根据下述条件选择模式。quick 先运行 `bash ./scripts/verify-change.sh --plan`，再运行一次 `bash ./scripts/verify-change.sh`；full 先运行 `bash ./scripts/verify-change.sh --plan --full`，再运行一次 `bash ./scripts/verify-change.sh --full`。计划与执行使用同一模式，选择 full 时不先执行 quick。
 - quick 是普通 Issue 的默认收尾。iOS quick 只在固定 `iPad Pro 13-inch (M5)` Simulator 上编译 App，不编译或运行整个 XCTest 测试包；需要回归测试时，在开发阶段运行与问题直接相关的 selector。
+- 修改共享协议、跨栈接口或同一用户链路的多个产品栈，本身不要求本地 full。必须对接口兼容、错误语义和降级链路运行定向检查；只有同时命中下述 full 条件时才升级。
 - 只有以下任一条件成立时，才执行 `bash ./scripts/verify-change.sh --full`：
-  - 修改 Go/iOS 共享协议、跨栈接口或同一用户链路的多个产品栈；
   - 修改鉴权、权限、持久化格式或迁移、消息 exactly-once、并发、重连等高风险语义；
   - 大范围重构导致直接影响范围无法可靠界定；
+  - 必要回归缺少等价 CI 覆盖，且本地 full 能补齐该缺口；
   - 准备正式发布，或用户明确要求完整回归。
-- Issue 已完成、改动文件较多、准备提交和“为了保险”都不是 full 的触发条件。quick 或 CI 失败时先定位，修复后只重跑失败项；修复引入新影响时补相应检查，不自动升级为全量流程。
+- 运行 full 前，检查 full 计划中的命令，并核对这些命令所调用脚本的实际目标、配置和 selector。full 计划已经覆盖 quick 项目时，不另跑 quick；full 没有覆盖当前风险所需的专项时，才额外补验。所选 full 计划中的每一项仍须在本轮执行，不能因开发阶段或以前轮次运行过等价测试而跳过。
+- 普通本地 full 不默认扫描完整 Git 历史；它保留必要的 PR Gate 自检和 Codex 协议检查。修改公开仓库安全门自身时，仍执行完整安全检查。`Public Repository Safety` 在 `main` push 和 `workflow_dispatch` 使用 full-history，在 Pull Request 使用增量检查。
+- `--plan` 保持详细输出。实际执行时，计划、结果汇总和每项完整输出分别写入脚本报告结果目录中的 `plan.txt`、`summary.txt` 和编号日志；该目录默认位于本机临时目录。控制台只显示状态、实际耗时和失败项的有限日志。不要另建统计系统。
+- 前置静态检查失败时，不再启动依赖它的重型检查；其他独立检查仍继续并汇总。非零退出、阻塞退出码 75、取消和超时都不能算通过，也不能跨轮引用旧结果。检查执行中收到 INT 或 TERM 时，只终止当前检查的进程组，并保留取消结果。
+- Issue 已完成、改动文件较多、准备提交和“为了保险”都不是 full 的触发条件。quick、本地 full 或 CI 失败时先定位，修复后只重跑失败项；修复引入新影响时补相应检查，不自动升级为全量流程。
 - 真机验证仍只用于相机、通知、Keychain、Tailscale/弱网、性能、发布前专项或 Issue 明确要求。普通 UI、文案、局部状态和单 package 修复不得默认启动真机。
+- 设备排队沿用现有租约等待预算。租约超时是阻塞，不能据此豁免检查或切换到其他设备。环境故障必须按日志和运行环境证据判断；`main` 有相同失败或重跑变绿都不能单独证明改动无关。
+- 等待长时间本地命令或 CI 时，使用宿主已有的阻塞或挂起工具。没有状态变化时，不反复运行 `tail`、`ps` 或派另一个 Agent 监视。
+- 必需检查必须对最新受检提交实际返回成功。使用不同 Xcode 或 SDK 的本地结果与 CI 结果分别记录，不能互相替代。
+- 如果宿主没有完成事件可继续唤醒当前任务，把 Issue 保持在 `Verify`，并交接 Commit、PR、CI 链接、已执行检查、未验证范围和恢复原任务的入口。负责人在 CI 成功或失败后回到原任务继续处理。开发结束本身不满足 `Done`。
 - 交付时只报告实际执行的检查，并明确列出延后到 PR Gate、真机或发布阶段的范围。不得把 quick 结果表述为完整回归通过。
 
 ## iOS 日常构建与模拟器标准

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,15 +25,25 @@ Bug 请尽量包含：
 ## 本地验证
 
 开发过程中只运行当前问题需要的最小检查，不要在每次微调后重复执行全量测试、
-Simulator 回归和真机验证。准备提交或推送前，统一执行一次：
+Simulator 回归和真机验证。完成最后一次代码修改后，根据风险选择下面一个流程。
+
+普通改动选择 quick：
 
 ```bash
 bash ./scripts/verify-change.sh --plan
 bash ./scripts/verify-change.sh
 ```
 
-第一条只展示变更来源、受影响栈、执行/跳过原因和真机延后项；确认计划后，第二条执行
-quick 验证。脚本会合并 `origin/main...HEAD`、暂存区、工作区和未跟踪文件并去重：
+命中下述 full 条件时选择 full：
+
+```bash
+bash ./scripts/verify-change.sh --plan --full
+bash ./scripts/verify-change.sh --full
+```
+
+计划与执行使用同一模式，不要先执行 quick 再运行 full。`--plan` 展示变更来源、受影响栈、
+命令、执行或跳过原因和真机延后项。
+脚本会合并 `origin/main...HEAD`、暂存区、工作区和未跟踪文件并去重：
 
 - 纯文档不启动 Go、Cargo、Xcode 或真机；
 - CI、脚本和发布控制面只运行语法检查及对应的无设备自测；
@@ -42,16 +52,27 @@ quick 验证。脚本会合并 `origin/main...HEAD`、暂存区、工作区和�
 - Rust、Mac App、共享契约和打包改动只进入各自的必要门禁；
 - 未映射路径会明确失败，不会被静默当作通过。
 
-开发过程中需要 XCTest 时，只运行与当前问题直接相关的 selector。只有共享协议或跨栈接口、
-鉴权/权限/持久化/并发/重连等高风险语义、大范围重构、准备正式发布，或用户明确要求时才升级：
+开发过程中需要 XCTest 时，只运行与当前问题直接相关的 selector。共享协议、跨栈接口或同一
+链路包含多个产品栈时，要定向覆盖接口兼容、错误语义和降级链路，但这类路径本身不要求
+本地 full。只有修改鉴权、权限、持久化或迁移、消息 exactly-once、并发、重连等高风险
+语义，影响范围无法界定的大重构，本地 full 能补齐必要回归的 CI 覆盖缺口，准备正式发布，或用户明确要求时才选择
+full。
 
-```bash
-bash ./scripts/verify-change.sh --full
-```
+选择 full 时，先检查 full 计划中的命令，并核对这些命令所调用脚本的实际目标、配置和
+selector。full 计划已经覆盖 quick 项目时，不另跑 quick；full 没有覆盖当前风险所需的专项
+时，才额外补验。full 计划列出的每一项仍须在本轮执行，不能用开发阶段或以前轮次的等价
+结果跳过。普通 UI、文案、单 package、测试文件、改动文件较多和准备提交都不是 full 的
+触发条件。
 
-`--full` 仍只覆盖受影响语言栈，并补齐仓库级 Gate。普通 UI、文案、单 package、测试文件、
-改动文件较多和准备提交都不是 full 的触发条件。CI 红灯时先重跑或定位失败的具体 job，
-不要为了“保险”把所有本地流程再跑一遍。
+实际执行会把 `plan.txt`、`summary.txt` 和每项编号日志写入脚本报告的结果目录；默认位置是
+本机临时目录。控制台只显示状态、实际耗时和失败项的有限日志。前置静态检查失败时，依赖它
+的重型检查不会启动；其他独立检查仍继续并汇总。非零退出、阻塞退出码 75、取消和超时都
+不能算通过，也不能用以前轮次的结果替代本轮结果。检查执行中收到 INT 或 TERM 时，脚本只终止当前
+检查的进程组，并保留取消结果。
+
+普通本地 full 不默认扫描完整 Git 历史，但保留必要的 PR Gate 自检和 Codex 协议检查。
+修改公开仓库安全门自身时，仍执行完整安全检查。`Public Repository Safety` 在 `main` push
+和 `workflow_dispatch` 使用 full-history，在 Pull Request 使用增量检查。
 
 日常 `build` / `run` 只通过 `bash ./scripts/ios-dev.sh` 执行，优先租用 available、paired、USB 连接的真机，再选择可达的本地网络真机。只有没有可达真机时才回退 `iPad Pro 13-inch (M5)` Simulator；检测到真机但全部忙时明确失败，不静默切换设备类型。`build-for-testing`、`test`、快照与 CI 精确固定这台 M5 iPad，忙或缺失时不切换 iPad mini。使用 `bash ./scripts/ios-dev.sh target` 查看目标和选择原因，使用 `bash ./scripts/ios-dev.sh leases` 查看跨 Worktree 租约和外部 `xcodebuild`；兼容性运行通过 `IOS_TARGET_MODE=simulator` 和 `IOS_SIMULATOR_NAME` 显式切换。
 
@@ -136,6 +157,25 @@ base/head 可读取且路径分类符合预期：
 
 ```bash
 bash ./scripts/ci-pr-scope.sh --base origin/main --head HEAD
+```
+
+收尾时必须确认最新受检提交的必需检查实际成功。现有 CI 会运行 Go 全仓 `test` 与 `vet`、
+三个 Rust crate、iOS 核心回归、Codex 协议和公开仓库安全检查；按路径不适用的 job 应为
+`skipped`。使用测试版 Xcode 的本地结果与使用稳定版 Xcode 的 CI 结果分别记录，不能互相替代。
+
+等待本地命令或 CI 时，使用宿主已有的阻塞或挂起能力。没有状态变化时，不反复运行
+`tail`、`ps`，也不安排另一个 Agent 监视。设备排队沿用现有租约等待预算；超时是阻塞，
+不能豁免检查或换设备。环境故障必须由日志和运行环境证据支持；`main` 有相同失败或重跑
+变绿都不能单独证明改动无关。
+
+如果宿主没有完成事件可继续唤醒当前任务，把 Issue 保持在 `Verify`，并按下面的内容交接。
+负责人在 CI 成功或失败后回到原任务继续处理；开发结束本身不满足 `Done`。
+
+```text
+Commit / PR：<提交、PR 与 CI 链接>
+本轮验证：<脚本输出的计划、结果汇总和分项日志；含实际耗时>
+未验证范围：<延后到 CI、真机或发布阶段的项目>
+恢复入口：<原 Codex 任务或 Issue，以及下一项动作>
 ```
 
 `main` 分支保护必须把名称精确为 `PR Gate` 的 check 设为 required，并让未完成或

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -15,7 +15,16 @@ for command_name in bash chmod cp git grep mkdir mktemp printf rm; do
 done
 
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/mimi-verify-change-test.XXXXXX")"
-trap 'rm -rf "$test_root"' EXIT
+runner_pid=""
+unrelated_pid=""
+cleanup() {
+  [[ -z "$runner_pid" ]] || kill -TERM "$runner_pid" 2>/dev/null || true
+  [[ -z "$unrelated_pid" ]] || kill -TERM "$unrelated_pid" 2>/dev/null || true
+  [[ -z "$runner_pid" ]] || wait "$runner_pid" 2>/dev/null || true
+  [[ -z "$unrelated_pid" ]] || wait "$unrelated_pid" 2>/dev/null || true
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
 
 assert_contains() {
   local output="$1"
@@ -141,6 +150,16 @@ assert_not_contains "$ios_full_output" "test-ios-localization-smoke.sh"
 assert_not_contains "$ios_full_output" "ios-dev.sh build-for-testing"
 assert_not_contains "$ios_full_output" "ios-dev.sh target"
 assert_not_contains "$ios_full_output" "ios-dev.sh leases"
+assert_not_contains "$ios_full_output" "bash ./scripts/check-public-repo-safety.sh"
+assert_not_contains "$ios_full_output" "CODE_SIGNING_ALLOWED=NO build"
+assert_contains "$ios_full_output" "bash ./scripts/check-pr-gate.sh"
+assert_contains "$ios_full_output" "专项缺项："
+assert_contains "$ios_full_output" "不因语言数量自动升级 full"
+assert_contains "$ios_full_output" "等待时保持 Verify，成功和失败均回原任务收尾"
+
+verify_full_output="$(assert_full_plan verify_full scripts/verify-change.sh)"
+assert_contains "$verify_full_output" "bash ./scripts/check-pr-gate.sh"
+assert_not_contains "$verify_full_output" "分层验证入口或说明变化必须通过无设备自测"
 
 mixed_full_output="$(assert_full_plan mixed_full internal/httpapi/router.go ios/MimiRemote/Sources/Features/Conversation/ConversationView.swift)"
 assert_contains "$mixed_full_output" "go test ./... -count=1"
@@ -164,6 +183,9 @@ assert_not_contains "$security_workflow_output" "bash ./scripts/check-pr-gate.sh
 security_verify_output="$(assert_plan security_verify scripts/check-public-repo-safety.sh scripts/verify-change.sh)"
 assert_contains "$security_verify_output" "bash ./scripts/check-public-repo-safety.sh"
 assert_not_contains "$security_verify_output" "分层验证入口或说明变化必须通过无设备自测"
+security_full_output="$(assert_full_plan security_full scripts/check-public-repo-safety.sh)"
+assert_contains "$security_full_output" "bash ./scripts/check-public-repo-safety.sh"
+assert_not_contains "$security_full_output" "bash ./scripts/check-pr-gate.sh"
 
 privacy_output="$(assert_plan ios_privacy ios/MimiRemote/Sources/Resources/PrivacyInfo.xcprivacy)"
 assert_contains "$privacy_output" "check-ios-network-security.sh"
@@ -287,7 +309,143 @@ if (cd "$repo_root" && bash ./scripts/verify-change.sh --plan --base "$unrelated
 fi
 assert_contains "$(<"$collection_failure_output")" "无法收集 committed 变更路径。"
 
-rm -rf "$test_root"
-trap - EXIT
+# 执行层用独立临时仓库与 fake 工具，覆盖失败汇总和真实进程取消，绝不启动编译器。
+execution_root="$test_root/execution-repository"
+mkdir -p "$execution_root/scripts" "$execution_root/bin" "$execution_root/internal/example"
+cp scripts/verify-change.sh scripts/ci-pr-scope.sh "$execution_root/scripts/"
+printf 'package example\n' > "$execution_root/internal/example/example.go"
+cat > "$execution_root/scripts/check-source-size.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'preflight\n' >> "$VERIFY_TEST_CALLS"
+exit "${VERIFY_TEST_PREFLIGHT_EXIT:-0}"
+SH
+cat > "$execution_root/bin/go" <<'SH'
+#!/usr/bin/env bash
+printf 'go %s\n' "$*" >> "$VERIFY_TEST_CALLS"
+printf 'go-log-first-line\n'
+for ((line=0; line<60; line++)); do printf 'go-log-line-%s\n' "$line"; done
+exit "${VERIFY_TEST_GO_EXIT:-0}"
+SH
+cat > "$execution_root/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+printf 'cargo %s\n' "$*" >> "$VERIFY_TEST_CALLS"
+printf 'quiet-cargo-success\n'
+exit 0
+SH
+cat > "$execution_root/scripts/ios-dev.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'ios %s\n' "$*" >> "$VERIFY_TEST_CALLS"
+if [[ -n "${VERIFY_TEST_HOLD:-}" ]]; then
+  mkdir "$VERIFY_TEST_HOLD.lease"
+  trap 'rm -rf "$VERIFY_TEST_HOLD.lease"' EXIT
+  trap 'exit 143' TERM
+  sleep 300 &
+  child=$!
+  printf '%s %s\n' "$$" "$child" > "$VERIFY_TEST_HOLD"
+  wait "$child"
+fi
+exit "${VERIFY_TEST_IOS_EXIT:-0}"
+SH
+chmod +x "$execution_root/bin/go" "$execution_root/bin/cargo"
+git -C "$execution_root" init -q
+git -C "$execution_root" config user.name "Mimi Verify Test"
+git -C "$execution_root" config user.email "verify-test@example.invalid"
+git -C "$execution_root" add .
+git -C "$execution_root" commit -qm baseline
+execution_paths="$test_root/execution.paths"
+printf '%s\0' internal/example/example.go ios/MimiRemote/Sources/Example.swift \
+  bridges/claude/crates/claude-bridge/src/lib.rs > "$execution_paths"
+execution_calls="$test_root/execution.calls"
+execution_output="$test_root/execution.output"
 
-echo "分层验证自测通过：docs/iOS/Go/Rust/contract/release/unknown、Gate 去重与四类 Git 变更来源均符合预期。"
+run_execution_case() {
+  : > "$execution_calls"
+  execution_code=0
+  (cd "$execution_root" && env PATH="$execution_root/bin:$PATH" TMPDIR="$test_root" \
+    VERIFY_TEST_CALLS="$execution_calls" "$@" \
+    bash ./scripts/verify-change.sh --paths-file "$execution_paths") \
+    > "$execution_output" 2>&1 || execution_code=$?
+  execution_summary="$(sed -n 's/^结果汇总：//p' "$execution_output")"
+  [[ -f "$execution_summary" ]] || fail "执行后必须留下结果汇总。"
+}
+
+run_execution_case VERIFY_TEST_GO_EXIT=7
+[[ "$execution_code" -eq 7 ]] || fail "独立检查失败必须保留非零退出码。"
+assert_contains "$(<"$execution_calls")" "ios build"
+assert_contains "$(<"$execution_calls")" "cargo test --locked"
+assert_contains "$(<"$execution_summary")" "失败 |"
+assert_contains "$(<"$execution_summary")" "exit=7"
+assert_contains "$(<"$execution_summary")" "通过 |"
+assert_not_contains "$(<"$execution_output")" "go-log-first-line"
+assert_not_contains "$(<"$execution_output")" "quiet-cargo-success"
+assert_contains "$(<"$execution_output")" "go-log-line-59"
+assert_contains "$(<"${execution_summary%/*}/3.log")" "go-log-first-line"
+assert_contains "$(<"${execution_summary%/*}/plan.txt")" "PR Gate scope："
+
+run_execution_case VERIFY_TEST_PREFLIGHT_EXIT=1
+[[ "$execution_code" -eq 1 ]] || fail "前置失败不能算验证通过。"
+assert_contains "$(<"$execution_summary")" "阻塞（前置检查失败）"
+assert_not_contains "$(<"$execution_calls")" "go test"
+assert_not_contains "$(<"$execution_calls")" "ios build"
+assert_not_contains "$(<"$execution_calls")" "cargo test"
+
+run_execution_case VERIFY_TEST_IOS_EXIT=75
+[[ "$execution_code" -eq 75 ]] || fail "设备阻塞必须保留退出码 75。"
+assert_contains "$(<"$execution_summary")" "阻塞 |"
+assert_contains "$(<"$execution_calls")" "cargo test --locked"
+
+run_execution_case VERIFY_TEST_GO_EXIT=75 VERIFY_TEST_IOS_EXIT=9
+[[ "$execution_code" -eq 9 ]] || fail "已有阻塞不能掩盖另一独立检查的真实失败。"
+assert_contains "$(<"$execution_summary")" "阻塞 |"
+assert_contains "$(<"$execution_summary")" "失败 |"
+
+run_execution_case VERIFY_TEST_GO_EXIT=124
+[[ "$execution_code" -eq 124 ]] || fail "子命令超时不能算通过。"
+assert_contains "$(<"$execution_summary")" "超时 |"
+
+run_execution_case VERIFY_TEST_GO_EXIT=130
+[[ "$execution_code" -eq 130 ]] || fail "子命令取消必须使整轮取消。"
+assert_contains "$(<"$execution_summary")" "取消 |"
+assert_contains "$(<"$execution_summary")" "未运行 |"
+assert_not_contains "$(<"$execution_calls")" "ios build"
+
+# 同一 HEAD 下再次执行仍真正调用工具；这些日志不是自动跳过检查的缓存。
+run_execution_case VERIFY_TEST_GO_EXIT=0
+[[ "$execution_code" -eq 0 ]] || fail "全部检查通过应返回零。"
+assert_contains "$(<"$execution_calls")" "go test"
+assert_not_contains "$(<"$execution_output")" "go-log-line-59"
+assert_not_contains "$(<"$execution_summary")" "未运行 |"
+
+hold_file="$test_root/held-check.pids"
+: > "$execution_calls"
+sleep 300 &
+unrelated_pid=$!
+(cd "$execution_root" && exec env PATH="$execution_root/bin:$PATH" TMPDIR="$test_root" \
+  VERIFY_TEST_CALLS="$execution_calls" VERIFY_TEST_HOLD="$hold_file" \
+  bash ./scripts/verify-change.sh --paths-file "$execution_paths") > "$execution_output" 2>&1 &
+runner_pid=$!
+for ((attempt=0; attempt<100; attempt++)); do
+  [[ ! -s "$hold_file" ]] || break
+  sleep 0.05
+done
+[[ -s "$hold_file" ]] || fail "取消测试未进入正在运行的检查。"
+read -r held_pid held_child_pid < "$hold_file"
+kill -TERM "$runner_pid"
+execution_code=0
+wait "$runner_pid" || execution_code=$?
+runner_pid=""
+[[ "$execution_code" -eq 143 ]] || fail "取消入口必须返回 143。"
+execution_summary="$(sed -n 's/^结果汇总：//p' "$execution_output")"
+[[ -f "$execution_summary" ]] || fail "取消后必须保留汇总。"
+assert_contains "$(<"$execution_summary")" "取消 |"
+assert_contains "$(<"$execution_summary")" "未运行 |"
+[[ ! -d "$hold_file.lease" ]] || fail "取消后目标入口必须完成租约清理。"
+if kill -0 "$held_pid" 2>/dev/null || kill -0 "$held_child_pid" 2>/dev/null; then
+  fail "取消后本轮检查仍有子进程存活。"
+fi
+kill -0 "$unrelated_pid" 2>/dev/null || fail "取消误伤了不属于本轮检查的进程。"
+kill -TERM "$unrelated_pid"
+wait "$unrelated_pid" 2>/dev/null || true
+unrelated_pid=""
+
+echo "分层验证自测通过：范围与来源、full 覆盖边界、失败汇总、有限日志、阻塞、取消和进程清理均符合预期。"

--- a/scripts/test-verify-change.sh
+++ b/scripts/test-verify-change.sh
@@ -330,6 +330,7 @@ cat > "$execution_root/bin/cargo" <<'SH'
 #!/usr/bin/env bash
 printf 'cargo %s\n' "$*" >> "$VERIFY_TEST_CALLS"
 printf 'quiet-cargo-success\n'
+[[ "$1" != fmt ]] || exit "${VERIFY_TEST_FMT_EXIT:-0}"
 exit 0
 SH
 cat > "$execution_root/scripts/ios-dev.sh" <<'SH'
@@ -385,9 +386,15 @@ assert_contains "$(<"${execution_summary%/*}/plan.txt")" "PR Gate scope："
 run_execution_case VERIFY_TEST_PREFLIGHT_EXIT=1
 [[ "$execution_code" -eq 1 ]] || fail "前置失败不能算验证通过。"
 assert_contains "$(<"$execution_summary")" "阻塞（前置检查失败）"
-assert_not_contains "$(<"$execution_calls")" "go test"
+assert_not_contains "$(<"$execution_calls")" "go test ./internal/example"
 assert_not_contains "$(<"$execution_calls")" "ios build"
+assert_contains "$(<"$execution_calls")" "cargo test --locked"
+
+run_execution_case VERIFY_TEST_FMT_EXIT=8
+[[ "$execution_code" -eq 8 ]] || fail "Rust 前置失败不能算通过。"
 assert_not_contains "$(<"$execution_calls")" "cargo test"
+assert_contains "$(<"$execution_calls")" "go test ./internal/example"
+assert_contains "$(<"$execution_calls")" "ios build"
 
 run_execution_case VERIFY_TEST_IOS_EXIT=75
 [[ "$execution_code" -eq 75 ]] || fail "设备阻塞必须保留退出码 75。"
@@ -412,7 +419,7 @@ assert_not_contains "$(<"$execution_calls")" "ios build"
 # 同一 HEAD 下再次执行仍真正调用工具；这些日志不是自动跳过检查的缓存。
 run_execution_case VERIFY_TEST_GO_EXIT=0
 [[ "$execution_code" -eq 0 ]] || fail "全部检查通过应返回零。"
-assert_contains "$(<"$execution_calls")" "go test"
+assert_contains "$(<"$execution_calls")" "go test ./internal/example"
 assert_not_contains "$(<"$execution_output")" "go-log-line-59"
 assert_not_contains "$(<"$execution_summary")" "未运行 |"
 

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -455,6 +455,7 @@ done
 
 checks=()
 check_reasons=()
+check_domains=()
 
 add_check() {
   local reason="$1"
@@ -465,6 +466,8 @@ add_check() {
   done
   check_reasons+=("$reason")
   checks+=("$command")
+  # 前置项标记它阻塞的技术栈，重型项标记自身技术栈；空值表示没有构建依赖。
+  check_domains+=("${3:-}")
 }
 
 shell_quote() {
@@ -485,7 +488,7 @@ if [[ "${#shell_paths[@]}" -gt 0 ]]; then
     [[ -z "$shell_command" ]] || shell_command+=" && "
     shell_command+="bash -n -- $(shell_quote "$path")"
   done
-  add_check "变更的 Shell 脚本先做语法检查" "$shell_command"
+  add_check "变更的 Shell 脚本先做语法检查" "$shell_command" "all"
 fi
 
 if [[ "${#yaml_paths[@]}" -gt 0 ]]; then
@@ -494,7 +497,7 @@ if [[ "${#yaml_paths[@]}" -gt 0 ]]; then
   for path in "${yaml_paths[@]}"; do
     yaml_command+=" $(shell_quote "$path")"
   done
-  add_check "变更的 YAML 文件先做语法解析" "$yaml_command"
+  add_check "变更的 YAML 文件先做语法解析" "$yaml_command" "all"
 fi
 
 if [[ "${#ruby_paths[@]}" -gt 0 ]]; then
@@ -504,7 +507,7 @@ if [[ "${#ruby_paths[@]}" -gt 0 ]]; then
     [[ -z "$ruby_command" ]] || ruby_command+=" && "
     ruby_command+="ruby -c -- $(shell_quote "$path")"
   done
-  add_check "变更的 Ruby 脚本先做语法检查" "$ruby_command"
+  add_check "变更的 Ruby 脚本先做语法检查" "$ruby_command" "all"
 fi
 
 if [[ "${#python_paths[@]}" -gt 0 ]]; then
@@ -513,7 +516,7 @@ if [[ "${#python_paths[@]}" -gt 0 ]]; then
   for path in "${python_paths[@]}"; do
     python_command+=" $(shell_quote "$path")"
   done
-  add_check "变更的 Python 脚本先做无产物语法检查" "$python_command"
+  add_check "变更的 Python 脚本先做无产物语法检查" "$python_command" "all"
 fi
 
 if [[ "$docs_scope" == true ]]; then
@@ -543,10 +546,10 @@ if [[ "$has_repository_security_control" == true ]]; then
   add_check "公开仓库安全门自身变化必须执行完整安全检查" "bash ./scripts/check-public-repo-safety.sh"
 fi
 if [[ "$has_ios_privacy_control" == true ]]; then
-  add_check "iOS 网络与隐私边界变化必须执行专项静态检查" "bash ./scripts/check-ios-network-security.sh && bash ./scripts/check-ios-privacy-manifest.sh"
+  add_check "iOS 网络与隐私边界变化必须执行专项静态检查" "bash ./scripts/check-ios-network-security.sh && bash ./scripts/check-ios-privacy-manifest.sh" "ios"
 fi
 if [[ "$has_ios_device_control" == true ]]; then
-  add_check "iOS 目标、Tailcat 构建、租约和真机 GUI 交接变化使用专项自测" "bash ./scripts/test-tailcat-mobile-build.sh && bash ./scripts/test-ios-device-management.sh && bash ./scripts/test-ios-device-gui-handoff-macos.sh"
+  add_check "iOS 目标、Tailcat 构建、租约和真机 GUI 交接变化使用专项自测" "bash ./scripts/test-tailcat-mobile-build.sh && bash ./scripts/test-ios-device-management.sh && bash ./scripts/test-ios-device-gui-handoff-macos.sh" "ios"
 fi
 if [[ "$has_ios_asc_control" == true ]]; then
   add_check "App Store Connect CLI 封装变化使用本地 fake ASC 自测" "bash ./scripts/test-ios-asc-cli.sh"
@@ -561,17 +564,17 @@ if [[ "$has_agentd_restart_control" == true ]]; then
   add_check "agentd 本地重启链路只执行无安装副作用的 self-test" "bash ./scripts/restart-agentd-dev-macos.sh --self-test"
 fi
 if [[ "$has_development_cache_control" == true ]]; then
-  add_check "本地重型构建必须复用仓库外缓存并串行写入" "bash ./scripts/test-development-cache.sh"
+  add_check "本地重型构建必须复用仓库外缓存并串行写入" "bash ./scripts/test-development-cache.sh" "all"
 fi
 if [[ "$has_contract" == true ]]; then
-  add_check "Go/iOS 共享契约变化" "bash ./scripts/check-mimi-protocol-contract.sh"
+  add_check "Go/iOS 共享契约变化" "bash ./scripts/check-mimi-protocol-contract.sh" "go ios"
 fi
 if [[ "$direct_go" == true || "$direct_ios" == true || "$has_source_size_control" == true ]]; then
   # 先用秒级门禁拦住超大源文件，避免等到 Xcode/Go 构建后才失败。
-  add_check "Go/iOS 源码体积快速门禁" "bash ./scripts/check-source-size.sh"
+  add_check "Go/iOS 源码体积快速门禁" "bash ./scripts/check-source-size.sh" "go ios"
 fi
 if [[ "$direct_rust" == true ]]; then
-  add_check "Rust 格式检查" "cargo fmt --all -- --check"
+  add_check "Rust 格式检查" "cargo fmt --all -- --check" "rust"
 fi
 if [[ "$mode" == "full" ]]; then
   # 普通本地 full 不重复扫描完整历史。PR 增量与 main 完整历史扫描由现有
@@ -584,35 +587,35 @@ preflight_count="${#checks[@]}"
 
 if [[ "$direct_go" == true ]]; then
   if [[ "$mode" == "full" || "$go_requires_full" == true || "${#go_packages[@]}" -gt 8 ]]; then
-    add_check "Go 受影响范围使用完整回归" "go test ./... -count=1"
+    add_check "Go 受影响范围使用完整回归" "go test ./... -count=1" "go"
   elif [[ "${#go_packages[@]}" -gt 0 ]]; then
     go_test_command="go test"
     for package_path in "${go_packages[@]}"; do
       go_test_command+=" $(shell_quote "$package_path")"
     done
     go_test_command+=" -count=1"
-    add_check "Go quick 只测试直接变更的 package" "$go_test_command"
+    add_check "Go quick 只测试直接变更的 package" "$go_test_command" "go"
   elif [[ "$has_contract" == false ]]; then
-    add_check "Go 受影响范围无法定位 package，使用完整回归" "go test ./... -count=1"
+    add_check "Go 受影响范围无法定位 package，使用完整回归" "go test ./... -count=1" "go"
   fi
   if [[ "$mode" == "full" ]]; then
-    add_check "Go full 补充静态分析" "go vet ./..."
+    add_check "Go full 补充静态分析" "go vet ./..." "go"
   fi
 fi
 
 if [[ "$has_tailcat_source" == true ]]; then
-  add_check "Tailcat 独立 Go module 变化使用自身测试" "(cd experiments/tailcat && go test ./... -count=1)"
+  add_check "Tailcat 独立 Go module 变化使用自身测试" "(cd experiments/tailcat && go test ./... -count=1)" "ios"
 fi
 
 if [[ "$direct_ios" == true ]]; then
   if [[ "$mode" == "full" ]]; then
     # Go 变更由上方独立 Go 计划覆盖；iOS 阶段不在 macOS/Simulator 链路重复执行。
-    add_check "iOS full 单次执行核心链路与双语资源回归" "bash ./scripts/test-conversation-regressions.sh --ios-only"
+    add_check "iOS full 单次执行核心链路与双语资源回归" "bash ./scripts/test-conversation-regressions.sh --ios-only" "ios"
   else
     # quick 只证明生产 App 能在固定 M5 Simulator 上编译。整个 XCTest 测试包会随
     # 项目增长而持续变慢；问题相关 selector 应在开发阶段单独执行，完整集合交给 full/CI。
     add_check "iOS quick 只编译 App，不编译或运行 XCTest" \
-      "IOS_TARGET_MODE=simulator IOS_SIMULATOR_ID= IOS_SIMULATOR_NAME='iPad Pro 13-inch (M5)' bash ./scripts/ios-dev.sh build"
+      "IOS_TARGET_MODE=simulator IOS_SIMULATOR_ID= IOS_SIMULATOR_NAME='iPad Pro 13-inch (M5)' bash ./scripts/ios-dev.sh build" "ios"
   fi
 fi
 
@@ -626,11 +629,11 @@ if [[ "$direct_rust" == true ]]; then
   [[ "$rust_codex" == true ]] && rust_test_command+=" -p alleycat-codex-proto"
   [[ "$rust_core" == true ]] && rust_test_command+=" -p alleycat-bridge-core"
   [[ "$rust_claude" == true ]] && rust_test_command+=" -p alleycat-claude-bridge"
-  add_check "Rust 只回归变更 crate 及其下游 crate" "$rust_test_command"
+  add_check "Rust 只回归变更 crate 及其下游 crate" "$rust_test_command" "rust"
 fi
 
 if [[ "$direct_macos" == true ]]; then
-  add_check "Mac App 变更执行统一无签名编译测试" "bash ./scripts/test-macos-app.sh"
+  add_check "Mac App 变更执行统一无签名编译测试" "bash ./scripts/test-macos-app.sh" "macos"
 fi
 
 print_plan() {
@@ -728,6 +731,9 @@ print_plan() {
   for index in "${!checks[@]}"; do
     echo "$((index + 1)). ${check_reasons[$index]}"
     echo "   ${checks[$index]}"
+    if [[ "$index" -lt "$preflight_count" && -n "${check_domains[$index]}" ]]; then
+      echo "   前置失败阻塞：${check_domains[$index]}"
+    fi
   done
 }
 
@@ -763,7 +769,7 @@ done
 overall_started="$SECONDS"
 current_index=-1
 check_pid=""
-preflight_failed=false
+blocked_domains=" "
 overall_code=0
 
 write_result_summary() {
@@ -836,7 +842,8 @@ trap 'cancel_run 143' TERM
 set -m
 echo "Mimi 分层验证：${mode}，${#checks[@]} 项；完整计划：${result_dir}/plan.txt"
 for index in "${!checks[@]}"; do
-  if [[ "$index" -ge "$preflight_count" && "$preflight_failed" == true ]]; then
+  if [[ "$index" -ge "$preflight_count" ]] && \
+     [[ "$blocked_domains" == *" all "* || "$blocked_domains" == *" ${check_domains[$index]} "* ]]; then
     result_states[$index]="阻塞（前置检查失败）"
     echo "<== [$((index + 1))/${#checks[@]}] ${result_states[$index]}：${check_reasons[$index]}"
     continue
@@ -868,7 +875,9 @@ for index in "${!checks[@]}"; do
     if [[ "$overall_code" -eq 0 || ( "$overall_code" -eq 75 && "$check_code" -ne 75 ) ]]; then
       overall_code="$check_code"
     fi
-    [[ "$index" -ge "$preflight_count" ]] || preflight_failed=true
+    if [[ "$index" -lt "$preflight_count" && -n "${check_domains[$index]}" ]]; then
+      blocked_domains+="${check_domains[$index]} "
+    fi
     echo "日志：${result_dir}/$((index + 1)).log（末尾最多 40 行、8 KiB）"
     tail -n 40 "$result_dir/$((index + 1)).log" | tail -c 8192
     if [[ "$check_code" -eq 130 || "$check_code" -eq 143 ]]; then

--- a/scripts/verify-change.sh
+++ b/scripts/verify-change.sh
@@ -12,6 +12,8 @@ usage() {
 
 默认执行 quick 验证：分析 origin/main...HEAD、暂存区、工作区和未跟踪文件，
 只运行受影响栈的最小检查。--plan 只打印计划；--full 升级为受影响栈的完整本地回归。
+执行时只输出分项状态与有限的失败日志；完整计划、结果和日志保存在输出的临时目录。
+quick 与 full 选择一轮执行，专项测试是否被覆盖仍需核对；不跨轮复用旧结果。
 EOF
 }
 
@@ -518,10 +520,10 @@ if [[ "$docs_scope" == true ]]; then
   add_check "文档与公开发布说明使用轻量静态门禁" "bash ./scripts/check-docs-static.sh"
 fi
 
-if [[ "$has_gate_control" == true && "$has_repository_security_control" == false ]]; then
+if [[ ( "$has_gate_control" == true || "$mode" == "full" ) && "$has_repository_security_control" == false ]]; then
   add_check "CI 编排或路径分类变化必须通过 Gate 自检" "bash ./scripts/check-pr-gate.sh"
 fi
-if [[ "$has_verify_control" == true && "$has_gate_control" == false && "$has_repository_security_control" == false ]]; then
+if [[ "$has_verify_control" == true && "$has_gate_control" == false && "$mode" != "full" && "$has_repository_security_control" == false ]]; then
   # check-pr-gate.sh 已包含这项自测；同一轮不要嵌套执行两次。
   add_check "分层验证入口或说明变化必须通过无设备自测" "bash ./scripts/test-verify-change.sh"
 fi
@@ -549,7 +551,7 @@ fi
 if [[ "$has_ios_asc_control" == true ]]; then
   add_check "App Store Connect CLI 封装变化使用本地 fake ASC 自测" "bash ./scripts/test-ios-asc-cli.sh"
 fi
-if [[ "$has_critical_mapping_control" == true && "$has_gate_control" == false && "$has_repository_security_control" == false ]]; then
+if [[ "$has_critical_mapping_control" == true && "$has_gate_control" == false && "$mode" != "full" && "$has_repository_security_control" == false ]]; then
   add_check "关键用户链路 selector 变化执行静态映射自检" "bash ./scripts/check-critical-regressions.sh"
 fi
 if [[ "$has_linear_polling_control" == true ]]; then
@@ -568,6 +570,17 @@ if [[ "$direct_go" == true || "$direct_ios" == true || "$has_source_size_control
   # 先用秒级门禁拦住超大源文件，避免等到 Xcode/Go 构建后才失败。
   add_check "Go/iOS 源码体积快速门禁" "bash ./scripts/check-source-size.sh"
 fi
+if [[ "$direct_rust" == true ]]; then
+  add_check "Rust 格式检查" "cargo fmt --all -- --check"
+fi
+if [[ "$mode" == "full" ]]; then
+  # 普通本地 full 不重复扫描完整历史。PR 增量与 main 完整历史扫描由现有
+  # Public Repository Safety 工作流执行；安全门自身变更仍走上面的完整检查。
+  add_check "full 模式补齐 Codex 协议检查" "bash ./scripts/check-codex-protocol.sh"
+fi
+
+# 前置门禁失败时不继续昂贵的语言构建；后面的测试互相独立，失败后仍可汇总。
+preflight_count="${#checks[@]}"
 
 if [[ "$direct_go" == true ]]; then
   if [[ "$mode" == "full" || "$go_requires_full" == true || "${#go_packages[@]}" -gt 8 ]]; then
@@ -604,7 +617,6 @@ if [[ "$direct_ios" == true ]]; then
 fi
 
 if [[ "$direct_rust" == true ]]; then
-  add_check "Rust 格式检查" "cargo fmt --all -- --check"
   rust_test_command='CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(bash ./scripts/development-cache-path.sh cargo/target)}" cargo test --locked'
   if [[ "$rust_all" == true || "$mode" == "full" ]]; then
     rust_codex=true
@@ -621,117 +633,254 @@ if [[ "$direct_macos" == true ]]; then
   add_check "Mac App 变更执行统一无签名编译测试" "bash ./scripts/test-macos-app.sh"
 fi
 
-if [[ "$mode" == "full" ]]; then
-  # public-repo-safety 末尾已经调用 check-pr-gate；full 不再提前重复执行一次。
-  add_check "full 模式补齐公开仓库安全检查（包含 PR Gate 自检）" "bash ./scripts/check-public-repo-safety.sh"
-  add_check "full 模式补齐 Codex 协议检查" "bash ./scripts/check-codex-protocol.sh"
-fi
+print_plan() {
+  plan_suffix=""
+  [[ "$plan_only" -eq 1 ]] && plan_suffix="（仅计划）"
+  echo "Mimi 分层验证计划"
+  echo "- 模式：${mode}${plan_suffix}"
+  if [[ -n "$paths_file" ]]; then
+    echo "- 变更来源：显式 paths file"
+  else
+    echo "- Base：${base_ref}"
+    echo "- 来源计数：committed=${committed_count}, staged=${staged_count}, unstaged=${unstaged_count}, untracked=${untracked_count}"
+  fi
+  echo "- 去重后路径：${#changed_paths[@]}"
+  echo "- PR Gate scope：go=${go_scope}, ios=${ios_scope}, rust=${rust_scope}, macos=${macos_scope}, docs=${docs_scope}"
+  echo
 
-plan_suffix=""
-[[ "$plan_only" -eq 1 ]] && plan_suffix="（仅计划）"
-echo "Mimi 分层验证计划"
-echo "- 模式：${mode}${plan_suffix}"
-if [[ -n "$paths_file" ]]; then
-  echo "- 变更来源：显式 paths file"
-else
-  echo "- Base：${base_ref}"
-  echo "- 来源计数：committed=${committed_count}, staged=${staged_count}, unstaged=${unstaged_count}, untracked=${untracked_count}"
-fi
-echo "- 去重后路径：${#changed_paths[@]}"
-echo "- PR Gate scope：go=${go_scope}, ios=${ios_scope}, rust=${rust_scope}, macos=${macos_scope}, docs=${docs_scope}"
-echo
+  echo "验证阶段："
+  if [[ "$mode" == "full" ]]; then
+    echo "- 当前：full；交付报告必须说明命中的高风险条件。"
+  else
+    echo "- 当前：quick；只在最后一次代码修改后执行一次，不要在每个微调后重复执行。"
+  fi
+  echo "- 开发中：只运行问题直接相关的 package、XCTest selector、快照或静态检查。"
+  echo "- full 条件：高风险状态语义、影响范围无法界定的大重构、本地 full 能补齐必要回归的 CI 覆盖缺口、正式发布或用户明确要求。"
+  echo "- 跨栈或共享协议：定向覆盖接口兼容与失败/降级链路；不因语言数量自动升级 full。"
+  echo "- 非 full 条件：普通 UI、文案、单 package、测试文件、改动文件较多、准备提交或“为了保险”。"
+  if [[ "$has_contract" == true ]]; then
+    echo "- 自动高风险信号：检测到 Go/iOS 共享协议路径；核对兼容语义和定向契约覆盖后评估 full。"
+  elif [[ "$direct_go" == true && "$direct_ios" == true ]] || \
+       [[ "$direct_go" == true && "$direct_rust" == true ]] || \
+       [[ "$direct_go" == true && "$direct_macos" == true ]] || \
+       [[ "$direct_ios" == true && "$direct_rust" == true ]] || \
+       [[ "$direct_ios" == true && "$direct_macos" == true ]] || \
+       [[ "$direct_rust" == true && "$direct_macos" == true ]]; then
+    echo "- 自动高风险信号：检测到多个产品栈；先确认接口语义与定向覆盖，不自动执行 full。"
+  else
+    echo "- 自动高风险信号：未检测到；除非存在脚本无法识别的高风险语义，否则保持 quick。"
+  fi
+  echo
 
-echo "验证阶段："
-if [[ "$mode" == "full" ]]; then
-  echo "- 当前：full；交付报告必须说明命中的高风险条件。"
-else
-  echo "- 当前：quick；只在最后一次代码修改后执行一次，不要在每个微调后重复执行。"
-fi
-echo "- 开发中：只运行问题直接相关的 package、XCTest selector、快照或静态检查。"
-echo "- full 条件：共享协议/跨栈接口，高风险状态语义，影响范围无法界定的大重构，正式发布或用户明确要求。"
-echo "- 非 full 条件：普通 UI、文案、单 package、测试文件、改动文件较多、准备提交或“为了保险”。"
-if [[ "$has_contract" == true ]]; then
-  echo "- 自动高风险信号：检测到 Go/iOS 共享协议路径；建议显式评估 full。"
-elif [[ "$direct_go" == true && "$direct_ios" == true ]] || \
-     [[ "$direct_go" == true && "$direct_rust" == true ]] || \
-     [[ "$direct_go" == true && "$direct_macos" == true ]] || \
-     [[ "$direct_ios" == true && "$direct_rust" == true ]] || \
-     [[ "$direct_ios" == true && "$direct_macos" == true ]] || \
-     [[ "$direct_rust" == true && "$direct_macos" == true ]]; then
-  echo "- 自动高风险信号：检测到多个产品栈；建议确认是否修改同一跨栈接口。"
-else
-  echo "- 自动高风险信号：未检测到；除非存在脚本无法识别的高风险语义，否则保持 quick。"
-fi
-echo
+  if [[ "${#changed_paths[@]}" -eq 0 ]]; then
+    echo "没有发现需要验证的变更。"
+    return 0
+  fi
 
-if [[ "${#changed_paths[@]}" -eq 0 ]]; then
-  echo "没有发现需要验证的变更。"
-  exit 0
-fi
-
-echo "变更路径："
-for path in "${changed_paths[@]}"; do
-  echo "- ${path}"
-done
-echo
-
-if [[ "$all_docs" == true ]]; then
-  echo "判定：纯文档/静态内容；不启动 Go、Cargo、Xcode 或真机。"
-elif [[ "$has_control" == true && "$direct_go" == false && "$direct_ios" == false && "$direct_rust" == false && "$direct_macos" == false ]]; then
-  echo "判定：CI/脚本/发布控制面；只运行语法与映射自检，不启动语言构建。"
-else
-  echo "判定：包含产品源码；只验证直接受影响的语言栈。"
-fi
-
-echo "跳过的语言栈："
-[[ "$direct_go" == false ]] && echo "- Go：没有直接 Go 产品路径。"
-[[ "$direct_ios" == false ]] && echo "- iOS：没有直接 iOS 产品路径，不启动 Xcode/Simulator/真机。"
-[[ "$direct_rust" == false ]] && echo "- Rust：没有直接 bridge 产品路径。"
-[[ "$direct_macos" == false ]] && echo "- Mac App：没有直接 Mac App 产品路径。"
-if [[ "$direct_go" == true && "$direct_ios" == true && "$direct_rust" == true && "$direct_macos" == true ]]; then
-  echo "- 无：四个产品栈均受影响。"
-fi
-
-if [[ "$direct_ios" == true ]]; then
-  echo "真机：默认延后。相机、通知、Keychain、Tailscale/弱网、性能和发布前专项仍必须单独真机验收。"
-fi
-if [[ "${#powershell_paths[@]}" -gt 0 ]]; then
-  echo "Windows：PowerShell 脚本的执行与平台语义延后到 Windows CI；本地不启动额外虚拟机。"
-fi
-if [[ "$mode" == "quick" ]]; then
-  echo "完整回归：默认延后到 --full 或 PR Gate；不要在每个微调后重复执行。"
-fi
-if [[ "${#unknown_paths[@]}" -gt 0 ]]; then
-  echo "人工确认：以下路径没有验证映射，quick 不会把它们静默视为通过："
-  for path in "${unknown_paths[@]}"; do
+  echo "变更路径："
+  for path in "${changed_paths[@]}"; do
     echo "- ${path}"
   done
-fi
-echo
+  echo
 
-echo "将执行 ${#checks[@]} 项："
-for index in "${!checks[@]}"; do
-  echo "$((index + 1)). ${check_reasons[$index]}"
-  echo "   ${checks[$index]}"
-done
+  if [[ "$all_docs" == true ]]; then
+    echo "判定：纯文档/静态内容；不启动 Go、Cargo、Xcode 或真机。"
+  elif [[ "$has_control" == true && "$direct_go" == false && "$direct_ios" == false && "$direct_rust" == false && "$direct_macos" == false ]]; then
+    echo "判定：CI/脚本/发布控制面；只运行语法与映射自检，不启动语言构建。"
+  else
+    echo "判定：包含产品源码；只验证直接受影响的语言栈。"
+  fi
+
+  echo "跳过的语言栈："
+  [[ "$direct_go" == false ]] && echo "- Go：没有直接 Go 产品路径。"
+  [[ "$direct_ios" == false ]] && echo "- iOS：没有直接 iOS 产品路径，不启动 Xcode/Simulator/真机。"
+  [[ "$direct_rust" == false ]] && echo "- Rust：没有直接 bridge 产品路径。"
+  [[ "$direct_macos" == false ]] && echo "- Mac App：没有直接 Mac App 产品路径。"
+  if [[ "$direct_go" == true && "$direct_ios" == true && "$direct_rust" == true && "$direct_macos" == true ]]; then
+    echo "- 无：四个产品栈均受影响。"
+  fi
+
+  if [[ "$direct_ios" == true ]]; then
+    echo "真机：默认延后。相机、通知、Keychain、Tailscale/弱网、性能和发布前专项仍必须单独真机验收。"
+  fi
+  if [[ "${#powershell_paths[@]}" -gt 0 ]]; then
+    echo "Windows：PowerShell 脚本的执行与平台语义延后到 Windows CI；本地不启动额外虚拟机。"
+  fi
+  if [[ "$mode" == "quick" ]]; then
+    echo "完整回归：默认延后到 --full 或 PR Gate；不要在每个微调后重复执行。"
+  else
+    echo "覆盖核对：Go/Rust full 扩大本轮 package/crate 测试集；iOS full 构建 App 并运行核心 selector。"
+    echo "专项缺项：对照实际命令、目标、配置与 selector 补齐；不能把 full 当作所有专项均已覆盖。"
+  fi
+  echo "结果复用：本轮重新执行计划，不自动引用此前或其他 Worktree 的通过记录。"
+  echo "安全检查：普通 PR 由 CI 增量扫描，main push/手动安全工作流扫描完整历史；安全门自身变更仍本地完整检查。"
+  echo "CI 交接：核对 PR 最新受检提交及必需检查；不同工具链结果分开记录。等待时保持 Verify，成功和失败均回原任务收尾。"
+  echo "等待方式：由执行工具挂起等待完成，不反复读取无变化日志；未确认宿主完成事件时不承诺自动恢复。"
+  if [[ "${#unknown_paths[@]}" -gt 0 ]]; then
+    echo "人工确认：以下路径没有验证映射，quick 不会把它们静默视为通过："
+    for path in "${unknown_paths[@]}"; do
+      echo "- ${path}"
+    done
+  fi
+  echo
+
+  echo "将执行 ${#checks[@]} 项："
+  for index in "${!checks[@]}"; do
+    echo "$((index + 1)). ${check_reasons[$index]}"
+    echo "   ${checks[$index]}"
+  done
+}
 
 if [[ "$plan_only" -eq 1 ]]; then
+  print_plan
   exit 0
 fi
 
 if [[ "${#unknown_paths[@]}" -gt 0 ]]; then
+  print_plan
   fail "存在未映射路径；请先人工确认风险并补充映射，不要用 quick 静默跳过。"
 fi
+if [[ "${#changed_paths[@]}" -eq 0 ]]; then
+  print_plan
+  exit 0
+fi
 
-overall_started="$SECONDS"
+# 日志是诊断记录，不是可复用的通过凭据。放在仓库外，避免改变下一轮变更集合。
+result_dir="$(mktemp -d "${TMPDIR:-/tmp}/mimi-verify-results.XXXXXX")"
+print_plan > "$result_dir/plan.txt"
+result_head="$(git rev-parse HEAD)"
+result_branch="$(git branch --show-current)"
+result_dirty="$(git status --porcelain --untracked-files=normal)"
+result_started="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+result_states=()
+result_codes=()
+result_seconds=()
 for index in "${!checks[@]}"; do
+  result_states+=("未运行")
+  result_codes+=("-")
+  result_seconds+=("0")
+done
+overall_started="$SECONDS"
+current_index=-1
+check_pid=""
+preflight_failed=false
+overall_code=0
+
+write_result_summary() {
+  local index
+  {
+    echo "Mimi 分层验证结果（仅诊断，不用于跨轮复用）"
+    echo "模式：${mode}；Branch：${result_branch}；HEAD：${result_head}"
+    if [[ -n "$result_dirty" ]]; then
+      echo "输入：包含未提交或未跟踪改动；HEAD 不代表全部受检输入。"
+    else
+      echo "输入：启动时工作区干净。"
+    fi
+    echo "开始：${result_started}；总耗时：$((SECONDS - overall_started))s；退出码：${overall_code}"
+    echo "完整计划：${result_dir}/plan.txt"
+    for index in "${!checks[@]}"; do
+      echo "$((index + 1)). ${result_states[$index]} | ${result_seconds[$index]}s | exit=${result_codes[$index]} | ${check_reasons[$index]}"
+      echo "   命令：${checks[$index]}"
+      [[ ! -f "$result_dir/$((index + 1)).log" ]] || echo "   日志：${result_dir}/$((index + 1)).log"
+    done
+    echo "CI：此结果不代表 PR Gate 通过；核对最新受检提交和必需检查，保持 Verify 直至完成收尾。"
+  } > "$result_dir/summary.txt"
+}
+
+finish_run() {
+  local exit_code=$?
+  # 收尾只写一次结果，避免第二次取消打断汇总文件。
+  trap '' INT TERM
+  trap - EXIT
+  overall_code="$exit_code"
+  if [[ "$current_index" -ge 0 && "${result_states[$current_index]}" == "运行中" ]]; then
+    result_states[$current_index]="未完成"
+    result_codes[$current_index]="$exit_code"
+    result_seconds[$current_index]="$((SECONDS - started))"
+  fi
+  write_result_summary
+  rm -rf "$temporary_root"
+  echo "结果汇总：${result_dir}/summary.txt"
+}
+
+cancel_run() {
+  local exit_code="$1"
+  local cancellation_guard
+  trap '' INT TERM
+  if [[ -n "$check_pid" ]]; then
+    # 每项检查拥有独立进程组。只终止本轮检查及其子进程，让设备入口先释放租约。
+    kill -TERM -- "-$check_pid" 2>/dev/null || true
+    (trap - INT TERM; sleep 5; kill -KILL -- "-$check_pid" 2>/dev/null || true) &
+    cancellation_guard=$!
+    wait "$check_pid" 2>/dev/null || true
+    if kill -0 -- "-$check_pid" 2>/dev/null; then
+      wait "$cancellation_guard" 2>/dev/null || true
+    else
+      kill -TERM -- "-$cancellation_guard" 2>/dev/null || true
+      wait "$cancellation_guard" 2>/dev/null || true
+    fi
+  fi
+  if [[ "$current_index" -ge 0 && "${result_states[$current_index]}" == "运行中" ]]; then
+    result_states[$current_index]="取消"
+    result_codes[$current_index]="$exit_code"
+    result_seconds[$current_index]="$((SECONDS - started))"
+  fi
+  echo "分层验证已取消；剩余检查未运行。"
+  exit "$exit_code"
+}
+
+trap finish_run EXIT
+trap 'cancel_run 130' INT
+trap 'cancel_run 143' TERM
+# 非交互 Bash 也为每项后台命令建立独立进程组，使取消不波及其他 Worktree。
+set -m
+echo "Mimi 分层验证：${mode}，${#checks[@]} 项；完整计划：${result_dir}/plan.txt"
+for index in "${!checks[@]}"; do
+  if [[ "$index" -ge "$preflight_count" && "$preflight_failed" == true ]]; then
+    result_states[$index]="阻塞（前置检查失败）"
+    echo "<== [$((index + 1))/${#checks[@]}] ${result_states[$index]}：${check_reasons[$index]}"
+    continue
+  fi
+  current_index="$index"
   started="$SECONDS"
-  echo
   echo "==> [$((index + 1))/${#checks[@]}] ${check_reasons[$index]}"
-  echo "    ${checks[$index]}"
-  bash -c "${checks[$index]}"
-  echo "<== 通过，用时 $((SECONDS - started))s"
+  result_states[$index]="运行中"
+  bash -c "${checks[$index]}" > "$result_dir/$((index + 1)).log" 2>&1 &
+  check_pid=$!
+  if wait "$check_pid"; then
+    check_code=0
+  else
+    check_code=$?
+  fi
+  check_pid=""
+  result_codes[$index]="$check_code"
+  result_seconds[$index]="$((SECONDS - started))"
+  case "$check_code" in
+    0) result_states[$index]="通过" ;;
+    75) result_states[$index]="阻塞" ;;
+    124) result_states[$index]="超时" ;;
+    130|143) result_states[$index]="取消" ;;
+    *) result_states[$index]="失败" ;;
+  esac
+  echo "<== ${result_states[$index]}，用时 ${result_seconds[$index]}s，退出码 ${check_code}"
+  if [[ "$check_code" -ne 0 ]]; then
+    # 75 仅表示暂时阻塞；其他检查真正失败时，不能让最早的设备占用掩盖失败。
+    if [[ "$overall_code" -eq 0 || ( "$overall_code" -eq 75 && "$check_code" -ne 75 ) ]]; then
+      overall_code="$check_code"
+    fi
+    [[ "$index" -ge "$preflight_count" ]] || preflight_failed=true
+    echo "日志：${result_dir}/$((index + 1)).log（末尾最多 40 行、8 KiB）"
+    tail -n 40 "$result_dir/$((index + 1)).log" | tail -c 8192
+    if [[ "$check_code" -eq 130 || "$check_code" -eq 143 ]]; then
+      overall_code="$check_code"
+      break
+    fi
+  fi
 done
 
-echo
-echo "分层验证通过：${#checks[@]} 项，总用时 $((SECONDS - overall_started))s。"
+if [[ "$overall_code" -eq 0 ]]; then
+  echo "分层验证通过：${#checks[@]} 项，总用时 $((SECONDS - overall_started))s。"
+else
+  echo "分层验证未通过：存在失败、阻塞、超时或取消；仅重跑受影响检查，不把剩余项记为通过。"
+fi
+exit "$overall_code"


### PR DESCRIPTION
本地验证在一项检查失败后立即退出，后续独立检查没有结果，收尾时容易重复执行 quick/full 并反复读取日志。本次让验证入口汇总独立检查的结果，默认只输出状态、耗时和有限失败日志；完整计划与分项日志保存在仓库外临时目录。

- 前置检查按依赖技术栈阻塞：Go/iOS 行数或契约门禁不阻止 Rust 测试，Rust 格式失败不阻止 Go/iOS。计划明确显示阻塞范围；独立检查仍继续汇总。
- 阻塞、超时和取消保持非零结果；设备占用不会掩盖另一项真实失败。检查执行中收到 INT/TERM 时只清理当前检查的进程组，并保留取消和未运行结果。
- 规则改为先查看所选模式的计划，再执行一次 quick 或 full；跨栈本身不自动要求本地 full，仍须覆盖接口兼容及失败/降级链路。
- 普通本地 full 保留 Gate 自检和 Codex 协议检查，完整历史安全扫描继续由既有 main push/手动安全工作流承担；安全门自身改动仍本地完整检查。PR Gate 配置未变。
- 明确 CI 最新受检提交、成功/失败后的原任务恢复和 Verify 交接。首版不实现跨轮结果自动复用或宿主自动唤醒。

验证：源码体积门禁、最新验证计划、差异与 Shell 语法检查通过。首版 quick 6 项通过；依赖范围修正后的 quick 其余 5 项通过，自测断言曾把 cargo test 误认成 go test，改为完整命令后只重跑失败的 `bash ./scripts/test-verify-change.sh`，现已通过。自测覆盖双向技术栈隔离、独立失败继续、有限日志、75/124/130、真实 TERM 取消、子进程与模拟租约清理及无关进程保护。本轮未启动真实 Go/Rust/Xcode 构建。CI 以最新提交对应的 PR Gate 为准。

Refs #445