### PR TITLE
从 App 新建的 Claude 会话也自动生成标题

### DIFF
--- a/docs/auto-thread-titles.md
+++ b/docs/auto-thread-titles.md
@@ -4,10 +4,11 @@
 
 新建 Codex 会话发送第一条用户请求后，由 Mac 端自动生成简短标题并持久化到 app-server。移动端应尽快看到标题，但标题生成不能阻塞正常对话，也不能把 Codex 凭据下放到 iPhone / iPad。
 
-MVP 只覆盖通过 Mimi Remote 新建的 Codex 会话：
+覆盖通过 Mimi Remote 新建的 Codex 和 Claude 会话：
 
 - `thread/start` 新建后，首个成功转发的 `turn/start` 或任务 `thread/queue/add` 触发一次；
-- `thread/resume`、历史线程、Claude 实验通道不触发；
+- `thread/resume`、历史线程不触发；
+- Claude 会话：Claude 桌面 / 终端自己会把 `custom-title` / `ai-title` 写进 transcript，bridge 读作会话名；只有从 App 新建、由 bridge `claude -p` 驱动的会话没有标题，因此同样走这条链路。标题文本仍由 Codex 临时线程生成（bridge 没有 ephemeral 线程，也不该为标题起一个真实 Claude 会话），写回前的 `thread/read` 和 `thread/name/set` 改走 bridge socket 的匿名内部连接；
 - 用户或其他客户端已经设置名称时不覆盖；
 - 失败时保留移动端现有的首条消息预览，不影响 Turn 生命周期。
 
@@ -92,10 +93,13 @@ export AGENTD_APP_SERVER_AUTO_TITLE=false
 
 日志只记录脱敏后的 thread token 和失败分类（取消、超时、生成失败），不记录原始 Prompt、模型输出、标题或本地路径。
 
+`app_server.auto_title` / `AGENTD_APP_SERVER_AUTO_TITLE` 同时控制 Codex 与 Claude 两条 runtime，没有单独的 Claude 开关。
+
 ## 风险与优化
 
 - **额度成本：**每个新 Codex 会话增加一次低推理请求。当前用串行、输入上限、一次性触发和开关控制；后续只有在真实使用量需要时才增加配额感知或批处理。
 - **手动改名竞态：**协议没有 CAS，仍存在第二次读取与写回之间的极短窗口。若 Codex 后续提供版本号或条件写接口，应替换为原子写。
 - **连接中断：**标题已持久化但补发 notification 失败时，当前 UI 可能暂时保留预览；下次列表刷新会得到正式名称，不重试模型请求。
 - **协议漂移：**实现依赖公开的 `thread/read`、`thread/start`、`turn/start.outputSchema`、`item/completed`、`turn/completed` 和 `thread/name/set`。升级固定 Codex 协议基线时必须运行协议快照和 Go 测试。
-- **扩展范围：**暂不为恢复的无标题历史会话补标题，也不覆盖 Claude。只有真实用户反馈表明需要时，再设计显式“重新生成标题”操作。
+- **扩展范围：**暂不为恢复的无标题历史会话补标题。只有真实用户反馈表明需要时，再设计显式“重新生成标题”操作。
+- **Claude 依赖 Codex 生成：**Claude 会话的标题文本由 Codex 临时线程生成。Codex 不可用（未登录、app-server 不可达）或 bridge 不可用时跳过本次任务，会话保持无标题、列表继续显示首条消息预览，不影响对话。写回后即使 Claude 之后写入自己的 `ai-title`，bridge 也只在会话名仍等于上一次扫描到的 transcript 标题时才跟随更新，不会覆盖已写回的自动标题。

--- a/docs/claude-bridge-architecture.md
+++ b/docs/claude-bridge-architecture.md
@@ -84,6 +84,7 @@ sequenceDiagram
 - `thread/turns/list` 按 `itemsView` 返回：`summary` 只保留用户与助手文本，工具过程由 `thread/items/list` 按 turn 分页补齐，和 Codex 首屏走同一条路；`full` 或省略时仍带全部 item。裁剪只在请求带 `itemsListAvailable: true` 时生效，这个字段由 agentd 网关写入，表示网关会转发 `thread/items/list`；新 bridge 配旧 agentd 时没有这个字段，bridge 照旧回完整 item。此前 bridge 无视 `itemsView`，一个 18 MB 会话的首页要 400–650 KB，移动端经中继打开明显更慢。
 - bridge 的协议输入输出是逐行 JSON；`agentd` 不把整段上下文重新拼成额外提示词。
 - Claude Code 登录态和可恢复历史由用户本机 Claude Code 环境管理，不上传到 Mimi Remote 服务器。
+- 会话名优先取 Claude 自己写进 transcript 的 `custom-title` / `ai-title`；从 App 新建的会话没有这类记录，由 `agentd` 的自动标题任务（见 `auto-thread-titles.md`）通过 bridge socket 的匿名内部连接调用 `thread/read` / `thread/name/set` 写回，标题文本仍由 Codex 临时线程生成。
 
 ### 观测与恢复
 

--- a/internal/httpapi/appserver_gateway_threads.go
+++ b/internal/httpapi/appserver_gateway_threads.go
@@ -1483,7 +1483,7 @@ func (p *appServerGatewayPolicy) threadsFromResult(raw json.RawMessage, pending 
 			runtimeID:            normalizeAppServerRuntimeID(p.runtimeID),
 			canAcceptDirectInput: item.CanAcceptDirectInput != nil && *item.CanAcceptDirectInput,
 			directInputKnown:     item.CanAcceptDirectInput != nil,
-			autoTitleEligible:    pending.method == "thread/start" && normalizeAppServerRuntimeID(p.runtimeID) == "codex",
+			autoTitleEligible:    pending.method == "thread/start" && autoThreadTitleRuntimeSupported(p.runtimeID),
 			// browse 作用域用 canonical 路径绑定，避免同一目录的不同写法绕过精确匹配。
 			cwd:     scope.realPath,
 			scopeID: scope.id,

--- a/internal/httpapi/appserver_gateway_websocket.go
+++ b/internal/httpapi/appserver_gateway_websocket.go
@@ -2,7 +2,6 @@ package httpapi
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
@@ -171,21 +170,7 @@ func (r *Router) processClientFrameToAppServer(ctx context.Context, client *webs
 	writeDuration := time.Since(writeStart)
 	monitor.recordForward("client_to_upstream", len(payload), len(forwardPayload), policyDuration, writeDuration, forwardPayload)
 	monitor.logSessionListStage(forwardPayload, "upstream_written", writeDuration)
-	r.scheduleAutoThreadTitleFromMessage(forwardPayload, policy, func(threadID string, title string) {
-		// thread/name/set 由独立 loopback 连接执行，它产生的 notification 只回到
-		// 那条连接；这里给发起会话的移动端补发同形通知，让 UI 无需轮询即可更新。
-		notification, err := json.Marshal(map[string]any{
-			"method": "thread/name/updated",
-			"params": map[string]any{
-				"threadId":   threadID,
-				"threadName": title,
-			},
-		})
-		if err != nil {
-			return
-		}
-		_ = writeWebSocketFrame(client, clientWriteMu, websocket.TextMessage, notification)
-	})
+	r.scheduleAutoThreadTitleFromMessage(forwardPayload, policy, autoThreadTitleClientNotifier(client, clientWriteMu))
 	return "", false
 }
 

--- a/internal/httpapi/auto_thread_title.go
+++ b/internal/httpapi/auto_thread_title.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 const (
@@ -34,7 +36,47 @@ type autoThreadTitleRequest struct {
 	ThreadID string
 	CWD      string
 	Prompt   string
-	Notify   func(threadID string, title string)
+	// RuntimeID 决定目标线程的读取与写回通道：codex 走 app-server，claude 走 bridge。
+	// 标题文本无论哪条 runtime 都由 Codex 临时线程生成。
+	RuntimeID string
+	Notify    func(threadID string, title string)
+}
+
+// autoThreadTitleRuntimeSupported 列出自动标题覆盖的 runtime。历史线程、resume 与
+// 其他 runtime 不触发。
+func autoThreadTitleRuntimeSupported(runtimeID string) bool {
+	switch normalizeAppServerRuntimeID(runtimeID) {
+	case "codex", "claude":
+		return true
+	default:
+		return false
+	}
+}
+
+// autoThreadTitleRPC 是标题任务对目标线程的最小依赖：Codex 用 WebSocket，Claude
+// bridge 用 socket JSONL，两者都只需要 initialize 和请求/响应。
+type autoThreadTitleRPC interface {
+	initializeClient(ctx context.Context, name string, title string, version string) (string, error)
+	call(ctx context.Context, method string, params any, result any) error
+}
+
+// autoThreadTitleClientNotifier 给发起会话的移动端补发 thread/name/updated。
+// thread/name/set 由独立内部连接执行，它产生的 notification 只回到那条连接，
+// 这里补发同形通知让 UI 无需轮询即可更新。
+func autoThreadTitleClientNotifier(client *websocket.Conn, clientWriteMu *sync.Mutex) func(threadID string, title string) {
+	return func(threadID string, title string) {
+		notification, err := json.Marshal(map[string]any{
+			"method": "thread/name/updated",
+			"params": map[string]any{
+				"threadId":   threadID,
+				"threadName": title,
+			},
+		})
+		if err != nil {
+			return
+		}
+		_ = writeWebSocketFrame(client, clientWriteMu, websocket.TextMessage, notification)
+	}
 }
 
 // autoThreadTitleScheduler 把 gateway 热路径与模型调用隔开，测试可注入纯内存实现。
@@ -162,12 +204,19 @@ func autoThreadTitleErrorReason(err error) string {
 	}
 }
 
+// codexAutoThreadTitleGenerator 用 Codex 临时线程生成标题文本；目标线程按
+// runtime 分别通过 app-server 或 Claude bridge 读取和写回。
 type codexAutoThreadTitleGenerator struct {
 	router *Router
+	// dialClaudeBridge 供测试注入假 bridge；生产使用 supervisor 的 socket。
+	dialClaudeBridge func(ctx context.Context) (*claudeBridgeRPC, error)
 }
 
 func newCodexAutoThreadTitleGenerator(router *Router) *codexAutoThreadTitleGenerator {
-	return &codexAutoThreadTitleGenerator{router: router}
+	return &codexAutoThreadTitleGenerator{
+		router:           router,
+		dialClaudeBridge: router.dialClaudeBridgeRPC,
+	}
 }
 
 func (g *codexAutoThreadTitleGenerator) GenerateAndSet(
@@ -176,6 +225,27 @@ func (g *codexAutoThreadTitleGenerator) GenerateAndSet(
 ) (string, bool, error) {
 	if g == nil || g.router == nil {
 		return "", false, errors.New("auto title generator 未配置")
+	}
+	// Claude 线程先连 bridge：bridge 不可用时直接跳过，不白白占用一次 Codex 请求。
+	var target autoThreadTitleRPC
+	if normalizeAppServerRuntimeID(request.RuntimeID) == "claude" {
+		if g.dialClaudeBridge == nil {
+			return "", false, errors.New("Claude bridge 内部连接未配置")
+		}
+		bridge, err := g.dialClaudeBridge(ctx)
+		if err != nil {
+			return "", false, err
+		}
+		defer bridge.close()
+		if _, err := bridge.initializeClient(
+			ctx,
+			autoThreadTitleClientName,
+			autoThreadTitleClientTitle,
+			g.router.version,
+		); err != nil {
+			return "", false, err
+		}
+		target = bridge
 	}
 	upstreamURL, err := g.router.appServerUpstreamWebSocketURL()
 	if err != nil {
@@ -213,7 +283,10 @@ func (g *codexAutoThreadTitleGenerator) GenerateAndSet(
 	); err != nil {
 		return "", false, err
 	}
-	named, err := autoThreadAlreadyNamed(ctx, &rpc, request.ThreadID)
+	if target == nil {
+		target = &rpc
+	}
+	named, err := autoThreadAlreadyNamed(ctx, target, request.ThreadID)
 	if err != nil || named {
 		return "", false, err
 	}
@@ -235,11 +308,11 @@ func (g *codexAutoThreadTitleGenerator) GenerateAndSet(
 
 	// thread/name/set 没有 CAS 参数。写回前紧邻再读一次，是当前公开协议下
 	// 避免覆盖用户手动改名的最小竞态窗口。
-	named, err = autoThreadAlreadyNamed(ctx, &rpc, request.ThreadID)
+	named, err = autoThreadAlreadyNamed(ctx, target, request.ThreadID)
 	if err != nil || named {
 		return "", false, err
 	}
-	if err := rpc.call(ctx, "thread/name/set", map[string]any{
+	if err := target.call(ctx, "thread/name/set", map[string]any{
 		"threadId": request.ThreadID,
 		"name":     title,
 	}, &struct{}{}); err != nil {
@@ -248,7 +321,7 @@ func (g *codexAutoThreadTitleGenerator) GenerateAndSet(
 	return title, true, nil
 }
 
-func autoThreadAlreadyNamed(ctx context.Context, rpc *runtimeWebSocketRPC, threadID string) (bool, error) {
+func autoThreadAlreadyNamed(ctx context.Context, rpc autoThreadTitleRPC, threadID string) (bool, error) {
 	var response struct {
 		Thread struct {
 			Name *string `json:"name"`
@@ -566,9 +639,10 @@ func (p *appServerGatewayPolicy) takeAutoThreadTitleRequest(payload []byte) (aut
 		prompt = autoThreadTitleFallbackUntitled
 	}
 	return autoThreadTitleRequest{
-		ThreadID: thread.id,
-		CWD:      thread.cwd,
-		Prompt:   prompt,
+		ThreadID:  thread.id,
+		CWD:       thread.cwd,
+		Prompt:    prompt,
+		RuntimeID: thread.runtimeID,
 	}, true
 }
 

--- a/internal/httpapi/claude_auto_thread_title_test.go
+++ b/internal/httpapi/claude_auto_thread_title_test.go
@@ -1,0 +1,248 @@
+package httpapi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClaudeBridgeState 记录假 bridge 收到的请求。它用 net.Pipe 模拟 bridge socket，
+// 只实现自动标题任务需要的 initialize / thread/read / thread/name/set。
+type fakeClaudeBridgeState struct {
+	mu                 sync.Mutex
+	name               string
+	readCalls          int
+	setName            string
+	initialized        bool
+	serverRequestReply string
+}
+
+func newFakeClaudeBridge(t *testing.T, existingName string, injectServerRequest bool) (func(context.Context) (*claudeBridgeRPC, error), *fakeClaudeBridgeState) {
+	t.Helper()
+	state := &fakeClaudeBridgeState{name: existingName}
+	dial := func(ctx context.Context) (*claudeBridgeRPC, error) {
+		clientEnd, serverEnd := net.Pipe()
+		go serveFakeClaudeBridge(t, serverEnd, state, injectServerRequest)
+		rpc := newClaudeBridgeRPC(clientEnd)
+		rpc.stopCancelClose = context.AfterFunc(ctx, func() { _ = clientEnd.Close() })
+		return rpc, nil
+	}
+	return dial, state
+}
+
+func serveFakeClaudeBridge(t *testing.T, conn net.Conn, state *fakeClaudeBridgeState, injectServerRequest bool) {
+	t.Helper()
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	writeLine := func(payload map[string]any) bool {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return false
+		}
+		_, err = conn.Write(append(encoded, '\n'))
+		return err == nil
+	}
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+		var frame runtimeWebSocketFrame
+		if json.Unmarshal(line, &frame) != nil {
+			continue
+		}
+		switch frame.Method {
+		case "initialize":
+			state.mu.Lock()
+			state.initialized = true
+			state.mu.Unlock()
+			writeLine(map[string]any{"jsonrpc": "2.0", "id": json.RawMessage(frame.ID), "result": map[string]any{"userAgent": "alleycat-claude-bridge/0.2.10"}})
+		case "initialized":
+			continue
+		case "thread/read":
+			state.mu.Lock()
+			state.readCalls++
+			name := state.name
+			state.mu.Unlock()
+			if injectServerRequest {
+				// bridge 反向 request（如审批）不属于内部任务：客户端必须回标准错误，
+				// 且不能把它当成 thread/read 的响应。
+				writeLine(map[string]any{"jsonrpc": "2.0", "id": "server-1", "method": "item/tool/call", "params": map[string]any{}})
+				reply, err := reader.ReadBytes('\n')
+				if err != nil {
+					return
+				}
+				state.mu.Lock()
+				state.serverRequestReply = strings.TrimSpace(string(reply))
+				state.mu.Unlock()
+			}
+			var wireName any
+			if name != "" {
+				wireName = name
+			}
+			writeLine(map[string]any{"jsonrpc": "2.0", "id": json.RawMessage(frame.ID), "result": map[string]any{"thread": map[string]any{"id": "thread-claude", "name": wireName}}})
+		case "thread/name/set":
+			params, _ := decodeGatewayParams(frame.Params)
+			name, _ := gatewayStringParam(params, "name")
+			state.mu.Lock()
+			state.setName = name
+			state.name = name
+			state.mu.Unlock()
+			writeLine(map[string]any{"jsonrpc": "2.0", "id": json.RawMessage(frame.ID), "result": map[string]any{}})
+		default:
+			writeLine(map[string]any{"jsonrpc": "2.0", "id": json.RawMessage(frame.ID), "error": map[string]any{"code": -32601, "message": "unexpected method " + frame.Method}})
+		}
+	}
+}
+
+func TestClaudeAutoThreadTitleWritesBackThroughBridge(t *testing.T) {
+	upstreamURL, codex := newAutoThreadTitleUpstream(t, "", `{"title":"排查 SSH 连接报错"}`)
+	generator := newCodexAutoThreadTitleGenerator(autoThreadTitleTestRouter(t, upstreamURL))
+	dial, bridge := newFakeClaudeBridge(t, "", true)
+	generator.dialClaudeBridge = dial
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	title, updated, err := generator.GenerateAndSet(ctx, autoThreadTitleRequest{
+		ThreadID:  "thread-claude",
+		CWD:       t.TempDir(),
+		Prompt:    "有过用户反馈在配置的时候报这个错误，帮我看一下",
+		RuntimeID: "claude",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated || title != "排查 SSH 连接报错" {
+		t.Fatalf("Claude 标题生成结果异常：updated=%t title=%q", updated, title)
+	}
+
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if !bridge.initialized {
+		t.Fatal("内部连接必须先 initialize bridge")
+	}
+	if bridge.readCalls != 2 {
+		t.Fatalf("写回前后应各通过 bridge 读取一次目标线程，got=%d", bridge.readCalls)
+	}
+	if bridge.setName != title {
+		t.Fatalf("thread/name/set 必须写到 bridge：got=%q want=%q", bridge.setName, title)
+	}
+	if !strings.Contains(bridge.serverRequestReply, `"code":-32601`) || !strings.Contains(bridge.serverRequestReply, `"server-1"`) {
+		t.Fatalf("bridge 反向 request 必须被内部客户端拒绝：%s", bridge.serverRequestReply)
+	}
+
+	codex.mu.Lock()
+	defer codex.mu.Unlock()
+	if codex.readCalls != 0 || codex.setTitle != "" {
+		t.Fatalf("Claude 线程的读取和写回不得落到 Codex app-server：reads=%d set=%q", codex.readCalls, codex.setTitle)
+	}
+	if codex.threadStart["ephemeral"] != true || codex.turnStart["effort"] != "low" {
+		t.Fatalf("标题文本仍应由 Codex 临时线程生成：threadStart=%v turnStart=%v", codex.threadStart, codex.turnStart)
+	}
+}
+
+func TestClaudeAutoThreadTitleDoesNotOverwriteTranscriptTitle(t *testing.T) {
+	upstreamURL, codex := newAutoThreadTitleUpstream(t, "", `{"title":"模型标题"}`)
+	generator := newCodexAutoThreadTitleGenerator(autoThreadTitleTestRouter(t, upstreamURL))
+	// bridge 已从 transcript 读到 Claude 自己写的标题（custom-title / ai-title）。
+	dial, bridge := newFakeClaudeBridge(t, "Claude 自己的标题", false)
+	generator.dialClaudeBridge = dial
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	title, updated, err := generator.GenerateAndSet(ctx, autoThreadTitleRequest{
+		ThreadID:  "thread-claude",
+		CWD:       t.TempDir(),
+		Prompt:    "随便聊聊",
+		RuntimeID: "claude",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated || title != "" {
+		t.Fatalf("已有标题的 Claude 线程不得被覆盖：updated=%t title=%q", updated, title)
+	}
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if bridge.setName != "" {
+		t.Fatalf("不应调用 thread/name/set：%q", bridge.setName)
+	}
+	codex.mu.Lock()
+	defer codex.mu.Unlock()
+	if codex.threadStart != nil {
+		t.Fatal("已命名线程不应再消耗 Codex 生成请求")
+	}
+}
+
+func TestClaudeAutoThreadTitleSkipsWhenBridgeUnavailable(t *testing.T) {
+	upstreamURL, codex := newAutoThreadTitleUpstream(t, "", `{"title":"模型标题"}`)
+	generator := newCodexAutoThreadTitleGenerator(autoThreadTitleTestRouter(t, upstreamURL))
+	generator.dialClaudeBridge = func(context.Context) (*claudeBridgeRPC, error) {
+		return nil, errors.New("Claude bridge 未运行")
+	}
+
+	_, updated, err := generator.GenerateAndSet(context.Background(), autoThreadTitleRequest{
+		ThreadID:  "thread-claude",
+		CWD:       t.TempDir(),
+		Prompt:    "随便聊聊",
+		RuntimeID: "claude",
+	})
+	if err == nil || updated {
+		t.Fatalf("bridge 不可用时应跳过本次任务：updated=%t err=%v", updated, err)
+	}
+	codex.mu.Lock()
+	defer codex.mu.Unlock()
+	if codex.threadStart != nil || codex.readCalls != 0 {
+		t.Fatal("bridge 不可用时不应再连 Codex 生成标题")
+	}
+}
+
+func TestAutoThreadTitleRequestConsumesNewClaudeThreadOnce(t *testing.T) {
+	policy := &appServerGatewayPolicy{
+		runtimeID: "claude",
+		allowedThreads: map[string]appServerGatewayAllowedThread{
+			"thread-claude": {
+				id:                "thread-claude",
+				runtimeID:         "claude",
+				cwd:               "/tmp/project",
+				scopeID:           "project",
+				autoTitleEligible: true,
+			},
+		},
+	}
+	payload, err := json.Marshal(map[string]any{
+		"id":     3,
+		"method": "turn/start",
+		"params": map[string]any{
+			"threadId": "thread-claude",
+			"input":    []any{map[string]any{"type": "text", "text": "检查 SSH 报错"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, ok := policy.takeAutoThreadTitleRequest(payload)
+	if !ok {
+		t.Fatal("新 Claude thread 的首个 turn/start 应生成标题请求")
+	}
+	if request.RuntimeID != "claude" || request.ThreadID != "thread-claude" || request.CWD != "/tmp/project" {
+		t.Fatalf("标题请求必须带上 runtime 与线程绑定：%+v", request)
+	}
+	if _, ok := policy.takeAutoThreadTitleRequest(payload); ok {
+		t.Fatal("同一新 thread 的标题资格只能消费一次")
+	}
+}
+
+func TestAutoThreadTitleRuntimeSupported(t *testing.T) {
+	for runtimeID, want := range map[string]bool{"codex": true, "claude": true, "Claude": true, "": true, "pi": false} {
+		if got := autoThreadTitleRuntimeSupported(runtimeID); got != want {
+			t.Fatalf("runtime %q: got=%t want=%t", runtimeID, got, want)
+		}
+	}
+}

--- a/internal/httpapi/claude_bridge_rpc.go
+++ b/internal/httpapi/claude_bridge_rpc.go
@@ -1,0 +1,173 @@
+package httpapi
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// claudeBridgeRPC 直接对 resident Claude bridge 的 socket 发 JSON-RPC，供 agentd 的
+// 内部任务（自动标题）使用。不发 `_alleycat/attach`：bridge 会给这条连接一个匿名
+// 隔离会话，连接关闭即回收，不留 replay ring，也不会和移动端会话共用序号。
+// 请求/响应语义与 runtimeWebSocketRPC 一致：反向 request 一律拒绝，通知丢弃。
+type claudeBridgeRPC struct {
+	conn    net.Conn
+	reader  *bufio.Reader
+	writeMu sync.Mutex
+	nextID  int64
+	// stopCancelClose 解除 context 取消时的关连接钩子，正常关闭时先解除再关。
+	stopCancelClose func() bool
+}
+
+func newClaudeBridgeRPC(conn net.Conn) *claudeBridgeRPC {
+	return &claudeBridgeRPC{
+		conn:   conn,
+		reader: bufio.NewReaderSize(conn, 64*1024),
+	}
+}
+
+func (c *claudeBridgeRPC) close() {
+	if c == nil {
+		return
+	}
+	if c.stopCancelClose != nil {
+		c.stopCancelClose()
+	}
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+}
+
+func (c *claudeBridgeRPC) initializeClient(ctx context.Context, name string, title string, version string) (string, error) {
+	var result struct {
+		UserAgent string `json:"userAgent"`
+	}
+	if err := c.call(ctx, "initialize", map[string]any{
+		"clientInfo": map[string]any{
+			"name":    name,
+			"title":   title,
+			"version": version,
+		},
+		"capabilities": map[string]any{},
+	}, &result); err != nil {
+		return "", err
+	}
+	if err := c.notify(ctx, "initialized", map[string]any{}); err != nil {
+		return "", err
+	}
+	return result.UserAgent, nil
+}
+
+func (c *claudeBridgeRPC) notify(ctx context.Context, method string, params any) error {
+	return c.write(ctx, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+	})
+}
+
+func (c *claudeBridgeRPC) call(ctx context.Context, method string, params any, result any) error {
+	c.nextID++
+	id := c.nextID
+	if err := c.write(ctx, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	}); err != nil {
+		return err
+	}
+	for {
+		if err := setRuntimeWebSocketDeadline(ctx, c.conn.SetReadDeadline); err != nil {
+			return err
+		}
+		line, oversize, readErr := readBridgeStdoutLine(c.reader, int(appServerGatewayReadLimit))
+		if payload := bytes.TrimSpace(line); !oversize && len(payload) > 0 {
+			done, err := c.consumeFrame(ctx, payload, id, result)
+			if done || err != nil {
+				return err
+			}
+		}
+		if readErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return readErr
+		}
+	}
+}
+
+// consumeFrame 处理一帧：目标 id 的响应返回 done=true；反向 request 回标准错误；
+// 其余（通知、别的响应）忽略。
+func (c *claudeBridgeRPC) consumeFrame(ctx context.Context, payload []byte, id int64, result any) (bool, error) {
+	var frame runtimeWebSocketFrame
+	if json.Unmarshal(payload, &frame) != nil {
+		return false, nil
+	}
+	if strings.TrimSpace(frame.Method) != "" {
+		if runtimeRPCFrameHasID(frame.ID) {
+			// 内部任务不拥有审批等宿主能力；拒绝后继续等原调用的响应，
+			// 避免相同 id 的反向 request 被误判成成功 response。
+			if err := c.write(ctx, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      frame.ID,
+				"error": map[string]any{
+					"code":    -32601,
+					"message": "internal client does not support server requests",
+				},
+			}); err != nil {
+				return false, err
+			}
+		}
+		return false, nil
+	}
+	if strings.TrimSpace(string(frame.ID)) != strconv.FormatInt(id, 10) {
+		return false, nil
+	}
+	if frame.Error != nil {
+		return true, frame.Error
+	}
+	if len(frame.Result) == 0 {
+		return true, errors.New("Claude bridge RPC 响应缺少 result 或 error")
+	}
+	if result == nil {
+		return true, nil
+	}
+	return true, json.Unmarshal(frame.Result, result)
+}
+
+func (c *claudeBridgeRPC) write(ctx context.Context, payload any) error {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if err := setRuntimeWebSocketDeadline(ctx, c.conn.SetWriteDeadline); err != nil {
+		return err
+	}
+	return writeStdioBridgeCompactedFrame(c.conn, &c.writeMu, encoded)
+}
+
+// dialClaudeBridgeRPC 打开一条面向 resident bridge 的内部连接。bridge 未运行时直接
+// 报错，调用方按"跳过本次任务"处理，不会为了内部任务去拉起 bridge。
+func (r *Router) dialClaudeBridgeRPC(ctx context.Context) (*claudeBridgeRPC, error) {
+	if r == nil || r.claudeBridge == nil {
+		return nil, errors.New("Claude bridge 未配置")
+	}
+	conn, _, err := r.claudeBridge.dial()
+	if err != nil {
+		return nil, err
+	}
+	// 阻塞读不会因 context 取消自动返回；关闭连接才能保证任务超时或 agentd
+	// 关闭时立即退出。
+	rpc := newClaudeBridgeRPC(conn)
+	rpc.stopCancelClose = context.AfterFunc(ctx, func() {
+		_ = conn.Close()
+	})
+	return rpc, nil
+}

--- a/internal/httpapi/claude_gateway.go
+++ b/internal/httpapi/claude_gateway.go
@@ -542,6 +542,10 @@ func copyClientFramesToClaudeBridge(client *websocket.Conn, stdin io.Writer, cli
 		if monitor != nil {
 			monitor.recordForward("client_to_upstream", len(payload), len(compacted), policyDuration, time.Since(writeStart), compacted)
 		}
+		// 与 Codex 网关同一触发点：首条成功写给 bridge 的 turn/start 消费新线程的
+		// 标题资格。标题写回走 bridge 的独立匿名连接，这里只负责给发起会话的
+		// 移动端补发 thread/name/updated。
+		policy.router.scheduleAutoThreadTitleFromMessage(compacted, policy, autoThreadTitleClientNotifier(client, clientWriteMu))
 	}
 }
 


### PR DESCRIPTION
Refs #448

## 目标

从 App 新建的 Claude 会话也自动获得简短标题，工作区 / 会话列表显示"标题 + 首条消息"两行，和 Claude 桌面 / 终端创建的会话一致。

## 根因

Claude 桌面写 `custom-title`、终端 `claude` 写 `ai-title`，bridge 扫描 transcript 时读作会话名；bridge 自己起的 `claude -p` headless 会话没有任何标题记录。Mimi 的自动标题任务按 `docs/auto-thread-titles.md` 的 MVP 只覆盖 Codex（`autoTitleEligible` 只在 `runtimeID == "codex"` 置位，Claude 网关的转发路径也没有触发点），于是这类会话只能拿首条消息当主行。

## 实现（仅 agentd）

- 标题资格扩展到 Claude runtime（`autoThreadTitleRuntimeSupported`）；`autoThreadTitleRequest` 带上 `RuntimeID`。
- Claude 网关 `copyClientFramesToClaudeBridge` 在首条成功写给 bridge 的 `turn/start` 后调用同一个 `scheduleAutoThreadTitleFromMessage`；`thread/name/updated` 补发逻辑抽成 `autoThreadTitleClientNotifier`，两条网关共用。
- 生成器：标题文本仍由 Codex 临时线程生成（bridge 没有 ephemeral 线程，不该为标题起真实 Claude 会话）；Claude 线程的两次 `thread/read` 和 `thread/name/set` 改走新增的 `claudeBridgeRPC`——对 resident bridge socket 的匿名内部连接（不 attach，连接关闭即回收，反向 request 回 `-32601`，通知丢弃）。先连 bridge 再连 Codex，bridge 不可用时直接跳过，不白费一次 Codex 请求。
- 不覆盖已命名线程：bridge `thread/read` 会返回 transcript 标题或用户命名，写回前后各查一次，和 Codex 路径一致。
- 开关沿用 `app_server.auto_title` / `AGENTD_APP_SERVER_AUTO_TITLE`，没有单独的 Claude 开关。文档：`auto-thread-titles.md`、`claude-bridge-architecture.md`。

## 验证

- `go vet` + `go test ./internal/httpapi -count=1` 全包通过（63s）；自动标题相关 14 个用例（含新增 5 个）单独跑通过。
- 新增用例：通过假 bridge（`net.Pipe` JSONL）验证 Claude 线程的读取/写回不落到 Codex、bridge 反向 request 被拒绝、已有 transcript 标题不覆盖、bridge 不可用时不再消耗 Codex；`takeAutoThreadTitleRequest` 对 Claude 线程只消费一次并带 runtime。
- 静态门禁：`git diff --check`、docs、源码体积通过；`verify-change.sh --plan` 只命中 Go 栈。
- 未做真机 / Mac 运行态验收：需要重装 Mac App 后，从 iPad 新建一个 Claude 会话看列表出现标题。

## 风险

- Claude 会话的标题依赖 Codex 可用；Codex 未登录时 Claude 会话保持无标题（与今天一致）。
- Claude 网关转发路径的钩子只有单元测试覆盖共享函数，没有网关级集成测试（Claude 网关的测试夹具需要假 bridge 二进制）。
- 不为历史无标题会话补标题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFUPyGE8qStdD2zuRdDejF
