### PR TITLE
Claude 模型目录加缓存与预热，首次打开不再只显示别名；按最强模型排序

### DIFF
--- a/bridges/claude/crates/claude-bridge/src/bridge.rs
+++ b/bridges/claude/crates/claude-bridge/src/bridge.rs
@@ -155,6 +155,7 @@ pub struct ClaudeBridgeBuilder {
     /// uses [`crate::index::claude_projects_dir`].
     projects_dir_override: Option<PathBuf>,
     history_refresh_interval: Duration,
+    warm_model_catalog: bool,
 }
 
 impl Default for ClaudeBridgeBuilder {
@@ -169,6 +170,7 @@ impl Default for ClaudeBridgeBuilder {
             trust_persisted_cwd: false,
             projects_dir_override: None,
             history_refresh_interval: DEFAULT_HISTORY_REFRESH_INTERVAL,
+            warm_model_catalog: false,
         }
     }
 }
@@ -217,6 +219,13 @@ impl ClaudeBridgeBuilder {
     /// 调整显式历史扫描冷却窗口。生产使用默认值，测试可用更长窗口验证限频。
     pub fn history_refresh_interval(mut self, interval: Duration) -> Self {
         self.history_refresh_interval = interval;
+        self
+    }
+
+    /// 启动后在后台预热 CLI 模型目录。生产入口打开；测试默认关闭，避免每个
+    /// 测试 bridge 都拉起一个 CLI 查询。
+    pub fn warm_model_catalog(mut self, enabled: bool) -> Self {
+        self.warm_model_catalog = enabled;
         self
     }
 
@@ -272,6 +281,11 @@ impl ClaudeBridgeBuilder {
             max_processes,
             idle_ttl,
         ));
+
+        if self.warm_model_catalog {
+            let pool = Arc::clone(&pool);
+            tokio::spawn(async move { pool.warm_model_catalog().await });
+        }
 
         let hydrator = match self.projects_dir_override {
             Some(dir) => ClaudeHydrator::with_override_dir(dir),

--- a/bridges/claude/crates/claude-bridge/src/handlers/model.rs
+++ b/bridges/claude/crates/claude-bridge/src/handlers/model.rs
@@ -27,7 +27,7 @@ pub async fn handle_model_list(
     _params: p::ModelListParams,
 ) -> p::ModelListResponse {
     let data = match state.claude_pool().discover_models().await {
-        Ok(models) => models
+        Ok(models) => order_strongest_first(models)
             .into_iter()
             .filter_map(convert_model)
             .collect::<Vec<_>>(),
@@ -125,6 +125,55 @@ fn model_version_title(id: &str) -> Option<String> {
         title.push_str(&format!(" ({})", context.to_uppercase()));
     }
     Some(title)
+}
+
+/// 列表顺序：Default 固定第一，其余按家族（Fable > Opus > Sonnet > Haiku）再按版本号
+/// 降序，同版本优先 1M 上下文。CLI 自己的顺序把 Opus 排在 Fable 前面，用户要的是
+/// 最强模型在最上面。未知家族按 CLI 原顺序排在最后。
+fn order_strongest_first(mut models: Vec<ClaudeModelInfo>) -> Vec<ClaudeModelInfo> {
+    models.sort_by_key(catalog_rank);
+    models
+}
+
+fn catalog_rank(info: &ClaudeModelInfo) -> (u8, u8, [std::cmp::Reverse<u32>; 4], u8) {
+    if info.value == "default" {
+        return (0, 0, [std::cmp::Reverse(0); 4], 0);
+    }
+    let id = info
+        .resolved_model
+        .as_deref()
+        .unwrap_or(info.value.as_str());
+    let (base, context) = match id.split_once('[') {
+        Some((base, context)) => (base, context.trim_end_matches(']')),
+        None => (id, ""),
+    };
+    let base = base.strip_prefix("claude-").unwrap_or(base);
+    let family = base.split('-').next().unwrap_or("").to_ascii_lowercase();
+    let family_rank = match family.as_str() {
+        "fable" => 1,
+        "opus" => 2,
+        "sonnet" => 3,
+        "haiku" => 4,
+        _ => 5,
+    };
+    let mut version = [std::cmp::Reverse(0u32); 4];
+    for (slot, part) in base
+        .split('-')
+        .skip(1)
+        .take_while(|part| {
+            !part.is_empty() && part.len() < 8 && part.chars().all(|ch| ch.is_ascii_digit())
+        })
+        .take(4)
+        .enumerate()
+    {
+        version[slot] = std::cmp::Reverse(part.parse().unwrap_or(0));
+    }
+    let context_rank = if context.eq_ignore_ascii_case("1m") {
+        0
+    } else {
+        1
+    };
+    (1, family_rank, version, context_rank)
 }
 
 fn fallback_models() -> Vec<p::Model> {
@@ -262,5 +311,74 @@ mod tests {
             vec!["Claude Opus", "Claude Sonnet", "Claude Haiku"]
         );
         assert!(models[0].is_default);
+    }
+}
+
+#[cfg(test)]
+mod ordering_tests {
+    use super::*;
+
+    fn info(value: &str, resolved: Option<&str>) -> ClaudeModelInfo {
+        ClaudeModelInfo {
+            value: value.to_string(),
+            display_name: value.to_string(),
+            resolved_model: resolved.map(str::to_string),
+            description: String::new(),
+            supports_effort: None,
+            supported_effort_levels: None,
+        }
+    }
+
+    #[test]
+    fn strongest_model_first_after_default() {
+        // CLI 的原顺序：Default、Opus、Fable 5、Fable 5.1、Sonnet、Haiku。
+        let cli_order = vec![
+            info("default", None),
+            info("opus[1m]", Some("claude-opus-5[1m]")),
+            info("claude-fable-5[1m]", Some("claude-fable-5[1m]")),
+            info("claude-fable-5-1", Some("claude-fable-5-1")),
+            info("sonnet", Some("claude-sonnet-5")),
+            info("haiku", Some("claude-haiku-4-5-20251001")),
+        ];
+        let ordered: Vec<_> = order_strongest_first(cli_order)
+            .into_iter()
+            .map(|info| info.value)
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                "default",
+                "claude-fable-5-1",
+                "claude-fable-5[1m]",
+                "opus[1m]",
+                "sonnet",
+                "haiku"
+            ]
+        );
+    }
+
+    #[test]
+    fn unknown_families_and_aliases_keep_cli_order_at_the_end() {
+        let ordered: Vec<_> = order_strongest_first(vec![
+            info("mystery-model", None),
+            info("opus", None),
+            info("claude-opus-5[1m]", Some("claude-opus-5[1m]")),
+            info("claude-opus-5", Some("claude-opus-5")),
+            info("another-mystery", None),
+        ])
+        .into_iter()
+        .map(|info| info.value)
+        .collect();
+        // 同版本 1M 优先；无版本别名排在有版本的同家族之后；未知家族按原顺序垫底。
+        assert_eq!(
+            ordered,
+            vec![
+                "claude-opus-5[1m]",
+                "claude-opus-5",
+                "opus",
+                "mystery-model",
+                "another-mystery"
+            ]
+        );
     }
 }

--- a/bridges/claude/crates/claude-bridge/src/main.rs
+++ b/bridges/claude/crates/claude-bridge/src/main.rs
@@ -37,7 +37,11 @@ async fn main() -> Result<()> {
     // Parse and validate the transport before starting any child-process
     // discovery or other bridge initialization.
     let transport = transport_arg()?;
-    let bridge = ClaudeBridge::builder().from_env().build().await?;
+    let bridge = ClaudeBridge::builder()
+        .from_env()
+        .warm_model_catalog(true)
+        .build()
+        .await?;
 
     match transport {
         Transport::Unix(path) => {

--- a/bridges/claude/crates/claude-bridge/src/pool/mod.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/mod.rs
@@ -61,6 +61,8 @@ pub struct ClaudePool {
     /// 同一时刻只允许一个新进程完成“检查 + 启动 + 入池”，避免两个首轮消息
     /// 同时命中空池时为同一个 thread 重复启动 Claude。
     spawn_lock: Arc<Mutex<()>>,
+    /// CLI 模型目录缓存，所有连接共享；见 [`model_catalog::ModelCatalogCache`]。
+    model_catalog: Arc<model_catalog::ModelCatalogCache>,
 }
 
 impl std::fmt::Debug for ClaudePool {
@@ -128,6 +130,7 @@ impl ClaudePool {
             policy,
             launcher,
             spawn_lock: Arc::new(Mutex::new(())),
+            model_catalog: Arc::new(model_catalog::ModelCatalogCache::default()),
         }
     }
 
@@ -142,7 +145,29 @@ impl ClaudePool {
     }
 
     pub async fn discover_models(&self) -> anyhow::Result<Vec<model_catalog::ClaudeModelInfo>> {
-        model_catalog::discover(self.launcher.as_ref(), &self.claude_bin).await
+        self.model_catalog
+            .get_or_discover(
+                self.launcher.as_ref(),
+                &self.claude_bin,
+                model_catalog::CATALOG_QUERY_TIMEOUT,
+            )
+            .await
+    }
+
+    /// 启动时后台预热目录：让首个 `model/list` 命中缓存，而不是在 CLI 冷启动
+    /// 期间超时回退成别名。失败只记日志，不影响任何会话。
+    pub async fn warm_model_catalog(&self) {
+        if let Err(err) = self
+            .model_catalog
+            .get_or_discover(
+                self.launcher.as_ref(),
+                &self.claude_bin,
+                model_catalog::CATALOG_WARM_TIMEOUT,
+            )
+            .await
+        {
+            tracing::debug!(error = %err, "claude model catalog warm-up failed; will retry on demand");
+        }
     }
 
     /// Spawn a fresh claude process for a brand-new codex thread, mint a

--- a/bridges/claude/crates/claude-bridge/src/pool/model_catalog.rs
+++ b/bridges/claude/crates/claude-bridge/src/pool/model_catalog.rs
@@ -1,7 +1,7 @@
 //! 通过 CLI 的 SDK initialize 控制请求读取目录，不发送 user 消息。
 
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alleycat_bridge_core::{ProcessLauncher, ProcessSpec, StdioMode};
 use anyhow::{Context, Result, bail};
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClaudeModelInfo {
     pub value: String,
@@ -97,6 +97,87 @@ async fn discover_with_timeout(
     result
 }
 
+/// 目录有效期。CLI 目录只随 CLI 升级变化，10 分钟内重复查询没有意义。
+pub const CATALOG_TTL: Duration = Duration::from_secs(10 * 60);
+/// 发现失败后的冷却：期间不再为每个 model/list 都起一个 CLI。
+pub const CATALOG_FAILURE_COOLDOWN: Duration = Duration::from_secs(15);
+/// 按需查询的超时；启动预热允许更久，CLI 冷启动可能超过 10 秒。
+pub const CATALOG_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+pub const CATALOG_WARM_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Default)]
+struct CatalogState {
+    models: Option<Vec<ClaudeModelInfo>>,
+    fetched_at: Option<Instant>,
+    failed_at: Option<Instant>,
+}
+
+/// 进程级目录缓存。此前每次 `model/list` 都现起一个 CLI 做发现，首次失败或超时
+/// 就回退成无版本别名，而客户端会把这次结果缓存几分钟——用户看到的就是"第一次
+/// 打开只有 Opus / Sonnet / Haiku，第二次才正常"。这里做三件事：缓存、单飞
+/// （并发调用等同一次发现）、发现失败时优先返回上一次成功的目录。
+pub struct ModelCatalogCache {
+    state: tokio::sync::Mutex<CatalogState>,
+    ttl: Duration,
+    failure_cooldown: Duration,
+}
+
+impl Default for ModelCatalogCache {
+    fn default() -> Self {
+        Self::with_limits(CATALOG_TTL, CATALOG_FAILURE_COOLDOWN)
+    }
+}
+
+impl ModelCatalogCache {
+    pub fn with_limits(ttl: Duration, failure_cooldown: Duration) -> Self {
+        Self {
+            state: tokio::sync::Mutex::new(CatalogState::default()),
+            ttl,
+            failure_cooldown,
+        }
+    }
+
+    pub async fn get_or_discover(
+        &self,
+        launcher: &dyn ProcessLauncher,
+        claude_bin: &Path,
+        timeout: Duration,
+    ) -> Result<Vec<ClaudeModelInfo>> {
+        // 持锁跨越整个发现过程就是单飞：后来的调用者等它结束后直接命中缓存。
+        let mut state = self.state.lock().await;
+        let now = Instant::now();
+        if let (Some(models), Some(fetched_at)) = (&state.models, state.fetched_at)
+            && now.duration_since(fetched_at) < self.ttl
+        {
+            return Ok(models.clone());
+        }
+        if let Some(failed_at) = state.failed_at
+            && now.duration_since(failed_at) < self.failure_cooldown
+        {
+            return state
+                .models
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("CLI model catalog recently failed"));
+        }
+        match discover_with_timeout(launcher, claude_bin, timeout).await {
+            Ok(models) => {
+                state.models = Some(models.clone());
+                state.fetched_at = Some(Instant::now());
+                state.failed_at = None;
+                Ok(models)
+            }
+            Err(err) => {
+                state.failed_at = Some(Instant::now());
+                // 旧目录比无版本别名更接近事实；只有从未成功过才把错误抛给调用方。
+                match &state.models {
+                    Some(models) => Ok(models.clone()),
+                    None => Err(err),
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,6 +190,7 @@ mod tests {
         hang: bool,
         events: Arc<Mutex<Vec<&'static str>>>,
         request: Arc<Mutex<String>>,
+        launches: Arc<Mutex<usize>>,
     }
 
     struct FakeChild {
@@ -124,6 +206,7 @@ mod tests {
             spec: ProcessSpec,
         ) -> BoxFuture<'_, std::io::Result<Box<dyn ChildProcess>>> {
             Box::pin(async move {
+                *self.launches.lock().unwrap() += 1;
                 let args: Vec<_> = spec.args.iter().map(|s| s.to_string_lossy()).collect();
                 assert!(args.contains(&"--no-session-persistence".into()));
                 assert!(args.contains(&"--strict-mcp-config".into()));
@@ -190,6 +273,7 @@ mod tests {
             hang,
             events: Arc::default(),
             request: Arc::default(),
+            launches: Arc::default(),
         };
         let result =
             discover_with_timeout(&launcher, Path::new("claude"), Duration::from_millis(100)).await;
@@ -215,6 +299,75 @@ mod tests {
             .unwrap();
             assert_eq!(models[0].value, version);
         }
+    }
+
+    fn catalog_response(version: &str) -> String {
+        let response = json!({"type":"control_response","response":{"subtype":"success","request_id":"model-catalog","response":{"models":[{"value":version,"displayName":"Future"}]}}});
+        format!("{response}\n")
+    }
+
+    fn fake_launcher(output: String) -> FakeLauncher {
+        FakeLauncher {
+            output,
+            hang: false,
+            events: Arc::default(),
+            request: Arc::default(),
+            launches: Arc::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_serves_repeat_queries_without_relaunching_the_cli() {
+        let launcher = fake_launcher(catalog_response("claude-fable-9-1"));
+        let cache = ModelCatalogCache::default();
+        for _ in 0..3 {
+            let models = cache
+                .get_or_discover(&launcher, Path::new("claude"), Duration::from_millis(200))
+                .await
+                .unwrap();
+            assert_eq!(models[0].value, "claude-fable-9-1");
+        }
+        assert_eq!(
+            *launcher.launches.lock().unwrap(),
+            1,
+            "TTL 内不得重复起 CLI"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_keeps_last_good_catalog_when_refresh_fails_and_cools_down() {
+        // ttl=0 强制每次都刷新，便于模拟过期后的失败。
+        let cache = ModelCatalogCache::with_limits(Duration::ZERO, Duration::from_secs(60));
+        let good = fake_launcher(catalog_response("claude-fable-9-1"));
+        cache
+            .get_or_discover(&good, Path::new("claude"), Duration::from_millis(200))
+            .await
+            .unwrap();
+
+        let broken = fake_launcher(String::new());
+        let models = cache
+            .get_or_discover(&broken, Path::new("claude"), Duration::from_millis(200))
+            .await
+            .expect("刷新失败时必须返回上一次成功的目录");
+        assert_eq!(models[0].value, "claude-fable-9-1");
+        assert_eq!(*broken.launches.lock().unwrap(), 1);
+
+        let again = cache
+            .get_or_discover(&broken, Path::new("claude"), Duration::from_millis(200))
+            .await
+            .unwrap();
+        assert_eq!(again[0].value, "claude-fable-9-1");
+        assert_eq!(*broken.launches.lock().unwrap(), 1, "冷却期内不得再起 CLI");
+
+        let never_succeeded =
+            ModelCatalogCache::with_limits(Duration::ZERO, Duration::from_secs(60));
+        assert!(
+            never_succeeded
+                .get_or_discover(&broken, Path::new("claude"), Duration::from_millis(200))
+                .await
+                .is_err(),
+            "从未成功过时才把错误抛给调用方"
+        );
     }
 
     #[tokio::test]

--- a/docs/claude-bridge-architecture.md
+++ b/docs/claude-bridge-architecture.md
@@ -83,6 +83,7 @@ sequenceDiagram
 - bridge 先从 Claude JSONL 播种完整历史，再追加尚未 flush 的实时 turn；`thread/read` 和 `thread/turns/list` 不会因为本进程出现新 turn 而丢掉旧历史。
 - `thread/turns/list` 按 `itemsView` 返回：`summary` 只保留用户与助手文本，工具过程由 `thread/items/list` 按 turn 分页补齐，和 Codex 首屏走同一条路；`full` 或省略时仍带全部 item。裁剪只在请求带 `itemsListAvailable: true` 时生效，这个字段由 agentd 网关写入，表示网关会转发 `thread/items/list`；新 bridge 配旧 agentd 时没有这个字段，bridge 照旧回完整 item。此前 bridge 无视 `itemsView`，一个 18 MB 会话的首页要 400–650 KB，移动端经中继打开明显更慢。
 - bridge 的协议输入输出是逐行 JSON；`agentd` 不把整段上下文重新拼成额外提示词。
+- `model/list` 的目录来自 Claude CLI 的 SDK initialize，进程级缓存 10 分钟并单飞；发现失败时优先返回上一次成功的目录，15 秒内不重复起 CLI；bridge 启动时后台预热一次，避免首个请求在 CLI 冷启动期间超时回退成无版本别名。列表顺序固定为 Default、Fable、Opus、Sonnet、Haiku，家族内按版本号降序、同版本 1M 上下文优先。
 - Claude Code 登录态和可恢复历史由用户本机 Claude Code 环境管理，不上传到 Mimi Remote 服务器。
 
 ### 观测与恢复


### PR DESCRIPTION
Refs #440

## 目标

动态模型目录合入后的两个后续问题：① 首次打开模型选择器只显示 Opus / Sonnet / Haiku 无版本别名，第二次打开才正常；② 列表顺序照抄 CLI，最强模型不在最上面。

## 根因

`model/list` 每次都现起一个 `claude -p` 跑 SDK initialize 做发现（本机热态 2.3 秒，冷态更久，超时 10 秒），没有缓存也没有单飞；首次失败或超时就回退成 `fallback_models()` 的三个别名，而 iOS 对 `model/list` 的成功 / 空 / 失败结果都负缓存 5 分钟。

## 实现（仅 bridge，不改协议、不改 iOS）

- `pool/model_catalog.rs` 新增 `ModelCatalogCache`：目录缓存 10 分钟；持锁跨越发现过程即单飞（并发调用等同一次发现）；失败冷却 15 秒；发现失败时优先返回上一次成功的目录，只有从未成功过才把错误抛给调用方（此时仍回别名，允许发送）。
- `ClaudePool::warm_model_catalog`：bridge 启动时后台预热一次（30 秒超时），首个 `model/list` 直接命中缓存。builder 新增 `warm_model_catalog(bool)`，只在 `main.rs` 生产入口打开，测试 bridge 默认不预热。
- `handlers/model.rs`：`order_strongest_first`——Default 固定第一，其余按家族 Fable > Opus > Sonnet > Haiku、版本号降序、同版本 1M 上下文优先，未知家族按 CLI 原顺序垫底。本机结果：Default、Fable 5.1、Fable 5 (1M)、Opus 5 (1M)、Sonnet 5、Haiku 4.5。
- 文档：`claude-bridge-architecture.md` 补一条。

## 验证

- `cargo test -p alleycat-claude-bridge`：238 单测（含新增 4 个：缓存命中不重起 CLI、刷新失败返回旧目录并冷却、排序两例）+ 全部集成套件通过；`cargo fmt --check`、`git diff --check`、docs、源码体积门禁通过。
- 未做运行态验收：需要重装 Mac App 后在 iPad 上冷启动打开模型选择器，首次即应显示完整目录且 Fable 5.1 在 Default 之后第一位。

## 风险

- 缓存 10 分钟内 CLI 升级不会立刻反映在列表里；重启 bridge 或等过期即可。
- 排序规则按家族名硬编码，新家族会按 CLI 顺序排在已知家族之后。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFUPyGE8qStdD2zuRdDejF
