### PR TITLE
修复 Mac 服务重启后 Tailcat 消息与测速无法恢复

### DIFF
--- a/experiments/tailcat/internal/tunnel/forwarder.go
+++ b/experiments/tailcat/internal/tunnel/forwarder.go
@@ -210,27 +210,40 @@ func (f *Forwarder) proxy(localConn net.Conn, remotePort uint16) {
 	if err != nil {
 		return
 	}
-	attemptContext, stopAttempt := context.WithTimeout(dialContext, forwarderAttemptTimeout)
-	tunnelConn, err := client.transport.DialTCPPort(attemptContext, remotePort)
-	stopAttempt()
-	if err != nil && dialContext.Err() == nil {
-		client, err = f.recoverClient(dialContext, client)
-		if err == nil {
-			tunnelConn, err = client.transport.DialTCPPort(dialContext, remotePort)
+	for dialContext.Err() == nil {
+		attemptContext, stopAttempt := context.WithTimeout(dialContext, forwarderAttemptTimeout)
+		tunnelConn, err := client.transport.DialTCPPort(attemptContext, remotePort)
+		stopAttempt()
+		if err != nil && dialContext.Err() == nil {
+			client, err = f.recoverClient(dialContext, client)
+			if err == nil {
+				tunnelConn, err = client.transport.DialTCPPort(dialContext, remotePort)
+			}
 		}
-	}
-	if err != nil {
-		return
-	}
-	f.mu.Lock()
-	if f.current != client || f.ctx.Err() != nil {
+		if err != nil {
+			return
+		}
+		f.mu.Lock()
+		if dialContext.Err() != nil {
+			f.mu.Unlock()
+			tunnelConn.Close()
+			return
+		}
+		if f.current != client {
+			f.mu.Unlock()
+			tunnelConn.Close()
+			// 拨号成功也可能落后于并发恢复；尚未转发字节，可以共享恢复后重新拨号。
+			client, err = f.recoverClient(dialContext, client)
+			if err != nil {
+				return
+			}
+			continue
+		}
+		f.connections[localConn] = client
 		f.mu.Unlock()
-		tunnelConn.Close()
+
+		// 只重试建立 TCP，开始复制业务字节后绝不重放，结果未知的消息交给上层处理。
+		tailcat.ProxyConns(localConn, tunnelConn)
 		return
 	}
-	f.connections[localConn] = client
-	f.mu.Unlock()
-
-	// 只重试建立 TCP，开始复制业务字节后绝不重放，结果未知的消息交给上层处理。
-	tailcat.ProxyConns(localConn, tunnelConn)
 }

--- a/experiments/tailcat/internal/tunnel/forwarder.go
+++ b/experiments/tailcat/internal/tunnel/forwarder.go
@@ -24,10 +24,17 @@ type ForwarderConfig struct {
 }
 
 type Forwarder struct {
-	client   *tailcat.Client
-	listener net.Listener
-	done     chan struct{}
-	close    sync.Once
+	listener    net.Listener
+	done        chan struct{}
+	close       sync.Once
+	closeErr    error
+	ctx         context.Context
+	cancel      context.CancelFunc
+	mu          sync.Mutex
+	current     *forwarderClient
+	recovery    *forwarderRecovery
+	newClient   func() tunnelClient
+	connections map[net.Conn]*forwarderClient
 }
 
 func StartForwarder(ctx context.Context, config ForwarderConfig) (*Forwarder, error) {
@@ -44,11 +51,10 @@ func StartForwarder(ctx context.Context, config ForwarderConfig) (*Forwarder, er
 	if err != nil {
 		return nil, err
 	}
-	client := &tailcat.Client{
-		Server: tailcat.Addr(config.Address),
-		Key:    privateKey,
-		Logf:   logger.Discard,
+	newClient := func() tunnelClient {
+		return &tailcat.Client{Server: tailcat.Addr(config.Address), Key: privateKey, Logf: logger.Discard}
 	}
+	client := newClient()
 	pingContext, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	if _, err := client.Ping(pingContext); err != nil {
@@ -61,11 +67,7 @@ func StartForwarder(ctx context.Context, config ForwarderConfig) (*Forwarder, er
 		client.Close()
 		return nil, fmt.Errorf("监听本地端口：%w", err)
 	}
-	forwarder := &Forwarder{
-		client:   client,
-		listener: listener,
-		done:     make(chan struct{}),
-	}
+	forwarder := newForwarder(listener, client, newClient)
 	if config.EndpointPath != "" {
 		if err := writePrivateFile(config.EndpointPath, []byte(forwarder.Endpoint()+"\n")); err != nil {
 			forwarder.Close()
@@ -73,6 +75,7 @@ func StartForwarder(ctx context.Context, config ForwarderConfig) (*Forwarder, er
 		}
 	}
 	go forwarder.accept(config.RemotePort)
+	go forwarder.monitor()
 	return forwarder, nil
 }
 
@@ -101,10 +104,22 @@ type PathDiagnostic struct {
 }
 
 func (f *Forwarder) DiscoPing(ctx context.Context) (PathDiagnostic, error) {
-	if f == nil || f.client == nil {
+	if f == nil {
 		return PathDiagnostic{}, errors.New("Tailcat 客户端未启动")
 	}
-	result, err := f.client.DiscoPing(ctx)
+	client, err := f.clientForRequest(ctx)
+	if err != nil {
+		return PathDiagnostic{}, err
+	}
+	probeContext, cancel := context.WithTimeout(ctx, forwarderAttemptTimeout)
+	result, err := client.transport.DiscoPing(probeContext)
+	cancel()
+	if err != nil && ctx.Err() == nil {
+		client, err = f.recoverClient(ctx, client)
+		if err == nil {
+			result, err = client.transport.DiscoPing(ctx)
+		}
+	}
 	if err != nil {
 		return PathDiagnostic{}, err
 	}
@@ -134,17 +149,34 @@ func (f *Forwarder) DiscoPingJSON(ctx context.Context) (string, error) {
 }
 
 func (f *Forwarder) Close() error {
-	var closeError error
 	f.close.Do(func() {
+		f.mu.Lock()
 		close(f.done)
-		if err := f.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			closeError = err
+		f.cancel()
+		client, recovery := f.current, f.recovery
+		f.current = nil
+		connections := make([]net.Conn, 0, len(f.connections))
+		for connection := range f.connections {
+			connections = append(connections, connection)
 		}
-		if err := f.client.Close(); err != nil && closeError == nil {
-			closeError = err
+		f.mu.Unlock()
+		if err := f.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			f.closeErr = err
+		}
+		for _, connection := range connections {
+			connection.Close()
+		}
+		if client != nil {
+			if err := client.transport.Close(); err != nil && f.closeErr == nil {
+				f.closeErr = err
+			}
+		}
+		if recovery != nil {
+			// 等待恢复任务清理尚未发布的新引擎，Close 返回后不能留下同身份连接。
+			<-recovery.done
 		}
 	})
-	return closeError
+	return f.closeErr
 }
 
 func (f *Forwarder) accept(remotePort uint16) {
@@ -153,17 +185,52 @@ func (f *Forwarder) accept(remotePort uint16) {
 		if err != nil {
 			return
 		}
+		f.mu.Lock()
+		if f.ctx.Err() != nil {
+			f.mu.Unlock()
+			localConn.Close()
+			return
+		}
+		f.connections[localConn] = nil
+		f.mu.Unlock()
 		go f.proxy(localConn, remotePort)
 	}
 }
 
 func (f *Forwarder) proxy(localConn net.Conn, remotePort uint16) {
-	dialContext, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	tunnelConn, err := f.client.DialTCPPort(dialContext, remotePort)
-	if err != nil {
+	defer func() {
 		localConn.Close()
+		f.mu.Lock()
+		delete(f.connections, localConn)
+		f.mu.Unlock()
+	}()
+	dialContext, cancel := context.WithTimeout(f.ctx, 15*time.Second)
+	defer cancel()
+	client, err := f.clientForRequest(dialContext)
+	if err != nil {
 		return
 	}
+	attemptContext, stopAttempt := context.WithTimeout(dialContext, forwarderAttemptTimeout)
+	tunnelConn, err := client.transport.DialTCPPort(attemptContext, remotePort)
+	stopAttempt()
+	if err != nil && dialContext.Err() == nil {
+		client, err = f.recoverClient(dialContext, client)
+		if err == nil {
+			tunnelConn, err = client.transport.DialTCPPort(dialContext, remotePort)
+		}
+	}
+	if err != nil {
+		return
+	}
+	f.mu.Lock()
+	if f.current != client || f.ctx.Err() != nil {
+		f.mu.Unlock()
+		tunnelConn.Close()
+		return
+	}
+	f.connections[localConn] = client
+	f.mu.Unlock()
+
+	// 只重试建立 TCP，开始复制业务字节后绝不重放，结果未知的消息交给上层处理。
 	tailcat.ProxyConns(localConn, tunnelConn)
 }

--- a/experiments/tailcat/internal/tunnel/forwarder_recovery.go
+++ b/experiments/tailcat/internal/tunnel/forwarder_recovery.go
@@ -1,0 +1,197 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/tailscale/tailcat"
+	"tailscale.com/ipn/ipnstate"
+)
+
+// 先给现有路径一个有界机会，避免等满原来的 15 秒才发现服务端已重启。
+const forwarderAttemptTimeout = 3 * time.Second
+const forwarderRecoveryCooldown = time.Second
+const forwarderMonitorInterval = 10 * time.Second
+
+type tunnelClient interface {
+	Ping(context.Context) (tailcat.PingResult, error)
+	DiscoPing(context.Context) (*ipnstate.PingResult, error)
+	DialTCPPort(context.Context, uint16) (net.Conn, error)
+	Close() error
+}
+
+type forwarderClient struct {
+	transport tunnelClient
+}
+
+type forwarderRecovery struct {
+	done       chan struct{}
+	client     *forwarderClient
+	err        error
+	retryAfter time.Time
+}
+
+func newForwarder(listener net.Listener, client tunnelClient, factory func() tunnelClient) *Forwarder {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Forwarder{
+		listener:    listener,
+		done:        make(chan struct{}),
+		ctx:         ctx,
+		cancel:      cancel,
+		current:     &forwarderClient{transport: client},
+		newClient:   factory,
+		connections: make(map[net.Conn]*forwarderClient),
+	}
+}
+
+func (f *Forwarder) monitor() {
+	ticker := time.NewTicker(forwarderMonitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-f.done:
+			return
+		case <-ticker.C:
+			f.checkActiveClient()
+		}
+	}
+}
+
+func (f *Forwarder) checkActiveClient() {
+	f.mu.Lock()
+	client := f.current
+	active := false
+	for _, owner := range f.connections {
+		if owner != nil && owner == client {
+			active = true
+			break
+		}
+	}
+	f.mu.Unlock()
+	if !active || f.ctx.Err() != nil {
+		return
+	}
+	// 服务端重启可能让已建立的 WebSocket 永久等待。探测隧道本身，
+	// 不把业务响应慢当成故障；没有活动连接时也不产生后台流量。
+	ctx, cancel := context.WithTimeout(f.ctx, forwarderAttemptTimeout)
+	_, err := client.transport.DiscoPing(ctx)
+	cancel()
+	if err != nil && f.ctx.Err() == nil {
+		_, _ = f.recoverClient(f.ctx, client)
+	}
+}
+
+func (f *Forwarder) clientForRequest(ctx context.Context) (*forwarderClient, error) {
+	f.mu.Lock()
+	if err := ctx.Err(); err != nil {
+		f.mu.Unlock()
+		return nil, err
+	}
+	if f.ctx.Err() != nil {
+		f.mu.Unlock()
+		return nil, net.ErrClosed
+	}
+	if f.current != nil {
+		client := f.current
+		f.mu.Unlock()
+		return client, nil
+	}
+	r := f.recovery
+	if r == nil || (!r.retryAfter.IsZero() && !time.Now().Before(r.retryAfter)) {
+		r = f.startRecoveryLocked(nil)
+	}
+	f.mu.Unlock()
+	return f.waitRecovery(ctx, r)
+}
+
+func (f *Forwarder) recoverClient(ctx context.Context, failed *forwarderClient) (*forwarderClient, error) {
+	f.mu.Lock()
+	if err := ctx.Err(); err != nil {
+		f.mu.Unlock()
+		return nil, err
+	}
+	if f.ctx.Err() != nil {
+		f.mu.Unlock()
+		return nil, net.ErrClosed
+	}
+	if f.current != nil && f.current != failed {
+		// 旧请求的迟到错误不能再次销毁已经恢复的引擎。
+		client := f.current
+		f.mu.Unlock()
+		return client, nil
+	}
+	r := f.recovery
+	if f.current == failed {
+		r = f.startRecoveryLocked(failed)
+	}
+	f.mu.Unlock()
+	return f.waitRecovery(ctx, r)
+}
+
+func (f *Forwarder) startRecoveryLocked(old *forwarderClient) *forwarderRecovery {
+	r := &forwarderRecovery{done: make(chan struct{})}
+	f.current = nil
+	f.recovery = r
+	var connections []net.Conn
+	for connection, client := range f.connections {
+		if old != nil && client == old {
+			connections = append(connections, connection)
+		}
+	}
+	go f.rebuildClient(r, old, connections)
+	return r
+}
+
+func (f *Forwarder) rebuildClient(r *forwarderRecovery, old *forwarderClient, connections []net.Conn) {
+	for _, connection := range connections {
+		connection.Close()
+	}
+	// 同一身份同时连接 DERP 会互相抢占下行，必须先完全关闭旧引擎。
+	if old != nil {
+		r.err = old.transport.Close()
+	}
+	ctx, cancel := context.WithTimeout(f.ctx, 15*time.Second)
+	defer cancel()
+	if r.err == nil {
+		r.err = ctx.Err()
+	}
+	var client tunnelClient
+	if r.err == nil {
+		client = f.newClient()
+		_, r.err = client.Ping(ctx)
+	}
+	f.mu.Lock()
+	if r.err == nil && f.ctx.Err() == nil {
+		r.client = &forwarderClient{transport: client}
+		f.current = r.client
+		close(r.done)
+		f.mu.Unlock()
+		return
+	}
+	f.mu.Unlock()
+	if client != nil {
+		client.Close()
+	}
+	f.mu.Lock()
+	if r.err == nil {
+		r.err = net.ErrClosed
+	}
+	r.err = fmt.Errorf("恢复 Tailcat 连接：%w", r.err)
+	// 服务离线时，并发和连续请求共享失败结果；后续请求再尝试，不启动后台重试循环。
+	r.retryAfter = time.Now().Add(forwarderRecoveryCooldown)
+	close(r.done)
+	f.mu.Unlock()
+}
+
+func (f *Forwarder) waitRecovery(ctx context.Context, r *forwarderRecovery) (*forwarderClient, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-f.done:
+		return nil, net.ErrClosed
+	case <-r.done:
+		return r.client, r.err
+	}
+}

--- a/experiments/tailcat/internal/tunnel/forwarder_recovery_test.go
+++ b/experiments/tailcat/internal/tunnel/forwarder_recovery_test.go
@@ -335,3 +335,99 @@ func TestForwarderMonitorPreservesHealthySlowBusinessConnection(t *testing.T) {
 		t.Fatal("业务静默导致健康连接被销毁")
 	}
 }
+
+func TestForwarderRetriesSuccessfulDialInvalidatedByRecovery(t *testing.T) {
+	for _, completed := range []bool{false, true} {
+		name := "recovery_pending"
+		if completed {
+			name = "recovery_completed"
+		}
+		t.Run(name, func(t *testing.T) {
+			var received, created, dials atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received.Add(1)
+				body, _ := io.ReadAll(r.Body)
+				if string(body) != "one message" {
+					t.Errorf("请求内容为 %q", body)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+			target, _ := url.Parse(server.URL)
+			dialStarted, releaseDial := make(chan struct{}), make(chan struct{})
+			pingStarted, releasePing := make(chan struct{}), make(chan struct{})
+			staleClosed := make(chan struct{})
+			initial := &stubTunnelClient{dial: func(ctx context.Context, _ uint16) (net.Conn, error) {
+				close(dialStarted)
+				select {
+				case <-releaseDial:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				local, remote := net.Pipe()
+				go func() {
+					defer remote.Close()
+					defer close(staleClosed)
+					if n, _ := remote.Read(make([]byte, 1)); n != 0 {
+						t.Error("失效连接收到了业务字节")
+					}
+				}()
+				return local, nil
+			}}
+			next := &stubTunnelClient{
+				ping: func(ctx context.Context) error {
+					close(pingStarted)
+					select {
+					case <-releasePing:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				},
+				dial: func(ctx context.Context, _ uint16) (net.Conn, error) {
+					dials.Add(1)
+					return (&net.Dialer{}).DialContext(ctx, "tcp", target.Host)
+				},
+			}
+			f := newStubForwarder(t, initial, func() tunnelClient { created.Add(1); return next })
+			endpoint, old := f.Endpoint(), f.current
+			requestDone := make(chan error, 1)
+			go func() {
+				client := &http.Client{Timeout: 5 * time.Second}
+				response, err := client.Post(endpoint, "text/plain", strings.NewReader("one message"))
+				if err == nil {
+					response.Body.Close()
+					if response.StatusCode != http.StatusNoContent {
+						err = errors.New("响应状态不正确")
+					}
+				}
+				requestDone <- err
+			}()
+			awaitSignal(t, dialStarted)
+			recoveryDone := make(chan error, 1)
+			go func() { _, err := f.recoverClient(f.ctx, old); recoveryDone <- err }()
+			awaitSignal(t, pingStarted)
+			// 显式控制两种时序，避免依赖调度速度碰巧触发竞态。
+			if completed {
+				close(releasePing)
+				if err := <-recoveryDone; err != nil {
+					t.Fatal(err)
+				}
+			}
+			close(releaseDial)
+			awaitSignal(t, staleClosed)
+			if !completed {
+				close(releasePing)
+				if err := <-recoveryDone; err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := <-requestDone; err != nil {
+				t.Fatalf("尚未转发字节的请求被关闭：%v", err)
+			}
+			if received.Load() != 1 || created.Load() != 1 || dials.Load() != 1 || f.Endpoint() != endpoint {
+				t.Fatal("请求未恰好转发一次、重复恢复或本地入口改变")
+			}
+		})
+	}
+}

--- a/experiments/tailcat/internal/tunnel/forwarder_recovery_test.go
+++ b/experiments/tailcat/internal/tunnel/forwarder_recovery_test.go
@@ -1,0 +1,337 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tailscale/tailcat"
+	"tailscale.com/ipn/ipnstate"
+)
+
+type stubTunnelClient struct {
+	ping    func(context.Context) error
+	disco   func(context.Context) (*ipnstate.PingResult, error)
+	dial    func(context.Context, uint16) (net.Conn, error)
+	closeFn func() error
+	closes  atomic.Int32
+}
+
+func (c *stubTunnelClient) Ping(ctx context.Context) (tailcat.PingResult, error) {
+	if c.ping != nil {
+		return tailcat.PingResult{}, c.ping(ctx)
+	}
+	return tailcat.PingResult{}, nil
+}
+func (c *stubTunnelClient) DiscoPing(ctx context.Context) (*ipnstate.PingResult, error) {
+	if c.disco != nil {
+		return c.disco(ctx)
+	}
+	return &ipnstate.PingResult{DERPRegionID: 1, DERPRegionCode: "test"}, nil
+}
+func (c *stubTunnelClient) DialTCPPort(ctx context.Context, port uint16) (net.Conn, error) {
+	if c.dial != nil {
+		return c.dial(ctx, port)
+	}
+	return nil, errors.New("test dial unavailable")
+}
+func (c *stubTunnelClient) Close() error {
+	c.closes.Add(1)
+	if c.closeFn != nil {
+		return c.closeFn()
+	}
+	return nil
+}
+
+func newStubForwarder(t *testing.T, initial tunnelClient, factory func() tunnelClient) *Forwarder {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := newForwarder(listener, initial, factory)
+	t.Cleanup(func() { f.Close() })
+	go f.accept(8787)
+	return f
+}
+
+func awaitSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("等待测试同步超时")
+	}
+}
+
+func TestForwarderRecoveryIsSharedAndClosesOldBeforeCreatingNew(t *testing.T) {
+	closeStarted, releaseClose := make(chan struct{}), make(chan struct{})
+	oldClosed := atomic.Bool{}
+	initial := &stubTunnelClient{closeFn: func() error {
+		close(closeStarted)
+		<-releaseClose
+		oldClosed.Store(true)
+		return nil
+	}}
+	next := &stubTunnelClient{}
+	var created atomic.Int32
+	f := newStubForwarder(t, initial, func() tunnelClient {
+		if !oldClosed.Load() {
+			t.Error("旧引擎未关闭就创建了相同身份的新引擎")
+		}
+		created.Add(1)
+		return next
+	})
+	old := f.current
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var wg sync.WaitGroup
+	for i := 0; i < 24; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			recovered, err := f.recoverClient(ctx, old)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if recovered.transport != next {
+				t.Error("并发调用未得到相同的新引擎")
+			}
+		}()
+	}
+	awaitSignal(t, closeStarted)
+	if created.Load() != 0 {
+		t.Fatal("关闭旧引擎期间启动了新引擎")
+	}
+	close(releaseClose)
+	wg.Wait()
+	if created.Load() != 1 || initial.closes.Load() != 1 {
+		t.Fatal("并发失败触发了重复重建")
+	}
+	// 迟到的失败属于旧一代，不能再次关闭已恢复的引擎。
+	if _, err := f.recoverClient(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+	if created.Load() != 1 || next.closes.Load() != 0 {
+		t.Fatal("旧请求错误破坏了已恢复的引擎")
+	}
+}
+
+func TestForwarderRecoverySurvivesOneWaiterCancellation(t *testing.T) {
+	pingStarted, releasePing := make(chan struct{}), make(chan struct{})
+	next := &stubTunnelClient{ping: func(ctx context.Context) error {
+		close(pingStarted)
+		select {
+		case <-releasePing:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}}
+	f := newStubForwarder(t, &stubTunnelClient{}, func() tunnelClient { return next })
+	old := f.current
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { _, err := f.recoverClient(ctx, old); result <- err }()
+	awaitSignal(t, pingStarted)
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("取消返回 %v", err)
+	}
+	close(releasePing)
+	ctx, stop := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stop()
+	recovered, err := f.clientForRequest(ctx)
+	if err != nil || recovered.transport != next {
+		t.Fatalf("其他请求不能继续共享恢复：%v", err)
+	}
+}
+
+func TestForwarderCloseCancelsRecoveryAndReleasesLocalConnections(t *testing.T) {
+	pingStarted := make(chan struct{})
+	next := &stubTunnelClient{ping: func(ctx context.Context) error {
+		close(pingStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+	initial := &stubTunnelClient{}
+	f := newStubForwarder(t, initial, func() tunnelClient { return next })
+	local, err := net.Dial("tcp", f.listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer local.Close()
+	awaitSignal(t, pingStarted)
+	closed := make(chan struct{})
+	go func() { f.Close(); close(closed) }()
+	awaitSignal(t, closed)
+	if next.closes.Load() != 1 || initial.closes.Load() != 1 {
+		t.Fatal("关闭后仍有引擎未释放")
+	}
+	local.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := local.Read(make([]byte, 1)); err == nil {
+		t.Fatal("关闭后本地连接仍然开放")
+	} else if timeout, ok := err.(net.Error); ok && timeout.Timeout() {
+		t.Fatal("关闭未及时释放本地连接")
+	}
+	if _, err := f.clientForRequest(context.Background()); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("关闭后仍可获取引擎：%v", err)
+	}
+}
+
+func TestForwarderRecoveryFailureIsBoundedAndLaterRequestCanRetry(t *testing.T) {
+	offline := errors.New("server offline")
+	failed := &stubTunnelClient{ping: func(ctx context.Context) error {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Error("恢复没有超时边界")
+		}
+		return offline
+	}}
+	next := &stubTunnelClient{}
+	var created atomic.Int32
+	f := newStubForwarder(t, &stubTunnelClient{}, func() tunnelClient {
+		if created.Add(1) == 1 {
+			return failed
+		}
+		return next
+	})
+	if _, err := f.recoverClient(context.Background(), f.current); !errors.Is(err, offline) {
+		t.Fatalf("恢复错误为 %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := f.clientForRequest(context.Background()); !errors.Is(err, offline) {
+			t.Fatalf("离线错误为 %v", err)
+		}
+	}
+	if created.Load() != 1 || failed.closes.Load() != 1 {
+		t.Fatal("离线请求产生重建风暴或泄漏引擎")
+	}
+	time.Sleep(forwarderRecoveryCooldown)
+	recovered, err := f.clientForRequest(context.Background())
+	if err != nil || recovered.transport != next || created.Load() != 2 {
+		t.Fatalf("离线后无法再次恢复：%v", err)
+	}
+}
+
+func TestForwarderRecoversBeforeSendingAndDoesNotTreatHTTPAuthAsTunnelFailure(t *testing.T) {
+	var received atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "one message" {
+			t.Errorf("请求内容为 %q", body)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	target, _ := url.Parse(server.URL)
+	next := &stubTunnelClient{dial: func(ctx context.Context, _ uint16) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", target.Host)
+	}}
+	var created atomic.Int32
+	f := newStubForwarder(t, &stubTunnelClient{}, func() tunnelClient { created.Add(1); return next })
+	client := &http.Client{Timeout: 5 * time.Second}
+	response, err := client.Post(f.Endpoint(), "text/plain", strings.NewReader("one message"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized || received.Load() != 1 || created.Load() != 1 {
+		t.Fatal("请求被重发或鉴权错误触发了重建")
+	}
+}
+
+func TestForwarderNeverReplaysBytesAfterEstablishedStreamFails(t *testing.T) {
+	readDone := make(chan []byte, 1)
+	initial := &stubTunnelClient{dial: func(context.Context, uint16) (net.Conn, error) {
+		proxy, remote := net.Pipe()
+		go func() {
+			defer remote.Close()
+			body := make([]byte, len("one message"))
+			_, err := io.ReadFull(remote, body)
+			if err != nil {
+				readDone <- nil
+				return
+			}
+			readDone <- body
+			// 远端已接收消息，但没有返回结果就断开。
+		}()
+		return proxy, nil
+	}}
+	var created atomic.Int32
+	f := newStubForwarder(t, initial, func() tunnelClient { created.Add(1); return &stubTunnelClient{} })
+	local, err := net.Dial("tcp", f.listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer local.Close()
+	local.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := io.WriteString(local, "one message"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = local.Read(make([]byte, 1))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("连接断开结果为 %v", err)
+	}
+	if body := <-readDone; string(body) != "one message" {
+		t.Fatal("远端未收到预期消息")
+	}
+	if created.Load() != 0 {
+		t.Fatal("已转发业务字节后触发自动重建重放")
+	}
+}
+
+func TestForwarderMonitorRecoversAnEstablishedSilentConnection(t *testing.T) {
+	var probes atomic.Int32
+	initial := &stubTunnelClient{disco: func(context.Context) (*ipnstate.PingResult, error) {
+		probes.Add(1)
+		return nil, errors.New("peer disappeared")
+	}}
+	next := &stubTunnelClient{}
+	f := newStubForwarder(t, initial, func() tunnelClient { return next })
+	// 无活动连接时不探测，也不为未使用的隧道重建引擎。
+	f.checkActiveClient()
+	if probes.Load() != 0 {
+		t.Fatal("闲置隧道仍在发送探测")
+	}
+	local, remote := net.Pipe()
+	defer remote.Close()
+	f.mu.Lock()
+	f.connections[local] = f.current
+	f.mu.Unlock()
+	f.checkActiveClient()
+	remote.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := remote.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+		t.Fatalf("失效的旧连接未释放：%v", err)
+	}
+	recovered, err := f.clientForRequest(context.Background())
+	if err != nil || recovered.transport != next || probes.Load() != 1 {
+		t.Fatalf("存活探测未恢复连接：%v", err)
+	}
+}
+
+func TestForwarderMonitorPreservesHealthySlowBusinessConnection(t *testing.T) {
+	initial := &stubTunnelClient{}
+	var created atomic.Int32
+	f := newStubForwarder(t, initial, func() tunnelClient { created.Add(1); return &stubTunnelClient{} })
+	local, remote := net.Pipe()
+	defer remote.Close()
+	f.mu.Lock()
+	f.connections[local] = f.current
+	f.mu.Unlock()
+	// 业务流没有返回数据，但 DISCO 存活探测正常，不能关闭它或重发业务。
+	f.checkActiveClient()
+	if created.Load() != 0 || initial.closes.Load() != 0 {
+		t.Fatal("业务静默导致健康连接被销毁")
+	}
+}

--- a/experiments/tailcat/internal/tunnel/restart_recovery_integration_test.go
+++ b/experiments/tailcat/internal/tunnel/restart_recovery_integration_test.go
@@ -1,0 +1,159 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"tailscale.com/tstest/integration"
+)
+
+func TestForwarderRecoversAfterHostRestartWithoutChangingEndpoint(t *testing.T) {
+	t.Setenv("TS_DEBUG_ALWAYS_USE_DERP", "1")
+	for _, trigger := range []string{"http", "disco-ping", "established-websocket"} {
+		t.Run(trigger, func(t *testing.T) {
+			backend := newAgentdFixture(t)
+			target, err := url.Parse(backend.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			root := t.TempDir()
+			identityPath := filepath.Join(root, "client.json")
+			identity, err := LoadOrCreateClientIdentity(identityPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			region := integration.RunDERPAndSTUN(t, t.Logf, "127.0.0.1").Regions[1]
+			config := HostConfig{
+				TargetAddr: target.Host, RemotePort: 8787,
+				IdentityPath: filepath.Join(root, "host.json"), AddressPath: filepath.Join(root, "address"),
+				AllowedClientKeys: []string{identity.Public().String()}, Region: region,
+			}
+			host, err := StartHost(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { host.Close() }()
+			address := host.Address()
+			forwarder := startTestForwarder(t, address, identityPath)
+			defer forwarder.Close()
+			endpoint := forwarder.Endpoint()
+			transport := &http.Transport{DisableKeepAlives: true}
+			defer transport.CloseIdleConnections()
+			client := &http.Client{Transport: transport, Timeout: 8 * time.Second}
+			checkHTTP := func() error {
+				req, err := http.NewRequest(http.MethodGet, endpoint+"/api/readyz", nil)
+				if err != nil {
+					return err
+				}
+				req.Header.Set("Authorization", "Bearer "+experimentToken)
+				response, err := client.Do(req)
+				if err != nil {
+					return err
+				}
+				defer response.Body.Close()
+				if response.StatusCode != http.StatusOK {
+					return fmt.Errorf("unexpected status %d", response.StatusCode)
+				}
+				_, err = io.Copy(io.Discard, response.Body)
+				return err
+			}
+			if err := checkHTTP(); err != nil {
+				t.Fatal(err)
+			}
+			// 连续重启两次，确认恢复不是只对首次握手生效。Forwarder 与本地端点始终保留。
+			for restart := 0; restart < 2; restart++ {
+				var established *websocket.Conn
+				if trigger == "established-websocket" {
+					dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+					established, _, err = dialer.Dial("ws"+strings.TrimPrefix(endpoint, "http")+"/api/app-server/ws", http.Header{"Authorization": []string{"Bearer " + experimentToken}})
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer established.Close()
+				}
+				if err := host.Close(); err != nil {
+					t.Fatal(err)
+				}
+				host, err = StartHost(config)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if host.Address() != address {
+					t.Fatal("重启改变了服务端地址")
+				}
+				started := time.Now()
+				if established != nil {
+					// 不新建请求、不手动测速；旧 WebSocket 必须退出等待，供 App 自动重连。
+					established.SetReadDeadline(time.Now().Add(20 * time.Second))
+					_, _, readErr := established.ReadMessage()
+					established.Close()
+					if readErr == nil {
+						t.Fatal("服务重启后旧 WebSocket 没有断开")
+					}
+					if timeout, ok := readErr.(net.Error); ok && timeout.Timeout() {
+						t.Fatal("旧 WebSocket 一直挂起，自动探测未释放连接")
+					}
+				} else if trigger == "disco-ping" {
+					ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+					result, pingErr := forwarder.DiscoPing(ctx)
+					cancel()
+					if pingErr != nil {
+						t.Fatal(pingErr)
+					}
+					if result.Path == "unknown" {
+						t.Fatal("恢复后仍无法诊断路径")
+					}
+				} else {
+					// 多条新连接同时失败，必须共用恢复，不能相互抢占同身份 DERP 连接。
+					failures := make(chan error, 4)
+					for i := 0; i < 4; i++ {
+						go func() { failures <- checkHTTP() }()
+					}
+					for i := 0; i < 4; i++ {
+						if err := <-failures; err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+				if err := checkHTTP(); err != nil {
+					t.Fatal(err)
+				}
+				if forwarder.Endpoint() != endpoint {
+					t.Fatal("恢复改变了 App 使用的本地端点")
+				}
+				t.Logf("restart=%d trigger=%s recovered=%s", restart+1, trigger, time.Since(started).Round(time.Millisecond))
+				dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+				ws, response, err := dialer.Dial("ws"+strings.TrimPrefix(endpoint, "http")+"/api/app-server/ws", http.Header{"Authorization": []string{"Bearer " + experimentToken}})
+				if response != nil && response.Body != nil {
+					response.Body.Close()
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				ws.SetReadDeadline(time.Now().Add(5 * time.Second))
+				payload := []byte(`{"method":"thread/list","id":7}`)
+				if err := ws.WriteMessage(websocket.TextMessage, payload); err != nil {
+					ws.Close()
+					t.Fatal(err)
+				}
+				_, got, err := ws.ReadMessage()
+				ws.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(got) != string(payload) {
+					t.Fatal("恢复后 WebSocket 内容不一致")
+				}
+			}
+		})
+	}
+}

--- a/experiments/tailcat/internal/tunnel/tunnel_integration_test.go
+++ b/experiments/tailcat/internal/tunnel/tunnel_integration_test.go
@@ -226,9 +226,14 @@ func newAgentdFixture(t *testing.T) *httptest.Server {
 			return
 		}
 		defer connection.Close()
-		messageType, message, err := connection.ReadMessage()
-		if err == nil {
-			_ = connection.WriteMessage(messageType, message)
+		for {
+			messageType, message, err := connection.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := connection.WriteMessage(messageType, message); err != nil {
+				return
+			}
 		}
 	}))
 	server := httptest.NewServer(mux)


### PR DESCRIPTION
Mac 服务重启后，App 会保留已经完成过握手、但无法继续传输的 Tailcat Client。消息、测速和已建立的 WebSocket 因此可能一直等待，直到用户杀掉 App。现在由共享转发层识别失效并重建 Client，保留配对身份与本地 endpoint，让现有 REST/WebSocket 重连逻辑继续工作。

- TCP 建连或路径探测失败时，并发请求共用一次有界恢复；先关闭旧引擎，再启动同身份的新引擎，避免争抢 DERP 下行。旧请求的迟到错误不会销毁新引擎。
- 仍有活动连接时，每 10 秒探测一次隧道，探测超时为 3 秒。没有活动连接时不探测。重建会释放旧长连接，业务响应慢本身不会触发重建。
- 只在转发业务字节前重试建连。已经发送但结果未知的消息不会自动重放，HTTP 鉴权错误不会触发隧道重建。关闭代理会取消恢复并释放连接。

验证基于 main `89553c75`，受检提交为 `8b2f3b4c`：

- `go test -race ./internal/tunnel -run '^TestForwarder(Recovery|Close|Monitor|RecoversBefore|Never)' -count=1 -timeout=30s` 通过，覆盖并发、取消、清理、离线后重试、消息不重放与活动连接探测。
- `bash ./scripts/verify-change.sh --plan --full` 已核对；执行 full 后 7 项通过。协议项因全局 CLI 0.153.0 与仓库 0.151.0 不符而失败，随后用 `CODEX_BIN=codex npm exec --yes --package=@openai/codex@0.151.0 -- bash ./scripts/check-codex-protocol.sh` 单独补验通过，未修改全局 CLI。
- Tailcat 全模块测试通过，覆盖客户端持续运行、仅重启服务端、并发 HTTP、路径诊断、既有 WebSocket 自动退出等待，以及恢复后的 HTTP/WebSocket。
- iPad Pro 13-inch (M5)、Debug、Xcode 27 beta 6 / iOS 27 Simulator：555 项通过，3 项 Windows 真机测试按条件跳过。

当前没有可达真机。手机 5G 链路的部署复测、PR Gate 与合入 main 尚待完成；此 PR 不代表发布验收完成。

Refs #386